### PR TITLE
Align proposals domain with lotus-platform quality standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,6 @@ jobs:
         run: python -m pip check
       - name: Lint
         run: make lint
-      - name: Typecheck
-        run: make typecheck
       - name: OpenAPI Gate
         run: make openapi-gate
       - name: Migration Contract Smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install
-        run: make install
+        run: make install-ci
       - name: Verify Dependencies
         run: python -m pip check
       - name: Lint
@@ -72,7 +72,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install
-        run: make install
+        run: make install-ci
       - name: Run tests with coverage data
         env:
           COVERAGE_FILE: .coverage.${{ matrix.suite }}
@@ -96,7 +96,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pip"
       - name: Install
-        run: make install
+        run: make install-ci
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         run: python -m pip check
       - name: Lint
         run: make lint
+      - name: Typecheck
+        run: make typecheck
       - name: OpenAPI Gate
         run: make openapi-gate
       - name: Migration Contract Smoke

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Python 3.11 slim image for a smaller footprint
-FROM python:3.11-slim
+# Use the official Python 3.12 slim image to match project runtime requirements
+FROM python:3.12-slim
 
 # Set environment variables to prevent Python from writing .pyc files and buffering stdout
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -12,14 +12,12 @@ RUN adduser --disabled-password --gecos '' dpm-user
 # Set the working directory
 WORKDIR /app
 
-# Copy only runtime requirements first to leverage Docker layer caching
-COPY requirements-prod.txt .
+# Copy package metadata and source
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
 
 # Install runtime dependencies only
-RUN pip install -r requirements-prod.txt
-
-# Copy the core application code
-COPY src/ ./src/
+RUN pip install --upgrade pip && pip install .
 
 # Change ownership of the application files to the non-root user
 RUN chown -R dpm-user:dpm-user /app

--- a/Dockerfile.ci-local
+++ b/Dockerfile.ci-local
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /workspace
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+RUN python -m pip install --upgrade pip && pip install -e ".[dev]"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: install check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate migration-smoke migration-apply pre-commit docker-up docker-down
+.PHONY: install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate migration-smoke migration-apply pre-commit docker-build docker-up docker-down
 
 install:
-	pip install -r requirements.txt
-	pip install -r requirements-dev.txt
-	pip install pre-commit
+	python -m pip install --upgrade pip
+	pip install -e ".[dev]"
 	pre-commit install
+
+install-ci:
+	python -m pip install --upgrade pip
+	pip install -e ".[dev]"
 
 pre-commit:
 	pre-commit run --all-files
@@ -46,7 +49,6 @@ test-all-parallel:
 
 # Local execution flow aligned with .github/workflows/ci.yml
 ci-local: lint check-deps
-	python -m pip check
 	COVERAGE_FILE=.coverage.unit python -m pytest tests/unit --cov=src --cov-report=
 	COVERAGE_FILE=.coverage.integration python -m pytest tests/integration --cov=src --cov-report=
 	COVERAGE_FILE=.coverage.e2e python -m pytest tests/e2e --cov=src --cov-report=
@@ -92,13 +94,16 @@ run:
 	uvicorn src.api.main:app --reload --port 8000
 
 check-deps:
-	python scripts/dependency_health_check.py --requirements requirements.txt
+	python -m pip check
 
 security-audit:
-	python scripts/dependency_health_check.py --requirements requirements.txt
+	python -m pip_audit
+
+docker-build:
+	docker build -t lotus-manage:ci .
 
 docker-up:
-	docker-compose up -d --build
+	docker compose up -d --build
 
 docker-down:
-	docker-compose down
+	docker compose down

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,8 @@ target-version = "py312"
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 testpaths = ["tests"]
+markers = [
+  "unit: unit tests",
+  "integration: integration tests",
+  "e2e: end-to-end tests",
+]

--- a/src/core/dpm_runs/models.py
+++ b/src/core/dpm_runs/models.py
@@ -59,7 +59,9 @@ class DpmRunIdempotencyRecord(BaseModel):
 
 
 class DpmRunLookupResponse(BaseModel):
-    rebalance_run_id: str = Field(description="lotus-manage run identifier.", examples=["rr_abc12345"])
+    rebalance_run_id: str = Field(
+        description="lotus-manage run identifier.", examples=["rr_abc12345"]
+    )
     correlation_id: str = Field(
         description="Correlation identifier for the run.", examples=["corr-1234-abcd"]
     )
@@ -83,7 +85,9 @@ class DpmRunLookupResponse(BaseModel):
 
 
 class DpmRunListItemResponse(BaseModel):
-    rebalance_run_id: str = Field(description="lotus-manage run identifier.", examples=["rr_abc12345"])
+    rebalance_run_id: str = Field(
+        description="lotus-manage run identifier.", examples=["rr_abc12345"]
+    )
     correlation_id: str = Field(
         description="Correlation identifier associated with the run.",
         examples=["corr-1234-abcd"],
@@ -859,7 +863,9 @@ class DpmRunArtifactResponse(BaseModel):
         description="Artifact schema version for compatibility evolution.",
         examples=["1.0"],
     )
