### PR TITLE
test: keep lotus-manage local postgres internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ This repository owns lotus-manage runtime workflows.
 Advisor-led proposal workflows are owned by `lotus-advise`.
 
 API docs endpoint: `/docs`
+
+Local Docker runtime does not publish the internal PostgreSQL port by default.
+`postgres:5432` remains internal to the Compose network, and only the application port `8000`
+is published for local API access.

--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -5,8 +5,6 @@ services:
       POSTGRES_DB: manage_supportability
       POSTGRES_USER: manage
       POSTGRES_PASSWORD: manage
-    ports:
-      - "5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U manage -d manage_supportability"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,6 @@ services:
   postgres:
     image: postgres:17.6
     restart: unless-stopped
-    ports:
-      - "5432:5432"
     environment:
       - POSTGRES_DB=manage_supportability
       - POSTGRES_USER=manage

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+def test_local_docker_compose_does_not_publish_internal_postgres_port() -> None:
+    compose_text = Path("docker-compose.yml").read_text(encoding="utf-8")
+
+    assert "postgres:17.6" in compose_text
+    assert '"5432:5432"' not in compose_text
+    assert '"8000:8000"' in compose_text
+
+
+def test_ci_local_docker_compose_does_not_publish_internal_postgres_port() -> None:
+    compose_text = Path("docker-compose.ci-local.yml").read_text(encoding="utf-8")
+
+    assert "postgres:17.6" in compose_text
+    assert '"5432:5432"' not in compose_text
+
+
+def test_readme_documents_internal_postgres_port_stays_unpublished() -> None:
+    readme_text = Path("README.md").read_text(encoding="utf-8")
+
+    assert "does not publish the internal PostgreSQL port by default" in readme_text
+    assert "`postgres:5432` remains internal to the Compose network" in readme_text


### PR DESCRIPTION
## Summary
- stop publishing postgres from the manage local docker baselines
- document the intended local runtime port exposure
- add a runtime contract test for the compose defaults

## Validation
- python -m pytest -q