### PR TITLE
chore: Lotus naming cleanup for lotus-manage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lotus Manage
 
-Discretionary portfolio management (DPM) execution, supportability, and lifecycle service.
+Discretionary portfolio management (lotus-manage) execution, supportability, and lifecycle service.
 
-This repository owns DPM runtime workflows.
+This repository owns lotus-manage runtime workflows.
 Advisor-led proposal workflows are owned by `lotus-advise`.

--- a/docs/adr/ADR-0001-async-proposal-operations-and-correlation-retrieval.md
+++ b/docs/adr/ADR-0001-async-proposal-operations-and-correlation-retrieval.md
@@ -52,7 +52,7 @@ Introduce an operation-resource pattern for asynchronous lifecycle workflows:
   - approvals/consent recording (state-sensitive and audit-critical)
   - read endpoints (already lightweight and deterministic)
 - Deferred:
-  - async DPM batch analyze and async advisory simulate/artifact (can reuse same pattern later)
+  - async lotus-manage batch analyze and async advisory simulate/artifact (can reuse same pattern later)
 
 ## Consequences
 
@@ -68,4 +68,4 @@ Tradeoffs:
 
 - Add persistent operation store (PostgreSQL adapter) with retention policies.
 - Add optional callback/webhook completion pattern for external orchestrators.
-- Extend same operation pattern to selected DPM workflows where latency justifies async behavior.
+- Extend same operation pattern to selected lotus-manage workflows where latency justifies async behavior.

--- a/docs/adr/ADR-0002-dpm-simulate-idempotency-replay-contract.md
+++ b/docs/adr/ADR-0002-dpm-simulate-idempotency-replay-contract.md
@@ -1,8 +1,8 @@
-# ADR-0002: DPM Simulate Idempotency Replay Contract
+# ADR-0002: lotus-manage Simulate Idempotency Replay Contract
 
 - Status: Accepted
 - Date: 2026-02-20
-- Owners: DPM API / Platform
+- Owners: lotus-manage API / Platform
 
 ## Context
 
@@ -22,7 +22,7 @@ Adopt explicit replay semantics for `POST /rebalance/simulate`:
 
 ## Why
 
-- Aligns DPM and advisory API contracts.
+- Aligns lotus-manage and advisory API contracts.
 - Reduces duplicate execution risk under network retries.
 - Improves operational reproducibility and incident analysis.
 
@@ -39,4 +39,4 @@ Tradeoffs:
 ## Follow-ups
 
 - Add durable idempotency persistence for distributed deployment.
-- Add supportability lookup endpoint(s) for DPM idempotency keys if needed by operations.
+- Add supportability lookup endpoint(s) for lotus-manage idempotency keys if needed by operations.

--- a/docs/adr/ADR-0003-dpm-run-supportability-lookup-apis.md
+++ b/docs/adr/ADR-0003-dpm-run-supportability-lookup-apis.md
@@ -1,16 +1,16 @@
-# ADR-0003: DPM Run Supportability Lookup APIs
+# ADR-0003: lotus-manage Run Supportability Lookup APIs
 
 - Status: Accepted
 - Date: 2026-02-20
-- Owners: DPM API / Platform
+- Owners: lotus-manage API / Platform
 
 ## Context
 
-DPM now enforces idempotency replay semantics and propagates correlation ids. Operational teams still needed deterministic API-level lookups for run investigations without direct log or database access.
+lotus-manage now enforces idempotency replay semantics and propagates correlation ids. Operational teams still needed deterministic API-level lookups for run investigations without direct log or database access.
 
 ## Decision
 
-Introduce read-only DPM supportability endpoints:
+Introduce read-only lotus-manage supportability endpoints:
 
 1. `GET /rebalance/runs/{rebalance_run_id}`
 2. `GET /rebalance/runs/by-correlation/{correlation_id}`
@@ -33,7 +33,7 @@ Guard endpoints with runtime feature toggle:
 
 ## Why
 
-- Aligns DPM operational supportability with advisory lifecycle patterns.
+- Aligns lotus-manage operational supportability with advisory lifecycle patterns.
 - Improves incident response and auditability with deterministic retrieval paths.
 - Preserves clean separation of concerns (API router vs domain support service vs storage adapter).
 

--- a/docs/adr/ADR-0004-dpm-async-operation-selection-and-correlation-contract.md
+++ b/docs/adr/ADR-0004-dpm-async-operation-selection-and-correlation-contract.md
@@ -1,12 +1,12 @@
-# ADR-0004: DPM Async Operation Selection and Correlation Contract
+# ADR-0004: lotus-manage Async Operation Selection and Correlation Contract
 
 - Status: Accepted
 - Date: 2026-02-20
-- Owners: DPM API / Platform
+- Owners: lotus-manage API / Platform
 
 ## Context
 
-Supportability and orchestration needs differ by endpoint latency profile. DPM required a clear policy for which operations should expose asynchronous contracts and how business/support users should retrieve operation state deterministically.
+Supportability and orchestration needs differ by endpoint latency profile. lotus-manage required a clear policy for which operations should expose asynchronous contracts and how business/support users should retrieve operation state deterministically.
 
 ## Decision
 
@@ -36,7 +36,7 @@ Correlation contract:
 ## Why
 
 - Improves enterprise orchestration without forcing async complexity on all endpoints.
-- Aligns DPM with advisory operation-vocabulary patterns while preserving DPM business semantics.
+- Aligns lotus-manage with advisory operation-vocabulary patterns while preserving lotus-manage business semantics.
 - Keeps API separation clean:
   - submission endpoint
   - operation status endpoint

--- a/docs/adr/ADR-0005-dpm-derived-run-artifact-strategy.md
+++ b/docs/adr/ADR-0005-dpm-derived-run-artifact-strategy.md
@@ -1,12 +1,12 @@
-# ADR-0005: DPM Derived Run Artifact Strategy
+# ADR-0005: lotus-manage Derived Run Artifact Strategy
 
 - Status: Accepted
 - Date: 2026-02-20
-- Owners: DPM API / Platform
+- Owners: lotus-manage API / Platform
 
 ## Context
 
-DPM run supportability APIs exposed run metadata and payloads, but no deterministic artifact contract for business users, investigations, and replay validation.
+lotus-manage run supportability APIs exposed run metadata and payloads, but no deterministic artifact contract for business users, investigations, and replay validation.
 
 ## Decision
 
@@ -28,7 +28,7 @@ Service layer remains orchestration-only:
 
 - Avoids coupling artifact shape to simulation execution paths.
 - Preserves reproducibility while avoiding new persistence requirements in first slice.
-- Mirrors advisory architecture pattern (separate artifact builder module) with DPM-specific models and vocabulary.
+- Mirrors advisory architecture pattern (separate artifact builder module) with lotus-manage-specific models and vocabulary.
 
 ## Consequences
 

--- a/docs/adr/ADR-0006-dpm-async-execution-mode-inline-vs-accept-only.md
+++ b/docs/adr/ADR-0006-dpm-async-execution-mode-inline-vs-accept-only.md
@@ -1,12 +1,12 @@
-# ADR-0006: DPM Async Execution Mode (`INLINE` vs `ACCEPT_ONLY`)
+# ADR-0006: lotus-manage Async Execution Mode (`INLINE` vs `ACCEPT_ONLY`)
 
 - Status: Accepted
 - Date: 2026-02-20
-- Owners: DPM API / Platform
+- Owners: lotus-manage API / Platform
 
 ## Context
 
-RFC-0018 introduces asynchronous operation resources for DPM analysis workflows. Teams need configurable behavior between immediate inline execution and acceptance-only mode where execution is delegated later.
+RFC-0018 introduces asynchronous operation resources for lotus-manage analysis workflows. Teams need configurable behavior between immediate inline execution and acceptance-only mode where execution is delegated later.
 
 ## Decision
 

--- a/docs/adr/ADR-0007-dpm-workflow-gate-supportability-api-first.md
+++ b/docs/adr/ADR-0007-dpm-workflow-gate-supportability-api-first.md
@@ -1,4 +1,4 @@
-# ADR-0007: DPM Workflow Gate Supportability Is API-First
+# ADR-0007: lotus-manage Workflow Gate Supportability Is API-First
 
 ## Status
 
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-DPM support/investigation workflows need workflow gate visibility and operator actions without requiring direct database access. RFC-0020 introduces run workflow state and decisions (`APPROVE`, `REJECT`, `REQUEST_CHANGES`) with audit metadata.
+lotus-manage support/investigation workflows need workflow gate visibility and operator actions without requiring direct database access. RFC-0020 introduces run workflow state and decisions (`APPROVE`, `REJECT`, `REQUEST_CHANGES`) with audit metadata.
 
 ## Decision
 

--- a/docs/adr/ADR-0008-dpm-supportability-store-backend-selection.md
+++ b/docs/adr/ADR-0008-dpm-supportability-store-backend-selection.md
@@ -1,4 +1,4 @@
-# ADR-0008: DPM Supportability Store Backend Selection
+# ADR-0008: lotus-manage Supportability Store Backend Selection
 
 ## Status
 
@@ -6,11 +6,11 @@ Accepted
 
 ## Context
 
-RFC-0023 requires durable supportability storage while preserving current in-memory behavior for local development and backward compatibility. The DPM supportability domain now includes run records, idempotency mappings, async operation records, and workflow decision records.
+RFC-0023 requires durable supportability storage while preserving current in-memory behavior for local development and backward compatibility. The lotus-manage supportability domain now includes run records, idempotency mappings, async operation records, and workflow decision records.
 
 ## Decision
 
-Introduce backend selection for DPM supportability repository:
+Introduce backend selection for lotus-manage supportability repository:
 
 - `DPM_SUPPORTABILITY_STORE_BACKEND`
   - `IN_MEMORY` (default)

--- a/docs/adr/ADR-0009-postgresql-as-target-persistence-backend.md
+++ b/docs/adr/ADR-0009-postgresql-as-target-persistence-backend.md
@@ -1,4 +1,4 @@
-# ADR-0009: PostgreSQL as Target Persistence Backend for DPM and Advisory
+# ADR-0009: PostgreSQL as Target Persistence Backend for lotus-manage and Advisory
 
 ## Status
 
@@ -6,19 +6,19 @@ Accepted
 
 ## Context
 
-DPM and advisory workflows require durable, auditable, and scalable persistence for production operations. Current adapters (in-memory and SQLite) are useful for local development and incremental delivery but are not the long-term production target.
+lotus-manage and advisory workflows require durable, auditable, and scalable persistence for production operations. Current adapters (in-memory and SQLite) are useful for local development and incremental delivery but are not the long-term production target.
 
 ## Decision
 
 Set PostgreSQL as the target production persistence backend for both domains:
 
-- DPM supportability and lineage storage
+- lotus-manage supportability and lineage storage
 - advisory proposal lifecycle and supportability storage
 
 Keep in-memory (and optionally SQLite) adapters for local and test profiles behind backend configuration flags.
 
 ## Consequences
 
-- Unified enterprise persistence strategy across DPM and advisory.
+- Unified enterprise persistence strategy across lotus-manage and advisory.
 - Better concurrency, indexing, retention operations, and managed backup/HA capabilities.
 - Requires migration tooling discipline and staged rollout by environment.

--- a/docs/adr/ADR-0010-testing-strategy-fast-unit-and-postgres-parity.md
+++ b/docs/adr/ADR-0010-testing-strategy-fast-unit-and-postgres-parity.md
@@ -30,9 +30,9 @@ Adopt a layered testing model:
    - primary suite location: `tests/unit/`.
 
 2. Mandatory Postgres integration coverage for critical persistence flows:
-   - DPM supportability repository live integration tests.
+   - lotus-manage supportability repository live integration tests.
    - advisory proposal repository live integration tests.
-   - DPM policy-pack Postgres repository live integration tests.
+   - lotus-manage policy-pack Postgres repository live integration tests.
    - production-profile startup and guardrail reason-code checks in CI.
    - migration and cutover contract checks in CI.
    - integration suite location: `tests/integration/`.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,6 +1,6 @@
-# DPM Rebalance Engine Demo Scenarios
+# lotus-manage Rebalance Engine Demo Scenarios
 
-This folder contains JSON input files demonstrating key capabilities of the DPM Rebalance Engine. Run these scenarios through the API endpoints.
+This folder contains JSON input files demonstrating key capabilities of the lotus-manage Rebalance Engine. Run these scenarios through the API endpoints.
 
 ## Running Scenarios
 
@@ -25,30 +25,30 @@ curl -X GET "http://127.0.0.1:8000/rebalance/operations?status=SUCCEEDED&operati
 curl -X GET "http://127.0.0.1:8000/rebalance/operations/by-correlation/demo-corr-26-async"
 ```
 
-For DPM policy-pack resolution supportability:
+For lotus-manage policy-pack resolution supportability:
 ```bash
 curl -X GET "http://127.0.0.1:8000/rebalance/policies/effective" -H "X-Policy-Pack-Id: dpm_standard_v1" -H "X-Tenant-Policy-Pack-Id: dpm_tenant_default_v1" -H "X-Tenant-Id: tenant_001"
 ```
 
-For DPM policy-pack catalog and selected-pack presence diagnostics:
+For lotus-manage policy-pack catalog and selected-pack presence diagnostics:
 ```bash
 curl -X GET "http://127.0.0.1:8000/rebalance/policies/catalog" -H "X-Policy-Pack-Id: dpm_standard_v1" -H "X-Tenant-Policy-Pack-Id: dpm_tenant_default_v1" -H "X-Tenant-Id: tenant_001"
 ```
 
-For DPM policy-pack supportability + diagnostics scenario:
+For lotus-manage policy-pack supportability + diagnostics scenario:
 ```bash
 curl -X POST "http://127.0.0.1:8000/rebalance/simulate" -H "Content-Type: application/json" -H "Idempotency-Key: demo-31-policy-pack" -H "X-Policy-Pack-Id: dpm_standard_v1" -H "X-Tenant-Policy-Pack-Id: dpm_tenant_default_v1" -H "X-Tenant-Id: tenant_001" --data-binary "@docs/demo/31_dpm_policy_pack_supportability_diagnostics.json"
 curl -X GET "http://127.0.0.1:8000/rebalance/policies/effective" -H "X-Policy-Pack-Id: dpm_standard_v1" -H "X-Tenant-Policy-Pack-Id: dpm_tenant_default_v1" -H "X-Tenant-Id: tenant_001"
 curl -X GET "http://127.0.0.1:8000/rebalance/policies/catalog" -H "X-Policy-Pack-Id: dpm_standard_v1" -H "X-Tenant-Policy-Pack-Id: dpm_tenant_default_v1" -H "X-Tenant-Id: tenant_001"
 ```
 
-For DPM supportability summary metrics scenario:
+For lotus-manage supportability summary metrics scenario:
 ```bash
 curl -X POST "http://127.0.0.1:8000/rebalance/simulate" -H "Content-Type: application/json" -H "Idempotency-Key: demo-32-support-summary" -H "X-Correlation-Id: demo-corr-32-support-summary" --data-binary "@docs/demo/32_dpm_supportability_summary_metrics.json"
 curl -X GET "http://127.0.0.1:8000/rebalance/supportability/summary"
 ```
 
-For DPM policy-pack turnover override demo (requires `DPM_POLICY_PACKS_ENABLED=true`):
+For lotus-manage policy-pack turnover override demo (requires `DPM_POLICY_PACKS_ENABLED=true`):
 ```bash
 export DPM_POLICY_PACK_CATALOG_JSON='{"dpm_standard_v1":{"version":"1","turnover_policy":{"max_turnover_pct":"0.01"},"tax_policy":{"enable_tax_awareness":true,"max_realized_capital_gains":"100"}}}'
 export DPM_TENANT_POLICY_PACK_RESOLUTION_ENABLED=true
@@ -82,7 +82,7 @@ curl -X POST "http://127.0.0.1:8000/rebalance/simulate" -H "Content-Type: applic
 curl -X POST "http://127.0.0.1:8000/rebalance/simulate" -H "Content-Type: application/json" -H "Idempotency-Key: demo-policy-pack-idempotency-1" -H "X-Policy-Pack-Id: dpm_standard_v1" --data-binary "@docs/demo/01_standard_drift.json"
 ```
 
-For DPM supportability and deterministic artifact retrieval flow:
+For lotus-manage supportability and deterministic artifact retrieval flow:
 ```bash
 curl -X POST "http://127.0.0.1:8000/rebalance/simulate" -H "Content-Type: application/json" -H "Idempotency-Key: demo-27-supportability" -H "X-Correlation-Id: demo-corr-27-supportability" --data-binary "@docs/demo/27_dpm_supportability_artifact_flow.json"
 curl -X GET "http://127.0.0.1:8000/rebalance/runs?status=READY&portfolio_id=pf_demo_support_27&limit=20"
@@ -102,17 +102,17 @@ curl -X GET "http://127.0.0.1:8000/rebalance/runs/<rebalance_run_id>/artifact"
 Retention can be enabled for supportability records with:
 - `DPM_SUPPORTABILITY_RETENTION_DAYS=<positive_integer>`
 
-For DPM lineage supportability (enabled when `DPM_LINEAGE_APIS_ENABLED=true`):
+For lotus-manage lineage supportability (enabled when `DPM_LINEAGE_APIS_ENABLED=true`):
 ```bash
 curl -X GET "http://127.0.0.1:8000/rebalance/lineage/<entity_id>"
 ```
 
-For DPM idempotency history supportability (enabled when `DPM_IDEMPOTENCY_HISTORY_APIS_ENABLED=true`):
+For lotus-manage idempotency history supportability (enabled when `DPM_IDEMPOTENCY_HISTORY_APIS_ENABLED=true`):
 ```bash
 curl -X GET "http://127.0.0.1:8000/rebalance/idempotency/<idempotency_key>/history"
 ```
 
