### PR TITLE
docs(manage): align RFC-0082 upstream contract posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Discretionary portfolio management (lotus-manage) execution, supportability, and
 
 Repository-local engineering context: `REPOSITORY-ENGINEERING-CONTEXT.md`
 
+RFC-0082 upstream contract-family conformance map:
+`docs/standards/RFC-0082-upstream-contract-family-map.md`
+
 This repository owns lotus-manage runtime workflows.
 Advisor-led proposal workflows are owned by `lotus-advise`.
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -31,7 +31,8 @@ Current repository posture:
 1. `lotus-manage` is the management-side service after the split from `lotus-advise`,
 2. canonical local host runtime uses port `8001` so it can coexist with `lotus-advise`,
 3. local CI and Docker parity are already standardized under the RFC-0072 lane model,
-4. the service remains part of the canonical front-office validation path through `lotus-gateway`.
+4. upstream and source-data authority posture is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
+5. the service remains part of the canonical front-office validation path through `lotus-gateway`.
 
 ## Architecture And Module Map
 
@@ -58,7 +59,9 @@ Boundary rules:
 1. management workflows belong here,
 2. proposal and advisor-led flows belong in `lotus-advise`,
 3. host runtime identity and coexistence with `lotus-advise` are part of the operational contract,
-4. management capabilities should remain aligned with gateway-facing product expectations.
+4. management capabilities should remain aligned with gateway-facing product expectations,
+5. `lotus-core` remains the source-data authority for core-referenced portfolio, market-data, price, and FX inputs,
+6. REST/OpenAPI remains the canonical integration contract; gRPC is not justified for current management workflows.
 
 ## Repo-Native Commands
 
@@ -100,13 +103,16 @@ Most relevant current governance:
 3. `../lotus-platform/rfcs/RFC-0071-centralized-environment-scoped-service-addressing-and-ingress-governance.md`
 4. `../lotus-platform/rfcs/RFC-0072-platform-wide-multi-lane-ci-validation-and-release-governance.md`
 5. `../lotus-platform/rfcs/RFC-0073-lotus-ecosystem-engineering-context-and-agent-guidance-system.md`
+6. `../lotus-platform/rfcs/RFC-0082-lotus-core-domain-authority-and-analytics-serving-boundary-hardening.md`
+7. `docs/standards/RFC-0082-upstream-contract-family-map.md`
 
 ## Known Constraints And Implementation Notes
 
 1. management/advisory boundary clarity is a real quality concern after the split,
 2. canonical local host runtime matters because port coexistence with `lotus-advise` is intentional,
 3. local `pip check` and project-scoped security posture still matter for repo truth here,
-4. this repo should stay operationally aligned with gateway and platform startup sequences.
+4. `pas_ref`, inline bundle source-data lineage, and remaining advisory/proposal compatibility surfaces are RFC-0082 watchlist areas,
+5. this repo should stay operationally aligned with gateway and platform startup sequences.
 
 ## Context Maintenance Rule
 
@@ -116,7 +122,8 @@ Update this document when:
 2. runtime or coexistence assumptions with `lotus-advise` change,
 3. repo-native commands or CI expectations change,
 4. upstream or downstream integration posture changes materially,
