### PR TITLE
Tech debt batch 1: capabilities abstraction + shim cleanup

### DIFF
--- a/src/api/production_cutover_contract.py
+++ b/src/api/production_cutover_contract.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +9,7 @@ from src.api.persistence_profile import (
 )
 from src.api.routers.dpm_runs_config import supportability_postgres_dsn
 from src.api.routers.proposals_config import proposal_postgres_dsn
+from src.core.common.capabilities import has_psycopg
 
 
 def validate_production_cutover_contract(*, check_migrations: bool) -> None:
@@ -21,7 +21,7 @@ def validate_production_cutover_contract(*, check_migrations: bool) -> None:
 
 
 def validate_cutover_migrations_applied() -> None:
-    if find_spec("psycopg") is None:
+    if not has_psycopg():
         raise RuntimeError("CUTOVER_POSTGRES_DRIVER_MISSING")
     import psycopg
     from psycopg.rows import dict_row

--- a/src/api/routers/dpm_policy_packs.py
+++ b/src/api/routers/dpm_policy_packs.py
@@ -8,6 +8,7 @@ from src.api.routers.runtime_utils import (
     env_flag,
     normalize_backend_init_error,
 )
+from src.core.common.capabilities import psycopg_error_type
 from src.core.dpm.policy_pack_repository import DpmPolicyPackRepository
 from src.core.dpm.policy_packs import (
     DpmEffectivePolicyPackResolution,
@@ -84,12 +85,9 @@ def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
         TypeError,
         ValueError,
     ]
-    try:
-        import psycopg
-    except ImportError:
-        pass
-    else:
-        types.append(psycopg.Error)
+    error_type = psycopg_error_type()
+    if error_type is not None:
+        types.append(error_type)
     return tuple(types)
 
 

--- a/src/api/routers/dpm_runs_config.py
+++ b/src/api/routers/dpm_runs_config.py
@@ -1,6 +1,7 @@
 import os
 from typing import cast
 
+from src.core.common.capabilities import psycopg_error_type
 from src.core.dpm_runs.repository import DpmRunRepository
 from src.infrastructure.dpm_runs import (
     PostgresDpmRunRepository,
@@ -68,12 +69,9 @@ def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
         TypeError,
         ValueError,
     ]
-    try:
-        import psycopg
-    except ImportError:
-        pass
-    else:
-        types.append(psycopg.Error)
+    error_type = psycopg_error_type()
+    if error_type is not None:
+        types.append(error_type)
     return tuple(types)
 
 

--- a/src/api/routers/proposals_config.py
+++ b/src/api/routers/proposals_config.py
@@ -1,6 +1,7 @@
 import os
 from typing import cast
 
+from src.core.common.capabilities import psycopg_error_type
 from src.core.proposals.repository import ProposalRepository
 from src.infrastructure.proposals import PostgresProposalRepository
 
@@ -24,12 +25,9 @@ def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
         TypeError,
         ValueError,
     ]
-    try:
-        import psycopg
-    except ImportError:
-        pass
-    else:
-        types.append(psycopg.Error)
+    error_type = psycopg_error_type()
+    if error_type is not None:
+        types.append(error_type)
     return tuple(types)
 
 

--- a/src/core/common/capabilities.py
+++ b/src/core/common/capabilities.py
@@ -1,0 +1,29 @@
+from importlib.util import find_spec
+def has_optional_dependency(module_name: str) -> bool:
+    return find_spec(module_name) is not None
+
+
+def has_solver_dependencies() -> bool:
+    return has_optional_dependency("cvxpy") and has_optional_dependency("numpy")
+
+
+def has_psycopg() -> bool:
+    return has_optional_dependency("psycopg")
+
+
+def psycopg_error_type() -> type[BaseException] | None:
+    if not has_psycopg():
+        return None
+    try:
+        import psycopg
+    except Exception:
+        return None
+    return getattr(psycopg, "Error", None)
+
+
+__all__ = [
+    "has_optional_dependency",
+    "has_solver_dependencies",
+    "has_psycopg",
+    "psycopg_error_type",
+]

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from typing import Any
 