-For DPM workflow supportability endpoints (enabled only when `DPM_WORKFLOW_ENABLED=true`):
+For lotus-manage workflow supportability endpoints (enabled only when `DPM_WORKFLOW_ENABLED=true`):
 ```bash
 curl -X GET "http://127.0.0.1:8000/rebalance/runs/<rebalance_run_id>/workflow"
 curl -X GET "http://127.0.0.1:8000/rebalance/runs/by-correlation/<correlation_id>/workflow"
@@ -179,13 +179,13 @@ python scripts/run_demo_pack_live.py --base-url http://127.0.0.1:8000
 | `23_advisory_proposal_approval_client_consent.json` | **Proposal Consent Approval** | `EXECUTION_READY` lifecycle state | Records structured client consent and emits workflow event. |
 | `24_advisory_proposal_approval_compliance.json` | **Proposal Compliance Approval** | `AWAITING_CLIENT_CONSENT` lifecycle state | Records compliance approval and advances lifecycle. |
 | `25_advisory_proposal_transition_executed.json` | **Proposal Execution Transition** | `EXECUTED` lifecycle state | Records execution confirmation transition from execution-ready state. |
-| `26_dpm_async_batch_analysis.json` | **DPM Async Batch Analysis** | Async operation `SUCCEEDED` with partial-failure warning | Demonstrates `/rebalance/analyze/async` acceptance + operation lookup with `failed_scenarios` diagnostics. |
-| `27_dpm_supportability_artifact_flow.json` | **DPM Supportability + Artifact Flow** | `READY` run + deterministic artifact hash | Demonstrates run lookup by run id/correlation/idempotency and deterministic retrieval from `/rebalance/runs/{rebalance_run_id}/artifact`. |
-| `28_dpm_async_manual_execute_guard.json` | **DPM Async Manual Execute Guard** | Manual execute returns `409` on non-pending run | Demonstrates `/rebalance/operations/{operation_id}/execute` conflict guard when operation already completed inline. |
-| `29_dpm_workflow_gate_disabled_contract.json` | **DPM Workflow Gate Default Guard** | Workflow endpoints return `404 DPM_WORKFLOW_DISABLED` | Demonstrates feature-toggle default behavior for workflow supportability endpoints. |
-| `30_dpm_idempotency_history_supportability.json` | **DPM Idempotency History Supportability** | History returns two run mappings for same idempotency key | Demonstrates replay-disabled run recording and `GET /rebalance/idempotency/{idempotency_key}/history`. |
-| `31_dpm_policy_pack_supportability_diagnostics.json` | **DPM Policy-Pack Supportability Diagnostics** | `READY` plus policy diagnostics responses | Demonstrates policy endpoint diagnostics (`/policies/effective`, `/policies/catalog`) with policy headers and request simulation context. |
-| `32_dpm_supportability_summary_metrics.json` | **DPM Supportability Summary Metrics** | `READY` and summary response with expected metric fields | Demonstrates `/rebalance/supportability/summary` as the primary no-DB operational overview endpoint. |
+| `26_dpm_async_batch_analysis.json` | **lotus-manage Async Batch Analysis** | Async operation `SUCCEEDED` with partial-failure warning | Demonstrates `/rebalance/analyze/async` acceptance + operation lookup with `failed_scenarios` diagnostics. |
+| `27_dpm_supportability_artifact_flow.json` | **lotus-manage Supportability + Artifact Flow** | `READY` run + deterministic artifact hash | Demonstrates run lookup by run id/correlation/idempotency and deterministic retrieval from `/rebalance/runs/{rebalance_run_id}/artifact`. |
+| `28_dpm_async_manual_execute_guard.json` | **lotus-manage Async Manual Execute Guard** | Manual execute returns `409` on non-pending run | Demonstrates `/rebalance/operations/{operation_id}/execute` conflict guard when operation already completed inline. |
+| `29_dpm_workflow_gate_disabled_contract.json` | **lotus-manage Workflow Gate Default Guard** | Workflow endpoints return `404 DPM_WORKFLOW_DISABLED` | Demonstrates feature-toggle default behavior for workflow supportability endpoints. |
+| `30_dpm_idempotency_history_supportability.json` | **lotus-manage Idempotency History Supportability** | History returns two run mappings for same idempotency key | Demonstrates replay-disabled run recording and `GET /rebalance/idempotency/{idempotency_key}/history`. |
+| `31_dpm_policy_pack_supportability_diagnostics.json` | **lotus-manage Policy-Pack Supportability Diagnostics** | `READY` plus policy diagnostics responses | Demonstrates policy endpoint diagnostics (`/policies/effective`, `/policies/catalog`) with policy headers and request simulation context. |
+| `32_dpm_supportability_summary_metrics.json` | **lotus-manage Supportability Summary Metrics** | `READY` and summary response with expected metric fields | Demonstrates `/rebalance/supportability/summary` as the primary no-DB operational overview endpoint. |
 
 ## Feature Toggles Demonstrated
 

--- a/docs/demo/manual-validation-2026-02-20.md
+++ b/docs/demo/manual-validation-2026-02-20.md
@@ -9,14 +9,14 @@ Validated the end-to-end demo pack scenarios through live API calls in both runt
 
 Coverage includes:
 
-- DPM simulate demos (`01`-`08`)
-- DPM batch analyze demo (`09`)
-- DPM async batch analyze demo (`26`)
-- DPM supportability + deterministic artifact flow demo (`27`)
-- DPM async manual-execute guard demo (`28`)
-- DPM workflow gate default-disabled contract demo (`29`)
-- DPM policy-pack supportability diagnostics demo (`31`)
-- DPM supportability summary metrics demo (`32`)
+- lotus-manage simulate demos (`01`-`08`)
+- lotus-manage batch analyze demo (`09`)
+- lotus-manage async batch analyze demo (`26`)
+- lotus-manage supportability + deterministic artifact flow demo (`27`)
+- lotus-manage async manual-execute guard demo (`28`)
+- lotus-manage workflow gate default-disabled contract demo (`29`)
+- lotus-manage policy-pack supportability diagnostics demo (`31`)
+- lotus-manage supportability summary metrics demo (`32`)
 - Advisory simulate demos (`10`-`18`)
 - Advisory artifact demo (`19`)
 - Advisory lifecycle flow demos (`20`-`25`)
@@ -542,7 +542,7 @@ Demo pack validation passed for http://127.0.0.1:8000
 
 - CI workflow adds production-profile smoke job with:
   - `APP_PERSISTENCE_PROFILE=PRODUCTION`
-  - Postgres-backed DPM/advisory/policy-pack configuration
+  - Postgres-backed lotus-manage/advisory/policy-pack configuration
   - migration application via `python scripts/postgres_migrate.py --target all`
   - startup verification of `/docs`, `/rebalance/policies/effective`, and `/rebalance/proposals?limit=1`
 
@@ -556,7 +556,7 @@ Demo pack validation passed for http://127.0.0.1:8000
 ## RFC-0025 Slice 3 Negative Guardrail Validation
 
 - Production-profile negative startup checks validated by CI job `production-profile-guardrail-negatives`:
-  - DPM backend mismatch (`DPM_SUPPORTABILITY_STORE_BACKEND=IN_MEMORY`) fails startup with:
+  - lotus-manage backend mismatch (`DPM_SUPPORTABILITY_STORE_BACKEND=IN_MEMORY`) fails startup with:
     - `PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES`
   - Advisory backend mismatch (`PROPOSAL_STORE_BACKEND=IN_MEMORY`) fails startup with:
     - `PERSISTENCE_PROFILE_REQUIRES_ADVISORY_POSTGRES`
@@ -577,7 +577,7 @@ Demo pack validation passed for http://127.0.0.1:8000
   - enforces production profile and postgres-only persistence env defaults.
 
 - RFC-0025 DSN guardrail negatives are now validated in CI (`production-profile-guardrail-negatives`):
-  - missing DPM Postgres DSN -> `PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES_DSN`
+  - missing lotus-manage Postgres DSN -> `PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES_DSN`
   - missing advisory Postgres DSN -> `PERSISTENCE_PROFILE_REQUIRES_ADVISORY_POSTGRES_DSN`
   - missing policy-pack Postgres DSN with policy packs enabled -> `PERSISTENCE_PROFILE_REQUIRES_POLICY_PACK_POSTGRES_DSN`
 

--- a/docs/demo/postgres-cutover-checklist-2026-02-20.md
+++ b/docs/demo/postgres-cutover-checklist-2026-02-20.md
@@ -17,7 +17,7 @@ Production-style readiness checklist for RFC-0024 cutover controls.
 - [x] CI production profile startup smoke job added (`.github/workflows/ci.yml`)
 - [x] CI production profile guardrail negative checks added (`.github/workflows/ci.yml`)
 - [x] Live Postgres integration contracts present for:
-  - [x] DPM repository
+  - [x] lotus-manage repository
   - [x] advisory repository
 - [x] Production cutover contract CLI added (`scripts/production_cutover_check.py`)
 - [x] Production compose override published (`docker-compose.production.yml`)

--- a/docs/documentation/engine-know-how-advisory.md
+++ b/docs/documentation/engine-know-how-advisory.md
@@ -125,7 +125,7 @@ Persistence note:
 - Validates proposal input models (`ProposedCashFlow`, `ProposedTrade`).
 
 2. Before-state valuation
-- Uses the same valuation stack as DPM (`build_simulated_state`).
+- Uses the same valuation stack as lotus-manage (`build_simulated_state`).
 
 3. Apply proposal intents
 - Cash flows can be applied before trades (`proposal_apply_cash_flows_first`).

--- a/docs/documentation/engine-know-how-dpm.md
+++ b/docs/documentation/engine-know-how-dpm.md
@@ -1,16 +1,16 @@
-# DPM Rebalance Engine Know-How
+# lotus-manage Rebalance Engine Know-How
 
 Implementation scope:
 - API: `src/api/main.py` (`/rebalance/simulate`, `/rebalance/analyze`)
-- DPM run supportability router: `src/api/routers/dpm_runs.py`
-- DPM policy-pack supportability router: `src/api/routers/dpm_policy_packs.py`
-- DPM run supportability runtime config/env parsing: `src/api/routers/dpm_runs_config.py`
-- DPM run supportability service orchestration: `src/core/dpm_runs/service.py`
-- DPM run supportability DTO mappers: `src/core/dpm_runs/serializers.py`
-- DPM run supportability workflow transition helpers: `src/core/dpm_runs/workflow.py`
+- lotus-manage run supportability router: `src/api/routers/dpm_runs.py`
+- lotus-manage policy-pack supportability router: `src/api/routers/dpm_policy_packs.py`
+- lotus-manage run supportability runtime config/env parsing: `src/api/routers/dpm_runs_config.py`
+- lotus-manage run supportability service orchestration: `src/core/dpm_runs/service.py`
+- lotus-manage run supportability DTO mappers: `src/core/dpm_runs/serializers.py`
+- lotus-manage run supportability workflow transition helpers: `src/core/dpm_runs/workflow.py`
 - Models: `src/core/models.py`
 - Core orchestration: `src/core/dpm/engine.py` (`run_simulation`)
-- DPM modular internals:
+- lotus-manage modular internals:
   - `src/core/dpm/universe.py` (universe construction and shelf filtering)
   - `src/core/dpm/targets.py` (target generation and group-constraint application)
   - `src/core/dpm/intents.py` (security intent generation, tax-aware sell controls)
@@ -98,7 +98,7 @@ Implementation scope:
   - oldest/newest created-at timestamps for runs and operations
 
 ### `GET /rebalance/policies/effective`
-- Purpose: resolve and return effective DPM policy-pack selection for integration/support diagnostics.
+- Purpose: resolve and return effective lotus-manage policy-pack selection for integration/support diagnostics.
 - Optional headers:
   - `X-Policy-Pack-Id`
   - `X-Tenant-Policy-Pack-Id`
@@ -140,7 +140,7 @@ Swagger contract quality:
 - Policy endpoints are contract-tested as response-only (`GET` without request body).
 
 ### `GET /rebalance/runs/{rebalance_run_id}`
-- Purpose: retrieve one DPM run with full result payload and lineage metadata for support investigations.
+- Purpose: retrieve one lotus-manage run with full result payload and lineage metadata for support investigations.
 
 ### `GET /rebalance/runs/{rebalance_run_id}/support-bundle`
 - Purpose: retrieve one aggregated supportability bundle so investigations can run from one payload.
@@ -178,7 +178,7 @@ Swagger contract quality:
   - `include_idempotency_history`
 
 ### `GET /rebalance/runs`
-- Purpose: list DPM runs for supportability investigations.
+- Purpose: list lotus-manage runs for supportability investigations.
 - Filters:
   - `from` (created-at lower bound)
   - `to` (created-at upper bound)
@@ -190,10 +190,10 @@ Swagger contract quality:
   - `cursor`
 
 ### `GET /rebalance/runs/by-correlation/{correlation_id}`
-- Purpose: retrieve latest DPM run mapped to correlation id.
+- Purpose: retrieve latest lotus-manage run mapped to correlation id.
 
 ### `GET /rebalance/runs/by-request-hash/{request_hash}`
-- Purpose: retrieve latest DPM run mapped to canonical request hash.
+- Purpose: retrieve latest lotus-manage run mapped to canonical request hash.
 - Note: URL-encode `request_hash` when calling via path parameter.
 
 ### `GET /rebalance/runs/idempotency/{idempotency_key}`
@@ -285,7 +285,7 @@ Swagger contract quality:
 - `PENDING_REVIEW`: at least one soft-rule fail and no hard fail.
 - `BLOCKED`: any hard fail (rules, data quality, or reconciliation).
 
-## DPM Feature Flags
+## lotus-manage Feature Flags
 
 - `target_method`
 - `compare_target_methods`
@@ -325,7 +325,7 @@ Swagger contract quality:
   - `DPM_TENANT_POLICY_PACK_MAP_JSON` (JSON map: `tenant_id -> policy_pack_id`)
 
 Dependency policy note:
-- `link_buy_to_same_currency_sell_dependency=null` defaults to `true` in DPM.
+- `link_buy_to_same_currency_sell_dependency=null` defaults to `true` in lotus-manage.
 - when `false`, BUY security intents no longer depend on same-currency SELL intents.
 
 ## PostgreSQL Migration Tooling
@@ -345,7 +345,7 @@ Dependency policy note:
 - Production rollout runbook:
   - `docs/documentation/postgres-migration-rollout-runbook.md`
 
-## Tests That Lock DPM Behavior
+## Tests That Lock lotus-manage Behavior
 
 - API: `tests/unit/dpm/api/test_api_rebalance.py`
 - Engine: `tests/unit/dpm/engine/`
@@ -355,4 +355,4 @@ Dependency policy note:
 ## Deprecation Notes
 
 - `src/core/dpm_engine.py` is a compatibility shim and emits `DeprecationWarning`.
-- Use `src/core/dpm/engine.py` as the stable DPM engine import path.
+- Use `src/core/dpm/engine.py` as the stable lotus-manage engine import path.

--- a/docs/documentation/engine-know-how.md
+++ b/docs/documentation/engine-know-how.md
@@ -3,5 +3,5 @@
 This documentation has been split by engine type:
 
 - Project Overview (Business + BA + Engineering): `docs/documentation/project-overview.md`
-- DPM Rebalance Engine: `docs/documentation/engine-know-how-dpm.md`
+- lotus-manage Rebalance Engine: `docs/documentation/engine-know-how-dpm.md`
 - Advisory Proposal Engine: `docs/documentation/engine-know-how-advisory.md`

--- a/docs/documentation/postgres-migration-rollout-runbook.md
+++ b/docs/documentation/postgres-migration-rollout-runbook.md
@@ -4,7 +4,7 @@
 
 Runbook for forward-only schema migration rollout for:
 
-- DPM supportability Postgres namespace (`dpm`)
+- lotus-manage supportability Postgres namespace (`dpm`)
 - Advisory proposals Postgres namespace (`proposals`)
 
 ## Preconditions
@@ -61,7 +61,7 @@ python scripts/production_cutover_check.py --check-migrations
    - `DPM_SUPPORTABILITY_STORE_BACKEND=POSTGRES`
    - `PROPOSAL_STORE_BACKEND=POSTGRES`
    - `DPM_POLICY_PACK_CATALOG_BACKEND=POSTGRES` (when policy packs/admin APIs are enabled)
-5. Run smoke API checks for DPM and advisory.
+5. Run smoke API checks for lotus-manage and advisory.
 6. Shift traffic.
 
 Do not start app replicas with Postgres backend enabled before migrations have completed.

--- a/docs/documentation/project-overview.md
+++ b/docs/documentation/project-overview.md
@@ -8,7 +8,7 @@ This document explains the system at a high level for three audiences:
 ## What This Platform Does
 
 The platform provides deterministic portfolio decisioning APIs for:
-- **DPM rebalancing** (model-driven discretionary portfolio management),
+- **lotus-manage rebalancing** (model-driven discretionary portfolio management),
 - **Advisory proposals** (advisor-entered cash flows and manual trades).
 
 Architecture authority:
@@ -38,7 +38,7 @@ The API remains deterministic for identical inputs and options.
 
 ## Core Business Flows
 
-1. DPM flow
+1. lotus-manage flow
 - Input: portfolio snapshot, market snapshot, model targets, shelf, options.
 - Output: optimized rebalance intents with controls (tax, turnover, settlement, constraints).
 
@@ -64,7 +64,7 @@ The API remains deterministic for identical inputs and options.
 ## Architecture Summary
 
 - `src/api/`: FastAPI contracts and endpoint orchestration.
-- `src/core/dpm/`: DPM-specific engine modules.
+- `src/core/dpm/`: lotus-manage-specific engine modules.
 - `src/core/advisory/`: Advisory-specific modules (artifact, funding, intents, ids).
 - `src/core/common/`: Shared logic (simulation primitives, diagnostics, drift, suitability, canonical hashing, workflow gates).
 - `src/core/models.py`: shared request/response contracts and options.
@@ -72,7 +72,7 @@ The API remains deterministic for identical inputs and options.
 ## Test Strategy
 
 Tests are organized by responsibility:
-- `tests/unit/dpm/`: DPM API, engine, and DPM golden tests.
+- `tests/unit/dpm/`: lotus-manage API, engine, and lotus-manage golden tests.
 - `tests/unit/advisory/`: advisory API, engine, contracts, and advisory golden tests.
 - `tests/unit/shared/`: shared contracts/compliance/dependencies tests.
 - `tests/e2e/`: end-to-end workflow/demo scenario tests.
@@ -96,7 +96,7 @@ CI test execution model:
 
 ## Current Delivery Principle
 
-Keep DPM and advisory behavior separated by business logic, while sharing:
+Keep lotus-manage and advisory behavior separated by business logic, while sharing:
 - vocabulary,
 - control semantics,
 - deterministic primitives,

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -9,7 +9,7 @@ Governance boundary:
 
 | RFC | Title | Status | Depends On | File |
 | --- | --- | --- | --- | --- |
-| RFC-0001 | Enterprise Rebalance Simulation MVP (DPM Platform) | IMPLEMENTED | - | `docs/rfcs/RFC-0001-rebalance-simulation-mvp.md` |
+| RFC-0001 | Enterprise Rebalance Simulation MVP (lotus-manage Platform) | IMPLEMENTED | - | `docs/rfcs/RFC-0001-rebalance-simulation-mvp.md` |
 | RFC-0002 | Rebalance Simulation MVP Hardening & Enterprise Completeness | IMPLEMENTED | RFC-0001 | `docs/rfcs/RFC-0002-rebalance-simulation-mvp-hardening-enterprise-completeness.md` |
 | RFC-0003 | Rebalance Simulation Contract & Engine Completion (Audit Bundle) | IMPLEMENTED | RFC-0001, RFC-0002 | `docs/rfcs/RFC-0003-contract-engine-completion.md` |
 | RFC-0004 | Institutional After-State + Holdings-aware Golden Scenarios (Demo-tight, Pre-Persistence) | IMPLEMENTED | RFC-0003 | `docs/rfcs/RFC-0004-institutional-afterstate-holdings-goldens.md` |
@@ -30,24 +30,24 @@ Governance boundary:
 | RFC-0014E | Advisory Proposal Artifact | IMPLEMENTED | RFC-0014A, RFC-0014B, RFC-0014C, RFC-0014D | `docs/rfcs/advisory pack/refine/RFC-0014E-proposal-artifact.md` |
 | RFC-0014G | Proposal Persistence and Workflow Lifecycle | IMPLEMENTED (MVP DELIVERED, POSTGRES SLICES COMPLETED VIA RFC-0024) | RFC-0014A, RFC-0014E, RFC-0014F | `docs/rfcs/advisory pack/refine/RFC-0014G-proposal-persistence-workflow-lifecycle.md` |
 | RFC-0015 | Deferred Scope Consolidation and Completion Backlog | SUPERSEDED (TRIAGED) | RFC-0001..RFC-0013 | `docs/rfcs/RFC-0015-deferred-scope-consolidation-and-completion-backlog.md` |
-| RFC-0016 | DPM Idempotency Replay Contract for `/rebalance/simulate` | IMPLEMENTED | RFC-0001, RFC-0002, RFC-0007A | `docs/rfcs/RFC-0016-dpm-idempotency-replay-contract.md` |
-| RFC-0017 | DPM Run Supportability APIs (Run, Correlation, Idempotency Lookup) | IMPLEMENTED | RFC-0001, RFC-0002, RFC-0016 | `docs/rfcs/RFC-0017-dpm-run-supportability-apis.md` |
-| RFC-0018 | DPM Async Operations Resource | IMPLEMENTED | RFC-0013, RFC-0016, RFC-0017 | `docs/rfcs/RFC-0018-dpm-async-operations-resource.md` |
-| RFC-0019 | DPM Deterministic Run Artifact Contract | IMPLEMENTED (PHASE 1 - DERIVED ARTIFACT) | RFC-0003, RFC-0013, RFC-0017 | `docs/rfcs/RFC-0019-dpm-deterministic-run-artifact-contract.md` |
-| RFC-0020 | DPM Workflow Gate API and Persistence | IMPLEMENTED | RFC-0017, RFC-0019 | `docs/rfcs/RFC-0020-dpm-workflow-gate-api-and-persistence.md` |
-| RFC-0021 | DPM OpenAPI Contract Hardening and Separation of Request/Response Models | IMPLEMENTED | RFC-0007A, RFC-0016, RFC-0017 | `docs/rfcs/RFC-0021-dpm-openapi-contract-hardening.md` |
-| RFC-0022 | DPM Policy Pack Configuration Model | IMPLEMENTED | RFC-0008, RFC-0010, RFC-0011, RFC-0016 | `docs/rfcs/RFC-0022-dpm-policy-pack-configuration-model.md` |
-| RFC-0023 | DPM Persistent Supportability Store and Lineage APIs | IMPLEMENTED | RFC-0017, RFC-0018, RFC-0019 | `docs/rfcs/RFC-0023-dpm-persistent-supportability-store-and-lineage-apis.md` |
-| RFC-0024 | Unified PostgreSQL Persistence for DPM and Advisory | COMPLETED (SLICE 19) | RFC-0014G, RFC-0017, RFC-0018, RFC-0019, RFC-0020, RFC-0023 | `docs/rfcs/RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md` |
+| RFC-0016 | lotus-manage Idempotency Replay Contract for `/rebalance/simulate` | IMPLEMENTED | RFC-0001, RFC-0002, RFC-0007A | `docs/rfcs/RFC-0016-dpm-idempotency-replay-contract.md` |
+| RFC-0017 | lotus-manage Run Supportability APIs (Run, Correlation, Idempotency Lookup) | IMPLEMENTED | RFC-0001, RFC-0002, RFC-0016 | `docs/rfcs/RFC-0017-dpm-run-supportability-apis.md` |
+| RFC-0018 | lotus-manage Async Operations Resource | IMPLEMENTED | RFC-0013, RFC-0016, RFC-0017 | `docs/rfcs/RFC-0018-dpm-async-operations-resource.md` |
+| RFC-0019 | lotus-manage Deterministic Run Artifact Contract | IMPLEMENTED (PHASE 1 - DERIVED ARTIFACT) | RFC-0003, RFC-0013, RFC-0017 | `docs/rfcs/RFC-0019-dpm-deterministic-run-artifact-contract.md` |
+| RFC-0020 | lotus-manage Workflow Gate API and Persistence | IMPLEMENTED | RFC-0017, RFC-0019 | `docs/rfcs/RFC-0020-dpm-workflow-gate-api-and-persistence.md` |
+| RFC-0021 | lotus-manage OpenAPI Contract Hardening and Separation of Request/Response Models | IMPLEMENTED | RFC-0007A, RFC-0016, RFC-0017 | `docs/rfcs/RFC-0021-dpm-openapi-contract-hardening.md` |
+| RFC-0022 | lotus-manage Policy Pack Configuration Model | IMPLEMENTED | RFC-0008, RFC-0010, RFC-0011, RFC-0016 | `docs/rfcs/RFC-0022-dpm-policy-pack-configuration-model.md` |
+| RFC-0023 | lotus-manage Persistent Supportability Store and Lineage APIs | IMPLEMENTED | RFC-0017, RFC-0018, RFC-0019 | `docs/rfcs/RFC-0023-dpm-persistent-supportability-store-and-lineage-apis.md` |
+| RFC-0024 | Unified PostgreSQL Persistence for lotus-manage and Advisory | COMPLETED (SLICE 19) | RFC-0014G, RFC-0017, RFC-0018, RFC-0019, RFC-0020, RFC-0023 | `docs/rfcs/RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md` |
 | RFC-0025 | PostgreSQL-Only Production Mode Cutover | COMPLETED | RFC-0023, RFC-0024 | `docs/rfcs/RFC-0025-postgres-only-production-mode-cutover.md` |
 | RFC-0027 | Advisory Proposal Workflow Coverage Hardening (Approval Chain Paths) | IMPLEMENTED | RFC-0014G, RFC-0024 | `docs/rfcs/RFC-0027-advisory-proposal-workflow-coverage-hardening.md` |
-| RFC-0028 | DPM Integration Capabilities Contract | IMPLEMENTED | RFC-0021, RFC-0022, RFC-0027 | `docs/rfcs/RFC-0028-dpm-integration-capabilities-contract.md` |
-| RFC-0029 | Iterative Proposal Simulation Workspace Contract for Advisory and DPM Lifecycles | PROPOSED | RFC-0020, RFC-0021, RFC-0028 | `docs/rfcs/RFC-0029-iterative-proposal-simulation-workspace-contract.md` |
-| RFC-0030 | DPM Integration Pyramid Rebalance Wave 1 | IMPLEMENTED | RFC-0023, RFC-0024, RFC-0028 | `docs/rfcs/RFC-0030-dpm-integration-pyramid-rebalance-wave-1.md` |
-| RFC-0031 | DPM Integration Pyramid Wave 2 (Supportability and Guardrails) | IMPLEMENTED | RFC-0030 | `docs/rfcs/RFC-0031-dpm-integration-pyramid-wave-2-supportability-and-guardrails.md` |
-| RFC-0032 | DPM Pyramid Wave 3 (Integration and E2E Workflow Expansion) | IMPLEMENTED | RFC-0031 | `docs/rfcs/RFC-0032-dpm-pyramid-wave-3-integration-and-e2e-workflow-expansion.md` |
-| RFC-0033 | DPM Pyramid Wave 4 (Integration and E2E Expansion) | IMPLEMENTED | RFC-0032 | `docs/rfcs/RFC-0033-dpm-pyramid-wave-4-integration-e2e-expansion.md` |
-| RFC-0034 | DPM Pyramid Wave 5 (Integration Boundary Expansion) | IMPLEMENTED | RFC-0033 | `docs/rfcs/RFC-0034-dpm-pyramid-wave-5-integration-boundary-expansion.md` |
-| RFC-0035 | DPM Pyramid Wave 6 (Repository Integration Depth Expansion) | PROPOSED | RFC-0034 | `docs/rfcs/RFC-0035-dpm-pyramid-wave-6-repository-integration-depth-expansion.md` |
+| RFC-0028 | lotus-manage Integration Capabilities Contract | IMPLEMENTED | RFC-0021, RFC-0022, RFC-0027 | `docs/rfcs/RFC-0028-dpm-integration-capabilities-contract.md` |
+| RFC-0029 | Iterative Proposal Simulation Workspace Contract for Advisory and lotus-manage Lifecycles | PROPOSED | RFC-0020, RFC-0021, RFC-0028 | `docs/rfcs/RFC-0029-iterative-proposal-simulation-workspace-contract.md` |
+| RFC-0030 | lotus-manage Integration Pyramid Rebalance Wave 1 | IMPLEMENTED | RFC-0023, RFC-0024, RFC-0028 | `docs/rfcs/RFC-0030-dpm-integration-pyramid-rebalance-wave-1.md` |
+| RFC-0031 | lotus-manage Integration Pyramid Wave 2 (Supportability and Guardrails) | IMPLEMENTED | RFC-0030 | `docs/rfcs/RFC-0031-dpm-integration-pyramid-wave-2-supportability-and-guardrails.md` |
+| RFC-0032 | lotus-manage Pyramid Wave 3 (Integration and E2E Workflow Expansion) | IMPLEMENTED | RFC-0031 | `docs/rfcs/RFC-0032-dpm-pyramid-wave-3-integration-and-e2e-workflow-expansion.md` |
+| RFC-0033 | lotus-manage Pyramid Wave 4 (Integration and E2E Expansion) | IMPLEMENTED | RFC-0032 | `docs/rfcs/RFC-0033-dpm-pyramid-wave-4-integration-e2e-expansion.md` |
+| RFC-0034 | lotus-manage Pyramid Wave 5 (Integration Boundary Expansion) | IMPLEMENTED | RFC-0033 | `docs/rfcs/RFC-0034-dpm-pyramid-wave-5-integration-boundary-expansion.md` |
+| RFC-0035 | lotus-manage Pyramid Wave 6 (Repository Integration Depth Expansion) | PROPOSED | RFC-0034 | `docs/rfcs/RFC-0035-dpm-pyramid-wave-6-repository-integration-depth-expansion.md` |
 | RFC-0036 | PostgreSQL-Only Runtime Hard Cutover | PROPOSED | RFC-0025, RFC-0024 | `docs/rfcs/RFC-0036-postgres-only-runtime-hard-cutover.md` |
 

--- a/docs/rfcs/RFC-0001-rebalance-simulation-mvp.md
+++ b/docs/rfcs/RFC-0001-rebalance-simulation-mvp.md
@@ -1,4 +1,4 @@
-# RFC-0001: Enterprise Rebalance Simulation MVP (DPM Platform)
+# RFC-0001: Enterprise Rebalance Simulation MVP (lotus-manage Platform)
 
 | Metadata | Details |
 | --- | --- |
@@ -11,7 +11,7 @@
 
 ## 1. Executive Summary
 
-This RFC specifies the architecture and implementation details for the **Rebalance Simulation Service**, the "brain" of the Discretionary Portfolio Management (DPM) platform.
+This RFC specifies the architecture and implementation details for the **Rebalance Simulation Service**, the "brain" of the Discretionary Portfolio Management (lotus-manage) platform.
 
 The service provides a **single, golden endpoint** that accepts a portfolio snapshot and a mandate/model strategy, and deterministically calculates the required trades (`OrderIntents`) to bring the portfolio into alignment.
 

--- a/docs/rfcs/RFC-0004-institutional-afterstate-holdings-goldens.md
+++ b/docs/rfcs/RFC-0004-institutional-afterstate-holdings-goldens.md
@@ -35,7 +35,7 @@ The current implementation is close to RFC-0003 but is not "institution-grade" b
 * Many existing scenarios are effectively **cash-only** portfolios (positions empty), reducing confidence for real holdings.
 * Sample response `before/after_simulated.allocation` is empty/simplistic, making outputs hard to demo and audit.
 * Universe coverage, diagnostics, and rule results need stronger realism when holdings exist.
-* A demo needs curated examples that cover *real* DPM behaviors (drift rebalance, sell-to-fund, FX funding, shelf restrictions, missing data, etc.).
+* A demo needs curated examples that cover *real* lotus-manage behaviors (drift rebalance, sell-to-fund, FX funding, shelf restrictions, missing data, etc.).
 
 ---
 

--- a/docs/rfcs/RFC-0006B-pre-persistence-rules-scenarios-demo.md
+++ b/docs/rfcs/RFC-0006B-pre-persistence-rules-scenarios-demo.md
@@ -15,7 +15,7 @@ RFC-0006B bridges the gap between a functional calculator and a demo-credible, i
 
 1.  **Configurable Rules:** Replacing hard-coded thresholds (e.g., 5% cash, 10% concentration) with overrideable options/policies.
 2.  **Explicit Dependencies:** Ensuring every FX-funded Security Buy explicitly links to its funding FX trade in the `dependencies` list.
-3.  **Institutional Scenario Matrix:** Implementing the `GOLDEN_3xx` suite—12+ scenarios covering real-world DPM edge cases (Drift, Sell-to-Fund, Multi-Currency, Restricted Assets).
+3.  **Institutional Scenario Matrix:** Implementing the `GOLDEN_3xx` suite—12+ scenarios covering real-world lotus-manage edge cases (Drift, Sell-to-Fund, Multi-Currency, Restricted Assets).
 4.  **Demo Pack Tightening:** Updating `docs/demo/` so all scenarios are triggerable purely via JSON input, without code manipulation.
 
 ### 0.1 Implementation Alignment (As of 2026-02-17)

--- a/docs/rfcs/RFC-0016-dpm-idempotency-replay-contract.md
+++ b/docs/rfcs/RFC-0016-dpm-idempotency-replay-contract.md
@@ -1,4 +1,4 @@
-# RFC-0016: DPM Idempotency Replay Contract for `/rebalance/simulate`
+# RFC-0016: lotus-manage Idempotency Replay Contract for `/rebalance/simulate`
 
 | Metadata | Details |
 | --- | --- |
@@ -14,7 +14,7 @@ This RFC defines and implements explicit idempotency semantics for `POST /rebala
 - same `Idempotency-Key` + same canonical request payload -> return cached result
 - same `Idempotency-Key` + different canonical request payload -> return `409 Conflict`
 