-5. current-state rollout posture changes.
+5. RFC-0082 contract-family classification changes,
+6. current-state rollout posture changes.
 
 ## Cross-Links
 

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -1,0 +1,110 @@
+# RFC-0082 Upstream Contract Family Map
+
+This document records how `lotus-manage` fits the `lotus-platform` RFC-0082 boundary model.
+
+`lotus-manage` owns discretionary portfolio-management execution, rebalance simulation, what-if
+analysis, management-side workflow supportability, policy-pack behavior, idempotency, lineage, and
+run-support contracts. It does not own canonical portfolio ledger data, market-data source truth,
+performance analytics, risk analytics, advisory-only workflow, reporting, or UI experience
+composition.
+
+## Current Integration Posture
+
+1. REST/OpenAPI remains the governed integration contract for current `lotus-manage` public and
+   integration-facing APIs.
+2. No current `lotus-manage` integration requires or justifies gRPC.
+3. The current codebase does not contain an active outbound HTTP client to `lotus-core`,
+   `lotus-performance`, or `lotus-risk`.
+4. `lotus-manage` accepts portfolio snapshots, market-data snapshots, model targets, shelf data, and
+   options through request contracts. When those inputs are core-referenced, `lotus-core` remains the
+   source-data authority.
+5. `lotus-gateway` is the primary product-facing consumer of `lotus-manage` capabilities and workflow
+   surfaces.
+
+## `lotus-core` Contract Family Posture
+
+| Manage surface | Upstream authority relationship | RFC-0082 family | Manage use | Boundary rule |
+| --- | --- | --- | --- | --- |
+| `portfolio_snapshot` request payloads | source data should be `lotus-core`-governed when populated from platform state | Snapshot and simulation / Operational Read input | rebalance and what-if source state | manage may transform for execution, but must not become the ledger or portfolio read authority |
+| `market_data_snapshot` request payloads | prices and FX should remain core-governed source data when populated from platform state | Operational Read input / Analytics Input watchlist | valuation, settlement, tax, and rebalance execution support | manage may use inputs for execution, but source truth remains upstream |
+| `pas_ref` capability mode | references platform-owned state rather than accepting a full inline bundle | Snapshot and simulation input | stateful DPM execution posture advertised through capabilities | future stateful resolution must use governed core contracts rather than ad hoc reads |
+| inline bundle mode | caller supplies full input bundle | Local execution input | deterministic local simulation and analysis | bundle acceptance does not transfer source-data authority to manage |
+
+## Manage-Owned Contract Families
+
+| Surface | Route family | Owner | Boundary rule |
+| --- | --- | --- | --- |
+| rebalance simulation | `POST /rebalance/simulate` | `lotus-manage` | owns deterministic DPM execution result, policy application, controls, and workflow gate output |
+| what-if analysis | `POST /rebalance/analyze`, `POST /rebalance/analyze/async` | `lotus-manage` | owns scenario orchestration and run correlation semantics |
+| async operation execution | `/rebalance/operations/*` | `lotus-manage` | owns management-side operation state and supportability |
+| run supportability | `/rebalance/runs/*`, `/rebalance/supportability/summary` | `lotus-manage` | owns run lookup, lineage, idempotency mapping, support bundles, and deterministic artifacts |
+| policy-pack supportability | `/rebalance/policies/*` | `lotus-manage` | owns DPM policy-pack selection and diagnostics |
+| integration capabilities | `/integration/capabilities`, `/platform/capabilities` | `lotus-manage` | owns feature/workflow capability truth for gateway and platform consumers |
+
+## Split-Boundary Posture
+
+`lotus-advise` is the advisory workflow and proposal simulation authority after the repository split.
+Any remaining advisory-labeled or proposal-lifecycle surface in `lotus-manage` is treated as
+compatibility or managed cleanup surface unless a current repo RFC explicitly keeps it here.
+
+Boundary rules:
+
+1. advisor-led proposal workflow should not expand in `lotus-manage`,
+2. new advisory decision-summary, alternatives, suitability, or consent behavior belongs in
+   `lotus-advise`,
+3. gateway-facing management workflow should consume `lotus-manage` for DPM execution and
+   supportability only.
+
+## Conformance Rules
+
+1. `lotus-manage` may own execution decisions produced by its DPM engine from governed inputs.
+2. `lotus-manage` must not own canonical portfolio state, account state, transaction state, price
+   source truth, FX source truth, performance attribution, benchmark-relative interpretation, or risk
+   methodology.
+3. `pas_ref` and future stateful input modes must be implemented through governed `lotus-core`
+   snapshot, operational-read, analytics-input, or control-plane contracts.
+4. Inline bundle behavior must preserve lineage identifiers for portfolio and market-data snapshots so
+   callers can trace source authority.
+5. Gateway capability consumers must receive backend-owned feature and workflow truth from
+   `/integration/capabilities`; UI or gateway layers must not infer manage feature flags.
+6. Transport optimization discussions start with request shape, payload size, async execution,
+   idempotency, caching, and supportability. gRPC is not a default answer for management workflows.
+
+## Current Evidence
+
+Existing tests that cover this posture include:
+
+1. `tests/unit/dpm/api/test_integration_capabilities_api.py`
+2. `tests/unit/dpm/api/test_api_rebalance.py`
+3. `tests/unit/dpm/engine/test_engine_core_flows.py`
+4. `tests/unit/dpm/engine/test_engine_valuation_service.py`
+5. `tests/unit/dpm/engine/test_engine_workflow_gates.py`
+6. `tests/unit/dpm/supportability/test_dpm_run_workflow_service.py`
+7. `tests/unit/dpm/supportability/test_dpm_lineage_service.py`
+8. `tests/unit/dpm/supportability/test_dpm_idempotency_history_service.py`
+9. `tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py`
+10. `tests/integration/dpm/api/test_dpm_api_workflow_integration.py`
+11. `tests/integration/dpm/supportability/test_dpm_postgres_repository_integration.py`
+12. `tests/integration/dpm/supportability/test_dpm_policy_pack_postgres_repository_integration.py`
+
+This RFC-0082 documentation slice did not change runtime behavior, OpenAPI output, migrations, or
+upstream request/response contracts.
+
+## Gap Register
+
+1. `pas_ref` is advertised as a supported input mode, but the current code inspection did not find an
+   active outbound state-resolution client. When that becomes active, classify the exact `lotus-core`
+   routes before stabilizing the contract.
+2. Inline portfolio and market-data bundles are operationally useful, but they can blur source-data
+   authority. Keep snapshot identifiers, request hashes, and supportability bundles mandatory for
+   traceability.
+3. Remaining advisory/proposal-lifecycle surfaces in `lotus-manage` should not receive new advisory
+   scope unless a split-governance decision explicitly keeps them here.
+4. If DPM simulation becomes latency-constrained, prefer async execution, payload shaping, policy-pack
+   caching, and source-data retrieval design before considering a transport change.
+
+## Validation Lane
+
+This document is governed as Feature Lane documentation and contract proof. Escalate to PR Merge Gate
+only when a future slice changes management runtime behavior, public API contracts, migrations, or
+upstream coupling.

