### PR TITLE
docs: standardize lotus-manage readme and wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,149 @@
-# Lotus Manage
+# lotus-manage
 
-Discretionary portfolio management (lotus-manage) execution, supportability, and lifecycle service.
+Discretionary portfolio-management execution, supportability, and lifecycle service for the Lotus
+ecosystem.
 
-Repository-local engineering context: `REPOSITORY-ENGINEERING-CONTEXT.md`
+Repository-local engineering context:
+[REPOSITORY-ENGINEERING-CONTEXT.md](REPOSITORY-ENGINEERING-CONTEXT.md)
 
-RFC-0082 upstream contract-family conformance map:
-`docs/standards/RFC-0082-upstream-contract-family-map.md`
+RFC-0082 upstream contract-family map:
+[docs/standards/RFC-0082-upstream-contract-family-map.md](docs/standards/RFC-0082-upstream-contract-family-map.md)
 
-This repository owns lotus-manage runtime workflows.
-Advisor-led proposal workflows are owned by `lotus-advise`.
+## Purpose And Scope
+
+`lotus-manage` owns management-side workflows:
+
+- deterministic rebalance simulation
+- multi-scenario what-if analysis
+- async operation execution and polling
+- run supportability, lineage, idempotency, and artifact retrieval
+- policy-pack resolution and management-side workflow gating
+
+It does not own advisor-led proposal workflows. Those belong to `lotus-advise`.
+
+It also does not own canonical portfolio ledger data, market-data truth, risk methodology, or
+performance analytics authority.
+
+## Ownership And Boundaries
+
+`lotus-manage` is the management-side execution and supportability authority, but it is not the
+system of record for the upstream portfolio ecosystem.
+
+It depends on:
+
+- `lotus-core`
+  source-data authority for core-referenced portfolio, market-data, price, and FX inputs
+- `lotus-gateway`
+  primary product-facing consumer of rebalance, supportability, and capability-discovery surfaces
+
+Current posture under RFC-0082:
+
+1. rebalance simulation, policy-pack behavior, async operations, and run-support contracts are
+   owned here
+2. stateful `portfolio_id` mode must remain anchored to governed `lotus-core` authority
+3. remaining advisory or proposal-lifecycle routes in this repo are compatibility or cleanup
+   surfaces, not a mandate to expand advisory scope here
+
+## Current Operational Posture
+
+1. `lotus-manage` is the management-side service after the split from `lotus-advise`.
+2. Canonical local host runtime uses port `8001` so it can coexist with `lotus-advise` on `8000`.
+3. CI already enforces no-alias, OpenAPI, API vocabulary, migration-smoke, and security-audit
+   validation.
+4. Host/runtime coexistence and gateway-facing capability discovery are part of the operational
+   contract.
+
+## Architecture At A Glance
+
+Main runtime surfaces come from [src/api/main.py](src/api/main.py):
+
+- rebalance simulation
+  `/rebalance/simulate`, `/rebalance/analyze`, `/rebalance/analyze/async`
+- run supportability
+  `/rebalance/runs/*`, `/rebalance/operations/*`, `/rebalance/supportability/summary`,
+  `/rebalance/lineage/*`, `/rebalance/idempotency/*`
+- policy-pack supportability
+  `/rebalance/policies/*`
+- integration capabilities
+  `/integration/capabilities`, `/platform/capabilities`
+- compatibility advisory surfaces
+  proposal simulation and proposal lifecycle routes that remain present during split cleanup
+- platform surfaces
+  `/health`, `/health/live`, `/health/ready`, `/docs`
+
+Key code areas:
+
+- `src/api/`
+  FastAPI entrypoints, routers, readiness, observability, and OpenAPI enrichment
+- `src/core/dpm/`
+  discretionary portfolio-management simulation engine and supporting rebalance modules
+- `src/core/dpm_runs/`
+  async operation, workflow, artifact, and supportability services for rebalance runs
+- `src/core/proposals/`
+  compatibility proposal-lifecycle models and services still carried in this repo
+- `src/infrastructure/`
+  PostgreSQL migrations, repository backends, and policy-pack persistence
+- `docs/`
+  project overview, RFCs, runbooks, standards, and operational documentation
+
+## Quick Start
+
+Install dependencies:
+
+```bash
+make install
+```
+
+Run the service locally on the default development port:
+
+```bash
+make run
+```
+
+Run the canonical host runtime that coexists with `lotus-advise`:
+
+```bash
+make run-canonical
+```
 
 API docs endpoint: `/docs`
 
