### PR TITLE
Isolate lotus-manage docker postgres identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Lotus Advise
+# Lotus Manage
 
-Advisor-led proposal simulation and lifecycle service.
+Discretionary portfolio management (DPM) execution, supportability, and lifecycle service.
 
-This repository contains advisory-only workflows.
-Discretionary portfolio management (DPM) workflows are owned by `lotus-manage`.
+This repository owns DPM runtime workflows.
+Advisor-led proposal workflows are owned by `lotus-advise`.

--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -2,13 +2,13 @@ services:
   postgres:
     image: postgres:17.6
     environment:
-      POSTGRES_DB: dpm_supportability
-      POSTGRES_USER: dpm
-      POSTGRES_PASSWORD: dpm
+      POSTGRES_DB: manage_supportability
+      POSTGRES_USER: manage
+      POSTGRES_PASSWORD: manage
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U dpm -d dpm_supportability"]
+      test: ["CMD-SHELL", "pg_isready -U manage -d manage_supportability"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -26,8 +26,8 @@ services:
     environment:
       PIP_DISABLE_PIP_VERSION_CHECK: "1"
       PYTHONUNBUFFERED: "1"
-      DPM_SUPPORTABILITY_POSTGRES_DSN: postgresql://dpm:dpm@postgres:5432/dpm_supportability
-      PROPOSAL_POSTGRES_DSN: postgresql://dpm:dpm@postgres:5432/dpm_supportability
-      DPM_POSTGRES_INTEGRATION_DSN: postgresql://dpm:dpm@postgres:5432/dpm_supportability
-      PROPOSAL_POSTGRES_INTEGRATION_DSN: postgresql://dpm:dpm@postgres:5432/dpm_supportability
+      DPM_SUPPORTABILITY_POSTGRES_DSN: postgresql://manage:manage@postgres:5432/manage_supportability
+      PROPOSAL_POSTGRES_DSN: postgresql://manage:manage@postgres:5432/manage_supportability
+      DPM_POSTGRES_INTEGRATION_DSN: postgresql://manage:manage@postgres:5432/manage_supportability
+      PROPOSAL_POSTGRES_INTEGRATION_DSN: postgresql://manage:manage@postgres:5432/manage_supportability
     command: ["sh", "-lc", "make ci-local"]

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,13 +1,11 @@
 services:
-  lotus-advise:
+  lotus-manage:
     environment:
       - APP_PERSISTENCE_PROFILE=PRODUCTION
       - DPM_SUPPORTABILITY_STORE_BACKEND=POSTGRES
-      - DPM_SUPPORTABILITY_POSTGRES_DSN=postgresql://dpm:dpm@postgres:5432/dpm_supportability
+      - DPM_SUPPORTABILITY_POSTGRES_DSN=postgresql://manage:manage@postgres:5432/manage_supportability
       - PROPOSAL_STORE_BACKEND=POSTGRES
-      - PROPOSAL_POSTGRES_DSN=postgresql://dpm:dpm@postgres:5432/dpm_supportability
+      - PROPOSAL_POSTGRES_DSN=postgresql://manage:manage@postgres:5432/manage_supportability
       - DPM_POLICY_PACKS_ENABLED=true
       - DPM_POLICY_PACK_CATALOG_BACKEND=POSTGRES
-      - DPM_POLICY_PACK_POSTGRES_DSN=postgresql://dpm:dpm@postgres:5432/dpm_supportability
-
-
+      - DPM_POLICY_PACK_POSTGRES_DSN=postgresql://manage:manage@postgres:5432/manage_supportability

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
-  lotus-advise:
+  lotus-manage:
     build:
       context: .
       dockerfile: Dockerfile
-    image: lotus-advise:latest
+    image: lotus-manage:latest
     init: true
     restart: unless-stopped
     ports:
@@ -12,11 +12,11 @@ services:
       - ENVIRONMENT=production
       - APP_PERSISTENCE_PROFILE=${APP_PERSISTENCE_PROFILE:-PRODUCTION}
       - DPM_SUPPORTABILITY_STORE_BACKEND=${DPM_SUPPORTABILITY_STORE_BACKEND:-POSTGRES}
-      - DPM_SUPPORTABILITY_POSTGRES_DSN=${DPM_SUPPORTABILITY_POSTGRES_DSN:-postgresql://dpm:dpm@postgres:5432/dpm_supportability}
+      - DPM_SUPPORTABILITY_POSTGRES_DSN=${DPM_SUPPORTABILITY_POSTGRES_DSN:-postgresql://manage:manage@postgres:5432/manage_supportability}
       - PROPOSAL_STORE_BACKEND=${PROPOSAL_STORE_BACKEND:-POSTGRES}
-      - PROPOSAL_POSTGRES_DSN=${PROPOSAL_POSTGRES_DSN:-postgresql://dpm:dpm@postgres:5432/dpm_supportability}
+      - PROPOSAL_POSTGRES_DSN=${PROPOSAL_POSTGRES_DSN:-postgresql://manage:manage@postgres:5432/manage_supportability}
       - DPM_POLICY_PACK_CATALOG_BACKEND=${DPM_POLICY_PACK_CATALOG_BACKEND:-POSTGRES}
-      - DPM_POLICY_PACK_POSTGRES_DSN=${DPM_POLICY_PACK_POSTGRES_DSN:-postgresql://dpm:dpm@postgres:5432/dpm_supportability}
+      - DPM_POLICY_PACK_POSTGRES_DSN=${DPM_POLICY_PACK_POSTGRES_DSN:-postgresql://manage:manage@postgres:5432/manage_supportability}
     healthcheck:
       test:
         [
@@ -41,19 +41,17 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_DB=dpm_supportability
-      - POSTGRES_USER=dpm
-      - POSTGRES_PASSWORD=dpm
+      - POSTGRES_DB=manage_supportability
+      - POSTGRES_USER=manage
+      - POSTGRES_PASSWORD=manage
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U dpm -d dpm_supportability"]
+      test: ["CMD-SHELL", "pg_isready -U manage -d manage_supportability"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 10s
     volumes:
-      - dpm-postgres-data:/var/lib/postgresql/data
+      - manage-postgres-data:/var/lib/postgresql/data
 
 volumes:
-  dpm-postgres-data:
-
-
+  manage-postgres-data:

--- a/scripts/check_monetary_float_usage.py
+++ b/scripts/check_monetary_float_usage.py
@@ -1,4 +1,3 @@
-import re
 import sys
 from pathlib import Path
 

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,3 +1,5 @@
 from src.api.main import app
 
 SERVICE_NAME = "lotus-manage"
+
+__all__ = ["app", "SERVICE_NAME"]

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -269,7 +269,7 @@ def generate_targets_solver(
         return [], "BLOCKED"
 
     for idx, i_id in enumerate(tradeable_ids):
-        solved_weight = Decimal(str(max(float(w.value[idx]), 0.0))).quantize(Decimal("0.0001"))
+        raw_weight = Decimal(str(w.value[idx]))
+        solved_weight = max(raw_weight, Decimal("0")).quantize(Decimal("0.0001"))
         eligible_targets[i_id] = solved_weight
-
     return build_target_trace(model, eligible_targets, buy_list, total_val, base_ccy), status


### PR DESCRIPTION
## Summary
- rename runtime service metadata to lotus-manage in compose overlays
- move default local/ci/prod DSNs to manage_supportability postgres database
- align postgres user/password defaults to manage
- refresh repo README ownership header

## Validation
- python -m ruff check scripts src/app/main.py src/core/target_generation.py
- python scripts/check_monetary_float_usage.py
- python -m pytest tests/integration/test_health.py tests/e2e/test_smoke.py -q