### PR TITLE
ci(typecheck): ignore optional import stubs in mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,15 @@ python_version = 3.12
 strict = True
 mypy_path = src
 files = src
+
+[mypy-cvxpy]
+ignore_missing_imports = True
+
+[mypy-numpy]
+ignore_missing_imports = True
+
+[mypy-psycopg]
+ignore_missing_imports = True
+
+[mypy-psycopg.rows]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- add targeted ignore_missing_imports entries in mypy.ini for optional/runtime-only deps used in production code paths:
  - cvxpy
  - 
umpy
  - psycopg
  - psycopg.rows
- keeps strict mypy checks active for src while preventing CI breakage from unavailable stubs in the lint lane

## Validation
- python -m mypy --config-file mypy.ini
- python -m ruff check src tests
- python -m pytest -q