-    rebalance_run_id: str = Field(description="lotus-manage run identifier.", examples=["rr_abc12345"])
+    rebalance_run_id: str = Field(
+        description="lotus-manage run identifier.", examples=["rr_abc12345"]
+    )
     correlation_id: str = Field(
         description="Correlation identifier associated with this run.",
         examples=["corr-1234-abcd"],

--- a/src/core/proposals/service.py
+++ b/src/core/proposals/service.py
@@ -3,15 +3,17 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from src.core.advisory.artifact import build_proposal_artifact
+from src.core.advisory.artifact_models import ProposalArtifact
 from src.core.advisory_engine import run_proposal_simulation
 from src.core.common.canonical import hash_canonical_payload
-from src.core.models import ProposalResult, ProposalSimulateRequest
+from src.core.models import GateDecision, ProposalResult, ProposalSimulateRequest
 from src.core.proposals.models import (
     ProposalApprovalRecord,
     ProposalApprovalRecordData,
     ProposalApprovalRequest,
     ProposalApprovalsResponse,
     ProposalAsyncAcceptedResponse,
+    ProposalAsyncError,
     ProposalAsyncOperationRecord,
     ProposalAsyncOperationStatusResponse,
     ProposalCreateRequest,
@@ -31,6 +33,7 @@ from src.core.proposals.models import (
     ProposalVersionRequest,
     ProposalWorkflowEvent,
     ProposalWorkflowEventRecord,
+    ProposalWorkflowEventType,
     ProposalWorkflowState,
     ProposalWorkflowTimelineResponse,
 )
@@ -49,6 +52,12 @@ TRANSITION_MAP: dict[tuple[ProposalWorkflowState, str], ProposalWorkflowState] =
     ("AWAITING_CLIENT_CONSENT", "REJECTED"): "REJECTED",
     ("EXECUTION_READY", "EXECUTED"): "EXECUTED",
     ("EXECUTION_READY", "EXPIRED"): "EXPIRED",
+}
+
+APPROVAL_TRANSITION_RULES: dict[str, tuple[ProposalWorkflowState, ProposalWorkflowEventType]] = {
+    "RISK": ("RISK_REVIEW", "RISK_APPROVED"),
+    "COMPLIANCE": ("COMPLIANCE_REVIEW", "COMPLIANCE_APPROVED"),
+    "CLIENT_CONSENT": ("AWAITING_CLIENT_CONSENT", "CLIENT_CONSENT_RECORDED"),
 }
 
 
@@ -245,12 +254,11 @@ class ProposalWorkflowService:
         version = self._repository.get_current_version(proposal_id=proposal_id)
         if version is None:
             raise ProposalNotFoundError("PROPOSAL_VERSION_NOT_FOUND")
+        version_detail = self._to_version_detail(version, include_evidence=include_evidence)
         return ProposalDetailResponse(
             proposal=self._to_summary(proposal),
-            current_version=self._to_version_detail(version, include_evidence=include_evidence),
-            last_gate_decision=(
-                self._to_version_detail(version, include_evidence=include_evidence).gate_decision
-            ),
+            current_version=version_detail,
+            last_gate_decision=version_detail.gate_decision,
         )
 
     def list_proposals(
@@ -293,11 +301,14 @@ class ProposalWorkflowService:
         if proposal is None:
             raise ProposalNotFoundError("PROPOSAL_NOT_FOUND")
         approvals = self._repository.list_approvals(proposal_id=proposal_id)
+        approval_records: list[ProposalApprovalRecord] = []
+        for approval in approvals:
+            converted = self._to_approval(approval)
+            if converted is not None:
+                approval_records.append(converted)
         return ProposalApprovalsResponse(
             proposal_id=proposal_id,
-            approvals=[
-                self._to_approval(approval) for approval in approvals if approval is not None
-            ],
+            approvals=approval_records,
         )
 
     def get_lineage(self, *, proposal_id: str) -> ProposalLineageResponse:
@@ -697,10 +708,14 @@ class ProposalWorkflowService:
             artifact_hash=version.artifact_hash,
             simulation_hash=version.simulation_hash,
             status_at_creation=version.status_at_creation,
-            proposal_result=version.proposal_result_json,
-            artifact=version.artifact_json,
+            proposal_result=ProposalResult.model_validate(version.proposal_result_json),
+            artifact=ProposalArtifact.model_validate(version.artifact_json),
             evidence_bundle=evidence_bundle_json,
-            gate_decision=version.gate_decision_json,
+            gate_decision=(
+                GateDecision.model_validate(version.gate_decision_json)
+                if version.gate_decision_json is not None
+                else None
+            ),
         )
 
     def _to_event(self, event: ProposalWorkflowEventRecord) -> ProposalWorkflowEvent:
@@ -796,7 +811,11 @@ class ProposalWorkflowService:
                 if operation.result_json is not None
                 else None
             ),
-            error=operation.error_json,
+            error=(
+                ProposalAsyncError.model_validate(operation.error_json)
+                if operation.error_json is not None
+                else None
+            ),
         )
 
     def _run_simulation(
@@ -859,32 +878,22 @@ class ProposalWorkflowService:
         current_state: ProposalWorkflowState,
         approval_type: str,
         approved: bool,
-    ) -> tuple[str, ProposalWorkflowState]:
-        if approval_type == "RISK":
-            if current_state != "RISK_REVIEW":
-                raise ProposalTransitionError("INVALID_APPROVAL_STATE")
-            return (
-                "RISK_APPROVED" if approved else "REJECTED",
-                "AWAITING_CLIENT_CONSENT" if approved else "REJECTED",
-            )
+    ) -> tuple[ProposalWorkflowEventType, ProposalWorkflowState]:
+        rule = APPROVAL_TRANSITION_RULES.get(approval_type)
+        if rule is None:
+            raise ProposalTransitionError("INVALID_APPROVAL_TYPE")
 
-        if approval_type == "COMPLIANCE":
-            if current_state != "COMPLIANCE_REVIEW":
-                raise ProposalTransitionError("INVALID_APPROVAL_STATE")
-            return (
-                "COMPLIANCE_APPROVED" if approved else "REJECTED",
-                "AWAITING_CLIENT_CONSENT" if approved else "REJECTED",
-            )
+        expected_state, approved_event_type = rule
+        if current_state != expected_state:
+            raise ProposalTransitionError("INVALID_APPROVAL_STATE")
+
+        if not approved:
+            return "REJECTED", "REJECTED"
 
         if approval_type == "CLIENT_CONSENT":
-            if current_state != "AWAITING_CLIENT_CONSENT":
-                raise ProposalTransitionError("INVALID_APPROVAL_STATE")
-            return (
-                "CLIENT_CONSENT_RECORDED" if approved else "REJECTED",
-                "EXECUTION_READY" if approved else "REJECTED",
-            )
+            return approved_event_type, "EXECUTION_READY"
 
-        raise ProposalTransitionError("INVALID_APPROVAL_TYPE")
+        return approved_event_type, "AWAITING_CLIENT_CONSENT"
 
 
 def _utc_now() -> datetime:

--- a/tests/integration/dpm/api/test_dpm_api_workflow_integration.py
+++ b/tests/integration/dpm/api/test_dpm_api_workflow_integration.py
@@ -222,7 +222,9 @@ def test_health_endpoints_integration_contract() -> None:
 
 def test_integration_capabilities_contract_default_consumer() -> None:
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default")
+        response = client.get(
+            "/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default"
+        )
 
     assert response.status_code == 200
     body = response.json()

