### PR TITLE
test(ci): make solver scenarios capability-aware

### DIFF
--- a/tests/e2e/demo/test_demo_scenarios.py
+++ b/tests/e2e/demo/test_demo_scenarios.py
@@ -5,6 +5,7 @@ Verifies that the public demo scenarios in docs/demo/ execute correctly.
 
 import json
 import os
+from importlib.util import find_spec
 
 import pytest
 from fastapi.testclient import TestClient
@@ -23,6 +24,7 @@ from src.core.models import (
 from tests.shared.factories import valid_api_payload
 
 DEMO_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs", "demo")
+_SOLVER_AVAILABLE = find_spec("cvxpy") is not None and find_spec("numpy") is not None
 
 
 def load_demo_scenario(filename):
@@ -90,8 +92,12 @@ def test_demo_scenario_execution(filename, expected_status):
 
     result = run_simulation(portfolio, market_data, model, shelf, options)
 
-    assert result.status == expected_status, (
-        f"Scenario {filename} failed. Got {result.status}, expected {expected_status}"
+    effective_expected = expected_status
+    if filename == "08_solver_mode.json" and not _SOLVER_AVAILABLE:
+        effective_expected = "BLOCKED"
+
+    assert result.status == effective_expected, (
+        f"Scenario {filename} failed. Got {result.status}, expected {effective_expected}"
     )
 
 

--- a/tests/unit/dpm/golden/test_golden_scenarios.py
+++ b/tests/unit/dpm/golden/test_golden_scenarios.py
@@ -6,6 +6,7 @@ import glob
 import json
 import os
 from decimal import Decimal
+from importlib.util import find_spec
 from typing import Any, Dict
 
 import pytest
@@ -40,10 +41,14 @@ SCENARIOS = sorted(
     for path in glob.glob(os.path.join(GOLDEN_DIR, "*.json"))
     if _is_rebalance_golden_fixture(path)
 )
+_SOLVER_AVAILABLE = find_spec("cvxpy") is not None and find_spec("numpy") is not None
 
 
 @pytest.mark.parametrize("filename", SCENARIOS)
 def test_golden_scenario(filename):
+    if filename.startswith("scenario_12_solver_") and not _SOLVER_AVAILABLE:
+        pytest.skip("Solver golden scenarios require cvxpy and numpy")
+
     data = load_golden_file(filename)
     inputs = data["inputs"]
     expected = data.get("expected_output") or data.get("expected_outputs")


### PR DESCRIPTION
## Summary
- make solver demo/golden scenarios environment-aware when optional solver deps are unavailable on CI runners
- fallback expected status for demo solver scenario to BLOCKED when solver backend is absent
- skip solver-only golden fixtures when cvxpy/
umpy are not installed

## Validation
- python -m pytest tests/unit/dpm/golden/test_golden_scenarios.py tests/e2e/demo/test_demo_scenarios.py -q
- python -m pytest -q
- python -m ruff check src tests
- python -m mypy --config-file mypy.ini
