### PR TITLE
RFC-0067 rollout for lotus-manage (OpenAPI + vocabulary + no-alias) [v2]

### DIFF
--- a/scripts/api_vocabulary_inventory.py
+++ b/scripts/api_vocabulary_inventory.py
@@ -399,7 +399,9 @@ def _normalize_for_compare(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def main() -> int:
-    parser = ArgumentParser(description="Generate and validate lotus-manage API vocabulary inventory")
+    parser = ArgumentParser(
+        description="Generate and validate lotus-manage API vocabulary inventory"
+    )
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
     parser.add_argument("--validate-only", action="store_true")
     args = parser.parse_args()

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -123,7 +123,9 @@ def _ensure_operation_documentation(schema: dict[str, Any], service_name: str) -
             if not operation.get("summary"):
                 operation["summary"] = f"{method.upper()} {path}"
             if not operation.get("description"):
-                operation["description"] = f"{method.upper()} operation for {path} in {service_name}."
+                operation["description"] = (
+                    f"{method.upper()} operation for {path} in {service_name}."
+                )
             if not operation.get("tags"):
                 if path.startswith("/health"):
                     operation["tags"] = ["Health"]
@@ -165,4 +167,3 @@ def enrich_openapi_schema(schema: dict[str, Any], *, service_name: str) -> dict[
     _ensure_operation_documentation(schema, service_name=service_name)
     _ensure_schema_documentation(schema)
     return schema
-


### PR DESCRIPTION
Supersedes #21 after CI formatting fix.\n\nIncludes:\n- no-alias contract rollout\n- openapi enrichment + quality gate\n- API vocabulary inventory + drift gate\n- CI/Makefile gate wiring\n- full test and mypy pass evidence in local validation