+from src.core.common.capabilities import has_solver_dependencies
 from src.core.models import DiagnosticsData, EngineOptions, Money, ShelfEntry, TargetInstrument
 
 _SOLVER_STATUS_OPTIMAL = {"optimal", "optimal_inaccurate"}
@@ -180,6 +181,9 @@ def generate_targets_solver(
     base_ccy: str,
     diagnostics: DiagnosticsData,
 ) -> tuple[list[TargetInstrument], str]:
+    if not has_solver_dependencies():
+        diagnostics.warnings.append("SOLVER_ERROR")
+        return [], "BLOCKED"
     try:
         import cvxpy as _cp
         import numpy as _np

--- a/src/infrastructure/dpm_policy_packs/postgres.py
+++ b/src/infrastructure/dpm_policy_packs/postgres.py
@@ -1,9 +1,9 @@
 import json
 from contextlib import closing
 from datetime import datetime, timezone
-from importlib.util import find_spec
 from typing import Any
 
+from src.core.common.capabilities import has_psycopg
 from src.core.dpm.policy_packs import DpmPolicyPackDefinition
 from src.infrastructure.postgres_migrations import apply_postgres_migrations
 
@@ -12,7 +12,7 @@ class PostgresDpmPolicyPackRepository:
     def __init__(self, *, dsn: str) -> None:
         if not dsn:
             raise RuntimeError("DPM_POLICY_PACK_POSTGRES_DSN_REQUIRED")
-        if find_spec("psycopg") is None:
+        if not has_psycopg():
             raise RuntimeError("DPM_POLICY_PACK_POSTGRES_DRIVER_MISSING")
         self._dsn = dsn
         self._init_db()

--- a/src/infrastructure/dpm_runs/postgres.py
+++ b/src/infrastructure/dpm_runs/postgres.py
@@ -1,9 +1,9 @@
 import json
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
-from importlib.util import find_spec
 from typing import Any, Optional, cast
 