-This aligns DPM behavior with advisory simulation behavior and improves enterprise-grade retry safety.
+This aligns lotus-manage behavior with advisory simulation behavior and improves enterprise-grade retry safety.
 
 Implementation note (2026-02-20):
 - Implemented in `src/api/main.py` with canonical request hashing and bounded in-memory replay cache.
@@ -28,7 +28,7 @@ Implementation note (2026-02-20):
 `/rebalance/simulate` currently requires `Idempotency-Key` but does not enforce replay/conflict semantics. This creates ambiguity and increases operational risk for:
 - client retry handling
 - replayability and reconciliation investigations
-- API consistency between DPM and advisory
+- API consistency between lotus-manage and advisory
 
 ## 3. Goals and Non-Goals
 
@@ -41,7 +41,7 @@ Implementation note (2026-02-20):
 ### 3.2 Non-Goals
 - Persistent idempotency storage in this slice.
 - New API endpoints for idempotency lookup (can be follow-up).
-- Changing core DPM simulation logic.
+- Changing core lotus-manage simulation logic.
 
 ## 4. Proposed Design
 

--- a/docs/rfcs/RFC-0017-dpm-run-supportability-apis.md
+++ b/docs/rfcs/RFC-0017-dpm-run-supportability-apis.md
@@ -1,4 +1,4 @@
-# RFC-0017: DPM Run Supportability APIs (Run, Correlation, Idempotency Lookup)
+# RFC-0017: lotus-manage Run Supportability APIs (Run, Correlation, Idempotency Lookup)
 
 | Metadata | Details |
 | --- | --- |
@@ -10,7 +10,7 @@
 
 ## 1. Executive Summary
 
-Introduce DPM operational lookup APIs mirroring advisory supportability patterns:
+Introduce lotus-manage operational lookup APIs mirroring advisory supportability patterns:
 - lookup run by `rebalance_run_id`
 - lookup latest run by `correlation_id`
 - lookup idempotency mapping by `Idempotency-Key`
@@ -26,13 +26,13 @@ Implementation note (2026-02-20):
 
 ## 2. Problem Statement
 
-DPM now has idempotency replay semantics and correlation propagation, but lacks API retrieval surfaces for support teams. Troubleshooting currently requires log-level access instead of deterministic API-level evidence retrieval.
+lotus-manage now has idempotency replay semantics and correlation propagation, but lacks API retrieval surfaces for support teams. Troubleshooting currently requires log-level access instead of deterministic API-level evidence retrieval.
 
 ## 3. Goals and Non-Goals
 
 ### 3.1 Goals
 - Provide read-only support APIs for run investigations.
-- Reuse DPM/advisory vocabulary (`request_hash`, `correlation_id`, idempotency mapping).
+- Reuse lotus-manage/advisory vocabulary (`request_hash`, `correlation_id`, idempotency mapping).
 - Keep implementation configurable and architecture-aligned (port/adapter).
 
 ### 3.2 Non-Goals

--- a/docs/rfcs/RFC-0018-dpm-async-operations-resource.md
+++ b/docs/rfcs/RFC-0018-dpm-async-operations-resource.md
@@ -1,4 +1,4 @@
-# RFC-0018: DPM Async Operations Resource
+# RFC-0018: lotus-manage Async Operations Resource
 
 | Metadata | Details |
 | --- | --- |
@@ -9,7 +9,7 @@
 
 ## 1. Executive Summary
 
-Add asynchronous operation APIs for long-running DPM workloads, starting with batch analysis:
+Add asynchronous operation APIs for long-running lotus-manage workloads, starting with batch analysis:
 - `POST /rebalance/analyze/async`
 - `GET /rebalance/operations/{operation_id}`
 - `GET /rebalance/operations/by-correlation/{correlation_id}`
@@ -78,7 +78,7 @@ Implemented in current codebase:
   - `POST /rebalance/analyze/async`
   - `GET /rebalance/operations/{operation_id}`
   - `GET /rebalance/operations/by-correlation/{correlation_id}`
-- Operation lifecycle persistence in DPM supportability repository:
+- Operation lifecycle persistence in lotus-manage supportability repository:
   - `PENDING -> RUNNING -> SUCCEEDED | FAILED`
 - Feature flag:
   - `DPM_ASYNC_OPERATIONS_ENABLED`

--- a/docs/rfcs/RFC-0019-dpm-deterministic-run-artifact-contract.md
+++ b/docs/rfcs/RFC-0019-dpm-deterministic-run-artifact-contract.md
@@ -1,4 +1,4 @@
-# RFC-0019: DPM Deterministic Run Artifact Contract
+# RFC-0019: lotus-manage Deterministic Run Artifact Contract
 
 | Metadata | Details |
 | --- | --- |
@@ -9,7 +9,7 @@
 
 ## 1. Executive Summary
 
-Introduce a deterministic run artifact contract for DPM so every run can be retrieved as a stable business payload for support, replay validation, and lineage use cases.
+Introduce a deterministic run artifact contract for lotus-manage so every run can be retrieved as a stable business payload for support, replay validation, and lineage use cases.
 
 ## 2. Problem Statement
 
@@ -19,9 +19,9 @@ Current supportability APIs expose run metadata, but there is no single normaliz
 
 ### 3.1 Goals
 
-- Define a versioned DPM run artifact schema.
+- Define a versioned lotus-manage run artifact schema.
 - Keep artifact generation deterministic for the same stored run.
-- Reuse vocabulary where advisory and DPM overlap.
+- Reuse vocabulary where advisory and lotus-manage overlap.
 - Preserve existing endpoints and behavior.
 
 ### 3.2 Non-Goals
@@ -84,4 +84,4 @@ Additive endpoint only. Existing run and simulation APIs remain unchanged.
 ## 7. Status and Reason Code Conventions
 
 - Artifact retrieval does not introduce new business statuses.
-- Existing DPM run status vocabulary remains: `READY`, `PENDING_REVIEW`, `BLOCKED`.
+- Existing lotus-manage run status vocabulary remains: `READY`, `PENDING_REVIEW`, `BLOCKED`.

--- a/docs/rfcs/RFC-0020-dpm-workflow-gate-api-and-persistence.md
+++ b/docs/rfcs/RFC-0020-dpm-workflow-gate-api-and-persistence.md
@@ -1,4 +1,4 @@
-# RFC-0020: DPM Workflow Gate API and Persistence
+# RFC-0020: lotus-manage Workflow Gate API and Persistence
 
 | Metadata | Details |
 | --- | --- |
@@ -10,11 +10,11 @@
 
 ## 1. Executive Summary
 
-Add workflow gate APIs and persistence for DPM runs to support reviewer-assigned actions (approve, reject, request changes) with full auditability, aligned with advisory workflow lifecycle patterns.
+Add workflow gate APIs and persistence for lotus-manage runs to support reviewer-assigned actions (approve, reject, request changes) with full auditability, aligned with advisory workflow lifecycle patterns.
 
 ## 2. Problem Statement
 
-DPM exposes run diagnostics but lacks explicit workflow gate state transitions and reviewer decision records. Operations teams currently need external tooling for gating and traceability.
+lotus-manage exposes run diagnostics but lacks explicit workflow gate state transitions and reviewer decision records. Operations teams currently need external tooling for gating and traceability.
 
 ## 3. Goals and Non-Goals
 

--- a/docs/rfcs/RFC-0021-dpm-openapi-contract-hardening.md
+++ b/docs/rfcs/RFC-0021-dpm-openapi-contract-hardening.md
@@ -1,4 +1,4 @@
-# RFC-0021: DPM OpenAPI Contract Hardening and Separation of Request/Response Models
+# RFC-0021: lotus-manage OpenAPI Contract Hardening and Separation of Request/Response Models
 
 | Metadata | Details |
 | --- | --- |
@@ -9,7 +9,7 @@
 
 ## 1. Executive Summary
 
-Harden DPM OpenAPI contracts so request and response objects are explicitly separated, with complete field-level descriptions/examples and contract tests to prevent accidental schema drift.
+Harden lotus-manage OpenAPI contracts so request and response objects are explicitly separated, with complete field-level descriptions/examples and contract tests to prevent accidental schema drift.
 
 ## 2. Problem Statement
 
@@ -42,11 +42,11 @@ Schema ambiguity and mixed request/response models reduce integrator confidence 
 - Assertions for required fields, enums, and examples on targeted models.
 
 Phase-1 implemented:
-- Added DPM OpenAPI contract tests for async/supportability/artifact schemas and endpoint contracts:
+- Added lotus-manage OpenAPI contract tests for async/supportability/artifact schemas and endpoint contracts:
   - `tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py`
 - Validates:
-  - field-level descriptions/examples for key DPM response DTOs
-  - field-level descriptions/examples for DPM policy-pack resolution/catalog and nested policy DTOs
+  - field-level descriptions/examples for key lotus-manage response DTOs
+  - field-level descriptions/examples for lotus-manage policy-pack resolution/catalog and nested policy DTOs
   - request/response schema separation and response header docs on async analyze
   - request/response schema separation on:
     - `POST /rebalance/simulate`
@@ -57,7 +57,7 @@ Phase-1 implemented:
   - execute endpoint contract shape (`POST /rebalance/operations/{operation_id}/execute`)
   - artifact endpoint contract shape (`GET /rebalance/runs/{rebalance_run_id}/artifact`)
 Phase-2 implemented:
-- Extended DPM OpenAPI contract assertions for policy-pack management APIs:
+- Extended lotus-manage OpenAPI contract assertions for policy-pack management APIs:
   - `GET /rebalance/policies/catalog/{policy_pack_id}`
   - `PUT /rebalance/policies/catalog/{policy_pack_id}`
   - `DELETE /rebalance/policies/catalog/{policy_pack_id}`
@@ -72,12 +72,12 @@ Phase-2 implemented:
 - `DPM_STRICT_OPENAPI_VALIDATION` (default `true` in CI, configurable locally)
 
 Phase-1 implemented:
-- DPM contract test suite reads `DPM_STRICT_OPENAPI_VALIDATION`.
-- When set to `false`, strict DPM OpenAPI contract tests are skipped for local iteration.
+- lotus-manage contract test suite reads `DPM_STRICT_OPENAPI_VALIDATION`.
+- When set to `false`, strict lotus-manage OpenAPI contract tests are skipped for local iteration.
 
 ## 5. Test Plan
 
-- OpenAPI generation test for each DPM route family.
+- OpenAPI generation test for each lotus-manage route family.
 - Schema tests for required example/description coverage.
 - Regression tests for idempotency and supportability models.
 

--- a/docs/rfcs/RFC-0022-dpm-policy-pack-configuration-model.md
+++ b/docs/rfcs/RFC-0022-dpm-policy-pack-configuration-model.md
@@ -1,4 +1,4 @@
-# RFC-0022: DPM Policy Pack Configuration Model
+# RFC-0022: lotus-manage Policy Pack Configuration Model
 
 | Metadata | Details |
 | --- | --- |
@@ -10,11 +10,11 @@
 
 ## 1. Executive Summary
 
-Introduce a policy-pack configuration model so DPM rule behavior can be selected and tuned per business segment without code changes, similar to advisory configurability patterns.
+Introduce a policy-pack configuration model so lotus-manage rule behavior can be selected and tuned per business segment without code changes, similar to advisory configurability patterns.
 
 ## 2. Problem Statement
 
-DPM currently relies on distributed flags and static defaults. As product variants grow, this makes onboarding and controlled rollout harder than necessary.
+lotus-manage currently relies on distributed flags and static defaults. As product variants grow, this makes onboarding and controlled rollout harder than necessary.
 
 ## 3. Goals and Non-Goals
 