--- a/tests/integration/proposals/test_proposals_api_integration.py
+++ b/tests/integration/proposals/test_proposals_api_integration.py
@@ -1,0 +1,449 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+from src.api.routers.proposals import reset_proposal_workflow_service_for_tests
+
+
+def _proposal_payload(*, portfolio_id: str = "pf_integration_1", title: str = "integration proposal") -> dict:
+    return {
+        "created_by": "advisor_integration",
+        "simulate_request": {
+            "portfolio_snapshot": {
+                "portfolio_id": portfolio_id,
+                "base_currency": "USD",
+                "positions": [],
+                "cash_balances": [{"currency": "USD", "amount": "1000"}],
+            },
+            "market_data_snapshot": {"prices": [], "fx_rates": []},
+            "shelf_entries": [],
+            "options": {"enable_proposal_simulation": True},
+            "proposed_cash_flows": [],
+            "proposed_trades": [],
+        },
+        "metadata": {"title": title},
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_workflow_service() -> None:
+    reset_proposal_workflow_service_for_tests()
+    yield
+    reset_proposal_workflow_service_for_tests()
+
+
+def test_proposal_lifecycle_and_supportability_endpoints_roundtrip() -> None:
+    payload = _proposal_payload()
+    create_headers = {
+        "Idempotency-Key": "integration-proposal-create-1",
+        "X-Correlation-Id": "corr-integration-proposal-create-1",
+    }
+
+    with TestClient(app) as client:
+        created = client.post("/api/v1/rebalance/proposals", json=payload, headers=create_headers)
+        assert created.status_code == 200
+        proposal_id = created.json()["proposal"]["proposal_id"]
+
+        fetched = client.get(f"/api/v1/rebalance/proposals/{proposal_id}?include_evidence=false")
+        listed = client.get("/api/v1/rebalance/proposals?created_by=advisor_integration&limit=10")
+        version = client.get(
+            f"/api/v1/rebalance/proposals/{proposal_id}/versions/1?include_evidence=false"
+        )
+        transition = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/transitions",
+            json={
+                "event_type": "SUBMITTED_FOR_RISK_REVIEW",
+                "actor_id": "advisor_integration",
+                "expected_state": "DRAFT",
+                "reason": {"ticket": "integration-1"},
+            },
+            headers={"Idempotency-Key": "integration-proposal-transition-1"},
+        )
+        approval = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
+            json={
+                "approval_type": "RISK",
+                "approved": True,
+                "actor_id": "risk_integration",
+                "expected_state": "RISK_REVIEW",
+                "details": {"channel": "API"},
+            },
+            headers={"Idempotency-Key": "integration-proposal-approval-1"},
+        )
+        timeline = client.get(f"/api/v1/rebalance/proposals/{proposal_id}/workflow-events")
+        approvals = client.get(f"/api/v1/rebalance/proposals/{proposal_id}/approvals")
+        lineage = client.get(f"/api/v1/rebalance/proposals/{proposal_id}/lineage")
+        idem = client.get("/api/v1/rebalance/proposals/idempotency/integration-proposal-create-1")
+        supportability = client.get("/api/v1/rebalance/proposals/supportability/config")
+
+    assert fetched.status_code == 200
+    assert fetched.json()["current_version"]["evidence_bundle"] == {}
+    assert listed.status_code == 200
+    assert any(item["proposal_id"] == proposal_id for item in listed.json()["items"])
+    assert version.status_code == 200
+    assert version.json()["version_no"] == 1
+    assert transition.status_code == 200
+    assert transition.json()["current_state"] == "RISK_REVIEW"
+    assert approval.status_code == 200
+    assert approval.json()["current_state"] == "AWAITING_CLIENT_CONSENT"
+    assert timeline.status_code == 200
+    assert [event["event_type"] for event in timeline.json()["events"]] == [
+        "CREATED",
+        "SUBMITTED_FOR_RISK_REVIEW",
+        "RISK_APPROVED",
+    ]
+    assert approvals.status_code == 200
+    assert approvals.json()["approvals"][0]["approval_type"] == "RISK"
+    assert lineage.status_code == 200
+    assert [item["version_no"] for item in lineage.json()["versions"]] == [1]
+    assert idem.status_code == 200
+    assert idem.json()["proposal_id"] == proposal_id
+    assert supportability.status_code == 200
+    assert supportability.json()["store_backend"] in {"INMEMORY", "POSTGRES"}
+
+
+def test_proposal_lifecycle_error_contracts() -> None:
+    payload = _proposal_payload()
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/rebalance/proposals",
+            json=payload,
+            headers={"Idempotency-Key": "integration-proposal-errors-1"},
+        )
+        assert created.status_code == 200
+        proposal_id = created.json()["proposal"]["proposal_id"]
+
+        conflicting_payload = _proposal_payload(title="changed-title")
+        idempotency_conflict = client.post(
+            "/api/v1/rebalance/proposals",
+            json=conflicting_payload,
+            headers={"Idempotency-Key": "integration-proposal-errors-1"},
+        )
+        missing = client.get("/api/v1/rebalance/proposals/pp_missing")
+        invalid_transition = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/transitions",
+            json={
+                "event_type": "EXECUTED",
+                "actor_id": "advisor_integration",
+                "expected_state": "DRAFT",
+                "reason": {},
+            },
+        )
+        stale_state = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/transitions",
+            json={
+                "event_type": "SUBMITTED_FOR_RISK_REVIEW",
+                "actor_id": "advisor_integration",
+                "expected_state": "COMPLIANCE_REVIEW",
+                "reason": {},
+            },
+        )
+        invalid_version = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/versions",
+            json={
+                "created_by": "advisor_integration",
+                "simulate_request": {
+                    "portfolio_snapshot": {
+                        "portfolio_id": "pf_different",
+                        "base_currency": "USD",
+                        "positions": [],
+                        "cash_balances": [{"currency": "USD", "amount": "1000"}],
+                    },
+                    "market_data_snapshot": {"prices": [], "fx_rates": []},
+                    "shelf_entries": [],
+                    "options": {"enable_proposal_simulation": True},
+                    "proposed_cash_flows": [],
+                    "proposed_trades": [],
+                },
+            },
+        )
+        missing_timeline = client.get("/api/v1/rebalance/proposals/pp_missing/workflow-events")
+        missing_approvals = client.get("/api/v1/rebalance/proposals/pp_missing/approvals")
+        missing_lineage = client.get("/api/v1/rebalance/proposals/pp_missing/lineage")
+        missing_idem = client.get("/api/v1/rebalance/proposals/idempotency/missing-idem")
+
+    assert idempotency_conflict.status_code == 409
+    assert idempotency_conflict.json()["detail"].startswith("IDEMPOTENCY_KEY_CONFLICT")
+    assert missing.status_code == 404
+    assert missing.json()["detail"] == "PROPOSAL_NOT_FOUND"
+    assert invalid_transition.status_code == 422
+    assert invalid_transition.json()["detail"] == "INVALID_TRANSITION"
+    assert stale_state.status_code == 409
+    assert stale_state.json()["detail"].startswith("STATE_CONFLICT")
+    assert invalid_version.status_code == 422
+    assert invalid_version.json()["detail"] == "PORTFOLIO_CONTEXT_MISMATCH"
+    assert missing_timeline.status_code == 404
+    assert missing_approvals.status_code == 404
+    assert missing_lineage.status_code == 404
+    assert missing_idem.status_code == 404
+
+
+def test_async_proposal_endpoints_and_feature_flag_guards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _proposal_payload(portfolio_id="pf_async_1")
+    with TestClient(app) as client:
+        accepted = client.post(
+            "/api/v1/rebalance/proposals/async",
+            json=payload,
+            headers={
+                "Idempotency-Key": "integration-proposal-async-1",
+                "X-Correlation-Id": "corr-integration-proposal-async-1",
+            },
+        )
+        assert accepted.status_code == 202
+        operation_id = accepted.json()["operation_id"]
+
+        by_operation = client.get(f"/api/v1/rebalance/proposals/operations/{operation_id}")
+        by_correlation = client.get(
+            "/api/v1/rebalance/proposals/operations/by-correlation/"
+            "corr-integration-proposal-async-1"
+        )
+        assert by_operation.status_code == 200
+        assert by_correlation.status_code == 200
+        assert by_operation.json()["operation_id"] == operation_id
+        assert by_operation.json()["status"] == "SUCCEEDED"
+
+    reset_proposal_workflow_service_for_tests()
+    monkeypatch.setenv("PROPOSAL_ASYNC_OPERATIONS_ENABLED", "false")
+    with TestClient(app) as client:
+        async_disabled = client.get("/api/v1/rebalance/proposals/operations/op_missing")
+    assert async_disabled.status_code == 404
+    assert async_disabled.json()["detail"] == "PROPOSAL_ASYNC_OPERATIONS_DISABLED"
+
+    reset_proposal_workflow_service_for_tests()
+    monkeypatch.setenv("PROPOSAL_SUPPORT_APIS_ENABLED", "false")
+    with TestClient(app) as client:
+        support_disabled = client.get("/api/v1/rebalance/proposals/pp_missing/workflow-events")
+    assert support_disabled.status_code == 404
+    assert support_disabled.json()["detail"] == "PROPOSAL_SUPPORT_APIS_DISABLED"
+
+
+def test_async_proposal_version_and_not_found_lookups() -> None:
+    payload = _proposal_payload(portfolio_id="pf_async_version")
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/rebalance/proposals",
+            json=payload,
+            headers={"Idempotency-Key": "integration-proposal-async-version-base"},
+        )
+        assert created.status_code == 200
+        proposal_id = created.json()["proposal"]["proposal_id"]
+
+        accepted = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/versions/async",
+            json={
+                "created_by": "advisor_integration",
+                "simulate_request": payload["simulate_request"],
+            },
+            headers={"X-Correlation-Id": "corr-integration-proposal-async-version"},
+        )
+        assert accepted.status_code == 202
+        operation_id = accepted.json()["operation_id"]
+        by_operation = client.get(f"/api/v1/rebalance/proposals/operations/{operation_id}")
+        by_correlation = client.get(
+            "/api/v1/rebalance/proposals/operations/by-correlation/"
+            "corr-integration-proposal-async-version"
+        )
+        missing_operation = client.get("/api/v1/rebalance/proposals/operations/pop_missing")
+        missing_correlation = client.get(
+            "/api/v1/rebalance/proposals/operations/by-correlation/corr_missing"
+        )
+
+    assert by_operation.status_code == 200
+    assert by_operation.json()["status"] == "SUCCEEDED"
+    assert by_correlation.status_code == 200
+    assert missing_operation.status_code == 404
+    assert missing_operation.json()["detail"] == "PROPOSAL_ASYNC_OPERATION_NOT_FOUND"
+    assert missing_correlation.status_code == 404
+    assert missing_correlation.json()["detail"] == "PROPOSAL_ASYNC_OPERATION_NOT_FOUND"
+
+
+@pytest.mark.parametrize(
+    ("exception_obj", "expected_detail"),
+    [
+        (RuntimeError("PROPOSAL_POSTGRES_DSN_REQUIRED"), "PROPOSAL_POSTGRES_DSN_REQUIRED"),
+        (TypeError("boom"), "PROPOSAL_POSTGRES_CONNECTION_FAILED"),
+    ],
+)
+def test_supportability_config_backend_init_error_mapping(
+    monkeypatch: pytest.MonkeyPatch, exception_obj: Exception, expected_detail: str
+) -> None:
+    reset_proposal_workflow_service_for_tests()
+    monkeypatch.setattr(
+        "src.api.routers.proposals_config.build_repository",
+        lambda: (_ for _ in ()).throw(exception_obj),
+    )
+    with TestClient(app) as client:
+        response = client.get("/api/v1/rebalance/proposals/supportability/config")
+
+    assert response.status_code == 200
+    assert response.json()["backend_ready"] is False
+    assert response.json()["backend_init_error"] == expected_detail
+
+
+def test_create_proposal_validation_error_contract() -> None:
+    payload = _proposal_payload()
+    payload["simulate_request"]["options"]["enable_proposal_simulation"] = False
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/rebalance/proposals",
+            json=payload,
+            headers={"Idempotency-Key": "integration-proposal-invalid-create"},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"].startswith("PROPOSAL_SIMULATION_DISABLED")
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "body", "expected_status", "expected_detail"),
+    [
+        ("get", "/api/v1/rebalance/proposals/pp_missing/versions/1", None, 404, "PROPOSAL_VERSION_NOT_FOUND"),
+        (
+            "post",
+            "/api/v1/rebalance/proposals/pp_missing/versions",
+            {
+                "created_by": "advisor_integration",
+                "simulate_request": {
+                    "portfolio_snapshot": {
+                        "portfolio_id": "pf_integration_1",
+                        "base_currency": "USD",
+                        "positions": [],
+                        "cash_balances": [{"currency": "USD", "amount": "1000"}],
+                    },
+                    "market_data_snapshot": {"prices": [], "fx_rates": []},
+                    "shelf_entries": [],
+                    "options": {"enable_proposal_simulation": True},
+                    "proposed_cash_flows": [],
+                    "proposed_trades": [],
+                },
+            },
+            404,
+            "PROPOSAL_NOT_FOUND",
+        ),
+        (
+            "post",
+            "/api/v1/rebalance/proposals/pp_missing/transitions",
+            {
+                "event_type": "SUBMITTED_FOR_RISK_REVIEW",
+                "actor_id": "advisor_integration",
+                "expected_state": "DRAFT",
+                "reason": {},
+            },
+            404,
+            "PROPOSAL_NOT_FOUND",
+        ),
+        (
+            "post",
+            "/api/v1/rebalance/proposals/pp_missing/approvals",
+            {
+                "approval_type": "RISK",
+                "approved": True,
+                "actor_id": "risk_integration",
+                "expected_state": "RISK_REVIEW",
+                "details": {},
+            },
+            404,
+            "PROPOSAL_NOT_FOUND",
+        ),
+    ],
+)
+def test_lifecycle_not_found_matrix(
+    method: str, path: str, body: dict | None, expected_status: int, expected_detail: str
+) -> None:
+    with TestClient(app) as client:
+        if method == "get":
+            response = client.get(path)
+        else:
+            response = client.post(path, json=body)
+
+    assert response.status_code == expected_status
+    assert response.json()["detail"] == expected_detail
+
+
+def test_transition_and_approval_conflict_error_contracts() -> None:
+    payload = _proposal_payload(portfolio_id="pf_conflict")
+    with TestClient(app) as client:
+        created = client.post(
+            "/api/v1/rebalance/proposals",
+            json=payload,
+            headers={"Idempotency-Key": "integration-proposal-conflict-base"},
+        )
+        assert created.status_code == 200
+        proposal_id = created.json()["proposal"]["proposal_id"]
+
+        first_transition = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/transitions",
+            json={
+                "event_type": "SUBMITTED_FOR_RISK_REVIEW",
+                "actor_id": "advisor_integration",
+                "expected_state": "DRAFT",
+                "reason": {"source": "api"},
+            },
+            headers={"Idempotency-Key": "integration-transition-conflict"},
+        )
+        assert first_transition.status_code == 200
+
+        conflicting_transition = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/transitions",
+            json={
+                "event_type": "SUBMITTED_FOR_COMPLIANCE_REVIEW",
+                "actor_id": "advisor_integration",
+                "expected_state": "RISK_REVIEW",
+                "reason": {"source": "api"},
+            },
+            headers={"Idempotency-Key": "integration-transition-conflict"},
+        )
+        stale_approval = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
+            json={
+                "approval_type": "RISK",
+                "approved": True,
+                "actor_id": "risk_integration",
+                "expected_state": "COMPLIANCE_REVIEW",
+                "details": {},
+            },
+        )
+        invalid_approval_transition = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
+            json={
+                "approval_type": "CLIENT_CONSENT",
+                "approved": True,
+                "actor_id": "client_integration",
+                "expected_state": "RISK_REVIEW",
+                "details": {},
+            },
+        )
+        first_approval = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
+            json={
+                "approval_type": "RISK",
+                "approved": True,
+                "actor_id": "risk_integration",
+                "expected_state": "RISK_REVIEW",
+                "details": {"source": "api"},
+            },
+            headers={"Idempotency-Key": "integration-approval-conflict"},
+        )
+        conflicting_approval = client.post(
+            f"/api/v1/rebalance/proposals/{proposal_id}/approvals",
+            json={
+                "approval_type": "RISK",
+                "approved": False,
+                "actor_id": "risk_integration",
+                "expected_state": "RISK_REVIEW",
+                "details": {"source": "api"},
+            },
+            headers={"Idempotency-Key": "integration-approval-conflict"},
+        )
+
+    assert conflicting_transition.status_code == 409
+    assert conflicting_transition.json()["detail"].startswith("IDEMPOTENCY_KEY_CONFLICT")
+    assert stale_approval.status_code == 409
+    assert stale_approval.json()["detail"].startswith("STATE_CONFLICT")
+    assert invalid_approval_transition.status_code == 422
+    assert invalid_approval_transition.json()["detail"] == "INVALID_APPROVAL_STATE"
+    assert first_approval.status_code == 200
+    assert conflicting_approval.status_code == 409
+    assert conflicting_approval.json()["detail"].startswith("IDEMPOTENCY_KEY_CONFLICT")

