### PR TITLE
feat: lotus-manage owns rebalance API surface via bridge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
   "fastapi>=0.133.0",
   "uvicorn>=0.41.0",
+  "httpx>=0.28.0",
   "pydantic>=2.12.0",
   "pydantic-settings>=2.13.0",
   "prometheus-fastapi-instrumentator>=7.1.0"

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,10 +1,15 @@
-from fastapi import FastAPI, Response, status
+import os
+
+import httpx
+from fastapi import FastAPI, Request, Response, status
+from fastapi.responses import Response as FastAPIResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 from src.app.middleware.correlation import CorrelationIdMiddleware
 
 SERVICE_NAME = "lotus-manage"
 SERVICE_VERSION = "0.1.0"
 ROUNDING_POLICY_VERSION = "v1"
+UPSTREAM_BASE_URL = os.getenv("MANAGE_UPSTREAM_BASE_URL", "http://localhost:8000").rstrip("/")
 
 app = FastAPI(title=SERVICE_NAME, version=SERVICE_VERSION)
 app.add_middleware(CorrelationIdMiddleware, service_name=SERVICE_NAME)
@@ -52,3 +57,47 @@ async def integration_capabilities() -> dict:
             {"workflow_key": "manage_lifecycle", "enabled": True},
         ],
     }
+
+
+def _upstream_url(path: str, query: str) -> str:
+    if query:
+        return f"{UPSTREAM_BASE_URL}{path}?{query}"
+    return f"{UPSTREAM_BASE_URL}{path}"
+
+
+def _forward_headers(request: Request) -> dict[str, str]:
+    forwarded: dict[str, str] = {}
+    for key in ("x-correlation-id", "idempotency-key", "content-type", "accept"):
+        value = request.headers.get(key)
+        if value:
+            forwarded[key] = value
+    return forwarded
+
+
+async def _proxy_request(request: Request, path: str) -> FastAPIResponse:
+    body = await request.body()
+    timeout_seconds = float(os.getenv("MANAGE_UPSTREAM_TIMEOUT_SECONDS", "10"))
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        upstream = await client.request(
+            method=request.method,
+            url=_upstream_url(path, request.url.query),
+            content=body if body else None,
+            headers=_forward_headers(request),
+        )
+    response = FastAPIResponse(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        media_type=upstream.headers.get("content-type"),
+    )
+    corr_id = request.headers.get("x-correlation-id")
+    if corr_id:
+        response.headers["X-Correlation-Id"] = corr_id
+    return response
+
+
+@app.api_route(
+    "/rebalance/{proxy_path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+)
+async def rebalance_proxy(proxy_path: str, request: Request) -> FastAPIResponse:
+    return await _proxy_request(request, f"/rebalance/{proxy_path}")

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from src.app.main import app
+from fastapi.responses import JSONResponse
 
 
 def test_health_endpoints() -> None:
@@ -24,4 +25,37 @@ def test_integration_capabilities_contract() -> None:
     assert body['sourceService'] == 'lotus-manage'
     assert isinstance(body['features'], list)
     assert isinstance(body['workflows'], list)
+
+
+def test_rebalance_proxy_forwards_get(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    async def _stub_proxy(request, path):  # type: ignore[no-untyped-def]
+        captured["method"] = request.method
+        captured["path"] = path
+        captured["query"] = request.url.query
+        return JSONResponse({"ok": True}, status_code=200)
+
+    monkeypatch.setattr("src.app.main._proxy_request", _stub_proxy)
+    client = TestClient(app)
+    response = client.get("/rebalance/proposals?limit=5")
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+    assert captured == {"method": "GET", "path": "/rebalance/proposals", "query": "limit=5"}
+
+
+def test_rebalance_proxy_forwards_post(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    async def _stub_proxy(request, path):  # type: ignore[no-untyped-def]
+        captured["method"] = request.method
+        captured["path"] = path
+        return JSONResponse({"ok": True}, status_code=201)
+
+    monkeypatch.setattr("src.app.main._proxy_request", _stub_proxy)
+    client = TestClient(app)
+    response = client.post("/rebalance/proposals/simulate", json={"portfolio_id": "P1"})
+    assert response.status_code == 201
+    assert response.json()["ok"] is True
+    assert captured == {"method": "POST", "path": "/rebalance/proposals/simulate"}
 


### PR DESCRIPTION
## Summary\n- add rebalance proxy routes in lotus-manage\n- forward method/query/body/headers to upstream lotus-advise endpoint\n- keep correlation header propagation\n- add integration tests for GET/POST forwarding\n\n## Why\n- complete bounded-context rewiring without feature loss while internals continue extracting\n