### PR TITLE
ci: add migration smoke gate and docs endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
         run: make typecheck
       - name: OpenAPI Gate
         run: make openapi-gate
+      - name: Migration Contract Smoke
+        run: make migration-smoke
       - name: Security Audit
         run: make security-audit
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Discretionary portfolio management (lotus-manage) execution, supportability, and
 
 This repository owns lotus-manage runtime workflows.
 Advisor-led proposal workflows are owned by `lotus-advise`.
+
+API docs endpoint: `/docs`


### PR DESCRIPTION
## Summary
- add migration contract smoke step to CI workflow to satisfy required gates
- add API docs endpoint note to README

## Validation
- ran \utomation/Validate-Backend-Standards.ps1\ and \utomation/Validate-OpenAPI-Conformance.ps1\ from lotus-platform
- confirmed lotus-manage status is \ok\ in both reports