-Canonical local host runtime:
+## Validation And CI Lanes
+
+`lotus-manage` follows the Lotus multi-lane model:
+
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
+
+Repo-native gate mapping:
+
+- `make check`
+  lint, no-alias, typecheck, OpenAPI gate, API vocabulary gate, and unit tests
+- `make ci`
+  merge-gate style local proof with migration smoke, full coverage-backed tests, and security audit
+- `make ci-local`
+  local feature-lane split by unit, integration, and e2e coverage phases
+- `make ci-local-docker`
+  Docker parity for the local CI contract
+
+When the README changes, also run:
+
+```bash
+python -m pytest tests/unit/test_local_docker_runtime_contract.py -q
+```
+
+That test protects the local Docker runtime contract language.
+
+When DPM supportability or OpenAPI-facing docs change materially, also run:
+
+```bash
+python -m pytest tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py -q
+```
+
+## Runtime And Docker Posture
+
+Canonical host runtime:
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts/Start-CanonicalManage.ps1
@@ -24,3 +155,29 @@ while remaining reachable through canonical ingress as `http://manage.dev.lotus`
 Local Docker runtime does not publish the internal PostgreSQL port by default.
 `postgres:5432` remains internal to the Compose network, and only the application port `8000`
 is published for local API access.
+
+Operationally important truths:
+
+1. readiness and migration posture matter because supportability flows depend on persistence truth
+2. capability discovery through `/integration/capabilities` remains backend-owned and uses
+   canonical snake_case query parameters
+3. compatibility advisory routes should be maintained carefully but should not grow advisory scope
+
+## Documentation Map
+
+- project overview:
+  [docs/documentation/project-overview.md](docs/documentation/project-overview.md)
+- operations and CI strategy:
+  [docs/operations/development-workflow-and-ci-strategy.md](docs/operations/development-workflow-and-ci-strategy.md)
+- service runbook:
+  [docs/runbooks/service-operations.md](docs/runbooks/service-operations.md)
+- RFC index:
+  [docs/rfcs/README.md](docs/rfcs/README.md)
+- local standards:
+  [docs/standards](docs/standards)
+
+## Wiki Source
+
+Repository-authored wiki pages live under [wiki/](wiki). If the GitHub wiki is published later,
+keep `wiki/` as the canonical source and treat any separate `*.wiki.git` clone as publication
+plumbing only.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -42,7 +42,11 @@ Primary areas:
    management APIs, workflow logic, and supporting modules.
 2. `scripts/`
    OpenAPI, vocabulary, migration, and governance scripts.
-3. `tests/`
+3. `docs/`
+   project overview, runbooks, standards, demo evidence, and RFC documentation.
+4. `wiki/`
+   canonical authored source for repository wiki publication and operator onboarding summaries.
+5. `tests/`
    unit, integration, and e2e validation.
 
 ## Runtime And Integration Boundaries
@@ -92,7 +96,11 @@ Important validation expectations:
 
 1. no-alias, OpenAPI, API vocabulary, migration smoke, and security audit are active,
 2. PR-grade validation includes coverage-backed full test execution,
-3. host/runtime coexistence assumptions matter for canonical front-office startup.
+3. host/runtime coexistence assumptions matter for canonical front-office startup,
+4. README changes should preserve the local Docker runtime contract language enforced by
+   `tests/unit/test_local_docker_runtime_contract.py`,
+5. DPM supportability and OpenAPI-facing docs changes should respect the targeted contract tests in
+   `tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py`.
 
 ## Standards And RFCs That Govern This Repository
 
