### PR TITLE
Tech debt batch 2: typed test gate, contracts, and helper coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: make lint
       - name: Typecheck
         run: make typecheck
+      - name: Typecheck Critical Tests
+        run: make typecheck-tests-critical
       - name: OpenAPI Gate
         run: make openapi-gate
       - name: Migration Contract Smoke

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck lint monetary-float-guard format clean run check-deps security-audit openapi-gate migration-smoke migration-apply pre-commit docker-build docker-up docker-down
+.PHONY: install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard format clean run check-deps security-audit openapi-gate migration-smoke migration-apply pre-commit docker-build docker-up docker-down
 
 COVERAGE_FAIL_UNDER ?= 92
 
@@ -68,6 +68,9 @@ check-all: lint typecheck test-all
 
 typecheck:
 	mypy --config-file mypy.ini
+
+typecheck-tests-critical:
+	mypy tests/unit/core/test_capabilities.py tests/unit/dpm/engine/test_engine_workflow_gates.py
 
 openapi-gate:
 	python -m pytest tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py -q

--- a/src/api/routers/dpm_policy_packs.py
+++ b/src/api/routers/dpm_policy_packs.py
@@ -77,7 +77,7 @@ def policy_pack_postgres_dsn() -> str:
     return _policy_pack_postgres_dsn()
 
 