--- a/docs/standards/data-model-ownership.md
+++ b/docs/standards/data-model-ownership.md
@@ -1,18 +1,20 @@
 # Data Model Ownership
 
-- Service: `lotus-advise`
-- Ownership: advisory/discretionary proposal and policy execution domain schema.
+- Service: `lotus-manage`
+- Ownership: discretionary portfolio-management execution, supportability, policy-pack, and manage-local workflow persistence schema.
 
 ## Owned Domains
 
 - lotus-manage policy-pack persistence model.
-- Advisory proposal workflow persistence model.
+- lotus-manage run, supportability, lineage, and workflow persistence model.
+- Any remaining manage-local proposal workflow persistence while split-governance cleanup is in progress.
 - Schema migration history (`schema_migrations`) for lotus-manage namespaces.
 
 ## Service Boundaries
 
 - Core portfolio ledger, valuation, and transaction source data remains lotus-core-owned.
 - Advanced analytics are lotus-performance-owned and consumed through APIs where needed.
+- Advisor-led proposal workflow ownership belongs to lotus-advise.
 
 ## Schema Rules
 


### PR DESCRIPTION
## Summary
- map `lotus-manage` upstream consumption under RFC-0082
- clarify that management workflows stay on REST/OpenAPI and consume governed lotus-core source-data contracts
- keep the repo context and ownership docs aligned with the current management/advisory split

## Validation
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python -m mypy --config-file mypy.ini`
- `python -m pytest tests/unit -q`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/no_alias_contract_guard.py`
- `git diff --check`

## Notes
- local `make check` is currently blocked by a bare `ruff` executable lookup in the Makefile on this machine, so the equivalent Python-backed commands above were run directly and passed
- draft first so CI can run while the broader RFC-0082 rollout remains in flight across sibling repos