@@ -112,7 +120,11 @@ Most relevant current governance:
 2. canonical local host runtime matters because port coexistence with `lotus-advise` is intentional,
 3. local `pip check` and project-scoped security posture still matter for repo truth here,
 4. `portfolio_id` stateful-mode semantics, inline bundle source-data lineage, and remaining advisory/proposal compatibility surfaces are RFC-0082 watchlist areas,
-5. this repo should stay operationally aligned with gateway and platform startup sequences.
+5. this repo should stay operationally aligned with gateway and platform startup sequences,
+6. repo-local `wiki/` content should stay concise, operator-focused, and derived from repo truth
+   rather than duplicating the full `docs/` tree,
+7. `make check` may refresh generated API vocabulary output; docs-only slices should inspect that
+   diff and avoid committing timestamp-only churn when the semantic inventory is unchanged.
 
 ## Context Maintenance Rule
 
@@ -123,7 +135,8 @@ Update this document when:
 3. repo-native commands or CI expectations change,
 4. upstream or downstream integration posture changes materially,
 5. RFC-0082 contract-family classification changes,
-6. current-state rollout posture changes.
+6. current-state rollout posture changes,
+7. README or `wiki/` structure changes the repository-local onboarding or operator navigation model.
 
 ## Cross-Links
 

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -12,7 +12,7 @@
 - Liveness: /health/live
 - Readiness: /health/ready
 - General health: /health
