### PR TITLE
ci: align install flow with editable dev package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install
-        run: make install
+        run: make install-ci
       - name: Verify Dependencies
         run: python -m pip check
       - name: Lint
@@ -72,7 +72,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install
-        run: make install
+        run: make install-ci
       - name: Run tests with coverage data
         env:
           COVERAGE_FILE: .coverage.${{ matrix.suite }}
@@ -96,7 +96,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install
-        run: make install
+        run: make install-ci
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Python 3.11 slim image for a smaller footprint
-FROM python:3.11-slim
+# Use the official Python 3.12 slim image to match project runtime requirements
+FROM python:3.12-slim
 
 # Set environment variables to prevent Python from writing .pyc files and buffering stdout
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -12,14 +12,12 @@ RUN adduser --disabled-password --gecos '' dpm-user
 # Set the working directory
 WORKDIR /app
 
-# Copy only runtime requirements first to leverage Docker layer caching
-COPY requirements-prod.txt .
+# Copy package metadata and source
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
 
 # Install runtime dependencies only
-RUN pip install -r requirements-prod.txt
-
-# Copy the core application code
-COPY src/ ./src/
+RUN pip install --upgrade pip && pip install .
 
 # Change ownership of the application files to the non-root user
 RUN chown -R dpm-user:dpm-user /app

--- a/Dockerfile.ci-local
+++ b/Dockerfile.ci-local
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /workspace
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+RUN python -m pip install --upgrade pip && pip install -e ".[dev]"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: install check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate migration-smoke migration-apply pre-commit docker-up docker-down
+.PHONY: install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate migration-smoke migration-apply pre-commit docker-build docker-up docker-down
 
 install:
-	pip install -r requirements.txt
-	pip install -r requirements-dev.txt
-	pip install pre-commit
+	python -m pip install --upgrade pip
+	pip install -e ".[dev]"
 	pre-commit install
+
+install-ci:
+	python -m pip install --upgrade pip
+	pip install -e ".[dev]"
 
 pre-commit:
 	pre-commit run --all-files
@@ -46,7 +49,6 @@ test-all-parallel:
 
 # Local execution flow aligned with .github/workflows/ci.yml
 ci-local: lint check-deps
-	python -m pip check
 	COVERAGE_FILE=.coverage.unit python -m pytest tests/unit --cov=src --cov-report=
 	COVERAGE_FILE=.coverage.integration python -m pytest tests/integration --cov=src --cov-report=
 	COVERAGE_FILE=.coverage.e2e python -m pytest tests/e2e --cov=src --cov-report=
@@ -92,13 +94,16 @@ run:
 	uvicorn src.api.main:app --reload --port 8000
 
 check-deps:
-	python scripts/dependency_health_check.py --requirements requirements.txt
+	python -m pip check
 
 security-audit:
-	python scripts/dependency_health_check.py --requirements requirements.txt
+	python -m pip_audit
+
+docker-build:
+	docker build -t lotus-manage:ci .
 
 docker-up:
-	docker-compose up -d --build
+	docker compose up -d --build
 
 docker-down:
-	docker-compose down
+	docker compose down


### PR DESCRIPTION
## Summary
- switch CI workflow install steps to make install-ci`n- align Makefile install/check/security targets with editable dev package + pip check/pip_audit
- upgrade runtime Dockerfile to python 3.12 and install from project package metadata
- add Dockerfile.ci-local for parity CI container bootstrap

## Why
- removes drift between local/CI installs and repository packaging model