--- a/docs/rfcs/RFC-0023-dpm-persistent-supportability-store-and-lineage-apis.md
+++ b/docs/rfcs/RFC-0023-dpm-persistent-supportability-store-and-lineage-apis.md
@@ -1,4 +1,4 @@
-# RFC-0023: DPM Persistent Supportability Store and Lineage APIs
+# RFC-0023: lotus-manage Persistent Supportability Store and Lineage APIs
 
 | Metadata | Details |
 | --- | --- |
@@ -9,7 +9,7 @@
 
 ## 1. Executive Summary
 
-Add durable persistence and lineage APIs for DPM supportability data so operations teams can investigate historical runs, operation chains, and idempotency behavior beyond process lifetime.
+Add durable persistence and lineage APIs for lotus-manage supportability data so operations teams can investigate historical runs, operation chains, and idempotency behavior beyond process lifetime.
 
 ## 2. Problem Statement
 
@@ -84,7 +84,7 @@ No new business run statuses. Investigation responses use explicit technical sta
     - `DPM_SUPPORTABILITY_STORE_BACKEND` (`IN_MEMORY` | `SQL`, `SQLITE` alias supported)
     - `DPM_SUPPORTABILITY_SQL_PATH` (preferred SQL backend database file path)
     - `DPM_SUPPORTABILITY_SQLITE_PATH` (backward-compatible path alias)
-  - SQLite repository adapter for DPM supportability records:
+  - SQLite repository adapter for lotus-manage supportability records:
     - runs
     - idempotency mappings
     - async operations

--- a/docs/rfcs/RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md
+++ b/docs/rfcs/RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md
@@ -1,4 +1,4 @@
-# RFC-0024: Unified PostgreSQL Persistence for DPM and Advisory
+# RFC-0024: Unified PostgreSQL Persistence for lotus-manage and Advisory
 
 | Metadata | Details |
 | --- | --- |
@@ -9,18 +9,18 @@
 
 ## 1. Executive Summary
 
-Adopt PostgreSQL as the shared durable persistence backend for both DPM and advisory supportability/workflow lifecycles, using a common schema vocabulary and repository contracts while preserving existing API behavior.
+Adopt PostgreSQL as the shared durable persistence backend for both lotus-manage and advisory supportability/workflow lifecycles, using a common schema vocabulary and repository contracts while preserving existing API behavior.
 
 ## 2. Problem Statement
 
-Current state is split between in-memory adapters (advisory and default DPM) and SQLite (optional DPM backend). This is useful for incremental delivery but not sufficient for enterprise scale, concurrency, audit retention, and operational consistency across both businesses.
+Current state is split between in-memory adapters (advisory and default lotus-manage) and SQLite (optional lotus-manage backend). This is useful for incremental delivery but not sufficient for enterprise scale, concurrency, audit retention, and operational consistency across both businesses.
 
 ## 3. Goals and Non-Goals
 
 ### 3.1 Goals
 
 - Standardize on PostgreSQL for durable production persistence in both engines.
-- Reuse common naming and storage patterns across DPM and advisory where domain concepts overlap.
+- Reuse common naming and storage patterns across lotus-manage and advisory where domain concepts overlap.
 - Preserve backward-compatible API contracts and feature-flagged rollout controls.
 - Introduce migration discipline for schema evolution.
 
@@ -34,7 +34,7 @@ Current state is split between in-memory adapters (advisory and default DPM) and
 
 ### 4.1 Backend Targets
 
-- DPM supportability repository:
+- lotus-manage supportability repository:
   - runs
   - idempotency mappings
   - async operations
@@ -57,7 +57,7 @@ Current state is split between in-memory adapters (advisory and default DPM) and
   - `created_at`, `updated_at`
   - append-only event/decision records
 - Domain-specific states stay separated:
-  - DPM run workflow states and actions
+  - lotus-manage run workflow states and actions
   - advisory proposal workflow states and events
 - Persist canonical JSON snapshots for deterministic replay and artifact rebuilding.
 
@@ -72,7 +72,7 @@ Current state is split between in-memory adapters (advisory and default DPM) and
 
 ### 4.4 Configurability
 
-- DPM:
+- lotus-manage:
   - extend `DPM_SUPPORTABILITY_STORE_BACKEND` to include `POSTGRES`
   - connection config via `DPM_SUPPORTABILITY_POSTGRES_DSN`
 - Advisory:
@@ -89,7 +89,7 @@ Current state is split between in-memory adapters (advisory and default DPM) and
 ## 5. Test Plan
 
 - Contract tests for repository parity across backends.
-- API regression suite with Postgres backend enabled for DPM and advisory.
+- API regression suite with Postgres backend enabled for lotus-manage and advisory.
 - Migration smoke tests on empty and pre-seeded databases.
 - Determinism tests for artifact and replay-related payloads after persistence.
 
@@ -103,15 +103,15 @@ Current state is split between in-memory adapters (advisory and default DPM) and
 ## 7. Status and Reason Code Conventions
 
 - No change to business status vocabularies:
-  - DPM run status: `READY`, `PENDING_REVIEW`, `BLOCKED`
-  - DPM workflow status: `NOT_REQUIRED`, `PENDING_REVIEW`, `APPROVED`, `REJECTED`
+  - lotus-manage run status: `READY`, `PENDING_REVIEW`, `BLOCKED`
+  - lotus-manage workflow status: `NOT_REQUIRED`, `PENDING_REVIEW`, `APPROVED`, `REJECTED`
   - advisory workflow states remain as defined in RFC-0014G
 - Reason code naming remains uppercase snake case.
 
 ## 8. Implementation Status
 
 - Implemented (slice 1):
-  - DPM supportability backend contract now recognizes `POSTGRES` in configuration.
+  - lotus-manage supportability backend contract now recognizes `POSTGRES` in configuration.
   - Added DSN setting:
     - `DPM_SUPPORTABILITY_POSTGRES_DSN`
   - Guardrail behavior for early rollout:
@@ -119,7 +119,7 @@ Current state is split between in-memory adapters (advisory and default DPM) and
     - placeholder backend mode currently raises `DPM_SUPPORTABILITY_POSTGRES_NOT_IMPLEMENTED`
   - Existing default behavior remains unchanged (`IN_MEMORY` by default, `SQL`/`SQLITE` path unchanged).
 - Implemented (slice 2):
-  - Added `PostgresDpmRunRepository` backend scaffold and factory wiring for DPM supportability.
+  - Added `PostgresDpmRunRepository` backend scaffold and factory wiring for lotus-manage supportability.
   - Initialization guardrails:
     - missing DSN raises `DPM_SUPPORTABILITY_POSTGRES_DSN_REQUIRED`
     - missing `psycopg` dependency raises `DPM_SUPPORTABILITY_POSTGRES_DRIVER_MISSING`
@@ -285,7 +285,7 @@ Current state is split between in-memory adapters (advisory and default DPM) and
       - transactional `transition_proposal`
   - Manual runtime validation completed on `2026-02-20`:
     - uvicorn with advisory Postgres backend enabled
-    - Docker Compose with advisory + DPM Postgres backends enabled
+    - Docker Compose with advisory + lotus-manage Postgres backends enabled
     - full demo pack validation succeeded in both runtime modes.
 - Implemented (slice 16):
   - Added shared forward-only PostgreSQL migration runner:
@@ -313,7 +313,7 @@ Current state is split between in-memory adapters (advisory and default DPM) and
     - starts live Postgres service (`postgres:17.6`)
     - applies migrations via `python scripts/postgres_migrate.py --target all`
     - runs live Postgres integration contracts for:
-      - DPM repository
+      - lotus-manage repository
       - advisory repository
   - Added production rollout runbook:
     - `docs/documentation/postgres-migration-rollout-runbook.md`

--- a/docs/rfcs/RFC-0025-postgres-only-production-mode-cutover.md
+++ b/docs/rfcs/RFC-0025-postgres-only-production-mode-cutover.md
@@ -9,7 +9,7 @@
 
 ## 1. Executive Summary
 
-Define a staged production cutover plan where DPM/advisory persistence uses PostgreSQL-only
+Define a staged production cutover plan where lotus-manage/advisory persistence uses PostgreSQL-only
 backends in non-dev environments, while preserving in-memory/SQLite paths for local workflows.
 
 ## 2. Problem Statement
@@ -81,7 +81,7 @@ variance and incident complexity in production.
   - Added `APP_PERSISTENCE_PROFILE` guardrails (`LOCAL` | `PRODUCTION`).
   - Added startup fail-fast validation in app lifespan.
   - Enforced in `PRODUCTION`:
-    - DPM supportability backend must be `POSTGRES`.
+    - lotus-manage supportability backend must be `POSTGRES`.
     - advisory proposal store backend must be `POSTGRES`.
     - policy-pack catalog backend must be `POSTGRES` when policy packs/admin APIs are enabled.
   - Added unit tests and startup tests for all guardrail reason codes.
@@ -91,7 +91,7 @@ variance and incident complexity in production.
   - Updated deployment docs and runbook with explicit `LOCAL` vs `PRODUCTION` profile behavior.
 - Slice 3 completed (2026-02-21):
   - Added CI negative guardrail job asserting startup fails with explicit reason codes for:
-    - DPM backend misconfiguration in `PRODUCTION`
+    - lotus-manage backend misconfiguration in `PRODUCTION`
     - advisory backend misconfiguration in `PRODUCTION`
     - policy-pack backend misconfiguration in `PRODUCTION` when policy packs are enabled
 - Slice 4 completed (2026-02-21):
@@ -108,7 +108,7 @@ variance and incident complexity in production.
 - Slice 6 completed (2026-02-21):
   - Switched local container defaults to Postgres-backed runtime in `docker-compose.yml`.
   - Marked legacy runtime backends as deprecated via `DeprecationWarning`:
-    - DPM supportability: `IN_MEMORY`/`SQL`/`SQLITE`
+    - lotus-manage supportability: `IN_MEMORY`/`SQL`/`SQLITE`
     - advisory store: `IN_MEMORY`
     - policy-pack catalog: `ENV_JSON`
   - Captured rationale and transition policy in ADR-0011.

--- a/docs/rfcs/RFC-0028-dpm-integration-capabilities-contract.md
+++ b/docs/rfcs/RFC-0028-dpm-integration-capabilities-contract.md
@@ -1,11 +1,11 @@
-# RFC-0028 DPM Integration Capabilities Contract
+# RFC-0028 lotus-manage Integration Capabilities Contract
 
 - Status: Accepted
 - Date: 2026-02-23
 
 ## Summary
 
-Add `GET /integration/capabilities` to expose backend-governed DPM feature and workflow capability flags for BFF, PAS, and UI integration.
+Add `GET /integration/capabilities` to expose backend-governed lotus-manage feature and workflow capability flags for lotus-gateway, lotus-core, and UI integration.
 
 ## Contract
 
@@ -26,5 +26,5 @@ Outputs:
 ## Rationale
 
 1. Keeps workflow/feature control in backend.
-2. Enables BFF/UI to drive behavior from capability contracts.
-3. Aligns DPM with PAS and PA integration-governance direction.
+2. Enables lotus-gateway/UI to drive behavior from capability contracts.
+3. Aligns lotus-manage with lotus-core and lotus-performance integration-governance direction.

--- a/docs/rfcs/RFC-0029-iterative-proposal-simulation-workspace-contract.md
+++ b/docs/rfcs/RFC-0029-iterative-proposal-simulation-workspace-contract.md
@@ -1,12 +1,12 @@
-# RFC-0029: Iterative Proposal Simulation Workspace Contract for Advisory and DPM Lifecycles
+# RFC-0029: Iterative Proposal Simulation Workspace Contract for Advisory and lotus-manage Lifecycles
 
 - Status: PROPOSED
 - Date: 2026-02-24
-- Owners: DPM Rebalance Engine
+- Owners: lotus-manage Rebalance Engine
 
 ## Problem Statement
 
-Advisors and DPM users need an iterative build-refine-evaluate loop that supports repeated trade/cash adjustments with immediate constraint and portfolio impact feedback. Current workflow APIs are closer to run submission than interactive workspace collaboration.
+Advisors and lotus-manage users need an iterative build-refine-evaluate loop that supports repeated trade/cash adjustments with immediate constraint and portfolio impact feedback. Current workflow APIs are closer to run submission than interactive workspace collaboration.
 
 ## Root Cause
 
@@ -25,14 +25,14 @@ Advisors and DPM users need an iterative build-refine-evaluate loop that support
 
 ## Architectural Impact
 
-- DPM supports both interactive iteration and formal lifecycle progression.
+- lotus-manage supports both interactive iteration and formal lifecycle progression.
 - Better alignment with advisory domain behavior expected by private banking users.
 - Requires stronger idempotency and deterministic draft-state replay.
 
 ## Risks and Trade-offs
 
-- Session/state complexity increases in DPM API model.
-- Must carefully distinguish advisory-specific behavior vs DPM automation behavior.
+- Session/state complexity increases in lotus-manage API model.
+- Must carefully distinguish advisory-specific behavior vs lotus-manage automation behavior.
 - Additional persistence and audit requirements for draft iteration history.
 
 ## High-Level Implementation Approach
@@ -40,9 +40,9 @@ Advisors and DPM users need an iterative build-refine-evaluate loop that support
 1. Define draft session schema and mutation endpoints.
 2. Add normalized constraint/impact response contract.
 3. Add replay-safe persistence strategy for draft iterations.
-4. Add end-to-end tests with BFF and UI iterative loops.
+4. Add end-to-end tests with lotus-gateway and UI iterative loops.
 
 ## Dependencies
 
-- Consumed by AEA RFC-0010 and AW RFC-0007.
-- Integrates with PAS RFC-046 and PA RFC-032 for data and analytics feedback.
+- Consumed by lotus-gateway RFC-0010 and AW RFC-0007.
+- Integrates with lotus-core RFC-046 and lotus-performance RFC-032 for data and analytics feedback.

--- a/docs/rfcs/RFC-0030-dpm-integration-pyramid-rebalance-wave-1.md
+++ b/docs/rfcs/RFC-0030-dpm-integration-pyramid-rebalance-wave-1.md
@@ -1,8 +1,8 @@
-# RFC-0030 - DPM Integration Pyramid Rebalance Wave 1
+# RFC-0030 - lotus-manage Integration Pyramid Rebalance Wave 1
 
 ## Problem Statement
 
-DPM currently has strong overall coverage but an underweighted integration bucket in the test pyramid.
+lotus-manage currently has strong overall coverage but an underweighted integration bucket in the test pyramid.
 
 ## Root Cause
 
@@ -12,7 +12,7 @@ Most API workflow verification lives under `tests/unit` with mocked seams, while
 
 Add integration API workflow tests that exercise router + service + in-memory persistence boundaries without heavy mocking:
 
-- DPM rebalance simulation lifecycle with supportability lookups.
+- lotus-manage rebalance simulation lifecycle with supportability lookups.
 - Advisory proposal lifecycle creation/version/workflow timeline retrieval.
 
 ## Architectural Impact
@@ -26,6 +26,6 @@ No production code changes. Improves confidence in real service wiring and endpo
 
 ## High-Level Implementation
 
-1. Add integration fixture to reset DPM runtime singletons between tests.
-2. Add DPM run supportability integration workflow tests.
+1. Add integration fixture to reset lotus-manage runtime singletons between tests.
+2. Add lotus-manage run supportability integration workflow tests.
 3. Add advisory proposal lifecycle integration workflow tests.

--- a/docs/rfcs/RFC-0031-dpm-integration-pyramid-wave-2-supportability-and-guardrails.md
+++ b/docs/rfcs/RFC-0031-dpm-integration-pyramid-wave-2-supportability-and-guardrails.md
@@ -1,7 +1,7 @@
-# RFC-0031 DPM Integration Pyramid Wave 2 - Supportability and Guardrails
+# RFC-0031 lotus-manage Integration Pyramid Wave 2 - Supportability and Guardrails
 
 ## Problem Statement
-DPM backend coverage meets threshold, but integration-test proportion remains below the target pyramid range. Critical supportability and feature-guardrail API behaviors need stronger integration-level validation.
+lotus-manage backend coverage meets threshold, but integration-test proportion remains below the target pyramid range. Critical supportability and feature-guardrail API behaviors need stronger integration-level validation.
 
 ## Root Cause
 Existing integration tests focused on main happy paths and did not sufficiently validate:
@@ -12,9 +12,9 @@ Existing integration tests focused on main happy paths and did not sufficiently 
 
 ## Proposed Solution
 Add integration workflow tests for:
-1. DPM support-bundle lookups (by correlation/idempotency/operation).
-2. DPM idempotency history endpoint behavior under feature flags.
-3. DPM supportability summary guardrail when disabled.
+1. lotus-manage support-bundle lookups (by correlation/idempotency/operation).
+2. lotus-manage idempotency history endpoint behavior under feature flags.
+3. lotus-manage supportability summary guardrail when disabled.
 4. Proposal supportability config backend readiness/error branch.
 5. Proposal support/idempotency endpoints and disabled-support guardrail.
 

--- a/docs/rfcs/RFC-0032-dpm-pyramid-wave-3-integration-and-e2e-workflow-expansion.md
+++ b/docs/rfcs/RFC-0032-dpm-pyramid-wave-3-integration-and-e2e-workflow-expansion.md
@@ -1,15 +1,15 @@
-# RFC-0032 DPM Pyramid Wave 3 - Integration and E2E Workflow Expansion
+# RFC-0032 lotus-manage Pyramid Wave 3 - Integration and E2E Workflow Expansion
 
 ## Problem Statement
-DPM currently passes the 99% coverage gate but remains significantly unit-heavy in test-pyramid distribution, leaving integration and E2E contract behavior underrepresented.
+lotus-manage currently passes the 99% coverage gate but remains significantly unit-heavy in test-pyramid distribution, leaving integration and E2E contract behavior underrepresented.
 
 ## Root Cause
 Most API and workflow validation was implemented under `tests/unit`, while integration and E2E suites expanded slower than feature delivery.
 
 ## Proposed Solution
-Add a focused wave of integration and E2E tests for high-risk DPM and Advisory workflows:
-1. DPM supportability and async guardrails.
-2. DPM lineage and workflow decision APIs.
+Add a focused wave of integration and E2E tests for high-risk lotus-manage and Advisory workflows:
+1. lotus-manage supportability and async guardrails.
+2. lotus-manage lineage and workflow decision APIs.
 3. Proposal async create/version workflow contracts.
 4. E2E workflow paths for support-bundle optional sections, lineage filters, workflow decision listing, and proposal async flows.
 
@@ -23,4 +23,4 @@ No runtime behavior or API contract changes. This is a verification-depth increm
 ## High-Level Implementation Approach
 1. Extend integration suites under `tests/integration/dpm/api` and `tests/integration/advisory/api`.
 2. Extend E2E workflow coverage under `tests/e2e/demo`.
-3. Validate with targeted suites plus full DPM coverage gate.
+3. Validate with targeted suites plus full lotus-manage coverage gate.

--- a/docs/rfcs/RFC-0033-dpm-pyramid-wave-4-integration-e2e-expansion.md
+++ b/docs/rfcs/RFC-0033-dpm-pyramid-wave-4-integration-e2e-expansion.md
@@ -1,7 +1,7 @@
-# RFC-0033 - DPM Pyramid Wave 4 Integration/E2E Expansion
+# RFC-0033 - lotus-manage Pyramid Wave 4 Integration/E2E Expansion
 
 ## Problem Statement
-DPM currently meets 99% coverage but still fails platform test-pyramid ratio targets because integration/e2e scenario depth is too low relative to unit tests.
+lotus-manage currently meets 99% coverage but still fails platform test-pyramid ratio targets because integration/e2e scenario depth is too low relative to unit tests.
 
 ## Root Cause
 - Prior quality waves concentrated on unit-level correctness and supportability internals.
@@ -9,8 +9,8 @@ DPM currently meets 99% coverage but still fails platform test-pyramid ratio tar
 
 ## Proposed Solution
 Add a dedicated integration/e2e expansion wave focused on:
-- DPM supportability API feature-flag gate matrix.
-- DPM supportability API not-found matrix across lookup variants.
+- lotus-manage supportability API feature-flag gate matrix.
+- lotus-manage supportability API not-found matrix across lookup variants.
 - Advisory proposal lifecycle/support API gate and not-found matrix.
 - E2E supportability and workflow lookup/error-path assertions.
 
@@ -22,7 +22,7 @@ No production behavior changes. This improves confidence at service boundaries a
 - Broader feature-flag matrix can increase flakiness if test isolation is weak.
 
 ## High-Level Implementation Approach
-1. Add integration matrix tests in existing DPM and advisory API integration suites.
+1. Add integration matrix tests in existing lotus-manage and advisory API integration suites.
 2. Add focused e2e matrix tests for lookup and not-found behavior.
 3. Run `make test-integration`, `make test-e2e`, and `make test-all-fast`.
 4. Monitor CI and merge once green.

--- a/docs/rfcs/RFC-0034-dpm-pyramid-wave-5-integration-boundary-expansion.md
+++ b/docs/rfcs/RFC-0034-dpm-pyramid-wave-5-integration-boundary-expansion.md
@@ -1,7 +1,7 @@
-# RFC-0034 - DPM Pyramid Wave 5 Integration Boundary Expansion
+# RFC-0034 - lotus-manage Pyramid Wave 5 Integration Boundary Expansion
 
 ## Problem Statement