-def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
+def postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
     types: list[type[BaseException]] = [
         ConnectionError,
         OSError,
@@ -89,6 +89,10 @@ def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
     if error_type is not None:
         types.append(error_type)
     return tuple(types)
+
+
+def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
+    return postgres_connection_exception_types()
 
 
 def _build_policy_pack_repository() -> DpmPolicyPackRepository:

--- a/src/api/routers/dpm_runs_config.py
+++ b/src/api/routers/dpm_runs_config.py
@@ -61,7 +61,7 @@ def supportability_postgres_dsn() -> str:
     return os.getenv("DPM_SUPPORTABILITY_POSTGRES_DSN", "").strip()
 
 
-def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
+def postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
     types: list[type[BaseException]] = [
         ConnectionError,
         OSError,
@@ -73,6 +73,10 @@ def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
     if error_type is not None:
         types.append(error_type)
     return tuple(types)
+
+
+def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
+    return postgres_connection_exception_types()
 
 
 def build_repository() -> DpmRunRepository:

--- a/src/api/routers/proposals_config.py
+++ b/src/api/routers/proposals_config.py
@@ -17,7 +17,7 @@ def proposal_postgres_dsn() -> str:
     return os.getenv("PROPOSAL_POSTGRES_DSN", "").strip()
 
 
-def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
+def postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
     types: list[type[BaseException]] = [
         ConnectionError,
         OSError,
@@ -29,6 +29,10 @@ def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
     if error_type is not None:
         types.append(error_type)
     return tuple(types)
+
+
+def _postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
+    return postgres_connection_exception_types()
 
 
 def build_repository() -> ProposalRepository:

--- a/src/api/routers/runtime_utils.py
+++ b/src/api/routers/runtime_utils.py
@@ -2,6 +2,8 @@ import os
 
 from fastapi import HTTPException, status
 
+from src.core.common.capabilities import psycopg_error_type
+
 
 def env_flag(name: str, default: bool) -> bool:
     value = os.getenv(name)
@@ -22,3 +24,17 @@ def normalize_backend_init_error(*, detail: str, required_detail: str, fallback_
     if detail == required_detail:
         return detail
     return fallback_detail
+
+
+def postgres_connection_exception_types() -> tuple[type[BaseException], ...]:
+    types: list[type[BaseException]] = [
+        ConnectionError,
+        OSError,
+        TimeoutError,
+        TypeError,
+        ValueError,
+    ]
+    error_type = psycopg_error_type()
+    if error_type is not None:
+        types.append(error_type)
+    return tuple(types)

--- a/src/core/common/capabilities.py
+++ b/src/core/common/capabilities.py
@@ -1,4 +1,6 @@
 from importlib.util import find_spec
+
+
 def has_optional_dependency(module_name: str) -> bool:
     return find_spec(module_name) is not None
 

--- a/tests/integration/proposals/test_proposals_api_integration.py
+++ b/tests/integration/proposals/test_proposals_api_integration.py
@@ -104,6 +104,25 @@ def test_proposal_lifecycle_and_supportability_endpoints_roundtrip() -> None:
     assert supportability.json()["store_backend"] in {"INMEMORY", "POSTGRES"}
 
 
+def test_proposal_supportability_config_success_contract_shape() -> None:
+    with TestClient(app) as client:
+        response = client.get("/api/v1/rebalance/proposals/supportability/config")
+
+    assert response.status_code == 200
+    assert sorted(response.json().keys()) == [
+        "allow_portfolio_id_change_on_new_version",
+        "async_operations_enabled",
+        "backend_init_error",
+        "backend_ready",
+        "lifecycle_enabled",
+        "require_expected_state",
+        "require_proposal_simulation_flag",
+        "store_backend",
+        "store_evidence_bundle",
+        "support_apis_enabled",
+    ]
+
+
 def test_proposal_lifecycle_error_contracts() -> None:
     payload = _proposal_payload()
     with TestClient(app) as client:

--- a/tests/unit/core/test_capabilities.py
+++ b/tests/unit/core/test_capabilities.py
@@ -1,28 +1,30 @@
-from types import ModuleType
 import sys
+from types import ModuleType
+
+from _pytest.monkeypatch import MonkeyPatch
 
 from src.core.common import capabilities
 
 
-def test_solver_dependency_flag_matches_component_flags():
+def test_solver_dependency_flag_matches_component_flags() -> None:
     assert capabilities.has_solver_dependencies() == (
         capabilities.has_optional_dependency("cvxpy")
         and capabilities.has_optional_dependency("numpy")
     )
 
 
-def test_psycopg_error_type_none_when_driver_missing(monkeypatch):
+def test_psycopg_error_type_none_when_driver_missing(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(capabilities, "has_psycopg", lambda: False)
     assert capabilities.psycopg_error_type() is None
 
 
-def test_psycopg_error_type_from_driver_module(monkeypatch):
+def test_psycopg_error_type_from_driver_module(monkeypatch: MonkeyPatch) -> None:
     fake = ModuleType("psycopg")
 
     class FakeError(Exception):
         pass
 
-    fake.Error = FakeError
+    setattr(fake, "Error", FakeError)
     monkeypatch.setattr(capabilities, "has_psycopg", lambda: True)
     monkeypatch.setitem(sys.modules, "psycopg", fake)
 

--- a/tests/unit/core/test_target_generation_helpers.py
+++ b/tests/unit/core/test_target_generation_helpers.py
@@ -1,0 +1,75 @@
+from decimal import Decimal
+
+from src.core.models import EngineOptions, GroupConstraint, ShelfEntry
+from src.core.target_generation import (
+    _build_solver_attempts,
+    _collect_infeasibility_hints,
+    _solver_failure_reason,
+)
+
+
+class _CpStub:
+    OSQP = "OSQP"
+    SCS = "SCS"
+
+
+def test_build_solver_attempts_order_and_profiles() -> None:
+    attempts = _build_solver_attempts(_CpStub)
+    assert [attempt[0] for attempt in attempts] == ["OSQP", "SCS"]
+    assert attempts[0][1][0]["max_iter"] == 2_000
+    assert attempts[1][1][0]["max_iters"] == 5_000
+
+
+def test_solver_failure_reason_classification() -> None:
+    assert _solver_failure_reason(None) == "SOLVER_ERROR"
+    assert _solver_failure_reason("infeasible") == "INFEASIBLE_INFEASIBLE"
+    assert _solver_failure_reason("unbounded_inaccurate") == "UNBOUNDED_UNBOUNDED_INACCURATE"
+    assert _solver_failure_reason("optimal") == "SOLVER_NON_OPTIMAL_OPTIMAL"
+
+
+def test_collect_infeasibility_hints_reports_capacity_and_group_lock() -> None:
+    options = EngineOptions(
+        cash_band_min_weight=Decimal("0.10"),
+        cash_band_max_weight=Decimal("0.20"),
+        single_position_max_weight=Decimal("0.10"),
+        group_constraints={"sector:TECH": GroupConstraint(max_weight=Decimal("0.30"))},
+    )
+    eligible_targets = {
+        "EQ_TECH_LOCKED": Decimal("0.40"),
+        "EQ_NON_TECH": Decimal("0.10"),
+        "EQ_BUY_1": Decimal("0.25"),
+        "EQ_BUY_2": Decimal("0.25"),
+    }
+    shelf = [
+        ShelfEntry(
+            instrument_id="EQ_TECH_LOCKED",
+            status="SELL_ONLY",
+            attributes={"sector": "TECH"},
+        ),
+        ShelfEntry(
+            instrument_id="EQ_NON_TECH",
+            status="APPROVED",
+            attributes={"sector": "FIN"},
+        ),
+        ShelfEntry(
+            instrument_id="EQ_BUY_1",
+            status="APPROVED",
+            attributes={"sector": "FIN"},
+        ),
+        ShelfEntry(
+            instrument_id="EQ_BUY_2",
+            status="APPROVED",
+            attributes={"sector": "FIN"},
+        ),
+    ]
+
+    hints = _collect_infeasibility_hints(
+        tradeable_ids=["EQ_BUY_1", "EQ_BUY_2"],
+        locked_weight=Decimal("0.50"),
+        options=options,
+        eligible_targets=eligible_targets,
+        shelf=shelf,
+    )
+
+    assert "INFEASIBILITY_HINT_SINGLE_POSITION_CAPACITY" in hints
+    assert "INFEASIBILITY_HINT_LOCKED_GROUP_WEIGHT_sector:TECH" in hints

--- a/tests/unit/dpm/engine/test_engine_workflow_gates.py
+++ b/tests/unit/dpm/engine/test_engine_workflow_gates.py
@@ -1,26 +1,83 @@
-from types import SimpleNamespace
+from decimal import Decimal
+from typing import Literal
 
 from src.core.common.workflow_gates import evaluate_gate_decision
-from src.core.models import EngineOptions, RuleResult
+from src.core.models import (
+    DiagnosticsData,
+    EngineOptions,
+    RuleResult,
+    SuitabilityEvidence,
+    SuitabilityEvidenceSnapshotIds,
+    SuitabilityIssue,
+    SuitabilityResult,
+    SuitabilitySummary,
+)
 
 
-def _rule(rule_id: str, severity: str, status: str = "FAIL", reason_code: str = "X"):
+def _rule(
+    rule_id: str,
+    severity: Literal["HARD", "SOFT", "INFO"],
+    status: Literal["PASS", "FAIL"] = "FAIL",
+    reason_code: str = "X",
+) -> RuleResult:
     return RuleResult(
         rule_id=rule_id,
         severity=severity,
         status=status,
-        measured="1",
-        threshold={"max": "0"},
+        measured=Decimal("1"),
+        threshold={"max": Decimal("0")},
         reason_code=reason_code,
     )
 
 
-def test_workflow_gate_blocked_dominates():
+def _diagnostics(
+    *,
+    price_missing: list[str] | None = None,
+    fx_missing: list[str] | None = None,
+) -> DiagnosticsData:
+    return DiagnosticsData(
+        data_quality={
+            "price_missing": price_missing or [],
+            "fx_missing": fx_missing or [],
+        }
+    )
+
+
+def _high_suitability_result() -> SuitabilityResult:
+    issue = SuitabilityIssue(
+        issue_id="SUIT_ISSUER_MAX",
+        issue_key="ISSUER_MAX|X",
+        dimension="ISSUER",
+        severity="HIGH",
+        status_change="NEW",
+        summary="Issuer concentration exceeded",
+        details={},
+        evidence=SuitabilityEvidence(
+            as_of="md_1",
+            snapshot_ids=SuitabilityEvidenceSnapshotIds(
+                portfolio_snapshot_id="pf_1",
+                market_data_snapshot_id="md_1",
+            ),
+        ),
+    )
+    return SuitabilityResult(
+        summary=SuitabilitySummary(
+            new_count=1,
+            resolved_count=0,
+            persistent_count=0,
+            highest_severity_new="HIGH",
+        ),
+        issues=[issue],
+        recommended_gate="COMPLIANCE_REVIEW",
+    )
+
+
+def test_workflow_gate_blocked_dominates() -> None:
     gate = evaluate_gate_decision(
         status="BLOCKED",
         rule_results=[_rule("INSUFFICIENT_CASH", "HARD")],
         suitability=None,
-        diagnostics=SimpleNamespace(data_quality={"price_missing": [], "fx_missing": []}),
+        diagnostics=_diagnostics(),
         options=EngineOptions(),
         default_requires_client_consent=False,
     )
@@ -28,18 +85,12 @@ def test_workflow_gate_blocked_dominates():
     assert gate.recommended_next_step == "FIX_INPUT"
 
 
-def test_workflow_gate_compliance_for_new_high_suitability():
-    high_issue = SimpleNamespace(
-        status_change="NEW",
-        severity="HIGH",
-        issue_id="SUIT_ISSUER_MAX",
-        issue_key="ISSUER_MAX|X",
-    )
+def test_workflow_gate_compliance_for_new_high_suitability() -> None:
     gate = evaluate_gate_decision(
         status="READY",
         rule_results=[],
-        suitability=SimpleNamespace(issues=[high_issue]),
-        diagnostics=SimpleNamespace(data_quality={"price_missing": [], "fx_missing": []}),
+        suitability=_high_suitability_result(),
+        diagnostics=_diagnostics(),
         options=EngineOptions(),
         default_requires_client_consent=True,
     )
@@ -47,12 +98,12 @@ def test_workflow_gate_compliance_for_new_high_suitability():
     assert gate.recommended_next_step == "COMPLIANCE_REVIEW"
 
 
-def test_workflow_gate_risk_for_soft_fail():
+def test_workflow_gate_risk_for_soft_fail() -> None:
     gate = evaluate_gate_decision(
         status="PENDING_REVIEW",
         rule_results=[_rule("CASH_BAND", "SOFT")],
         suitability=None,
-        diagnostics=SimpleNamespace(data_quality={"price_missing": [], "fx_missing": []}),
+        diagnostics=_diagnostics(),
         options=EngineOptions(),
         default_requires_client_consent=False,
     )
@@ -60,12 +111,12 @@ def test_workflow_gate_risk_for_soft_fail():
     assert gate.recommended_next_step == "RISK_REVIEW"
 
 
-def test_workflow_gate_execution_ready_for_clean_dpm():
+def test_workflow_gate_execution_ready_for_clean_dpm() -> None:
     gate = evaluate_gate_decision(
         status="READY",
         rule_results=[],
         suitability=None,
-        diagnostics=SimpleNamespace(data_quality={"price_missing": [], "fx_missing": []}),
+        diagnostics=_diagnostics(),
         options=EngineOptions(),
         default_requires_client_consent=False,
     )
@@ -73,12 +124,12 @@ def test_workflow_gate_execution_ready_for_clean_dpm():
     assert gate.recommended_next_step == "EXECUTE"
 
 
-def test_workflow_gate_execution_ready_when_client_consent_already_obtained():
+def test_workflow_gate_execution_ready_when_client_consent_already_obtained() -> None:
     gate = evaluate_gate_decision(
         status="READY",
         rule_results=[],
         suitability=None,
-        diagnostics=SimpleNamespace(data_quality={"price_missing": [], "fx_missing": []}),
+        diagnostics=_diagnostics(),
         options=EngineOptions(client_consent_already_obtained=True),
         default_requires_client_consent=True,
     )
@@ -86,20 +137,12 @@ def test_workflow_gate_execution_ready_when_client_consent_already_obtained():
     assert gate.recommended_next_step == "EXECUTE"
 
 
-def test_workflow_gate_prioritizes_data_quality_in_reason_sorting():
-    high_issue = SimpleNamespace(
-        status_change="NEW",
-        severity="HIGH",
-        issue_id="SUIT_ISSUER_MAX",
-        issue_key="ISSUER_MAX|X",
-    )
+def test_workflow_gate_prioritizes_data_quality_in_reason_sorting() -> None:
     gate = evaluate_gate_decision(
         status="READY",
         rule_results=[_rule("CASH_BAND", "SOFT", reason_code="SOFT_CASH_BAND")],
-        suitability=SimpleNamespace(issues=[high_issue]),
-        diagnostics=SimpleNamespace(
-            data_quality={"price_missing": ["A"], "fx_missing": ["USD/SGD"]}
-        ),
+        suitability=_high_suitability_result(),
+        diagnostics=_diagnostics(price_missing=["A"], fx_missing=["USD/SGD"]),
         options=EngineOptions(),
         default_requires_client_consent=False,
     )

--- a/tests/unit/dpm/engine/test_engine_workflow_gates.py
+++ b/tests/unit/dpm/engine/test_engine_workflow_gates.py
@@ -97,7 +97,9 @@ def test_workflow_gate_prioritizes_data_quality_in_reason_sorting():
         status="READY",
         rule_results=[_rule("CASH_BAND", "SOFT", reason_code="SOFT_CASH_BAND")],
         suitability=SimpleNamespace(issues=[high_issue]),
-        diagnostics=SimpleNamespace(data_quality={"price_missing": ["A"], "fx_missing": ["USD/SGD"]}),
+        diagnostics=SimpleNamespace(
+            data_quality={"price_missing": ["A"], "fx_missing": ["USD/SGD"]}
+        ),
         options=EngineOptions(),
         default_requires_client_consent=False,
     )


### PR DESCRIPTION
## Scope
- add staged critical test typecheck gate (make typecheck-tests-critical) and wire it into CI
- tighten typing in workflow-gate/capabilities test modules so they pass mypy explicitly
- add target-generation helper unit coverage for solver attempt ordering, failure reasons, and infeasibility hints
- add supportability config success-contract shape assertion for proposals API
- keep backward compatibility for private postgres exception helper names while centralizing runtime exception typing utility

## Validation
- python -m ruff check src tests
- python -m mypy src
- python -m mypy tests/unit/core/test_capabilities.py tests/unit/dpm/engine/test_engine_workflow_gates.py
- python -m pytest -q
