### PR TITLE
Fix app export and monetary-float lint regressions

### DIFF
--- a/scripts/check_monetary_float_usage.py
+++ b/scripts/check_monetary_float_usage.py
@@ -1,4 +1,3 @@
-import re
 import sys
 from pathlib import Path
 

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,3 +1,5 @@
 from src.api.main import app
 
 SERVICE_NAME = "lotus-manage"
+
+__all__ = ["app", "SERVICE_NAME"]

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -269,7 +269,7 @@ def generate_targets_solver(
         return [], "BLOCKED"
 
     for idx, i_id in enumerate(tradeable_ids):
-        solved_weight = Decimal(str(max(float(w.value[idx]), 0.0))).quantize(Decimal("0.0001"))
+        raw_weight = Decimal(str(w.value[idx]))
+        solved_weight = max(raw_weight, Decimal("0")).quantize(Decimal("0.0001"))
         eligible_targets[i_id] = solved_weight
-
     return build_target_trace(model, eligible_targets, buy_list, total_val, base_ccy), status


### PR DESCRIPTION
## Summary
- restore src.app.main app export for smoke/integration import compatibility
- remove unused imports flagged by lint in scripts
- eliminate monetary float usage in target generation by using Decimal-safe clamping

## Validation
- python -m ruff check scripts src/app/main.py src/core/target_generation.py
- python scripts/check_monetary_float_usage.py
- python -m pytest tests/integration/test_health.py tests/e2e/test_smoke.py -q

## Notes
- This is a minimal gap-closure patch to avoid conflicts with parallel migration work.