--- a/tests/unit/dpm/api/test_api_rebalance.py
+++ b/tests/unit/dpm/api/test_api_rebalance.py
@@ -1669,8 +1669,12 @@ def test_openapi_title_and_tag_grouping(client):
     assert "Advisory Simulation" in tags
     assert "Advisory Proposal Lifecycle" in tags
 
-    assert openapi["paths"]["/api/v1/rebalance/simulate"]["post"]["tags"] == ["lotus-manage Simulation"]
-    assert openapi["paths"]["/api/v1/rebalance/analyze"]["post"]["tags"] == ["lotus-manage What-If Analysis"]
+    assert openapi["paths"]["/api/v1/rebalance/simulate"]["post"]["tags"] == [
+        "lotus-manage Simulation"
+    ]
+    assert openapi["paths"]["/api/v1/rebalance/analyze"]["post"]["tags"] == [
+        "lotus-manage What-If Analysis"
+    ]
     assert openapi["paths"]["/api/v1/rebalance/analyze/async"]["post"]["tags"] == [
         "lotus-manage What-If Analysis"
     ]

--- a/tests/unit/dpm/api/test_integration_capabilities_api.py
+++ b/tests/unit/dpm/api/test_integration_capabilities_api.py
@@ -5,7 +5,9 @@ from src.api.main import app
 
 def test_integration_capabilities_default_contract():
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default")
+        response = client.get(
+            "/integration/capabilities?consumerSystem=lotus-gateway&tenantId=default"
+        )
 
     assert response.status_code == 200
     body = response.json()
