### PR TITLE
feat: add canonical lotus-manage runtime startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 dist/
 build/
 *.pyc
+manage-*.log

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,9 @@ clean:
 run:
 	uvicorn src.api.main:app --reload --port 8000
 
+run-canonical:
+	uvicorn src.api.main:app --reload --host 0.0.0.0 --port 8001
+
 check-deps:
 	python -m pip check
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ Advisor-led proposal workflows are owned by `lotus-advise`.
 
 API docs endpoint: `/docs`
 
+Canonical local host runtime:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/Start-CanonicalManage.ps1
+```
+
+This starts `lotus-manage` on host port `8001` so it can coexist with `lotus-advise` on `8000`
+while remaining reachable through canonical ingress as `http://manage.dev.lotus`.
+
 Local Docker runtime does not publish the internal PostgreSQL port by default.
 `postgres:5432` remains internal to the Compose network, and only the application port `8000`
 is published for local API access.

--- a/scripts/Start-CanonicalManage.ps1
+++ b/scripts/Start-CanonicalManage.ps1
@@ -1,0 +1,59 @@
+param(
+  [int]$Port = 8001,
+  [string]$ListenHost = "0.0.0.0",
+  [switch]$Foreground
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$python = if (Test-Path (Join-Path $repoRoot ".venv\\Scripts\\python.exe")) {
+  Join-Path $repoRoot ".venv\\Scripts\\python.exe"
+} else {
+  "C:\\Python313\\python.exe"
+}
+
+$env:PYTHONPATH = Join-Path $repoRoot "src"
+$arguments = @(
+  "-m", "uvicorn",
+  "src.api.main:app",
+  "--host", $ListenHost,
+  "--port", "$Port"
+)
+
+if ($Foreground) {
+  Push-Location $repoRoot
+  try {
+    & $python @arguments
+    exit $LASTEXITCODE
+  } finally {
+    Pop-Location
+  }
+}
+
+try {
+  $existing = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop |
+    Select-Object -ExpandProperty OwningProcess -Unique
+  foreach ($pid in $existing) {
+    Stop-Process -Id $pid -Force -ErrorAction SilentlyContinue
+  }
+} catch {
+}
+
+$stdout = Join-Path $repoRoot "manage-$Port.out.log"
+$stderr = Join-Path $repoRoot "manage-$Port.err.log"
+try { if (Test-Path $stdout) { Remove-Item $stdout -Force -ErrorAction Stop } } catch {}
+try { if (Test-Path $stderr) { Remove-Item $stderr -Force -ErrorAction Stop } } catch {}
+
+Start-Process -FilePath $python `
+  -ArgumentList $arguments `
+  -WorkingDirectory $repoRoot `
+  -RedirectStandardOutput $stdout `
+  -RedirectStandardError $stderr | Out-Null
+
+Start-Sleep -Seconds 5
+$response = Invoke-WebRequest -Uri "http://127.0.0.1:$Port/health/ready" -UseBasicParsing -TimeoutSec 15
+if ($response.StatusCode -lt 200 -or $response.StatusCode -ge 300) {
+  throw "lotus-manage canonical startup failed on port $Port."
+}
+
+Write-Host "lotus-manage canonical startup ready on http://127.0.0.1:$Port"


### PR DESCRIPTION
## Summary
- add a canonical lotus-manage startup command on host port 8001
- document the coexistence rule with lotus-advise on 8000
- ignore transient canonical runtime logs

## Validation
- python -m ruff check .
- python -m ruff format --check .
- python scripts/check_monetary_float_usage.py
- python -m mypy --config-file mypy.ini
- python scripts/openapi_quality_gate.py
- python scripts/no_alias_contract_guard.py
- python scripts/api_vocabulary_inventory.py --validate-only
- python -m pytest tests/unit -q