-DPM remains outside target test-pyramid ratios despite strong coverage because integration/e2e scenario breadth is still comparatively low.
+lotus-manage remains outside target test-pyramid ratios despite strong coverage because integration/e2e scenario breadth is still comparatively low.
 
 ## Root Cause
 - Existing integration coverage emphasizes happy-path roundtrips.
@@ -9,7 +9,7 @@ DPM remains outside target test-pyramid ratios despite strong coverage because i
 
 ## Proposed Solution
 Expand integration coverage with boundary matrices:
-- DPM workflow lookup/action not-found and feature-flag guard matrices.
+- lotus-manage workflow lookup/action not-found and feature-flag guard matrices.
 - Advisory lifecycle/support/async feature-flag guard matrices.
 - Advisory post-route not-found matrices for transitions and approvals.
 
@@ -21,6 +21,6 @@ No runtime behavior changes. This is integration-safety hardening for API contra
 - Requires strict test isolation for env flag toggles and in-memory stores.
 
 ## High-Level Implementation Approach
-1. Add matrix-driven integration cases in existing DPM and advisory API integration suites.
+1. Add matrix-driven integration cases in existing lotus-manage and advisory API integration suites.
 2. Validate with targeted integration runs and full coverage-gated suite.
 3. Merge and re-measure pyramid distribution.

--- a/docs/rfcs/RFC-0035-dpm-pyramid-wave-6-repository-integration-depth-expansion.md
+++ b/docs/rfcs/RFC-0035-dpm-pyramid-wave-6-repository-integration-depth-expansion.md
@@ -1,13 +1,13 @@
-# RFC-0035: DPM Pyramid Wave 6 - Repository Integration Depth Expansion
+# RFC-0035: lotus-manage Pyramid Wave 6 - Repository Integration Depth Expansion
 
 ## Problem Statement
-DPM test coverage is at `99%`, but the integration slice remains below target pyramid guidance (`<15%`). Existing integration tests validate API workflows well, but repository boundary cases still have partial parity versus unit scaffolds.
+lotus-manage test coverage is at `99%`, but the integration slice remains below target pyramid guidance (`<15%`). Existing integration tests validate API workflows well, but repository boundary cases still have partial parity versus unit scaffolds.
 
 ## Proposed Change
 Add meaningful PostgreSQL repository-integration tests for:
-- DPM supportability repository (`dpm_runs`): cursor edge cases, filter combinations, workflow-decision paging, summary aggregation semantics, and retention guardrails.
+- lotus-manage supportability repository (`dpm_runs`): cursor edge cases, filter combinations, workflow-decision paging, summary aggregation semantics, and retention guardrails.
 - Advisory proposal repository (`proposals`): simulation idempotency persistence, list pagination/cursor semantics, workflow event/approval ordering, transition without approval, and version retrieval paths.
-- DPM policy-pack repository: empty-state behavior, rich policy definition roundtrip, deterministic ordering, and delete semantics.
+- lotus-manage policy-pack repository: empty-state behavior, rich policy definition roundtrip, deterministic ordering, and delete semantics.
 
 ## Architectural Impact
 No runtime behavior changes. This RFC increases confidence at service-boundary persistence contracts and improves pyramid balance with integration-heavy validation.
@@ -29,4 +29,4 @@ Mitigations:
 ## Success Criteria
 - New tests pass in fake and live-Postgres modes.
 - Coverage gate remains at or above 99%.
-- Integration test count increases enough to move DPM closer to target pyramid distribution.
+- Integration test count increases enough to move lotus-manage closer to target pyramid distribution.

--- a/docs/rfcs/RFC-0036-postgres-only-runtime-hard-cutover.md
+++ b/docs/rfcs/RFC-0036-postgres-only-runtime-hard-cutover.md
@@ -19,7 +19,7 @@ Perform a hard cutover to PostgreSQL-only runtime persistence:
 ## Architectural Impact
 - Strengthens service boundaries and runtime determinism.
 - Eliminates hidden divergence between local and production persistence behavior.
-- Aligns DPM runtime with platform governance: no legacy runtime backend support.
+- Aligns lotus-manage runtime with platform governance: no legacy runtime backend support.
 
 ## Risks and Trade-offs
 - Local bootstrap now requires PostgreSQL DSNs and setup.

--- a/docs/rfcs/advisory pack/refine/RFC-0014F-advisory-workflow-gates.md
+++ b/docs/rfcs/advisory pack/refine/RFC-0014F-advisory-workflow-gates.md
@@ -30,7 +30,7 @@ This is a stateless “workflow brain” that interprets:
 and returns a consistent **GateDecision** block in both:
 - `/rebalance/proposals/simulate` response
 - `/rebalance/proposals/artifact` (if implemented)
- - `/rebalance/simulate` response (shared DPM vocabulary)
+ - `/rebalance/simulate` response (shared lotus-manage vocabulary)
 
 ---
 
@@ -52,7 +52,7 @@ Without explicit gates, UIs and downstream systems must infer workflow from raw 
 ### 2.1 In Scope
 - Define `GateDecision` schema and deterministic evaluation logic.
 - Add `gate_decision` to proposal simulation result and proposal artifact.
-- Add `gate_decision` to DPM rebalance simulation result for shared workflow semantics.
+- Add `gate_decision` to lotus-manage rebalance simulation result for shared workflow semantics.
 - Define mapping rules from:
   - rule_results (HARD/FAIL, SOFT/FAIL)
   - suitability summary (new issues and severities)
@@ -243,9 +243,9 @@ If RFC-0014E implemented:
 * include the same `gate_decision` in `summary.recommended_next_step`
 * include full block in artifact top-level to support workflow routing
 
-### 7.3 DPM simulate response
+### 7.3 lotus-manage simulate response
 
-Add `gate_decision` to DPM `/rebalance/simulate` response with shared semantics:
+Add `gate_decision` to lotus-manage `/rebalance/simulate` response with shared semantics:
 - clean discretionary runs default to `EXECUTION_READY` unless consent policy is enabled
 - blocked and pending-review flows map to deterministic workflow gates
 
@@ -262,7 +262,7 @@ Add `gate_decision` to DPM `/rebalance/simulate` response with shared semantics:
 4. Wire into:
    * advisory simulate (`ProposalResult.gate_decision`)
    * advisory artifact (`ProposalArtifact.gate_decision`)
-   * DPM simulate (`RebalanceResult.gate_decision`)
+   * lotus-manage simulate (`RebalanceResult.gate_decision`)
 5. Add unit/API/contract coverage.
 
 ---
@@ -299,7 +299,7 @@ Each asserts:
 * Implemented: responses include `gate_decision` with stable schema.
 * Implemented: deterministic gate policy with test coverage.
 * Implemented: standardized reason codes and deterministic sorting.
-* Implemented: advisory artifact and simulate include gate decision; DPM simulate includes shared gate decision.
+* Implemented: advisory artifact and simulate include gate decision; lotus-manage simulate includes shared gate decision.
 
 ---
 
@@ -316,4 +316,4 @@ Each asserts:
 1. Workflow gates are derived from deterministic policy evaluation over status, rule outcomes, suitability severity, and key diagnostics.
 2. `BLOCKED` always dominates gate outcomes and routes to input-fix workflow.
 3. Clean feasible proposals route to client-consent or execution-ready based on consent options.
-4. Shared gate vocabulary is applied consistently in advisory simulate, advisory artifact, and DPM simulate responses.
+4. Shared gate vocabulary is applied consistently in advisory simulate, advisory artifact, and lotus-manage simulate responses.

--- a/docs/standards/data-model-ownership.md
+++ b/docs/standards/data-model-ownership.md
@@ -5,14 +5,14 @@
 
 ## Owned Domains
 
-- DPM policy-pack persistence model.
+- lotus-manage policy-pack persistence model.
 - Advisory proposal workflow persistence model.
-- Schema migration history (`schema_migrations`) for DPM namespaces.
+- Schema migration history (`schema_migrations`) for lotus-manage namespaces.
 
 ## Service Boundaries
 
-- Core portfolio ledger, valuation, and transaction source data remains PAS-owned.
-- Advanced analytics are PA-owned and consumed through APIs where needed.
+- Core portfolio ledger, valuation, and transaction source data remains lotus-core-owned.
+- Advanced analytics are lotus-performance-owned and consumed through APIs where needed.
 
 ## Schema Rules
 

--- a/docs/standards/durability-consistency.md
+++ b/docs/standards/durability-consistency.md
@@ -1,4 +1,4 @@
-# Durability and Consistency Standard (DPM)
+# Durability and Consistency Standard (lotus-manage)
 
 - Standard reference: `lotus-platform/Durability and Consistency Standard.md`
 - Scope: discretionary and advisory workflow simulation/lifecycle write operations.

--- a/docs/standards/enterprise-readiness.md
+++ b/docs/standards/enterprise-readiness.md
@@ -1,4 +1,4 @@
-# Enterprise Readiness Baseline (DPM)
+# Enterprise Readiness Baseline (lotus-manage)
 
 - Standard reference: `lotus-platform/Enterprise Readiness Standard.md`
 - Scope: discretionary/advisory decision workflows, policy enforcement, and run supportability APIs.

--- a/docs/standards/scalability-availability.md
+++ b/docs/standards/scalability-availability.md
@@ -1,6 +1,6 @@
 # Scalability and Availability Standard Alignment
 
-Service: DPM
+Service: lotus-manage
 
 This repository adopts the platform-wide standard defined in lotus-platform/Scalability and Availability Standard.md.
 
@@ -26,18 +26,18 @@ This repository adopts the platform-wide standard defined in lotus-platform/Scal
 ## Availability Baseline
 
 - Internal SLO baseline: p95 synchronous proposal API latency < 400 ms; error rate < 1%.
-- Recovery targets: RTO 30 minutes and RPO 15 minutes for persisted DPM operations.
+- Recovery targets: RTO 30 minutes and RPO 15 minutes for persisted lotus-manage operations.
 - Backup and restore validation is required for proposal/run stores in every deployment environment.
 
 ## Caching Policy Baseline
 
-- DPM only permits explicit bounded caches for idempotency and workflow supportability lookups.
+- lotus-manage only permits explicit bounded caches for idempotency and workflow supportability lookups.
 - Cache use-cases must define TTL and max-size controls with clear invalidation ownership.
 - Stale-read behavior is disallowed for correctness-critical rebalance outcomes; stale supportability reads must be explicitly documented.
 
 ## Scale Signal Metrics Coverage
 
-- DPM exports `/metrics` for HTTP and workflow instrumentation.
+- lotus-manage exports `/metrics` for HTTP and workflow instrumentation.
 - Platform-shared infrastructure metrics for CPU/memory, DB latency/pool behavior, and queue lag are sourced from:
   - `lotus-platform/platform-stack/prometheus/prometheus.yml`
   - `lotus-platform/platform-stack/docker-compose.yml`