@@ -27,7 +29,9 @@ def test_integration_capabilities_env_overrides(monkeypatch):
     monkeypatch.setenv("DPM_POLICY_VERSION", "tenant-x-v2")
 
     with TestClient(app) as client:
-        response = client.get("/integration/capabilities?consumerSystem=lotus-performance&tenantId=tenant-x")
+        response = client.get(
+            "/integration/capabilities?consumerSystem=lotus-performance&tenantId=tenant-x"
+        )
 
     assert response.status_code == 200
     body = response.json()

--- a/tests/unit/proposals/test_proposal_workflow_service.py
+++ b/tests/unit/proposals/test_proposal_workflow_service.py
@@ -1,0 +1,748 @@
+import pytest
+from datetime import datetime, timezone
+
+from src.core.proposals.models import (
+    ProposalApprovalRecordData,
+    ProposalApprovalRequest,
+    ProposalIdempotencyRecord,
+    ProposalCreateRequest,
+    ProposalRecord,
+    ProposalStateTransitionRequest,
+    ProposalVersionRequest,
+)
+from src.core.proposals.service import (
+    ProposalLifecycleError,
+    ProposalIdempotencyConflictError,
+    ProposalNotFoundError,
+    ProposalStateConflictError,
+    ProposalTransitionError,
+    ProposalValidationError,
+    ProposalWorkflowService,
+)
+from src.infrastructure.proposals import InMemoryProposalRepository
+
+
+def _service(
+    *,
+    require_expected_state: bool = True,
+    allow_portfolio_id_change_on_new_version: bool = False,
+    require_proposal_simulation_flag: bool = True,
+) -> ProposalWorkflowService:
+    return ProposalWorkflowService(
+        repository=InMemoryProposalRepository(),
+        require_expected_state=require_expected_state,
+        allow_portfolio_id_change_on_new_version=allow_portfolio_id_change_on_new_version,
+        require_proposal_simulation_flag=require_proposal_simulation_flag,
+    )
+
+
+def _create_payload() -> ProposalCreateRequest:
+    return ProposalCreateRequest.model_validate(
+        {
+            "created_by": "advisor_1",
+            "simulate_request": {
+                "portfolio_snapshot": {
+                    "portfolio_id": "pf_1",
+                    "base_currency": "USD",
+                    "positions": [],
+                    "cash_balances": [{"currency": "USD", "amount": "1000"}],
+                },
+                "market_data_snapshot": {"prices": [], "fx_rates": []},
+                "shelf_entries": [],
+                "options": {"enable_proposal_simulation": True},
+                "proposed_cash_flows": [],
+                "proposed_trades": [],
+            },
+            "metadata": {"title": "Risk flow test"},
+        }
+    )
+
+
+def _version_payload(*, portfolio_id: str = "pf_1", enable_simulation: bool = True) -> ProposalVersionRequest:
+    return ProposalVersionRequest.model_validate(
+        {
+            "created_by": "advisor_1",
+            "simulate_request": {
+                "portfolio_snapshot": {
+                    "portfolio_id": portfolio_id,
+                    "base_currency": "USD",
+                    "positions": [],
+                    "cash_balances": [{"currency": "USD", "amount": "1000"}],
+                },
+                "market_data_snapshot": {"prices": [], "fx_rates": []},
+                "shelf_entries": [],
+                "options": {"enable_proposal_simulation": enable_simulation},
+                "proposed_cash_flows": [],
+                "proposed_trades": [],
+            },
+        }
+    )
+
+
+def _create_draft(service: ProposalWorkflowService) -> str:
+    created = service.create_proposal(
+        payload=_create_payload(),
+        idempotency_key="idem-create-1",
+        correlation_id="corr-create-1",
+    )
+    return created.proposal.proposal_id
+
+
+def _submit_for_risk_review(service: ProposalWorkflowService, proposal_id: str) -> None:
+    service.transition_state(
+        proposal_id=proposal_id,
+        payload=ProposalStateTransitionRequest(
+            event_type="SUBMITTED_FOR_RISK_REVIEW",
+            actor_id="advisor_1",
+            expected_state="DRAFT",
+            reason={"ticket": "risk-123"},
+        ),
+    )
+
+
+def test_risk_approval_transition_updates_state_and_audit_history():
+    service = _service()
+    proposal_id = _create_draft(service)
+    _submit_for_risk_review(service, proposal_id)
+
+    transition = service.record_approval(
+        proposal_id=proposal_id,
+        idempotency_key="idem-risk-approval-1",
+        payload=ProposalApprovalRequest(
+            approval_type="RISK",
+            approved=True,
+            actor_id="risk_officer_1",
+            details={"channel": "IN_PERSON"},
+            expected_state="RISK_REVIEW",
+        ),
+    )
+
+    assert transition.current_state == "AWAITING_CLIENT_CONSENT"
+    assert transition.latest_workflow_event.event_type == "RISK_APPROVED"
+    assert transition.approval is not None
+    assert transition.approval.approval_type == "RISK"
+    assert transition.approval.approved is True
+
+    timeline = service.get_workflow_timeline(proposal_id=proposal_id)
+    assert timeline.current_state == "AWAITING_CLIENT_CONSENT"
+    assert [event.event_type for event in timeline.events] == [
+        "CREATED",
+        "SUBMITTED_FOR_RISK_REVIEW",
+        "RISK_APPROVED",
+    ]
+
+    approvals = service.get_approvals(proposal_id=proposal_id)
+    assert len(approvals.approvals) == 1
+    assert approvals.approvals[0].details["channel"] == "IN_PERSON"
+    assert approvals.approvals[0].details["idempotency_key"] == "idem-risk-approval-1"
+
+
+def test_record_approval_is_idempotent_and_rejects_payload_conflict():
+    service = _service()
+    proposal_id = _create_draft(service)
+    _submit_for_risk_review(service, proposal_id)
+
+    payload = ProposalApprovalRequest(
+        approval_type="RISK",
+        approved=True,
+        actor_id="risk_officer_2",
+        details={"source": "workflow_api"},
+        expected_state="RISK_REVIEW",
+    )
+    first = service.record_approval(
+        proposal_id=proposal_id,
+        payload=payload,
+        idempotency_key="idem-approval-2",
+    )
+    second = service.record_approval(
+        proposal_id=proposal_id,
+        payload=payload,
+        idempotency_key="idem-approval-2",
+    )
+
+    assert second.latest_workflow_event.event_id == first.latest_workflow_event.event_id
+    assert second.approval is not None and first.approval is not None
+    assert second.approval.approval_id == first.approval.approval_id
+
+    with pytest.raises(ProposalIdempotencyConflictError, match="IDEMPOTENCY_KEY_CONFLICT"):
+        service.record_approval(
+            proposal_id=proposal_id,
+            payload=ProposalApprovalRequest(
+                approval_type="RISK",
+                approved=False,
+                actor_id="risk_officer_2",
+                details={"source": "workflow_api"},
+                expected_state="RISK_REVIEW",
+            ),
+            idempotency_key="idem-approval-2",
+        )
+
+
+def test_transition_requires_expected_state_and_rejects_stale_state():
+    service = _service(require_expected_state=True)
+    proposal_id = _create_draft(service)
+
+    with pytest.raises(ProposalStateConflictError, match="expected_state is required"):
+        service.transition_state(
+            proposal_id=proposal_id,
+            payload=ProposalStateTransitionRequest(
+                event_type="SUBMITTED_FOR_RISK_REVIEW",
+                actor_id="advisor_1",
+                reason={},
+            ),
+        )
+
+    with pytest.raises(ProposalStateConflictError, match="expected_state mismatch"):
+        service.transition_state(
+            proposal_id=proposal_id,
+            payload=ProposalStateTransitionRequest(
+                event_type="SUBMITTED_FOR_RISK_REVIEW",
+                actor_id="advisor_1",
+                expected_state="COMPLIANCE_REVIEW",
+                reason={},
+            ),
+        )
+
+
+def test_client_consent_approval_is_rejected_when_state_is_not_awaiting_consent():
+    service = _service()
+    proposal_id = _create_draft(service)
+
+    with pytest.raises(ProposalTransitionError, match="INVALID_APPROVAL_STATE"):
+        service.record_approval(
+            proposal_id=proposal_id,
+            payload=ProposalApprovalRequest(
+                approval_type="CLIENT_CONSENT",
+                approved=True,
+                actor_id="client_1",
+                details={"channel": "EMAIL"},
+                expected_state="DRAFT",
+            ),
+        )
+
+
+def test_create_proposal_is_idempotent_and_conflict_safe():
+    service = _service()
+    payload = _create_payload()
+
+    first = service.create_proposal(
+        payload=payload,
+        idempotency_key="idem-create-main",
+        correlation_id="corr-main",
+    )
+    second = service.create_proposal(
+        payload=payload,
+        idempotency_key="idem-create-main",
+        correlation_id="corr-other",
+    )
+
+    assert second.proposal.proposal_id == first.proposal.proposal_id
+    assert second.version.proposal_version_id == first.version.proposal_version_id
+
+    changed_payload = _create_payload()
+    changed_payload.metadata.title = "Changed title"
+    with pytest.raises(ProposalIdempotencyConflictError, match="IDEMPOTENCY_KEY_CONFLICT"):
+        service.create_proposal(
+            payload=changed_payload,
+            idempotency_key="idem-create-main",
+            correlation_id="corr-main",
+        )
+
+
+def test_get_proposal_hides_evidence_when_requested_and_lists_versions_in_lineage():
+    service = _service()
+    proposal_id = _create_draft(service)
+
+    service.create_version(
+        proposal_id=proposal_id,
+        payload=_version_payload(),
+        correlation_id="corr-v2",
+    )
+
+    detail = service.get_proposal(proposal_id=proposal_id, include_evidence=False)
+    assert detail.current_version.version_no == 2
+    assert detail.current_version.evidence_bundle == {}
+    assert detail.last_gate_decision == detail.current_version.gate_decision
+
+    lineage = service.get_lineage(proposal_id=proposal_id)
+    assert [version.version_no for version in lineage.versions] == [1, 2]
+
+
+def test_list_proposals_and_idempotency_lookup_surface_persisted_records():
+    service = _service()
+    first = service.create_proposal(
+        payload=_create_payload(),
+        idempotency_key="idem-list-1",
+        correlation_id=None,
+    )
+    second_payload = _create_payload()
+    second_payload.created_by = "advisor_2"
+    second_payload.simulate_request.portfolio_snapshot.portfolio_id = "pf_2"
+    second = service.create_proposal(
+        payload=second_payload,
+        idempotency_key="idem-list-2",
+        correlation_id=None,
+    )
+
+    first_page = service.list_proposals(
+        portfolio_id=None,
+        state=None,
+        created_by=None,
+        created_from=None,
+        created_to=None,
+        limit=1,
+        cursor=None,
+    )
+    assert len(first_page.items) == 1
+    assert first_page.next_cursor is not None
+
+    second_page = service.list_proposals(
+        portfolio_id=None,
+        state=None,
+        created_by=None,
+        created_from=None,
+        created_to=None,
+        limit=5,
+        cursor=first_page.next_cursor,
+    )
+    assert len(second_page.items) == 1
+    assert {first_page.items[0].proposal_id, second_page.items[0].proposal_id} == {
+        first.proposal.proposal_id,
+        second.proposal.proposal_id,
+    }
+
+    filtered = service.list_proposals(
+        portfolio_id="pf_2",
+        state="DRAFT",
+        created_by="advisor_2",
+        created_from=None,
+        created_to=None,
+        limit=10,
+        cursor=None,
+    )
+    assert [item.proposal_id for item in filtered.items] == [second.proposal.proposal_id]
+
+    idem_lookup = service.get_idempotency_lookup(idempotency_key="idem-list-1")
+    assert idem_lookup.proposal_id == first.proposal.proposal_id
+
+
+def test_create_version_enforces_state_and_portfolio_rules():
+    service = _service()
+    proposal_id = _create_draft(service)
+
+    with pytest.raises(ProposalValidationError, match="PORTFOLIO_CONTEXT_MISMATCH"):
+        service.create_version(
+            proposal_id=proposal_id,
+            payload=_version_payload(portfolio_id="pf_other"),
+            correlation_id="corr-mismatch",
+        )
+
+    flexible = _service(allow_portfolio_id_change_on_new_version=True)
+    flexible_id = _create_draft(flexible)
+    created = flexible.create_version(
+        proposal_id=flexible_id,
+        payload=_version_payload(portfolio_id="pf_other"),
+        correlation_id=None,
+    )
+    assert created.version.version_no == 2
+
+    service.transition_state(
+        proposal_id=proposal_id,
+        payload=ProposalStateTransitionRequest(
+            event_type="CANCELLED",
+            actor_id="advisor_1",
+            expected_state="DRAFT",
+            reason={},
+        ),
+    )
+    with pytest.raises(ProposalValidationError, match="PROPOSAL_TERMINAL_STATE"):
+        service.create_version(
+            proposal_id=proposal_id,
+            payload=_version_payload(),
+            correlation_id="corr-terminal",
+        )
+
+
+def test_transition_state_idempotency_replay_and_conflict():
+    service = _service()
+    proposal_id = _create_draft(service)
+
+    payload = ProposalStateTransitionRequest(
+        event_type="SUBMITTED_FOR_RISK_REVIEW",
+        actor_id="advisor_1",
+        expected_state="DRAFT",
+        reason={"source": "workflow"},
+    )
+    first = service.transition_state(
+        proposal_id=proposal_id,
+        payload=payload,
+        idempotency_key="idem-transition-1",
+    )
+    replay = service.transition_state(
+        proposal_id=proposal_id,
+        payload=payload,
+        idempotency_key="idem-transition-1",
+    )
+
+    assert first.latest_workflow_event.event_id == replay.latest_workflow_event.event_id
+    assert replay.current_state == "RISK_REVIEW"
+
+    with pytest.raises(ProposalIdempotencyConflictError, match="IDEMPOTENCY_KEY_CONFLICT"):
+        service.transition_state(
+            proposal_id=proposal_id,
+            payload=ProposalStateTransitionRequest(
+                event_type="SUBMITTED_FOR_COMPLIANCE_REVIEW",
+                actor_id="advisor_1",
+                expected_state="RISK_REVIEW",
+                reason={"source": "workflow"},
+            ),
+            idempotency_key="idem-transition-1",
+        )
+
+
+def test_async_create_proposal_and_version_operations_report_status():
+    service = _service()
+    create_payload = _create_payload()
+
+    accepted = service.submit_create_proposal_async(
+        payload=create_payload,
+        idempotency_key="idem-async-create",
+        correlation_id=None,
+    )
+    service.execute_create_proposal_async(
+        operation_id=accepted.operation_id,
+        payload=create_payload,
+        idempotency_key="idem-async-create",
+        correlation_id=accepted.correlation_id,
+    )
+    create_status = service.get_async_operation(operation_id=accepted.operation_id)
+    by_correlation = service.get_async_operation_by_correlation(
+        correlation_id=accepted.correlation_id
+    )
+    assert create_status.status == "SUCCEEDED"
+    assert by_correlation.operation_id == accepted.operation_id
+    assert create_status.result is not None
+
+    proposal_id = create_status.result.proposal.proposal_id
+    version_accepted = service.submit_create_version_async(
+        proposal_id=proposal_id,
+        payload=_version_payload(),
+        correlation_id="corr-async-v2",
+    )
+    service.execute_create_version_async(
+        operation_id=version_accepted.operation_id,
+        proposal_id=proposal_id,
+        payload=_version_payload(),
+        correlation_id="corr-async-v2",
+    )
+    version_status = service.get_async_operation(operation_id=version_accepted.operation_id)
+    assert version_status.status == "SUCCEEDED"
+    assert version_status.result is not None
+    assert version_status.result.version.version_no == 2
+
+
+def test_async_operation_failure_sets_structured_error_payload():
+    service = _service(require_proposal_simulation_flag=True)
+    proposal_id = _create_draft(service)
+
+    bad_payload = _version_payload(enable_simulation=False)
+    accepted = service.submit_create_version_async(
+        proposal_id=proposal_id,
+        payload=bad_payload,
+        correlation_id="corr-bad-async-v2",
+    )
+    service.execute_create_version_async(
+        operation_id=accepted.operation_id,
+        proposal_id=proposal_id,
+        payload=bad_payload,
+        correlation_id="corr-bad-async-v2",
+    )
+
+    status = service.get_async_operation(operation_id=accepted.operation_id)
+    assert status.status == "FAILED"
+    assert status.error is not None
+    assert status.error.code == "ProposalValidationError"
+
+
+def test_missing_entities_raise_not_found_contract_errors():
+    service = _service()
+
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_NOT_FOUND"):
+        service.get_proposal(proposal_id="missing")
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_NOT_FOUND"):
+        service.get_workflow_timeline(proposal_id="missing")
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_NOT_FOUND"):
+        service.get_approvals(proposal_id="missing")
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_NOT_FOUND"):
+        service.get_lineage(proposal_id="missing")
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_IDEMPOTENCY_KEY_NOT_FOUND"):
+        service.get_idempotency_lookup(idempotency_key="missing")
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_ASYNC_OPERATION_NOT_FOUND"):
+        service.get_async_operation(operation_id="missing")
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_ASYNC_OPERATION_NOT_FOUND"):
+        service.get_async_operation_by_correlation(correlation_id="missing")
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_VERSION_NOT_FOUND"):
+        service.get_version(proposal_id="missing", version_no=1)
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_NOT_FOUND"):
+        service.transition_state(
+            proposal_id="missing",
+            payload=ProposalStateTransitionRequest(
+                event_type="CANCELLED",
+                actor_id="advisor_1",
+                expected_state="DRAFT",
+                reason={},
+            ),
+        )
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_NOT_FOUND"):
+        service.record_approval(
+            proposal_id="missing",
+            payload=ProposalApprovalRequest(
+                approval_type="RISK",
+                approved=True,
+                actor_id="risk_1",
+                details={},
+                expected_state="RISK_REVIEW",
+            ),
+        )
+
+
+def test_record_approval_replay_requires_corresponding_replayed_event(monkeypatch):
+    service = _service()
+    proposal_id = _create_draft(service)
+
+    approval = ProposalApprovalRecordData(
+        approval_id="pap_missing_event",
+        proposal_id=proposal_id,
+        approval_type="RISK",
+        approved=True,
+        actor_id="risk_1",
+        occurred_at=service._repository.get_proposal(proposal_id=proposal_id).created_at,
+        details_json={"idempotency_key": "idem-x", "idempotency_request_hash": "hash-x"},
+        related_version_no=1,
+    )
+    monkeypatch.setattr(service, "_get_replayed_approval", lambda **_: approval)
+    monkeypatch.setattr(service, "_get_replayed_event", lambda **_: None)
+
+    with pytest.raises(ProposalLifecycleError, match="PROPOSAL_IDEMPOTENCY_REFERENT_NOT_FOUND"):
+        service.record_approval(
+            proposal_id=proposal_id,
+            payload=ProposalApprovalRequest(
+                approval_type="RISK",
+                approved=True,
+                actor_id="risk_1",
+                details={},
+                expected_state="DRAFT",
+            ),
+            idempotency_key="idem-x",
+        )
+
+
+def test_approval_paths_cover_rejection_and_client_consent_execution_ready():
+    service = _service()
+    proposal_id = _create_draft(service)
+    _submit_for_risk_review(service, proposal_id)
+
+    rejected = service.record_approval(
+        proposal_id=proposal_id,
+        payload=ProposalApprovalRequest(
+            approval_type="RISK",
+            approved=False,
+            actor_id="risk_2",
+            details={"reason": "constraint breach"},
+            expected_state="RISK_REVIEW",
+        ),
+    )
+    assert rejected.current_state == "REJECTED"
+    assert rejected.latest_workflow_event.event_type == "REJECTED"
+
+    second_service = _service()
+    second_proposal = _create_draft(second_service)
+    _submit_for_risk_review(second_service, second_proposal)
+    second_service.record_approval(
+        proposal_id=second_proposal,
+        payload=ProposalApprovalRequest(
+            approval_type="RISK",
+            approved=True,
+            actor_id="risk_3",
+            details={},
+            expected_state="RISK_REVIEW",
+        ),
+    )
+    consent = second_service.record_approval(
+        proposal_id=second_proposal,
+        payload=ProposalApprovalRequest(
+            approval_type="CLIENT_CONSENT",
+            approved=True,
+            actor_id="client_2",
+            details={"channel": "DIGITAL_SIGNATURE"},
+            expected_state="AWAITING_CLIENT_CONSENT",
+        ),
+    )
+    assert consent.current_state == "EXECUTION_READY"
+    assert consent.latest_workflow_event.event_type == "CLIENT_CONSENT_RECORDED"
+
+
+def test_invalid_transition_and_missing_async_operation_are_non_destructive():
+    service = _service()
+    proposal_id = _create_draft(service)
+
+    with pytest.raises(ProposalTransitionError, match="INVALID_TRANSITION"):
+        service.transition_state(
+            proposal_id=proposal_id,
+            payload=ProposalStateTransitionRequest(
+                event_type="EXECUTED",
+                actor_id="ops_1",
+                expected_state="DRAFT",
+                reason={},
+            ),
+        )
+
+    # Unknown operations are ignored by executor methods to preserve idempotent worker behavior.
+    service.execute_create_proposal_async(
+        operation_id="pop_missing",
+        payload=_create_payload(),
+        idempotency_key="idem-missing-op",
+        correlation_id="corr-missing-op",
+    )
+    service.execute_create_version_async(
+        operation_id="pop_missing",
+        proposal_id=proposal_id,
+        payload=_version_payload(),
+        correlation_id="corr-missing-op-v2",
+    )
+
+
+def test_async_create_proposal_failure_records_error_details():
+    service = _service(require_proposal_simulation_flag=True)
+    invalid_payload = _create_payload()
+    invalid_payload.simulate_request.options.enable_proposal_simulation = False
+
+    accepted = service.submit_create_proposal_async(
+        payload=invalid_payload,
+        idempotency_key="idem-async-create-fail",
+        correlation_id="corr-async-create-fail",
+    )
+    service.execute_create_proposal_async(
+        operation_id=accepted.operation_id,
+        payload=invalid_payload,
+        idempotency_key="idem-async-create-fail",
+        correlation_id="corr-async-create-fail",
+    )
+
+    status = service.get_async_operation(operation_id=accepted.operation_id)
+    assert status.status == "FAILED"
+    assert status.error is not None
+    assert status.error.code == "ProposalValidationError"
+
+
+def test_get_proposal_requires_current_version_record():
+    service = _service()
+    now = datetime.now(timezone.utc)
+
+    orphan = ProposalRecord(
+        proposal_id="pp_orphan_1",
+        portfolio_id="pf_orphan",
+        mandate_id=None,
+        jurisdiction=None,
+        created_by="advisor_1",
+        created_at=now,
+        last_event_at=now,
+        current_state="DRAFT",
+        current_version_no=1,
+        title="orphan",
+        advisor_notes=None,
+    )
+    service._repository.create_proposal(orphan)
+
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_VERSION_NOT_FOUND"):
+        service.get_proposal(proposal_id="pp_orphan_1")
+
+
+def test_lineage_skips_missing_version_numbers():
+    service = _service()
+    proposal_id = _create_draft(service)
+    proposal = service._repository.get_proposal(proposal_id=proposal_id)
+    assert proposal is not None
+    proposal.current_version_no = 3
+    service._repository.update_proposal(proposal)
+
+    lineage = service.get_lineage(proposal_id=proposal_id)
+    assert [item.version_no for item in lineage.versions] == [1]
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_VERSION_NOT_FOUND"):
+        service.get_version(proposal_id=proposal_id, version_no=3)
+
+
+def test_create_version_requires_existing_proposal():
+    service = _service()
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_NOT_FOUND"):
+        service.create_version(
+            proposal_id="pp_missing",
+            payload=_version_payload(),
+            correlation_id="corr-missing-proposal",
+        )
+
+
+def test_internal_helpers_cover_remaining_error_contracts():
+    service = _service()
+    proposal_id = _create_draft(service)
+
+    assert service._to_approval(None) is None
+
+    assert (
+        service._get_replayed_approval(
+            proposal_id=proposal_id,
+            idempotency_key="idem-none",
+            request_hash="hash-none",
+        )
+        is None
+    )
+    service._repository.create_approval(
+        ProposalApprovalRecordData(
+            approval_id="pap_target_key",
+            proposal_id=proposal_id,
+            approval_type="RISK",
+            approved=True,
+            actor_id="risk_officer",
+            occurred_at=datetime.now(timezone.utc),
+            details_json={"idempotency_key": "idem-target", "idempotency_request_hash": "hash-target"},
+            related_version_no=1,
+        )
+    )
+    service._repository.create_approval(
+        ProposalApprovalRecordData(
+            approval_id="pap_other_key",
+            proposal_id=proposal_id,
+            approval_type="RISK",
+            approved=True,
+            actor_id="risk_officer",
+            occurred_at=datetime.now(timezone.utc),
+            details_json={"idempotency_key": "idem-other", "idempotency_request_hash": "hash-other"},
+            related_version_no=1,
+        )
+    )
+    matched = service._get_replayed_approval(
+        proposal_id=proposal_id,
+        idempotency_key="idem-target",
+        request_hash="hash-target",
+    )
+    assert matched is not None
+    assert matched.approval_id == "pap_target_key"
+
+    with pytest.raises(ProposalTransitionError, match="INVALID_APPROVAL_TYPE"):
+        service._resolve_approval_transition(
+            current_state="RISK_REVIEW",
+            approval_type="UNKNOWN",
+            approved=True,
+        )
+
+    service._repository.save_idempotency(
+        ProposalIdempotencyRecord(
+            idempotency_key="idem-bad-ref",
+            request_hash="hash-1",
+            proposal_id="pp_missing_ref",
+            proposal_version_no=99,
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    with pytest.raises(ProposalNotFoundError, match="PROPOSAL_IDEMPOTENCY_REFERENT_NOT_FOUND"):
+        service._read_create_response(proposal_id="pp_missing_ref", version_no=99)


### PR DESCRIPTION
## Summary
- add high-signal unit and integration coverage for proposal lifecycle, supportability, and async workflows
- refactor ProposalWorkflowService for stronger typing and cleaner response conversion paths
- register pytest test-bucket markers in project config
- add explicit make typecheck CI step to satisfy backend standards gate

## Validation
- python -m ruff check src tests
- python -m pytest -q (514 passed)
- python -m pytest -q tests/integration/proposals/test_proposals_api_integration.py tests/unit/proposals/test_proposal_workflow_service.py --cov=src.core.proposals.service --cov=src.api.routers.proposals_lifecycle_routes --cov=src.api.routers.proposals_support_routes --cov=src.api.routers.proposals_async_routes --cov-report=term-missing
  - proposals service/routes coverage: 100%
- powershell -ExecutionPolicy Bypass -File automation/Measure-Test-Pyramid.ps1 (lotus-manage pyramid now ok)
- powershell -ExecutionPolicy Bypass -File automation/Validate-Backend-Standards.ps1 (lotus-manage status now ok)

## Notes
- repo-wide mypy still has existing cross-domain debt; this PR limits changes to proposal-domain alignment and standards gates.