+from src.core.common.capabilities import has_psycopg
 from src.core.dpm_runs.models import (
     DpmAsyncOperationRecord,
     DpmLineageEdgeRecord,
@@ -20,7 +20,7 @@ class PostgresDpmRunRepository:
     def __init__(self, *, dsn: str) -> None:
         if not dsn:
             raise RuntimeError("DPM_SUPPORTABILITY_POSTGRES_DSN_REQUIRED")
-        if find_spec("psycopg") is None:
+        if not has_psycopg():
             raise RuntimeError("DPM_SUPPORTABILITY_POSTGRES_DRIVER_MISSING")
         self._dsn = dsn
         self._init_db()

--- a/src/infrastructure/proposals/postgres.py
+++ b/src/infrastructure/proposals/postgres.py
@@ -1,9 +1,9 @@
 import json
 from contextlib import closing
 from datetime import datetime
-from importlib.util import find_spec
 from typing import Any, Optional, cast
 
+from src.core.common.capabilities import has_psycopg
 from src.core.proposals.models import (
     ProposalApprovalRecordData,
     ProposalAsyncOperationRecord,
@@ -21,7 +21,7 @@ class PostgresProposalRepository:
     def __init__(self, *, dsn: str) -> None:
         if not dsn:
             raise RuntimeError("PROPOSAL_POSTGRES_DSN_REQUIRED")
-        if find_spec("psycopg") is None:
+        if not has_psycopg():
             raise RuntimeError("PROPOSAL_POSTGRES_DRIVER_MISSING")
         self._dsn = dsn
         self._init_db()

--- a/tests/e2e/demo/test_demo_scenarios.py
+++ b/tests/e2e/demo/test_demo_scenarios.py
@@ -5,7 +5,6 @@ Verifies that the public demo scenarios in docs/demo/ execute correctly.
 
 import json
 import os
-from importlib.util import find_spec
 
 import pytest
 from fastapi.testclient import TestClient
@@ -13,7 +12,8 @@ from fastapi.testclient import TestClient
 from src.api.main import app, get_db_session
 from src.api.routers.dpm_runs import reset_dpm_run_support_service_for_tests
 from src.api.routers.proposals import reset_proposal_workflow_service_for_tests
-from src.core.dpm_engine import run_simulation
+from src.core.common.capabilities import has_solver_dependencies
+from src.core.dpm.engine import run_simulation
 from src.core.models import (
     EngineOptions,
     MarketDataSnapshot,
@@ -24,7 +24,7 @@ from src.core.models import (
 from tests.shared.factories import valid_api_payload
 
 DEMO_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs", "demo")
-_SOLVER_AVAILABLE = find_spec("cvxpy") is not None and find_spec("numpy") is not None
+_SOLVER_AVAILABLE = has_solver_dependencies()
 
 
 def load_demo_scenario(filename):

--- a/tests/unit/core/test_capabilities.py
+++ b/tests/unit/core/test_capabilities.py
@@ -1,0 +1,29 @@
+from types import ModuleType
+import sys
+
+from src.core.common import capabilities
+
+
+def test_solver_dependency_flag_matches_component_flags():
+    assert capabilities.has_solver_dependencies() == (
+        capabilities.has_optional_dependency("cvxpy")
+        and capabilities.has_optional_dependency("numpy")
+    )
+
+
+def test_psycopg_error_type_none_when_driver_missing(monkeypatch):
+    monkeypatch.setattr(capabilities, "has_psycopg", lambda: False)
+    assert capabilities.psycopg_error_type() is None
+
+
+def test_psycopg_error_type_from_driver_module(monkeypatch):
+    fake = ModuleType("psycopg")
+
+    class FakeError(Exception):
+        pass
+
+    fake.Error = FakeError
+    monkeypatch.setattr(capabilities, "has_psycopg", lambda: True)
+    monkeypatch.setitem(sys.modules, "psycopg", fake)
+
+    assert capabilities.psycopg_error_type() is FakeError

--- a/tests/unit/dpm/api/test_api_rebalance.py
+++ b/tests/unit/dpm/api/test_api_rebalance.py
@@ -1229,7 +1229,7 @@ def test_dpm_policy_pack_catalog_overrides_turnover_option(client, monkeypatch):
     )
 
     payload = get_valid_payload()
-    from src.core.dpm_engine import run_simulation as real_run
+    from src.core.dpm.engine import run_simulation as real_run
     from src.core.models import (
         EngineOptions,
         MarketDataSnapshot,
@@ -1461,7 +1461,7 @@ def test_dpm_policy_pack_catalog_overrides_options_using_tenant_resolver(client,
         '{"tenant_pack":{"version":"1","turnover_policy":{"max_turnover_pct":"0.02"}}}',
     )
     payload = get_valid_payload()
-    from src.core.dpm_engine import run_simulation as real_run
+    from src.core.dpm.engine import run_simulation as real_run
     from src.core.models import (
         EngineOptions,
         MarketDataSnapshot,
@@ -1811,7 +1811,7 @@ def test_analyze_scenarios_are_processed_in_sorted_name_order(client):
     payload.pop("options")
     payload["scenarios"] = {"z_case": {"options": {}}, "a_case": {"options": {}}}
 
-    from src.core.dpm_engine import run_simulation as real_run
+    from src.core.dpm.engine import run_simulation as real_run
     from src.core.models import (
         EngineOptions,
         MarketDataSnapshot,

--- a/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 
 from src.core.dpm.execution import build_settlement_ladder
-from src.core.dpm_engine import _generate_fx_and_simulate, run_simulation
+from src.core.dpm.engine import _generate_fx_and_simulate, run_simulation
 from src.core.models import (
     EngineOptions,
     SecurityTradeIntent,

--- a/tests/unit/dpm/engine/coverage/test_engine_status_blocking.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_status_blocking.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import EngineOptions, Money, ValuationMode
 from tests.shared.assertions import assert_status
 from tests.shared.factories import position, price, shelf_entry

--- a/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import pytest
 from pydantic import ValidationError
 
-from src.core.dpm_engine import _apply_group_constraints, _generate_targets, run_simulation
+from src.core.dpm.engine import _apply_group_constraints, _generate_targets, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, GroupConstraint, ShelfEntry
 from tests.shared.assertions import assert_status
 from tests.shared.factories import model_portfolio, position, target

--- a/tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from src.core.dpm_engine import _apply_turnover_limit, _calculate_turnover_score, run_simulation
+from src.core.dpm.engine import _apply_turnover_limit, _calculate_turnover_score, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, Money, SecurityTradeIntent
 from tests.shared.assertions import assert_status, security_intents
 from tests.shared.factories import (

--- a/tests/unit/dpm/engine/coverage/test_engine_universe_data_quality.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_universe_data_quality.py
@@ -1,4 +1,4 @@
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import (
     EngineOptions,
 )

--- a/tests/unit/dpm/engine/test_engine_core_flows.py
+++ b/tests/unit/dpm/engine/test_engine_core_flows.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import (
     EngineOptions,
     Money,

--- a/tests/unit/dpm/engine/test_engine_edge_cases.py
+++ b/tests/unit/dpm/engine/test_engine_edge_cases.py
@@ -1,4 +1,4 @@
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import EngineOptions
 from tests.shared.assertions import assert_dq_contains, assert_status, find_excluded
 from tests.shared.factories import (

--- a/tests/unit/dpm/engine/test_engine_module_shim.py
+++ b/tests/unit/dpm/engine/test_engine_module_shim.py
@@ -1,8 +1,17 @@
+import importlib
+
+import pytest
+
 import src.core.advisory_engine as advisory_engine
-import src.core.dpm_engine as dpm_engine
-import src.core.engine as engine
+import src.core.dpm.engine as dpm_engine_impl
 
 
 def test_engine_shim_exports_expected_entrypoints():
-    assert engine.run_simulation is dpm_engine.run_simulation
+    with pytest.warns(DeprecationWarning):
+        dpm_engine = importlib.import_module("src.core.dpm_engine")
+    with pytest.warns(DeprecationWarning):
+        engine = importlib.import_module("src.core.engine")
+
+    assert engine.run_simulation is dpm_engine_impl.run_simulation
+    assert dpm_engine.run_simulation is dpm_engine_impl.run_simulation
     assert engine.run_proposal_simulation is advisory_engine.run_proposal_simulation

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import (
     Money,
 )

--- a/tests/unit/dpm/engine/test_engine_settlement_awareness.py
+++ b/tests/unit/dpm/engine/test_engine_settlement_awareness.py
@@ -1,4 +1,4 @@
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import EngineOptions
 from tests.shared.assertions import assert_status
 from tests.shared.factories import (

--- a/tests/unit/dpm/engine/test_engine_shelf_status_matrix.py
+++ b/tests/unit/dpm/engine/test_engine_shelf_status_matrix.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import EngineOptions
 from tests.shared.assertions import find_excluded
 from tests.shared.factories import (

--- a/tests/unit/dpm/engine/test_engine_solver_behavior.py
+++ b/tests/unit/dpm/engine/test_engine_solver_behavior.py
@@ -5,7 +5,7 @@ from importlib.util import find_spec
 
 import pytest
 
-from src.core.dpm_engine import _generate_targets, run_simulation
+from src.core.dpm.engine import _generate_targets, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, GroupConstraint, ShelfEntry
 from src.core.target_generation import _solver_failure_reason
 from tests.shared.factories import (

--- a/tests/unit/dpm/engine/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/test_engine_target_generation.py
@@ -9,7 +9,7 @@ from importlib.util import find_spec
 
 import pytest
 
-from src.core.dpm_engine import _generate_targets
+from src.core.dpm.engine import _generate_targets
 from src.core.models import (
     DiagnosticsData,
     EngineOptions,

--- a/tests/unit/dpm/engine/test_engine_tax_awareness.py
+++ b/tests/unit/dpm/engine/test_engine_tax_awareness.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import EngineOptions
 from tests.shared.assertions import assert_status, security_intents
 from tests.shared.factories import (

--- a/tests/unit/dpm/engine/test_engine_turnover_control.py
+++ b/tests/unit/dpm/engine/test_engine_turnover_control.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 
-from src.core.dpm_engine import run_simulation
+from src.core.dpm.engine import run_simulation
 from src.core.models import EngineOptions
 from tests.shared.assertions import assert_status, security_intents
 from tests.shared.factories import (

--- a/tests/unit/dpm/engine/test_engine_workflow_gates.py
+++ b/tests/unit/dpm/engine/test_engine_workflow_gates.py
@@ -84,3 +84,29 @@ def test_workflow_gate_execution_ready_when_client_consent_already_obtained():
     )
     assert gate.gate == "EXECUTION_READY"
     assert gate.recommended_next_step == "EXECUTE"
+
+
+def test_workflow_gate_prioritizes_data_quality_in_reason_sorting():
+    high_issue = SimpleNamespace(
+        status_change="NEW",
+        severity="HIGH",
+        issue_id="SUIT_ISSUER_MAX",
+        issue_key="ISSUER_MAX|X",
+    )
+    gate = evaluate_gate_decision(
+        status="READY",
+        rule_results=[_rule("CASH_BAND", "SOFT", reason_code="SOFT_CASH_BAND")],
+        suitability=SimpleNamespace(issues=[high_issue]),
+        diagnostics=SimpleNamespace(data_quality={"price_missing": ["A"], "fx_missing": ["USD/SGD"]}),
+        options=EngineOptions(),
+        default_requires_client_consent=False,
+    )
+    assert gate.gate == "COMPLIANCE_REVIEW_REQUIRED"
+    assert gate.summary.hard_fail_count == 0
+    assert gate.summary.soft_fail_count == 1
+    assert gate.summary.new_high_suitability_count == 1
+    assert gate.summary.new_medium_suitability_count == 0
+    assert [reason.reason_code for reason in gate.reasons[:2]] == [
+        "DATA_QUALITY_MISSING_FX",
+        "DATA_QUALITY_MISSING_PRICE",
+    ]

--- a/tests/unit/dpm/golden/test_golden_scenarios.py
+++ b/tests/unit/dpm/golden/test_golden_scenarios.py
@@ -6,12 +6,12 @@ import glob
 import json
 import os
 from decimal import Decimal
-from importlib.util import find_spec
 from typing import Any, Dict
 
 import pytest
 
-from src.core.dpm_engine import run_simulation
+from src.core.common.capabilities import has_solver_dependencies
+from src.core.dpm.engine import run_simulation
 from src.core.models import (
     EngineOptions,
     MarketDataSnapshot,
@@ -41,7 +41,7 @@ SCENARIOS = sorted(
     for path in glob.glob(os.path.join(GOLDEN_DIR, "*.json"))
     if _is_rebalance_golden_fixture(path)
 )
-_SOLVER_AVAILABLE = find_spec("cvxpy") is not None and find_spec("numpy") is not None
+_SOLVER_AVAILABLE = has_solver_dependencies()
 
 
 @pytest.mark.parametrize("filename", SCENARIOS)

--- a/tests/unit/dpm/supportability/test_dpm_policy_pack_postgres_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_policy_pack_postgres_repository.py
@@ -74,7 +74,7 @@ class _FakeConnection:
 
 def _build_repository(monkeypatch):
     connection = _FakeConnection()
-    monkeypatch.setattr(postgres_module, "find_spec", lambda _name: object())
+    monkeypatch.setattr(postgres_module, "has_psycopg", lambda: True)
     monkeypatch.setattr(
         PostgresDpmPolicyPackRepository,
         "_connect",
@@ -96,7 +96,7 @@ def test_postgres_policy_pack_repository_requires_dsn():
 
 
 def test_postgres_policy_pack_repository_requires_driver(monkeypatch):
-    monkeypatch.setattr(postgres_module, "find_spec", lambda _name: None)
+    monkeypatch.setattr(postgres_module, "has_psycopg", lambda: False)
     try:
         PostgresDpmPolicyPackRepository(dsn="postgresql://user:pass@localhost:5432/dpm")
     except RuntimeError as exc:
@@ -139,7 +139,7 @@ def test_postgres_policy_pack_repository_connect_uses_imported_driver(monkeypatc
         def _init_db(self):
             return None
 
-    monkeypatch.setattr(postgres_module, "find_spec", lambda _name: object())
+    monkeypatch.setattr(postgres_module, "has_psycopg", lambda: True)
     monkeypatch.setattr(
         postgres_module,
         "_import_psycopg",

--- a/tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py
+++ b/tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py
@@ -395,7 +395,7 @@ class _FakeConnection:
 
 def _build_repository(monkeypatch):
     fake_connection = _FakeConnection()
-    monkeypatch.setattr(postgres_module, "find_spec", lambda _name: object())
+    monkeypatch.setattr(postgres_module, "has_psycopg", lambda: True)
     monkeypatch.setattr(
         PostgresDpmRunRepository,
         "_connect",
@@ -415,7 +415,7 @@ def test_postgres_repository_requires_dsn():
 
 
 def test_postgres_repository_requires_driver(monkeypatch):
-    monkeypatch.setattr(postgres_module, "find_spec", lambda _name: None)
+    monkeypatch.setattr(postgres_module, "has_psycopg", lambda: False)
     try:
         PostgresDpmRunRepository(dsn="postgresql://user:pass@localhost:5432/dpm")
     except RuntimeError as exc:

--- a/tests/unit/shared/dependencies/test_production_cutover_contract.py
+++ b/tests/unit/shared/dependencies/test_production_cutover_contract.py
@@ -110,7 +110,7 @@ def test_validate_cutover_migrations_applied_detects_missing(monkeypatch):
 
             return _Context()
 
-    monkeypatch.setattr(contract_module, "find_spec", lambda _name: object())
+    monkeypatch.setattr(contract_module, "has_psycopg", lambda: True)
     monkeypatch.setitem(__import__("sys").modules, "psycopg", _FakePsycopg)
     monkeypatch.setitem(
         __import__("sys").modules,
@@ -131,7 +131,7 @@ def test_validate_cutover_migrations_applied_detects_missing(monkeypatch):
 
 
 def test_validate_cutover_migrations_applied_requires_postgres_driver(monkeypatch):
-    monkeypatch.setattr(contract_module, "find_spec", lambda _name: None)
+    monkeypatch.setattr(contract_module, "has_psycopg", lambda: False)
     with pytest.raises(RuntimeError) as exc:
         contract_module.validate_cutover_migrations_applied()
     assert str(exc.value) == "CUTOVER_POSTGRES_DRIVER_MISSING"


### PR DESCRIPTION
## Scope
- replace repeated optional dependency checks with shared capability helpers (has_psycopg, has_solver_dependencies, psycopg_error_type)
- refactor postgres-backed repositories and config routers to use shared capability paths
- remove deprecated shim imports from active test suites; keep explicit shim-compat test with warning assertions
- add regression coverage for capability helpers and workflow-gate reason ordering
- update existing supportability/cutover tests to patch capability helpers instead of internal ind_spec details

## Validation
- python -m ruff check src tests
- python -m mypy src
- python -m pytest -q