-- Metadata: /metadata
+- OpenAPI docs: /docs
 
 ## Incident First Checks
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -1,0 +1,43 @@
+# API Surface
+
+## Core management surfaces
+
+- `POST /rebalance/simulate`
+  deterministic rebalance execution
+- `POST /rebalance/analyze`
+  synchronous what-if analysis
+- `POST /rebalance/analyze/async`
+  async what-if orchestration
+
+## Run supportability surfaces
+
+- `/rebalance/runs/*`
+  run lookup, workflow state, artifacts, and support bundles
+- `/rebalance/operations/*`
+  async operation status and execution
+- `/rebalance/lineage/*`
+  lineage traversal
+- `/rebalance/idempotency/*`
+  idempotency history and replay support
+- `/rebalance/supportability/summary`
+  store-wide supportability snapshot
+
+## Policy and capability surfaces
+
+- `/rebalance/policies/*`
+  effective policy resolution and catalog supportability
+- `/integration/capabilities`
+- `/platform/capabilities`
+  backend-owned feature and workflow discovery for gateway and platform consumers
+
+## Compatibility surfaces
+
+- advisory simulation and proposal lifecycle routes remain present in the router layout
+- treat them as compatibility or managed cleanup scope unless a current repo RFC says otherwise
+
+## Platform surfaces
+
+- `/health`
+- `/health/live`
+- `/health/ready`
+- `/docs`

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,31 @@
+# Architecture
+
+## Runtime model
+
+- FastAPI service
+- management-side domain logic in `src/core/dpm/` and `src/core/dpm_runs/`
+- PostgreSQL-backed persistence and migrations under `src/infrastructure/`
+- consumed primarily through `lotus-gateway`
+
+## Code map
+
+- `src/api/`
+  routers, request handling, readiness, observability, and OpenAPI enrichment
+- `src/core/dpm/`
+  rebalance engine, policy-pack resolution, turnover, settlement, tax, and constraint logic
+- `src/core/dpm_runs/`
+  async operation, workflow, artifact, and supportability services
+- `src/core/common/`
+  shared simulation primitives, diagnostics, workflow gates, and canonical helpers
+- `src/core/proposals/`
+  compatibility proposal-lifecycle modules still present after the service split
+- `src/infrastructure/`
+  persistence backends, policy-pack repositories, and PostgreSQL migrations
+
+## Boundary notes
+
+1. `lotus-manage` owns execution decisions produced from governed inputs
+2. `lotus-core` remains source-data authority when request inputs are core-referenced
+3. `lotus-gateway` is the primary downstream product consumer
+4. REST/OpenAPI remains the canonical integration contract
+5. capability discovery is backend-owned through `/integration/capabilities`

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -1,0 +1,25 @@
+# Development Workflow
+
+## Branching and slice model
+
+- branch from `main`
+- keep one branch per RFC or documentation slice
+- use PR-first delivery
+
+## Repo-native commands
+
+- `make check`
+  fast local gate
+- `make ci`
+  PR-grade local proof
+- `make ci-local`
+  split local merge-gate flow
+- `make ci-local-docker`
+  Docker parity
+
+## Documentation workflow
+
+- keep `README.md` concise and operator-facing
+- keep `wiki/` as the authored wiki source
+- keep deep implementation detail in `docs/`
+- inspect generated API vocabulary diffs before committing docs-only slices

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -1,0 +1,30 @@
+# Getting Started
+
+## Install
+
+```bash
+make install
+```
+
+## Run locally
+
+Default local runtime:
+
+```bash
+make run
+```
+
+Canonical host runtime:
+
+```bash
+make run-canonical
+```
+
+That host runtime uses port `8001` so `lotus-manage` can coexist with `lotus-advise`.
+
+## First docs to read
+
+- [README.md](../README.md)
+- [docs/documentation/project-overview.md](../docs/documentation/project-overview.md)
+- [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)
+- [docs/runbooks/service-operations.md](../docs/runbooks/service-operations.md)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,42 @@
+# lotus-manage wiki
+
+`lotus-manage` is the discretionary portfolio-management and operational workflow service in Lotus.
+
+## Start here
+
+- Repo entrypoint: [README.md](../README.md)
+- Repo context: [REPOSITORY-ENGINEERING-CONTEXT.md](../REPOSITORY-ENGINEERING-CONTEXT.md)
+- Project overview: [docs/documentation/project-overview.md](../docs/documentation/project-overview.md)
+- Upstream contract map:
+  [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)
+
+## Repo role
+
+This repo owns:
+
+- deterministic rebalance simulation and what-if analysis
+- management-side async execution and supportability workflows
+- run artifacts, lineage, idempotency, and policy-pack supportability
+- management capability publication for gateway and platform consumers
+
+This repo does not own:
+
+- advisor-led proposal workflows
+- canonical portfolio ledger and source-data authority
+- risk methodology or performance analytics authority
+- UI experience composition
+
+## Navigation
+
+- [Overview](Overview)
+- [Architecture](Architecture)
+- [API Surface](API-Surface)
+- [Getting Started](Getting-Started)
+- [Development Workflow](Development-Workflow)
+- [Validation and CI](Validation-and-CI)
+- [Operations Runbook](Operations-Runbook)
+- [Integrations](Integrations)
+- [Security and Governance](Security-and-Governance)
+- [RFC Index](RFC-Index)
+- [Roadmap](Roadmap)
+- [Troubleshooting](Troubleshooting)

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -1,0 +1,21 @@
+# Integrations
+
+## Upstream and downstream posture
+
+- `lotus-core`
+  source-data authority when management flows use core-referenced portfolio or market inputs
+- `lotus-gateway`
+  primary consumer of management execution, supportability, and capability-discovery contracts
+
+## Boundary rules
+
+1. `lotus-manage` may execute deterministic rebalance decisions from governed inputs
+2. inline bundles do not transfer source-data authority to `lotus-manage`
+3. `portfolio_id` and future stateful modes must stay grounded in governed `lotus-core` contracts
+4. capability consumers should use canonical snake_case query parameters `consumer_system` and
+   `tenant_id`
+5. remaining advisory compatibility routes should not be used to expand advisory ownership here
+
+## Reference
+
+- [docs/standards/RFC-0082-upstream-contract-family-map.md](../docs/standards/RFC-0082-upstream-contract-family-map.md)

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -1,0 +1,24 @@
+# Operations Runbook
+
+## Important operational checks
+
+- verify readiness and migration posture before trusting supportability endpoints
+- confirm canonical host runtime uses port `8001` and ingress identity `manage.dev.lotus`
+- treat run-support or workflow lookup failures as persistence or migration issues first
+- use repo-native smoke and CI commands before inventing ad hoc runtime checks
+
+## Operational truths
+
+- host/runtime coexistence with `lotus-advise` is part of the service contract
+- supportability flows depend on truthful run persistence, lineage, and idempotency history
+- capability discovery is backend-owned and should not be inferred by downstream callers
+- local Docker keeps PostgreSQL internal to the Compose network by default
+
+## Key references
+
+- [docs/documentation/project-overview.md](../docs/documentation/project-overview.md)
+- [docs/documentation/postgres-migration-rollout-runbook.md](../docs/documentation/postgres-migration-rollout-runbook.md)
+- [docs/runbooks/service-operations.md](../docs/runbooks/service-operations.md)
+- [docs/standards/enterprise-readiness.md](../docs/standards/enterprise-readiness.md)
+- [docs/standards/migration-contract.md](../docs/standards/migration-contract.md)
+- [docs/standards/scalability-availability.md](../docs/standards/scalability-availability.md)

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -1,0 +1,30 @@
+# Overview
+
+## Business role
+
+`lotus-manage` owns discretionary portfolio-management execution and management-side workflow
+supportability. It turns governed portfolio inputs into deterministic rebalance decisions,
+supportability evidence, and operational workflow state.
+
+## Ownership boundaries
+
+This repo owns:
+
+1. rebalance simulation and what-if analysis
+2. async operation execution and run lookup
+3. policy-pack resolution and workflow-gate supportability
+4. run artifacts, lineage, idempotency, and management-side lifecycle support
+
+This repo does not own:
+
+1. advisor-led proposal workflows, which belong to `lotus-advise`
+2. canonical portfolio state and source-data truth, which belong to `lotus-core`
+3. risk methodology or performance analytics authority, which belong to `lotus-risk` and
+   `lotus-performance`
+
+## Current posture
+
+- management-side service after the `lotus-advise` split
+- canonical host runtime on port `8001` so both services can coexist locally
+- explicit no-alias, OpenAPI, vocabulary, migration, and security governance in CI
+- remaining advisory/proposal routes treated as compatibility or cleanup surfaces under RFC-0082

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -1,0 +1,46 @@
+# RFC Index
+
+## Platform RFCs that matter most here
+
+- RFC-0066
+- RFC-0067
+- RFC-0071
+- RFC-0072
+- RFC-0073
+- RFC-0082
+
+## High-value local RFCs
+
+- RFC-0001 to RFC-0013
+  core rebalance simulation, controls, optimization, and what-if analysis foundation
+- RFC-0016
+  idempotency replay contract
+- RFC-0017
+  run supportability APIs
+- RFC-0018
+  async operations resource
+- RFC-0019
+  deterministic run artifact contract
+- RFC-0020
+  workflow gate API and persistence
+- RFC-0021
+  OpenAPI hardening and request/response model separation
+- RFC-0022
+  policy-pack configuration model
+- RFC-0023
+  persistent supportability store and lineage APIs
+- RFC-0028
+  integration capabilities contract
+
+## Future-facing RFCs
+
+- RFC-0029
+  iterative workspace contract
+- RFC-0035
+  integration pyramid wave 6 depth expansion
+- RFC-0036
+  PostgreSQL-only runtime hard cutover
+
+## Full local RFC inventory
+
+- [docs/rfcs/README.md](../docs/rfcs/README.md)

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -1,0 +1,13 @@
+# Roadmap
+
+## Current direction
+
+- keep management-side execution and supportability boundaries clean after the service split
+- harden PostgreSQL-only runtime and migration posture
+- deepen integration and supportability validation without weakening deterministic contracts
+
+## Watchlist areas
+
+- `portfolio_id` stateful-mode implementation depth against governed `lotus-core` contracts
+- remaining advisory/proposal compatibility surfaces that still live in this repo
+- gateway capability-consumer alignment on canonical snake_case query parameters

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -1,0 +1,30 @@
+# Security and Governance
+
+## Current governance
+
+- RFC-0066
+  `lotus-advise` and `lotus-manage` split boundary
+- RFC-0067
+  centralized OpenAPI and vocabulary governance
+- RFC-0071
+  environment-scoped service addressing and ingress posture
+- RFC-0072
+  multi-lane CI and release governance
+- RFC-0073
+  ecosystem context and agent guidance system
+- RFC-0082
+  upstream authority and analytics serving boundary hardening
+
+## Repo-specific guardrails
+
+- no-alias contract guard is active
+- OpenAPI quality gate is active
+- API vocabulary inventory validation is active
+- migration smoke is part of the repo-native PR-grade contract
+- security audit is part of `make ci`
+
+## Operational discipline
+
+- keep management and advisory boundaries explicit
+- do not let gateway or UI infer capability truth that the backend already publishes
+- keep generated artifacts truthful and avoid timestamp-only churn in docs slices

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,22 @@
+# Troubleshooting
+
+## Common checks
+
+- if readiness fails, inspect persistence and migration posture first
+- if supportability endpoints return inconsistent results, verify run persistence and lineage stores
+- if local host startup collides with advisory runtime, confirm `lotus-manage` is using port `8001`
+- if capability discovery fails, check query parameter shape and backend route availability
+
+## Useful commands
+
+```bash
+make check
+make ci
+python -m pytest tests/unit/test_local_docker_runtime_contract.py -q
+python -m pytest tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py -q
+```
+
+## References
+
+- [docs/runbooks/service-operations.md](../docs/runbooks/service-operations.md)
+- [docs/documentation/postgres-migration-rollout-runbook.md](../docs/documentation/postgres-migration-rollout-runbook.md)

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -1,0 +1,39 @@
+# Validation and CI
+
+## Lane model
+
+`lotus-manage` uses:
+
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
+
+## Local command mapping
+
+- `make check`
+  lint, no-alias, typecheck, OpenAPI, API vocabulary, unit tests
+- `make ci`
+  migration smoke, full tests with coverage, security audit
+- `make ci-local`
+  split local validation across unit, integration, and e2e phases
+- `make ci-local-docker`
+  Docker parity for the local CI contract
+
+## Documentation contract proof
+
+When `README.md` changes, run:
+
+```bash
+python -m pytest tests/unit/test_local_docker_runtime_contract.py -q
+```
+
+That protects the local Docker runtime contract wording.
+
+When DPM supportability or OpenAPI-facing docs change, run:
+
+```bash
+python -m pytest tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py -q
+```
+
+If `make check` rewrites `docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json`,
+inspect the diff before committing. Timestamp-only `generatedAt` churn is not meaningful docs work.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,25 @@
+[Home](Home)
+
+[Overview](Overview)
+
+[Architecture](Architecture)
+
+[API Surface](API-Surface)
+
+[Getting Started](Getting-Started)
+
+[Development Workflow](Development-Workflow)
+
+[Validation and CI](Validation-and-CI)
+
+[Operations Runbook](Operations-Runbook)
+
+[Integrations](Integrations)
+
+[Security and Governance](Security-and-Governance)
+
+[RFC Index](RFC-Index)
+
+[Roadmap](Roadmap)
+
+[Troubleshooting](Troubleshooting)


### PR DESCRIPTION
## Summary
- standardize `README.md` as the concise repo front door for management-side ownership, boundaries, runtime posture, and validation commands
- add the repo-authored `wiki/` source set for onboarding, architecture, API grouping, operations, integrations, governance, and RFC navigation
- update repo context and service runbook to reflect the active docs contract tests, generated-artifact churn guidance, and current live route surface

## Validation
- `python -m pytest tests/unit/test_local_docker_runtime_contract.py tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py -q`
- `python -m mypy --config-file mypy.ini`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python -m pytest tests/unit -q`

## Notes
- `make check` reached the `mypy` step but the `mypy` executable was not on PATH in the current shell, so the equivalent repo-native commands were run directly via `python -m ...` instead.