--- a/scripts/postgres_migrate.py
+++ b/scripts/postgres_migrate.py
@@ -11,7 +11,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Apply forward-only PostgreSQL migrations for DPM and advisory stores."
+        description="Apply forward-only PostgreSQL migrations for lotus-manage and advisory stores."
     )
     parser.add_argument(
         "--target",
@@ -22,7 +22,7 @@ def main() -> int:
     parser.add_argument(
         "--dpm-dsn",
         default=os.getenv("DPM_SUPPORTABILITY_POSTGRES_DSN", "").strip(),
-        help="PostgreSQL DSN for DPM supportability migrations.",
+        help="PostgreSQL DSN for lotus-manage supportability migrations.",
     )
     parser.add_argument(
         "--proposals-dsn",

--- a/scripts/run_demo_pack_live.py
+++ b/scripts/run_demo_pack_live.py
@@ -56,7 +56,7 @@ def run_demo_pack(base_url: str) -> None:
     idem_32 = f"live-demo-32-support-summary-{run_token}"
     lifecycle_idem_20 = f"live-demo-lifecycle-20-{run_token}"
     with httpx.Client(base_url=base_url, timeout=timeout) as client:
-        # DPM single-run demos
+        # lotus-manage single-run demos
         dpm_files = [
             "01_standard_drift.json",
             "02_sell_to_fund.json",

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -91,15 +91,15 @@ app = FastAPI(
     ),
     openapi_tags=[
         {
-            "name": "DPM Simulation",
-            "description": "Core deterministic DPM simulation endpoints.",
+            "name": "lotus-manage Simulation",
+            "description": "Core deterministic lotus-manage simulation endpoints.",
         },
         {
-            "name": "DPM What-If Analysis",
+            "name": "lotus-manage What-If Analysis",
             "description": "Batch scenario analysis endpoints (sync and async).",
         },
         {
-            "name": "DPM Run Supportability",
+            "name": "lotus-manage Run Supportability",
             "description": "Run, operation, idempotency, and artifact retrieval endpoints.",
         },
         {

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -87,4 +87,3 @@ def setup_observability(app: FastAPI) -> None:
         response.headers["X-Trace-Id"] = trace_id
         response.headers["traceparent"] = f"00-{trace_id}-0000000000000001-01"
         return response
-

--- a/src/api/routers/dpm_policy_packs.py
+++ b/src/api/routers/dpm_policy_packs.py
@@ -22,7 +22,7 @@ from src.infrastructure.dpm_policy_packs import (
     PostgresDpmPolicyPackRepository,
 )
 
-router = APIRouter(tags=["DPM Run Supportability"])
+router = APIRouter(tags=["lotus-manage Run Supportability"])
 
 
 def resolve_dpm_policy_pack(
@@ -137,9 +137,9 @@ def reset_dpm_policy_pack_repository_for_tests() -> None:
     "/rebalance/policies/effective",
     response_model=DpmEffectivePolicyPackResolution,
     status_code=status.HTTP_200_OK,
-    summary="Resolve Effective DPM Policy Pack",
+    summary="Resolve Effective lotus-manage Policy Pack",
     description=(
-        "Returns the effective DPM policy-pack resolution using configured precedence "
+        "Returns the effective lotus-manage policy-pack resolution using configured precedence "
         "(request, tenant default, global default). This endpoint is read-only and "
         "intended for supportability and integration diagnostics."
     ),
@@ -181,9 +181,9 @@ def get_effective_dpm_policy_pack(
     "/rebalance/policies/catalog",
     response_model=DpmPolicyPackCatalogResponse,
     status_code=status.HTTP_200_OK,
-    summary="List DPM Policy Pack Catalog",
+    summary="List lotus-manage Policy Pack Catalog",
     description=(
-        "Returns the currently configured DPM policy-pack catalog and the effective "
+        "Returns the currently configured lotus-manage policy-pack catalog and the effective "
         "selection context for optional request and tenant headers."
     ),
 )
@@ -237,7 +237,7 @@ def get_dpm_policy_pack_catalog(
     "/rebalance/policies/catalog/{policy_pack_id}",
     response_model=DpmPolicyPackDefinition,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Policy Pack",
+    summary="Get lotus-manage Policy Pack",
     description="Returns one policy-pack definition by identifier.",
 )
 def get_dpm_policy_pack(
@@ -262,7 +262,7 @@ def get_dpm_policy_pack(
     "/rebalance/policies/catalog/{policy_pack_id}",
     response_model=DpmPolicyPackMutationResponse,
     status_code=status.HTTP_200_OK,
-    summary="Upsert DPM Policy Pack",
+    summary="Upsert lotus-manage Policy Pack",
     description="Creates or updates one policy-pack definition by identifier.",
 )
 def upsert_dpm_policy_pack(
@@ -294,7 +294,7 @@ def upsert_dpm_policy_pack(
 @router.delete(
     "/rebalance/policies/catalog/{policy_pack_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    summary="Delete DPM Policy Pack",
+    summary="Delete lotus-manage Policy Pack",
     description="Deletes one policy-pack definition by identifier when it exists.",
 )
 def delete_dpm_policy_pack(

--- a/src/api/routers/dpm_runs.py
+++ b/src/api/routers/dpm_runs.py
@@ -20,7 +20,7 @@ from src.core.dpm_runs import (
 from src.core.dpm_runs.repository import DpmRunRepository
 from src.core.models import RebalanceResult
 
-router = APIRouter(tags=["DPM Run Supportability"])
+router = APIRouter(tags=["lotus-manage Run Supportability"])
 
 _REPOSITORY = None
 _SERVICE: Optional[DpmRunSupportService] = None
@@ -165,9 +165,9 @@ def reset_dpm_run_support_service_for_tests() -> None:
     "/rebalance/runs",
     response_model=DpmRunListResponse,
     status_code=status.HTTP_200_OK,
-    summary="List DPM Runs",
+    summary="List lotus-manage Runs",
     description=(
-        "Returns paginated DPM runs filtered by creation time range, run status, and portfolio id."
+        "Returns paginated lotus-manage runs filtered by creation time range, run status, and portfolio id."
     ),
 )
 def list_runs(
@@ -243,7 +243,7 @@ def list_runs(
     "/rebalance/supportability/summary",
     response_model=DpmSupportabilitySummaryResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Supportability Summary",
+    summary="Get lotus-manage Supportability Summary",
     description=(
         "Returns supportability storage summary metrics (runs, operations, status counts, "
         "and temporal bounds) for operational investigation without direct database access."
@@ -264,8 +264,8 @@ def get_dpm_supportability_summary(
     "/rebalance/runs/by-correlation/{correlation_id}",
     response_model=DpmRunLookupResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run by Correlation Id",
-    description="Returns the latest DPM run mapped to a correlation id for investigation.",
+    summary="Get lotus-manage Run by Correlation Id",
+    description="Returns the latest lotus-manage run mapped to a correlation id for investigation.",
 )
 def get_run_by_correlation(
     correlation_id: Annotated[
@@ -288,8 +288,8 @@ def get_run_by_correlation(
     "/rebalance/runs/by-request-hash/{request_hash}",
     response_model=DpmRunLookupResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run by Request Hash",
-    description="Returns the latest DPM run mapped to a canonical request hash for investigation.",
+    summary="Get lotus-manage Run by Request Hash",
+    description="Returns the latest lotus-manage run mapped to a canonical request hash for investigation.",
 )
 def get_run_by_request_hash(
     request_hash: Annotated[
@@ -312,8 +312,8 @@ def get_run_by_request_hash(
     "/rebalance/runs/idempotency/{idempotency_key}",
     response_model=DpmRunIdempotencyLookupResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Idempotency Mapping",
-    description="Returns DPM idempotency key to run mapping for support investigations.",
+    summary="Get lotus-manage Idempotency Mapping",
+    description="Returns lotus-manage idempotency key to run mapping for support investigations.",
 )
 def get_run_idempotency_lookup(
     idempotency_key: Annotated[
@@ -336,7 +336,7 @@ def get_run_idempotency_lookup(
     "/rebalance/idempotency/{idempotency_key}/history",
     response_model=DpmRunIdempotencyHistoryResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Idempotency History",
+    summary="Get lotus-manage Idempotency History",
     description=(
         "Returns append-only run mapping history for one idempotency key, including request hash "
         "and correlation context for support investigations."
@@ -364,13 +364,13 @@ def get_run_idempotency_history(
     "/rebalance/runs/{rebalance_run_id}",
     response_model=DpmRunLookupResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run by Run Id",
-    description="Returns one DPM run payload and lineage metadata by run id.",
+    summary="Get lotus-manage Run by Run Id",
+    description="Returns one lotus-manage run payload and lineage metadata by run id.",
 )
 def get_run_by_run_id(
     rebalance_run_id: Annotated[
         str,
-        Path(description="DPM run identifier.", examples=["rr_abc12345"]),
+        Path(description="lotus-manage run identifier.", examples=["rr_abc12345"]),
     ],
     service: DpmRunSupportService = Depends(get_dpm_run_support_service),
 ) -> DpmRunLookupResponse:
@@ -385,7 +385,7 @@ def get_run_by_run_id(
     "/rebalance/runs/{rebalance_run_id}/support-bundle",
     response_model=DpmRunSupportBundleResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Support Bundle",
+    summary="Get lotus-manage Run Support Bundle",
     description=(
         "Returns an aggregated supportability bundle for one run, including run payload, "
         "lineage, workflow history, optional deterministic artifact, and optional mapped async "
@@ -395,7 +395,7 @@ def get_run_by_run_id(
 def get_dpm_run_support_bundle(
     rebalance_run_id: Annotated[
         str,
-        Path(description="DPM run identifier.", examples=["rr_abc12345"]),
+        Path(description="lotus-manage run identifier.", examples=["rr_abc12345"]),
     ],
     include_artifact: Annotated[
         bool,
@@ -439,7 +439,7 @@ def get_dpm_run_support_bundle(
     "/rebalance/runs/by-correlation/{correlation_id}/support-bundle",
     response_model=DpmRunSupportBundleResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Support Bundle by Correlation Id",
+    summary="Get lotus-manage Run Support Bundle by Correlation Id",
     description=(
         "Returns aggregated supportability bundle for run resolved by correlation id, "
         "including optional artifact, async operation, and idempotency history."
@@ -495,7 +495,7 @@ def get_dpm_run_support_bundle_by_correlation(
     "/rebalance/runs/idempotency/{idempotency_key}/support-bundle",
     response_model=DpmRunSupportBundleResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Support Bundle by Idempotency Key",
+    summary="Get lotus-manage Run Support Bundle by Idempotency Key",
     description=(
         "Returns aggregated supportability bundle for run resolved by idempotency key mapping, "
         "including optional artifact, async operation, and idempotency history."
@@ -551,7 +551,7 @@ def get_dpm_run_support_bundle_by_idempotency(
     "/rebalance/runs/by-operation/{operation_id}/support-bundle",
     response_model=DpmRunSupportBundleResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Support Bundle by Operation Id",
+    summary="Get lotus-manage Run Support Bundle by Operation Id",
     description=(
         "Returns aggregated supportability bundle for run resolved by asynchronous operation id, "
         "including optional artifact, async operation, and idempotency history."
@@ -607,7 +607,7 @@ def get_dpm_run_support_bundle_by_operation(
     "/rebalance/runs/{rebalance_run_id}/artifact",
     response_model=DpmRunArtifactResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Artifact by Run Id",
+    summary="Get lotus-manage Run Artifact by Run Id",
     description=(
         "Returns deterministic run artifact from supportability run data using configured "
         "artifact mode (`DERIVED` or `PERSISTED`)."
@@ -619,7 +619,7 @@ def get_dpm_run_support_bundle_by_operation(
 def get_run_artifact_by_run_id(
     rebalance_run_id: Annotated[
         str,
-        Path(description="DPM run identifier.", examples=["rr_abc12345"]),
+        Path(description="lotus-manage run identifier.", examples=["rr_abc12345"]),
     ],
     service: DpmRunSupportService = Depends(get_dpm_run_support_service),
 ) -> DpmRunArtifactResponse:

--- a/src/api/routers/dpm_runs_operations_routes.py
+++ b/src/api/routers/dpm_runs_operations_routes.py
@@ -16,7 +16,7 @@ from src.core.dpm_runs import (
     "/rebalance/operations",
     response_model=DpmAsyncOperationListResponse,
     status_code=status.HTTP_200_OK,
-    summary="List DPM Async Operations",
+    summary="List lotus-manage Async Operations",
     description=(
         "Returns asynchronous operation records with optional filters and cursor pagination."
     ),
@@ -95,7 +95,7 @@ def list_dpm_async_operations(
     "/rebalance/operations/{operation_id}",
     response_model=DpmAsyncOperationStatusResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Async Operation",
+    summary="Get lotus-manage Async Operation",
     description="Returns asynchronous operation status and terminal result/error payload.",
 )
 def get_dpm_async_operation(
@@ -117,7 +117,7 @@ def get_dpm_async_operation(
     "/rebalance/operations/by-correlation/{correlation_id}",
     response_model=DpmAsyncOperationStatusResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Async Operation by Correlation Id",
+    summary="Get lotus-manage Async Operation by Correlation Id",
     description="Returns asynchronous operation associated with correlation id.",
 )
 def get_dpm_async_operation_by_correlation(
@@ -139,7 +139,7 @@ def get_dpm_async_operation_by_correlation(
     "/rebalance/lineage/{entity_id}",
     response_model=DpmLineageResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Supportability Lineage by Entity Id",
+    summary="Get lotus-manage Supportability Lineage by Entity Id",
     description=(
         "Returns supportability lineage edges for an entity id, including correlation, "
         "idempotency, run, and operation relations."

--- a/src/api/routers/dpm_runs_workflow_routes.py
+++ b/src/api/routers/dpm_runs_workflow_routes.py
@@ -20,7 +20,7 @@ from src.core.dpm_runs.models import DpmWorkflowActionType
     "/rebalance/workflow/decisions",
     response_model=DpmWorkflowDecisionListResponse,
     status_code=status.HTTP_200_OK,
-    summary="List DPM Workflow Decisions",
+    summary="List lotus-manage Workflow Decisions",
     description=(
         "Returns paginated workflow decisions across runs with optional filters for "
         "supportability investigations."
@@ -30,7 +30,7 @@ def list_dpm_workflow_decisions(
     rebalance_run_id: Annotated[
         Optional[str],
         Query(
-            description="Optional DPM run id filter.",
+            description="Optional lotus-manage run id filter.",
             examples=["rr_abc12345"],
         ),
     ] = None,
@@ -107,7 +107,7 @@ def list_dpm_workflow_decisions(
     "/rebalance/workflow/decisions/by-correlation/{correlation_id}",
     response_model=DpmRunWorkflowHistoryResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Workflow Decisions by Correlation Id",
+    summary="Get lotus-manage Workflow Decisions by Correlation Id",
     description=(
         "Returns append-only workflow decision history for the run resolved by correlation id."
     ),
@@ -134,7 +134,7 @@ def get_dpm_workflow_decisions_by_correlation(
     "/rebalance/runs/{rebalance_run_id}/workflow",
     response_model=DpmRunWorkflowResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Workflow State",
+    summary="Get lotus-manage Run Workflow State",
     description=(
         "Returns workflow gate state and latest decision for run-level review supportability."
     ),
@@ -142,7 +142,7 @@ def get_dpm_workflow_decisions_by_correlation(
 def get_dpm_run_workflow(
     rebalance_run_id: Annotated[
         str,
-        Path(description="DPM run identifier.", examples=["rr_abc12345"]),
+        Path(description="lotus-manage run identifier.", examples=["rr_abc12345"]),
     ],
     service: DpmRunSupportService = shared.Depends(shared.get_dpm_run_support_service),
 ) -> DpmRunWorkflowResponse:
@@ -158,7 +158,7 @@ def get_dpm_run_workflow(
     "/rebalance/runs/by-correlation/{correlation_id}/workflow",
     response_model=DpmRunWorkflowResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Workflow State by Correlation Id",
+    summary="Get lotus-manage Run Workflow State by Correlation Id",
     description="Returns workflow gate state for run resolved by correlation id.",
 )
 def get_dpm_run_workflow_by_correlation(
@@ -180,7 +180,7 @@ def get_dpm_run_workflow_by_correlation(
     "/rebalance/runs/idempotency/{idempotency_key}/workflow",
     response_model=DpmRunWorkflowResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Workflow State by Idempotency Key",
+    summary="Get lotus-manage Run Workflow State by Idempotency Key",
     description="Returns workflow gate state for run resolved by idempotency key mapping.",
 )
 def get_dpm_run_workflow_by_idempotency(
@@ -202,7 +202,7 @@ def get_dpm_run_workflow_by_idempotency(
     "/rebalance/runs/{rebalance_run_id}/workflow/actions",
     response_model=DpmRunWorkflowResponse,
     status_code=status.HTTP_200_OK,
-    summary="Apply DPM Run Workflow Action",
+    summary="Apply lotus-manage Run Workflow Action",
     description=(
         "Applies one workflow action (`APPROVE`, `REJECT`, `REQUEST_CHANGES`) and returns "
         "updated workflow state."
@@ -211,7 +211,7 @@ def get_dpm_run_workflow_by_idempotency(
 def apply_dpm_run_workflow_action(
     rebalance_run_id: Annotated[
         str,
-        Path(description="DPM run identifier.", examples=["rr_abc12345"]),
+        Path(description="lotus-manage run identifier.", examples=["rr_abc12345"]),
     ],
     payload: DpmRunWorkflowActionRequest,
     service: DpmRunSupportService = shared.Depends(shared.get_dpm_run_support_service),
@@ -247,7 +247,7 @@ def apply_dpm_run_workflow_action(
     "/rebalance/runs/by-correlation/{correlation_id}/workflow/actions",
     response_model=DpmRunWorkflowResponse,
     status_code=status.HTTP_200_OK,
-    summary="Apply DPM Run Workflow Action by Correlation Id",
+    summary="Apply lotus-manage Run Workflow Action by Correlation Id",
     description=(
         "Applies one workflow action for run resolved by correlation id and returns updated "
         "workflow state."
@@ -292,7 +292,7 @@ def apply_dpm_run_workflow_action_by_correlation(
     "/rebalance/runs/idempotency/{idempotency_key}/workflow/actions",
     response_model=DpmRunWorkflowResponse,
     status_code=status.HTTP_200_OK,
-    summary="Apply DPM Run Workflow Action by Idempotency Key",
+    summary="Apply lotus-manage Run Workflow Action by Idempotency Key",
     description=(
         "Applies one workflow action for run resolved by idempotency key mapping and returns "
         "updated workflow state."
@@ -337,7 +337,7 @@ def apply_dpm_run_workflow_action_by_idempotency(
     "/rebalance/runs/{rebalance_run_id}/workflow/history",
     response_model=DpmRunWorkflowHistoryResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Workflow History",
+    summary="Get lotus-manage Run Workflow History",
     description=(
         "Returns append-only workflow decision history for run-level audit and investigation."
     ),
@@ -345,7 +345,7 @@ def apply_dpm_run_workflow_action_by_idempotency(
 def get_dpm_run_workflow_history(
     rebalance_run_id: Annotated[
         str,
-        Path(description="DPM run identifier.", examples=["rr_abc12345"]),
+        Path(description="lotus-manage run identifier.", examples=["rr_abc12345"]),
     ],
     service: DpmRunSupportService = shared.Depends(shared.get_dpm_run_support_service),
 ) -> DpmRunWorkflowHistoryResponse:
@@ -361,7 +361,7 @@ def get_dpm_run_workflow_history(
     "/rebalance/runs/by-correlation/{correlation_id}/workflow/history",
     response_model=DpmRunWorkflowHistoryResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Workflow History by Correlation Id",
+    summary="Get lotus-manage Run Workflow History by Correlation Id",
     description="Returns workflow decision history for run resolved by correlation id.",
 )
 def get_dpm_run_workflow_history_by_correlation(
@@ -383,7 +383,7 @@ def get_dpm_run_workflow_history_by_correlation(
     "/rebalance/runs/idempotency/{idempotency_key}/workflow/history",
     response_model=DpmRunWorkflowHistoryResponse,
     status_code=status.HTTP_200_OK,
-    summary="Get DPM Run Workflow History by Idempotency Key",
+    summary="Get lotus-manage Run Workflow History by Idempotency Key",
     description="Returns workflow decision history for run resolved by idempotency key mapping.",
 )
 def get_dpm_run_workflow_history_by_idempotency(

--- a/src/api/routers/dpm_simulation.py
+++ b/src/api/routers/dpm_simulation.py
@@ -29,7 +29,7 @@ router = APIRouter()
     "/rebalance/simulate",
     response_model=RebalanceResult,
     status_code=status.HTTP_200_OK,
-    tags=["DPM Simulation"],
+    tags=["lotus-manage Simulation"],
     summary="Simulate a Portfolio Rebalance",
     description=(
         "Runs one deterministic rebalance simulation.\\n\\n"
@@ -112,7 +112,7 @@ def simulate_rebalance(
     "/rebalance/analyze",
     response_model=BatchRebalanceResult,
     status_code=status.HTTP_200_OK,
-    tags=["DPM What-If Analysis"],
+    tags=["lotus-manage What-If Analysis"],
     summary="Analyze Multiple Rebalance Scenarios",
     description=(
         "Runs multiple named what-if scenarios using shared snapshots.\\n\\n"
@@ -171,7 +171,7 @@ def analyze_scenarios(
     "/rebalance/analyze/async",
     response_model=DpmAsyncAcceptedResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    tags=["DPM What-If Analysis"],
+    tags=["lotus-manage What-If Analysis"],
     summary="Analyze Multiple Rebalance Scenarios Asynchronously",
     description=(
         "Accepts named what-if scenarios for asynchronous execution.\\n\\n"
@@ -253,10 +253,10 @@ def analyze_scenarios_async(
     "/rebalance/operations/{operation_id}/execute",
     response_model=DpmAsyncOperationStatusResponse,
     status_code=status.HTTP_200_OK,
-    tags=["DPM Run Supportability"],
-    summary="Execute Pending DPM Async Operation",
+    tags=["lotus-manage Run Supportability"],
+    summary="Execute Pending lotus-manage Async Operation",
     description=(
-        "Executes one pending asynchronous DPM analyze operation. "
+        "Executes one pending asynchronous lotus-manage analyze operation. "
         "Intended for orchestrated `ACCEPT_ONLY` mode flows."
     ),
     responses={

--- a/src/api/routers/integration_capabilities.py
+++ b/src/api/routers/integration_capabilities.py
@@ -5,7 +5,7 @@ from typing import Literal
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
-ConsumerSystem = Literal["BFF", "PA", "DPM", "UI", "UNKNOWN"]
+ConsumerSystem = Literal["lotus-gateway", "lotus-performance", "lotus-manage", "UI", "UNKNOWN"]
 
 
 class FeatureCapability(BaseModel):
@@ -49,7 +49,7 @@ def _env_bool(name: str, default: bool) -> bool:
 @router.get("/integration/capabilities", response_model=IntegrationCapabilitiesResponse)
 @router.get("/platform/capabilities", response_model=IntegrationCapabilitiesResponse)
 async def get_integration_capabilities(
-    consumer_system: ConsumerSystem = Query("BFF", alias="consumerSystem"),
+    consumer_system: ConsumerSystem = Query("lotus-gateway", alias="consumerSystem"),
     tenant_id: str = Query("default", alias="tenantId"),
 ) -> IntegrationCapabilitiesResponse:
     lifecycle_enabled = _env_bool("DPM_CAP_PROPOSAL_LIFECYCLE_ENABLED", True)
@@ -72,20 +72,20 @@ async def get_integration_capabilities(
             FeatureCapability(
                 key="dpm.execution.stateful_pas_ref",
                 enabled=True,
-                owner_service="DPM",
-                description="Stateful DPM execution with PAS-referenced data.",
+                owner_service="lotus-manage",
+                description="Stateful lotus-manage execution with lotus-core-referenced data.",
             ),
             FeatureCapability(
                 key="dpm.execution.stateless_inline_bundle",
                 enabled=inline_bundle_enabled,
-                owner_service="DPM",
-                description="Stateless DPM execution using inline request bundles.",
+                owner_service="lotus-manage",
+                description="Stateless lotus-manage execution using inline request bundles.",
             ),
             FeatureCapability(
                 key="dpm.proposals.lifecycle",
                 enabled=lifecycle_enabled,
-                owner_service="DPM",
-                description="DPM lifecycle proposal and supportability workflows.",
+                owner_service="lotus-manage",
+                description="lotus-manage lifecycle proposal and supportability workflows.",
             ),
         ],
         workflows=[

--- a/src/api/services/dpm_simulation_service.py
+++ b/src/api/services/dpm_simulation_service.py
@@ -154,7 +154,7 @@ def simulate_rebalance(
         policy_pack=policy_pack_definition,
     )
     current_logger.debug(
-        "Resolved DPM policy pack for simulate. enabled=%s source=%s policy_pack_id=%s",
+        "Resolved lotus-manage policy pack for simulate. enabled=%s source=%s policy_pack_id=%s",
         policy_pack.enabled,
         policy_pack.source,
         policy_pack.selected_policy_pack_id,
@@ -368,7 +368,7 @@ def submit_and_optionally_execute_async_analysis(
         tenant_id=tenant_id,
     )
     current_logger.debug(
-        "Resolved DPM policy pack for analyze async. enabled=%s source=%s policy_pack_id=%s",
+        "Resolved lotus-manage policy pack for analyze async. enabled=%s source=%s policy_pack_id=%s",
         policy_pack.enabled,
         policy_pack.source,
         policy_pack.selected_policy_pack_id,

--- a/src/core/dpm/__init__.py
+++ b/src/core/dpm/__init__.py
@@ -1,4 +1,4 @@
-"""DPM simulation package."""
+"""lotus-manage simulation package."""
 
 from src.core.dpm.engine import run_simulation
 from src.core.dpm.policy_packs import (

--- a/src/core/dpm/engine.py
+++ b/src/core/dpm/engine.py
@@ -1,4 +1,4 @@
-"""DPM engine orchestration."""
+"""lotus-manage engine orchestration."""
 
 import uuid
 from copy import deepcopy

--- a/src/core/dpm/policy_packs.py
+++ b/src/core/dpm/policy_packs.py
@@ -11,7 +11,7 @@ DpmPolicyPackSource = Literal["DISABLED", "REQUEST", "TENANT_DEFAULT", "GLOBAL_D
 
 class DpmEffectivePolicyPackResolution(BaseModel):
     enabled: bool = Field(
-        description="Whether policy-pack resolution is enabled for DPM request processing.",
+        description="Whether policy-pack resolution is enabled for lotus-manage request processing.",
         examples=[False],
     )
     selected_policy_pack_id: Optional[str] = Field(

--- a/src/core/dpm_engine.py
+++ b/src/core/dpm_engine.py
@@ -1,5 +1,5 @@
 """
-Backward-compatible shim for DPM engine module path.
+Backward-compatible shim for lotus-manage engine module path.
 
 Preferred import:
 `from src.core.dpm.engine import run_simulation`

--- a/src/core/dpm_runs/models.py
+++ b/src/core/dpm_runs/models.py
@@ -14,7 +14,7 @@ DpmLineageEdgeType = Literal["CORRELATION_TO_RUN", "IDEMPOTENCY_TO_RUN", "OPERAT
 
 class DpmRunRecord(BaseModel):
     rebalance_run_id: str = Field(
-        description="Internal DPM run identifier.", examples=["rr_abc12345"]
+        description="Internal lotus-manage run identifier.", examples=["rr_abc12345"]
     )
     correlation_id: str = Field(
         description="Internal correlation identifier.", examples=["corr-1234-abcd"]
@@ -34,7 +34,7 @@ class DpmRunRecord(BaseModel):
         examples=["2026-02-20T12:00:00+00:00"],
     )
     result_json: Dict[str, Any] = Field(
-        description="Serialized DPM simulation result payload.",
+        description="Serialized lotus-manage simulation result payload.",
         examples=[{"rebalance_run_id": "rr_abc12345", "status": "READY"}],
     )
 
@@ -59,7 +59,7 @@ class DpmRunIdempotencyRecord(BaseModel):
 
 
 class DpmRunLookupResponse(BaseModel):
-    rebalance_run_id: str = Field(description="DPM run identifier.", examples=["rr_abc12345"])
+    rebalance_run_id: str = Field(description="lotus-manage run identifier.", examples=["rr_abc12345"])
     correlation_id: str = Field(
         description="Correlation identifier for the run.", examples=["corr-1234-abcd"]
     )
@@ -78,12 +78,12 @@ class DpmRunLookupResponse(BaseModel):
         examples=["2026-02-20T12:00:00+00:00"],
     )
     result: RebalanceResult = Field(
-        description="Full DPM simulation result payload for investigation and audit."
+        description="Full lotus-manage simulation result payload for investigation and audit."
     )
 
 
 class DpmRunListItemResponse(BaseModel):
-    rebalance_run_id: str = Field(description="DPM run identifier.", examples=["rr_abc12345"])
+    rebalance_run_id: str = Field(description="lotus-manage run identifier.", examples=["rr_abc12345"])
     correlation_id: str = Field(
         description="Correlation identifier associated with the run.",
         examples=["corr-1234-abcd"],
@@ -576,7 +576,7 @@ class DpmRunWorkflowDecisionRecord(BaseModel):
         examples=["dwd_001"],
     )
     run_id: str = Field(
-        description="DPM run identifier associated with workflow decision.",
+        description="lotus-manage run identifier associated with workflow decision.",
         examples=["rr_abc12345"],
     )
     action: DpmWorkflowActionType = Field(
@@ -613,7 +613,7 @@ class DpmRunWorkflowDecisionResponse(BaseModel):
         examples=["dwd_001"],
     )
     run_id: str = Field(
-        description="DPM run identifier associated with workflow decision.",
+        description="lotus-manage run identifier associated with workflow decision.",
         examples=["rr_abc12345"],
     )
     action: DpmWorkflowActionType = Field(
@@ -645,7 +645,7 @@ class DpmRunWorkflowDecisionResponse(BaseModel):
 
 class DpmRunWorkflowResponse(BaseModel):
     run_id: str = Field(
-        description="DPM run identifier.",
+        description="lotus-manage run identifier.",
         examples=["rr_abc12345"],
     )
     run_status: str = Field(
@@ -680,7 +680,7 @@ class DpmRunWorkflowResponse(BaseModel):
 
 class DpmRunWorkflowHistoryResponse(BaseModel):
     run_id: str = Field(
-        description="DPM run identifier.",
+        description="lotus-manage run identifier.",
         examples=["rr_abc12345"],
     )
     decisions: list[DpmRunWorkflowDecisionResponse] = Field(
@@ -859,7 +859,7 @@ class DpmRunArtifactResponse(BaseModel):
         description="Artifact schema version for compatibility evolution.",
         examples=["1.0"],
     )
-    rebalance_run_id: str = Field(description="DPM run identifier.", examples=["rr_abc12345"])
+    rebalance_run_id: str = Field(description="lotus-manage run identifier.", examples=["rr_abc12345"])
     correlation_id: str = Field(
         description="Correlation identifier associated with this run.",
         examples=["corr-1234-abcd"],
@@ -902,7 +902,7 @@ class DpmRunArtifactResponse(BaseModel):
         examples=[{"warnings": [], "data_quality": {"price_missing": [], "fx_missing": []}}],
     )
     result: RebalanceResult = Field(
-        description="Full persisted DPM run output used as artifact source of truth.",
+        description="Full persisted lotus-manage run output used as artifact source of truth.",
         examples=[{"rebalance_run_id": "rr_abc12345", "status": "READY"}],
     )
     evidence: DpmRunArtifactEvidence = Field(

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -485,7 +485,7 @@ class EngineOptions(BaseModel):
         default=None,
         description=(
             "Attach BUY intent dependency to a same-currency SELL intent. "
-            "When null, defaults are engine-specific: true for DPM, false for advisory."
+            "When null, defaults are engine-specific: true for lotus-manage, false for advisory."
         ),
         examples=[None, True, False],
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """
 FILE: tests/conftest.py
-Shared fixtures for DPM/advisory tests.
+Shared fixtures for lotus-manage/advisory tests.
 """
 
 import os
@@ -27,7 +27,11 @@ def _has_marker(item: pytest.Item, name: str) -> bool:
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     for item in items:
-        if _has_marker(item, "unit") or _has_marker(item, "integration") or _has_marker(item, "e2e"):
+        if (
+            _has_marker(item, "unit")
+            or _has_marker(item, "integration")
+            or _has_marker(item, "e2e")
+        ):
             continue
         path = Path(str(item.fspath)).as_posix().lower()
         if "/tests/integration/" in path or "_integration.py" in path:
@@ -94,9 +98,13 @@ def postgres_runtime_test_harness(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("DPM_SUPPORTABILITY_STORE_BACKEND", "POSTGRES")
     monkeypatch.setenv("PROPOSAL_STORE_BACKEND", "POSTGRES")
     monkeypatch.setenv("DPM_POLICY_PACK_CATALOG_BACKEND", "POSTGRES")
-    monkeypatch.setenv("DPM_SUPPORTABILITY_POSTGRES_DSN", "postgresql://test:test@localhost:5432/dpm")
+    monkeypatch.setenv(
+        "DPM_SUPPORTABILITY_POSTGRES_DSN", "postgresql://test:test@localhost:5432/dpm"
+    )
     monkeypatch.setenv("PROPOSAL_POSTGRES_DSN", "postgresql://test:test@localhost:5432/proposals")
-    monkeypatch.setenv("DPM_POLICY_PACK_POSTGRES_DSN", "postgresql://test:test@localhost:5432/policy")
+    monkeypatch.setenv(
+        "DPM_POLICY_PACK_POSTGRES_DSN", "postgresql://test:test@localhost:5432/policy"
+    )
 
     policy_repo = _TestPolicyPackRepository()
 

--- a/tests/e2e/demo/test_demo_scenarios.py
+++ b/tests/e2e/demo/test_demo_scenarios.py
@@ -431,7 +431,9 @@ def test_demo_dpm_workflow_decision_listing_via_api(monkeypatch):
                     "actor_id": "e2e_reviewer",
                 },
             )
-            decision_list = client.get("/api/v1/rebalance/workflow/decisions?action=APPROVE&limit=10")
+            decision_list = client.get(
+                "/api/v1/rebalance/workflow/decisions?action=APPROVE&limit=10"
+            )
         finally:
             app.dependency_overrides = original_overrides
 
@@ -643,5 +645,3 @@ def test_demo_supportability_feature_flag_guard_matrix(
 
     assert response.status_code == 404
     assert response.json()["detail"] == expected_detail
-
-

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -13,6 +13,3 @@ def test_versioned_proposals_surface_exists() -> None:
     client = TestClient(app)
     response = client.get("/api/v1/rebalance/proposals")
     assert response.status_code in {200, 400, 422, 503}
-
-
-

--- a/tests/integration/dpm/api/test_dpm_api_workflow_integration.py
+++ b/tests/integration/dpm/api/test_dpm_api_workflow_integration.py
@@ -119,7 +119,9 @@ def test_support_bundle_lookup_variants_roundtrip() -> None:
     }
 
     with TestClient(app) as client:
-        simulate = client.post("/api/v1/rebalance/simulate", json=valid_api_payload(), headers=headers)
+        simulate = client.post(
+            "/api/v1/rebalance/simulate", json=valid_api_payload(), headers=headers
+        )
         assert simulate.status_code == 200
         run_id = simulate.json()["rebalance_run_id"]
 
@@ -134,7 +136,9 @@ def test_support_bundle_lookup_variants_roundtrip() -> None:
         by_idempotency = client.get(
             "/api/v1/rebalance/runs/idempotency/integration-dpm-bundle-1/support-bundle"
         )
-        by_operation = client.get(f"/api/v1/rebalance/runs/by-operation/{operation_id}/support-bundle")
+        by_operation = client.get(
+            f"/api/v1/rebalance/runs/by-operation/{operation_id}/support-bundle"
+        )
 
     assert by_run.status_code == 200
     assert by_correlation.status_code == 200
@@ -218,7 +222,7 @@ def test_health_endpoints_integration_contract() -> None:
 
 def test_integration_capabilities_contract_default_consumer() -> None:
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=BFF&tenantId=default")
+        response = client.get("/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default")
 
     assert response.status_code == 200
     body = response.json()
@@ -288,7 +292,12 @@ def test_workflow_actions_and_decision_list_roundtrip(monkeypatch: pytest.Monkey
 @pytest.mark.parametrize(
     ("env_name", "env_value", "path", "expected_detail"),
     [
-        ("DPM_SUPPORT_APIS_ENABLED", "false", "/api/v1/rebalance/runs", "DPM_SUPPORT_APIS_DISABLED"),
+        (
+            "DPM_SUPPORT_APIS_ENABLED",
+            "false",
+            "/api/v1/rebalance/runs",
+            "DPM_SUPPORT_APIS_DISABLED",
+        ),
         (
             "DPM_ASYNC_OPERATIONS_ENABLED",
             "false",
@@ -325,7 +334,12 @@ def test_workflow_actions_and_decision_list_roundtrip(monkeypatch: pytest.Monkey
             "/api/v1/rebalance/lineage/corr_missing",
             "DPM_LINEAGE_APIS_DISABLED",
         ),
-        ("DPM_WORKFLOW_ENABLED", "false", "/api/v1/rebalance/workflow/decisions", "DPM_WORKFLOW_DISABLED"),
+        (
+            "DPM_WORKFLOW_ENABLED",
+            "false",
+            "/api/v1/rebalance/workflow/decisions",
+            "DPM_WORKFLOW_DISABLED",
+        ),
     ],
 )
 def test_supportability_feature_flag_guards(
@@ -411,7 +425,10 @@ def test_workflow_lookup_not_found_matrix(
     ("path", "expected_detail"),
     [
         ("/api/v1/rebalance/workflow/decisions", "DPM_WORKFLOW_DISABLED"),
-        ("/api/v1/rebalance/workflow/decisions/by-correlation/corr_missing", "DPM_WORKFLOW_DISABLED"),
+        (
+            "/api/v1/rebalance/workflow/decisions/by-correlation/corr_missing",
+            "DPM_WORKFLOW_DISABLED",
+        ),
         ("/api/v1/rebalance/runs/rr_missing/workflow", "DPM_WORKFLOW_DISABLED"),
         ("/api/v1/rebalance/runs/by-correlation/corr_missing/workflow", "DPM_WORKFLOW_DISABLED"),
         ("/api/v1/rebalance/runs/idempotency/idem_missing/workflow", "DPM_WORKFLOW_DISABLED"),
@@ -491,5 +508,3 @@ def test_workflow_action_feature_flag_guard_matrix(
 
     assert response.status_code == 404
     assert response.json()["detail"] == "DPM_WORKFLOW_DISABLED"
-
-

--- a/tests/integration/dpm/supportability/test_dpm_policy_pack_postgres_repository_integration.py
+++ b/tests/integration/dpm/supportability/test_dpm_policy_pack_postgres_repository_integration.py
@@ -126,5 +126,3 @@ def _reset_tables(repository: PostgresDpmPolicyPackRepository) -> None:
     with closing(repository._connect()) as connection:  # noqa: SLF001
         connection.execute("DELETE FROM dpm_policy_packs")
         connection.commit()
-
-

--- a/tests/integration/dpm/supportability/test_dpm_postgres_repository_integration.py
+++ b/tests/integration/dpm/supportability/test_dpm_postgres_repository_integration.py
@@ -665,5 +665,3 @@ def _reset_tables(repository: PostgresDpmRunRepository) -> None:
             "dpm_run_artifacts, dpm_async_operations, dpm_runs CASCADE"
         )
         connection.commit()
-
-

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -17,5 +17,3 @@ def test_integration_capabilities_contract() -> None:
     assert body["sourceService"] == SERVICE_NAME
     assert isinstance(body["features"], list)
     assert isinstance(body["workflows"], list)
-
-

--- a/tests/shared/assertions.py
+++ b/tests/shared/assertions.py
@@ -19,5 +19,3 @@ def security_intents(result):
 
 def fx_intents(result):
     return [i for i in result.intents if isinstance(i, FxSpotIntent)]
-
-

--- a/tests/shared/factories.py
+++ b/tests/shared/factories.py
@@ -93,5 +93,3 @@ def valid_api_payload() -> dict:
         "shelf_entries": [{"instrument_id": "EQ_1", "status": "APPROVED"}],
         "options": {},
     }
-
-

--- a/tests/unit/dpm/api/test_api_rebalance.py
+++ b/tests/unit/dpm/api/test_api_rebalance.py
@@ -156,7 +156,9 @@ def test_dpm_support_apis_lookup_by_run_correlation_and_idempotency(client):
     assert by_correlation.status_code == 200
     assert by_correlation.json()["rebalance_run_id"] == body["rebalance_run_id"]
 
-    by_request_hash = client.get(f"/api/v1/rebalance/runs/by-request-hash/{run_body['request_hash']}")
+    by_request_hash = client.get(
+        f"/api/v1/rebalance/runs/by-request-hash/{run_body['request_hash']}"
+    )
     assert by_request_hash.status_code == 200
     assert by_request_hash.json()["rebalance_run_id"] == body["rebalance_run_id"]
 
@@ -257,7 +259,9 @@ def test_dpm_support_runs_list_filters_and_cursor(client):
     assert first_lookup.status_code == 200
     first_request_hash = first_lookup.json()["request_hash"]
 
-    request_hash_rows = client.get(f"/api/v1/rebalance/runs?request_hash={first_request_hash}&limit=10")
+    request_hash_rows = client.get(
+        f"/api/v1/rebalance/runs?request_hash={first_request_hash}&limit=10"
+    )
     assert request_hash_rows.status_code == 200
     request_hash_body = request_hash_rows.json()
     assert len(request_hash_body["items"]) == 1
@@ -510,7 +514,9 @@ def test_dpm_async_operation_lookup_by_id_and_correlation(client):
     assert by_operation_body["result"] is None
     assert by_operation_body["error"] is None
 
-    by_correlation = client.get("/api/v1/rebalance/operations/by-correlation/corr-dpm-async-support-1")
+    by_correlation = client.get(
+        "/api/v1/rebalance/operations/by-correlation/corr-dpm-async-support-1"
+    )
     assert by_correlation.status_code == 200
     assert by_correlation.json()["operation_id"] == accepted.operation_id
 
@@ -533,7 +539,9 @@ def test_dpm_async_operation_list_filters_and_cursor(client):
     assert any(item["operation_id"] == two.operation_id for item in pending_body["items"])
     assert all(item["status"] == "PENDING" for item in pending_body["items"])
 
-    by_correlation = client.get("/api/v1/rebalance/operations?correlation_id=corr-dpm-ops-list-1&limit=10")
+    by_correlation = client.get(
+        "/api/v1/rebalance/operations?correlation_id=corr-dpm-ops-list-1&limit=10"
+    )
     assert by_correlation.status_code == 200
     correlation_body = by_correlation.json()
     assert len(correlation_body["items"]) == 1
@@ -545,7 +553,9 @@ def test_dpm_async_operation_list_filters_and_cursor(client):
     page_one_body = page_one.json()
     assert len(page_one_body["items"]) == 1
     assert page_one_body["next_cursor"] is not None
-    page_two = client.get(f"/api/v1/rebalance/operations?limit=1&cursor={page_one_body['next_cursor']}")
+    page_two = client.get(
+        f"/api/v1/rebalance/operations?limit=1&cursor={page_one_body['next_cursor']}"
+    )
     assert page_two.status_code == 200
     page_two_body = page_two.json()
     assert len(page_two_body["items"]) == 1
@@ -566,7 +576,9 @@ def test_dpm_async_operation_ttl_expiry_by_id_and_correlation(client, monkeypatc
     assert by_operation.status_code == 404
     assert by_operation.json()["detail"] == "DPM_ASYNC_OPERATION_NOT_FOUND"
 
-    by_correlation = client.get("/api/v1/rebalance/operations/by-correlation/corr-dpm-async-ttl-expired")
+    by_correlation = client.get(
+        "/api/v1/rebalance/operations/by-correlation/corr-dpm-async-ttl-expired"
+    )
     assert by_correlation.status_code == 404
     assert by_correlation.json()["detail"] == "DPM_ASYNC_OPERATION_NOT_FOUND"
 
@@ -734,7 +746,9 @@ def test_dpm_run_support_bundle_endpoint_by_correlation_and_idempotency(client):
     assert missing_by_correlation.status_code == 404
     assert missing_by_correlation.json()["detail"] == "DPM_RUN_NOT_FOUND"
 
-    missing_by_idempotency = client.get("/api/v1/rebalance/runs/idempotency/idem_missing/support-bundle")
+    missing_by_idempotency = client.get(
+        "/api/v1/rebalance/runs/idempotency/idem_missing/support-bundle"
+    )
     assert missing_by_idempotency.status_code == 404
     assert missing_by_idempotency.json()["detail"] == "DPM_IDEMPOTENCY_KEY_NOT_FOUND"
 
@@ -820,7 +834,9 @@ def test_dpm_workflow_router_not_found_mappings(client, monkeypatch):
     assert decisions_by_correlation.status_code == 404
     assert decisions_by_correlation.json()["detail"] == "DPM_RUN_NOT_FOUND"
 
-    history_by_idempotency = client.get("/api/v1/rebalance/runs/idempotency/idem_missing/workflow/history")
+    history_by_idempotency = client.get(
+        "/api/v1/rebalance/runs/idempotency/idem_missing/workflow/history"
+    )
     assert history_by_idempotency.status_code == 404
     assert history_by_idempotency.json()["detail"] == "DPM_IDEMPOTENCY_KEY_NOT_FOUND"
 
@@ -1281,7 +1297,9 @@ def test_dpm_policy_pack_catalog_overrides_turnover_option(client, monkeypatch):
 
 
 def test_effective_policy_pack_endpoint_resolution_precedence(client, monkeypatch):
-    disabled = client.get("/api/v1/rebalance/policies/effective", headers={"X-Policy-Pack-Id": "req_pack"})
+    disabled = client.get(
+        "/api/v1/rebalance/policies/effective", headers={"X-Policy-Pack-Id": "req_pack"}
+    )
     assert disabled.status_code == 200
     assert disabled.json() == {
         "enabled": False,
@@ -1544,7 +1562,9 @@ def test_analyze_async_accept_only_mode_keeps_operation_pending(client, monkeypa
     assert operation_body["result"] is None
     assert operation_body["error"] is None
 
-    by_correlation = client.get("/api/v1/rebalance/operations/by-correlation/corr-batch-async-accept-only")
+    by_correlation = client.get(
+        "/api/v1/rebalance/operations/by-correlation/corr-batch-async-accept-only"
+    )
     assert by_correlation.status_code == 200
     assert by_correlation.json()["operation_id"] == operation_id
     assert by_correlation.json()["status"] == "PENDING"
@@ -1643,20 +1663,22 @@ def test_openapi_title_and_tag_grouping(client):
     assert openapi["info"]["title"] == "Private Banking Rebalance API"
 
     tags = {tag["name"] for tag in openapi.get("tags", [])}
-    assert "DPM Simulation" in tags
-    assert "DPM What-If Analysis" in tags
-    assert "DPM Run Supportability" in tags
+    assert "lotus-manage Simulation" in tags
+    assert "lotus-manage What-If Analysis" in tags
+    assert "lotus-manage Run Supportability" in tags
     assert "Advisory Simulation" in tags
     assert "Advisory Proposal Lifecycle" in tags
 
-    assert openapi["paths"]["/api/v1/rebalance/simulate"]["post"]["tags"] == ["DPM Simulation"]
-    assert openapi["paths"]["/api/v1/rebalance/analyze"]["post"]["tags"] == ["DPM What-If Analysis"]
-    assert openapi["paths"]["/api/v1/rebalance/analyze/async"]["post"]["tags"] == ["DPM What-If Analysis"]
+    assert openapi["paths"]["/api/v1/rebalance/simulate"]["post"]["tags"] == ["lotus-manage Simulation"]
+    assert openapi["paths"]["/api/v1/rebalance/analyze"]["post"]["tags"] == ["lotus-manage What-If Analysis"]
+    assert openapi["paths"]["/api/v1/rebalance/analyze/async"]["post"]["tags"] == [
+        "lotus-manage What-If Analysis"
+    ]
     assert openapi["paths"]["/api/v1/rebalance/policies/effective"]["get"]["tags"] == [
-        "DPM Run Supportability"
+        "lotus-manage Run Supportability"
     ]
     assert openapi["paths"]["/api/v1/rebalance/policies/catalog"]["get"]["tags"] == [
-        "DPM Run Supportability"
+        "lotus-manage Run Supportability"
     ]
     assert openapi["paths"]["/api/v1/rebalance/proposals/simulate"]["post"]["tags"] == [
         "Advisory Simulation"
@@ -2090,10 +2112,14 @@ def test_dpm_run_workflow_endpoints_happy_path_and_invalid_transition(client, mo
     assert workflow_body["requires_review"] is True
     assert workflow_body["latest_decision"] is None
 
-    workflow_by_correlation = client.get("/api/v1/rebalance/runs/by-correlation/corr-workflow-1/workflow")
+    workflow_by_correlation = client.get(
+        "/api/v1/rebalance/runs/by-correlation/corr-workflow-1/workflow"
+    )
     assert workflow_by_correlation.status_code == 200
     assert workflow_by_correlation.json()["run_id"] == run_id
-    workflow_by_idempotency = client.get("/api/v1/rebalance/runs/idempotency/test-key-workflow-1/workflow")
+    workflow_by_idempotency = client.get(
+        "/api/v1/rebalance/runs/idempotency/test-key-workflow-1/workflow"
+    )
     assert workflow_by_idempotency.status_code == 200
     assert workflow_by_idempotency.json()["run_id"] == run_id
 
@@ -2320,7 +2346,9 @@ def test_dpm_run_workflow_endpoints_disabled_and_not_required_behavior(client, m
     assert not_required.status_code == 409
     assert not_required.json()["detail"] == "DPM_WORKFLOW_NOT_REQUIRED_FOR_RUN_STATUS"
 
-    missing_by_correlation = client.get("/api/v1/rebalance/runs/by-correlation/corr-missing/workflow")
+    missing_by_correlation = client.get(
+        "/api/v1/rebalance/runs/by-correlation/corr-missing/workflow"
+    )
     assert missing_by_correlation.status_code == 404
     assert missing_by_correlation.json()["detail"] == "DPM_RUN_NOT_FOUND"
     missing_by_idempotency = client.get("/api/v1/rebalance/runs/idempotency/idem-missing/workflow")
@@ -2354,5 +2382,3 @@ def test_dpm_run_workflow_endpoints_disabled_and_not_required_behavior(client, m
     workflow_decision_list_disabled = client.get("/api/v1/rebalance/workflow/decisions?limit=10")
     assert workflow_decision_list_disabled.status_code == 404
     assert workflow_decision_list_disabled.json()["detail"] == "DPM_WORKFLOW_DISABLED"
-
-

--- a/tests/unit/dpm/api/test_dpm_lineage_filters.py
+++ b/tests/unit/dpm/api/test_dpm_lineage_filters.py
@@ -62,5 +62,3 @@ def test_lineage_api_supports_filters_and_pagination(monkeypatch):
         )
         assert second_page.status_code == 200
         assert len(second_page.json()["edges"]) == 1
-
-

--- a/tests/unit/dpm/api/test_dpm_policy_pack_admin_api.py
+++ b/tests/unit/dpm/api/test_dpm_policy_pack_admin_api.py
@@ -81,5 +81,3 @@ def test_postgres_connection_exception_types_handles_missing_psycopg(monkeypatch
     monkeypatch.setattr(builtins, "__import__", _import)
     exception_types = _postgres_connection_exception_types()
     assert ConnectionError in exception_types
-
-

--- a/tests/unit/dpm/api/test_dpm_policy_pack_config.py
+++ b/tests/unit/dpm/api/test_dpm_policy_pack_config.py
@@ -82,5 +82,3 @@ def test_policy_pack_catalog_postgres_runtime_errors_return_503(monkeypatch):
         response = client.get("/api/v1/rebalance/policies/catalog")
         assert response.status_code == 503
         assert response.json()["detail"] == "DPM_POLICY_PACK_POSTGRES_CONNECTION_FAILED"
-
-

--- a/tests/unit/dpm/api/test_dpm_runs_config.py
+++ b/tests/unit/dpm/api/test_dpm_runs_config.py
@@ -129,5 +129,3 @@ def test_postgres_connection_exception_types_handles_missing_driver(monkeypatch)
     monkeypatch.setattr(builtins, "__import__", _import_with_psycopg_missing)
     exception_types = dpm_runs_config._postgres_connection_exception_types()
     assert ValueError in exception_types
-
-

--- a/tests/unit/dpm/api/test_integration_capabilities_api.py
+++ b/tests/unit/dpm/api/test_integration_capabilities_api.py
@@ -5,13 +5,13 @@ from src.api.main import app
 
 def test_integration_capabilities_default_contract():
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=BFF&tenantId=default")
+        response = client.get("/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default")
 
     assert response.status_code == 200
     body = response.json()
     assert body["contractVersion"] == "v1"
     assert body["sourceService"] == "lotus-manage"
-    assert body["consumerSystem"] == "BFF"
+    assert body["consumerSystem"] == "lotus-gateway"
     assert body["tenantId"] == "default"
     assert "features" in body
     assert "workflows" in body
@@ -27,15 +27,13 @@ def test_integration_capabilities_env_overrides(monkeypatch):
     monkeypatch.setenv("DPM_POLICY_VERSION", "tenant-x-v2")
 
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=PA&tenantId=tenant-x")
+        response = client.get("/integration/capabilities?consumerSystem=lotus-performance&tenantId=tenant-x")
 
     assert response.status_code == 200
     body = response.json()
-    assert body["consumerSystem"] == "PA"
+    assert body["consumerSystem"] == "lotus-performance"
     assert body["tenantId"] == "tenant-x"
     assert body["policyVersion"] == "tenant-x-v2"
     features = {item["key"]: item["enabled"] for item in body["features"]}
     assert features["dpm.proposals.lifecycle"] is False
     assert body["supportedInputModes"] == ["pas_ref"]
-
-

--- a/tests/unit/dpm/api/test_observability_api.py
+++ b/tests/unit/dpm/api/test_observability_api.py
@@ -22,7 +22,7 @@ def test_health_endpoints_available():
 def test_correlation_headers_are_exposed():
     client = TestClient(app)
     response = client.get(
-        "/integration/capabilities?consumerSystem=BFF&tenantId=default",
+        "/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default",
         headers={"X-Correlation-Id": "corr_dpm_1"},
     )
     assert response.status_code == 200
@@ -42,7 +42,7 @@ def test_traceparent_header_propagates_trace_id():
     client = TestClient(app)
     upstream_trace_id = "1234567890abcdef1234567890abcdef"
     response = client.get(
-        "/integration/capabilities?consumerSystem=BFF&tenantId=default",
+        "/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default",
         headers={"traceparent": f"00-{upstream_trace_id}-0000000000000001-01"},
     )
     assert response.status_code == 200
@@ -60,5 +60,3 @@ def test_load_concurrency_health_live_requests():
         statuses = list(pool.map(lambda _: _call_live(), range(32)))
 
     assert all(status == 200 for status in statuses)
-
-

--- a/tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py
+++ b/tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py
@@ -293,13 +293,17 @@ def test_dpm_async_and_supportability_endpoints_use_expected_request_response_co
     assert "X-Tenant-Policy-Pack-Id" in policy_catalog_params
     assert "X-Tenant-Id" in policy_catalog_params
 
-    policy_catalog_get_one = openapi["paths"]["/api/v1/rebalance/policies/catalog/{policy_pack_id}"]["get"]
+    policy_catalog_get_one = openapi["paths"][
+        "/api/v1/rebalance/policies/catalog/{policy_pack_id}"
+    ]["get"]
     assert "requestBody" not in policy_catalog_get_one
     assert policy_catalog_get_one["responses"]["200"]["content"]["application/json"]["schema"][
         "$ref"
     ].endswith("/DpmPolicyPackDefinition")
 
-    policy_catalog_upsert = openapi["paths"]["/api/v1/rebalance/policies/catalog/{policy_pack_id}"]["put"]
+    policy_catalog_upsert = openapi["paths"]["/api/v1/rebalance/policies/catalog/{policy_pack_id}"][
+        "put"
+    ]
     assert policy_catalog_upsert["requestBody"]["content"]["application/json"]["schema"][
         "$ref"
     ].endswith("/DpmPolicyPackUpsertRequest")
@@ -358,7 +362,9 @@ def test_dpm_async_and_supportability_endpoints_use_expected_request_response_co
     actual_params = {param["name"] for param in list_runs["parameters"]}
     assert expected_params.issubset(actual_params)
 
-    run_by_request_hash = openapi["paths"]["/api/v1/rebalance/runs/by-request-hash/{request_hash}"]["get"]
+    run_by_request_hash = openapi["paths"]["/api/v1/rebalance/runs/by-request-hash/{request_hash}"][
+        "get"
+    ]
     assert run_by_request_hash["responses"]["200"]["content"]["application/json"]["schema"][
         "$ref"
     ].endswith("/DpmRunLookupResponse")
@@ -368,7 +374,9 @@ def test_dpm_async_and_supportability_endpoints_use_expected_request_response_co
         "$ref"
     ].endswith("/DpmSupportabilitySummaryResponse")
 
-    support_bundle = openapi["paths"]["/api/v1/rebalance/runs/{rebalance_run_id}/support-bundle"]["get"]
+    support_bundle = openapi["paths"]["/api/v1/rebalance/runs/{rebalance_run_id}/support-bundle"][
+        "get"
+    ]
     assert support_bundle["responses"]["200"]["content"]["application/json"]["schema"][
         "$ref"
     ].endswith("/DpmRunSupportBundleResponse")
@@ -457,9 +465,9 @@ def test_dpm_async_and_supportability_endpoints_use_expected_request_response_co
         "/DpmLineageResponse"
     )
 
-    idempotency_history = openapi["paths"]["/api/v1/rebalance/idempotency/{idempotency_key}/history"][
-        "get"
-    ]
+    idempotency_history = openapi["paths"][
+        "/api/v1/rebalance/idempotency/{idempotency_key}/history"
+    ]["get"]
     assert idempotency_history["responses"]["200"]["content"]["application/json"]["schema"][
         "$ref"
     ].endswith("/DpmRunIdempotencyHistoryResponse")
@@ -483,9 +491,9 @@ def test_dpm_async_and_supportability_endpoints_use_expected_request_response_co
         "$ref"
     ].endswith("/DpmRunWorkflowResponse")
 
-    workflow_actions = openapi["paths"]["/api/v1/rebalance/runs/{rebalance_run_id}/workflow/actions"][
-        "post"
-    ]
+    workflow_actions = openapi["paths"][
+        "/api/v1/rebalance/runs/{rebalance_run_id}/workflow/actions"
+    ]["post"]
     workflow_action_request_ref = workflow_actions["requestBody"]["content"]["application/json"][
         "schema"
     ]["$ref"]
@@ -514,9 +522,9 @@ def test_dpm_async_and_supportability_endpoints_use_expected_request_response_co
         "schema"
     ]["$ref"].endswith("/DpmRunWorkflowResponse")
 
-    workflow_history = openapi["paths"]["/api/v1/rebalance/runs/{rebalance_run_id}/workflow/history"][
-        "get"
-    ]
+    workflow_history = openapi["paths"][
+        "/api/v1/rebalance/runs/{rebalance_run_id}/workflow/history"
+    ]["get"]
     assert workflow_history["responses"]["200"]["content"]["application/json"]["schema"][
         "$ref"
     ].endswith("/DpmRunWorkflowHistoryResponse")
@@ -534,5 +542,3 @@ def test_dpm_async_and_supportability_endpoints_use_expected_request_response_co
     assert workflow_history_by_idempotency["responses"]["200"]["content"]["application/json"][
         "schema"
     ]["$ref"].endswith("/DpmRunWorkflowHistoryResponse")
-
-

--- a/tests/unit/dpm/engine/conftest.py
+++ b/tests/unit/dpm/engine/conftest.py
@@ -33,5 +33,3 @@ def base_context():
         shelf_entry("SELL_ONLY_ASSET", status="SELL_ONLY", asset_class="EQUITY"),
     ]
     return pf, mkt, shelf
-
-

--- a/tests/unit/dpm/engine/coverage/conftest.py
+++ b/tests/unit/dpm/engine/coverage/conftest.py
@@ -34,5 +34,3 @@ def base_inputs():
     ]
     model = model_portfolio(targets=[target("TARGET_ASSET", "0.5")])
     return pf, mkt, model, shelf
-
-

--- a/tests/unit/dpm/engine/coverage/helpers.py
+++ b/tests/unit/dpm/engine/coverage/helpers.py
@@ -12,5 +12,3 @@ def usd_cash_portfolio(portfolio_id: str, amount: str = "1000"):
 
 def empty_diagnostics() -> DiagnosticsData:
     return DiagnosticsData(data_quality={}, suppressed_intents=[], warnings=[])
-
-

--- a/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
@@ -193,5 +193,3 @@ class TestIntentDependenciesAndSimulation:
         )
 
         assert diagnostics.cash_ladder_breaches == []
-
-

--- a/tests/unit/dpm/engine/coverage/test_engine_status_blocking.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_status_blocking.py
@@ -41,5 +41,3 @@ class TestFinalStatusAndBlocking:
         )
 
         assert_status(result, "PENDING_REVIEW")
-
-

--- a/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
@@ -172,5 +172,3 @@ class TestTargetGeneration:
 
         assert status == "READY"
         assert trace[0].instrument_id == "A"
-
-

--- a/tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py
@@ -337,5 +337,3 @@ def test_settlement_ladder_records_fx_cash_flows():
     assert_status(result, "READY")
     ladder_ccys = {p.currency for p in result.diagnostics.cash_ladder}
     assert {"SGD", "USD", "EUR"}.issubset(ladder_ccys)
-
-

--- a/tests/unit/dpm/engine/coverage/test_engine_universe_data_quality.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_universe_data_quality.py
@@ -78,5 +78,3 @@ class TestUniverseAndDataQuality:
         build_simulated_state(pf, mkt, shelf, dq, warns)
 
         assert "KRW/USD" in dq.get("fx_missing", [])
-
-

--- a/tests/unit/dpm/engine/test_engine_core_flows.py
+++ b/tests/unit/dpm/engine/test_engine_core_flows.py
@@ -129,5 +129,3 @@ def test_dust_suppression(base_context):
     assert len(result.intents) == 0
     assert len(result.diagnostics.suppressed_intents) == 1
     assert result.diagnostics.suppressed_intents[0].instrument_id == "AAPL"
-
-

--- a/tests/unit/dpm/engine/test_engine_edge_cases.py
+++ b/tests/unit/dpm/engine/test_engine_edge_cases.py
@@ -95,5 +95,3 @@ def test_allow_restricted_true_allows_restricted_target_trading():
 
     assert any(i.intent_type == "SECURITY_TRADE" and i.side == "BUY" for i in result.intents)
     assert find_excluded(result, "RESTRICTED_EQ") is None
-
-

--- a/tests/unit/dpm/engine/test_engine_module_shim.py
+++ b/tests/unit/dpm/engine/test_engine_module_shim.py
@@ -6,5 +6,3 @@ import src.core.engine as engine
 def test_engine_shim_exports_expected_entrypoints():
     assert engine.run_simulation is dpm_engine.run_simulation
     assert engine.run_proposal_simulation is advisory_engine.run_proposal_simulation
-
-

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -77,5 +77,3 @@ def test_reconciliation_object_populated_on_success(base_options):
     assert result.reconciliation is not None
     assert result.reconciliation.status == "OK"
     assert abs(result.reconciliation.delta.amount) < Decimal("1.0")
-
-

--- a/tests/unit/dpm/engine/test_engine_settlement_awareness.py
+++ b/tests/unit/dpm/engine/test_engine_settlement_awareness.py
@@ -94,5 +94,3 @@ def test_settlement_awareness_allows_configured_overdraft():
     assert result.diagnostics.cash_ladder
     assert result.diagnostics.cash_ladder_breaches == []
     assert "SETTLEMENT_OVERDRAFT_UTILIZED" in result.diagnostics.warnings
-
-

--- a/tests/unit/dpm/engine/test_engine_shelf_status_matrix.py
+++ b/tests/unit/dpm/engine/test_engine_shelf_status_matrix.py
@@ -65,5 +65,3 @@ def test_held_position_lock_reason_matrix(status, expected_reason):
     excluded = find_excluded(result, "HELD_X")
     assert excluded is not None
     assert expected_reason in excluded.reason_code
-
-

--- a/tests/unit/dpm/engine/test_engine_simulation_shared.py
+++ b/tests/unit/dpm/engine/test_engine_simulation_shared.py
@@ -181,5 +181,3 @@ def test_apply_fx_spot_to_portfolio_ignores_non_fx_intent():
     apply_fx_spot_to_portfolio(portfolio, intent)
 
     assert portfolio.cash_balances[0].amount == Decimal("1000")
-
-

--- a/tests/unit/dpm/engine/test_engine_solver_behavior.py
+++ b/tests/unit/dpm/engine/test_engine_solver_behavior.py
@@ -457,5 +457,3 @@ def test_solver_failure_reason_classification():
     assert _solver_failure_reason("infeasible_inaccurate") == "INFEASIBLE_INFEASIBLE_INACCURATE"
     assert _solver_failure_reason("unbounded") == "UNBOUNDED_UNBOUNDED"
     assert _solver_failure_reason("optimal") == "SOLVER_NON_OPTIMAL_OPTIMAL"
-
-

--- a/tests/unit/dpm/engine/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/test_engine_target_generation.py
@@ -193,5 +193,3 @@ def test_solver_target_gen_blocks_on_infeasible_constraints():
     assert status == "BLOCKED"
     assert trace == []
     assert any(w.startswith("INFEASIBLE_") for w in diag.warnings)
-
-

--- a/tests/unit/dpm/engine/test_engine_tax_awareness.py
+++ b/tests/unit/dpm/engine/test_engine_tax_awareness.py
@@ -104,5 +104,3 @@ def test_tax_awareness_budget_caps_sell_quantity_with_diagnostics():
     assert result.tax_impact is not None
     assert result.tax_impact.budget_used is not None
     assert result.tax_impact.budget_used.amount == Decimal("100")
-
-

--- a/tests/unit/dpm/engine/test_engine_turnover_control.py
+++ b/tests/unit/dpm/engine/test_engine_turnover_control.py
@@ -101,5 +101,3 @@ def test_turnover_cap_tie_break_is_instrument_id_ascending():
 
     assert [i.instrument_id for i in security_intents(result)] == ["A", "C"]
     assert [d.instrument_id for d in result.diagnostics.dropped_intents] == ["B"]
-
-

--- a/tests/unit/dpm/engine/test_engine_valuation_service.py
+++ b/tests/unit/dpm/engine/test_engine_valuation_service.py
@@ -99,5 +99,3 @@ def test_valuation_handles_missing_attributes():
 
     assert state.total_value.amount == Decimal("10")
     assert state.allocation_by_attribute == {}
-
-

--- a/tests/unit/dpm/engine/test_engine_workflow_gates.py
+++ b/tests/unit/dpm/engine/test_engine_workflow_gates.py
@@ -84,5 +84,3 @@ def test_workflow_gate_execution_ready_when_client_consent_already_obtained():
     )
     assert gate.gate == "EXECUTION_READY"
     assert gate.recommended_next_step == "EXECUTE"
-
-

--- a/tests/unit/dpm/engine/test_engine_wrapper_helpers.py
+++ b/tests/unit/dpm/engine/test_engine_wrapper_helpers.py
@@ -42,5 +42,3 @@ def test_build_settlement_ladder_wrapper_delegates(monkeypatch):
     )
     result = dpm_engine._build_settlement_ladder("pf", "shelf", "intents", "options", "diag")
     assert result["ok"][0] == "pf"
-
-

--- a/tests/unit/dpm/engine/test_policy_pack_resolution.py
+++ b/tests/unit/dpm/engine/test_policy_pack_resolution.py
@@ -294,5 +294,3 @@ def test_policy_pack_apply_no_override_returns_original():
     assert selected is not None
     effective_options = apply_policy_pack_to_engine_options(options=options, policy_pack=selected)
     assert effective_options.max_turnover_pct == Decimal("0.15")
-
-

--- a/tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py
+++ b/tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py
@@ -33,5 +33,3 @@ def test_build_resolver_enabled_uses_normalized_tenant_ids():
     assert resolver.resolve(tenant_id="tenant_1") == "pack_1"
     assert resolver.resolve(tenant_id=" tenant_2 ") == "pack_2"
     assert resolver.resolve(tenant_id="missing") is None
-
-

--- a/tests/unit/dpm/golden/test_golden_batch_analysis.py
+++ b/tests/unit/dpm/golden/test_golden_batch_analysis.py
@@ -79,5 +79,3 @@ def test_golden_batch_scenario_13_zero_turnover(client):
     metric = body["comparison_metrics"]["steady"]
     assert metric["security_intent_count"] == 0
     assert Decimal(metric["gross_turnover_notional_base"]["amount"]) == Decimal("0")
-
-

--- a/tests/unit/dpm/golden/test_golden_scenarios.py
+++ b/tests/unit/dpm/golden/test_golden_scenarios.py
@@ -131,5 +131,3 @@ def test_golden_scenario(filename):
                 act_item = next((a for a in act_attrs[attr_key] if a.key == exp_item["key"]), None)
                 assert act_item is not None
                 assert act_item.weight == Decimal(str(exp_item["weight"]))
-
-

--- a/tests/unit/dpm/supportability/test_dpm_idempotency_history_service.py
+++ b/tests/unit/dpm/supportability/test_dpm_idempotency_history_service.py
@@ -70,5 +70,3 @@ def test_idempotency_history_not_found_raises_consistent_error():
     service = DpmRunSupportService(repository=InMemoryDpmRunRepository())
     with pytest.raises(DpmRunNotFoundError, match="DPM_IDEMPOTENCY_KEY_NOT_FOUND"):
         service.get_idempotency_history(idempotency_key="idem-history-missing")
-
-

--- a/tests/unit/dpm/supportability/test_dpm_lineage_service.py
+++ b/tests/unit/dpm/supportability/test_dpm_lineage_service.py
@@ -56,5 +56,3 @@ def test_lineage_edges_are_recorded_for_run_idempotency_and_operation():
     assert len(by_operation.edges) == 1
     assert by_operation.edges[0].edge_type == "OPERATION_TO_CORRELATION"
     assert by_operation.edges[0].target_entity_id == "corr-op-lineage-1"
-
-

--- a/tests/unit/dpm/supportability/test_dpm_policy_pack_postgres_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_policy_pack_postgres_repository.py
@@ -163,5 +163,3 @@ def test_import_psycopg_returns_driver_and_row_factory(monkeypatch):
     psycopg, dict_row = postgres_module._import_psycopg()
     assert psycopg is fake_psycopg
     assert dict_row is fake_dict_row
-
-

--- a/tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py
+++ b/tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py
@@ -1022,5 +1022,3 @@ def test_import_psycopg_helper(monkeypatch):
     psycopg_module, dict_row = _import_psycopg()
     assert psycopg_module is fake_psycopg
     assert dict_row is fake_rows.dict_row
-
-

--- a/tests/unit/dpm/supportability/test_dpm_run_repository_backends.py
+++ b/tests/unit/dpm/supportability/test_dpm_run_repository_backends.py
@@ -793,5 +793,3 @@ def test_sqlite_repository_purge_expired_runs_noop_when_empty():
             now=datetime(2026, 2, 22, 12, 0, tzinfo=timezone.utc),
         )
         assert purged == 0
-
-

--- a/tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py
+++ b/tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py
@@ -144,5 +144,3 @@ def test_service_persisted_artifact_mode_backfills_missing_persisted_artifact():
     artifact = service.get_run_artifact(rebalance_run_id=result.rebalance_run_id)
     assert artifact.rebalance_run_id == result.rebalance_run_id
     assert repository.get_run_artifact(rebalance_run_id=result.rebalance_run_id) is not None
-
-

--- a/tests/unit/dpm/supportability/test_dpm_run_workflow_service.py
+++ b/tests/unit/dpm/supportability/test_dpm_run_workflow_service.py
@@ -251,5 +251,3 @@ def test_workflow_apis_raise_not_found_for_unknown_run():
 
     with pytest.raises(DpmRunNotFoundError, match="DPM_IDEMPOTENCY_KEY_NOT_FOUND"):
         service.get_workflow_history_by_idempotency(idempotency_key="idem-missing")
-
-

--- a/tests/unit/dpm/supportability/test_dpm_supportability_retention_service.py
+++ b/tests/unit/dpm/supportability/test_dpm_supportability_retention_service.py
@@ -92,5 +92,3 @@ def test_supportability_retention_purges_expired_run_records(repository):
 
     with pytest.raises(DpmRunNotFoundError, match="DPM_IDEMPOTENCY_KEY_NOT_FOUND"):
         service.get_idempotency_history(idempotency_key="idem-retention-old")
-
-

--- a/tests/unit/test_service_contract.py
+++ b/tests/unit/test_service_contract.py
@@ -3,5 +3,3 @@ from src.app.main import SERVICE_NAME
 
 def test_service_name_is_lotus_prefixed() -> None:
     assert SERVICE_NAME.startswith("lotus-")
-
-


### PR DESCRIPTION
This PR completes Lotus naming cleanup in lotus-manage by removing legacy platform names from code/docs/tests and aligning terminology with lotus-platform standards.