### PR TITLE
docs: tighten lotus-manage runtime identity guidance

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -100,7 +100,10 @@ Important validation expectations:
 4. README changes should preserve the local Docker runtime contract language enforced by
    `tests/unit/test_local_docker_runtime_contract.py`,
 5. DPM supportability and OpenAPI-facing docs changes should respect the targeted contract tests in
-   `tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py`.
+   `tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py`,
+6. current operational evidence docs under `docs/demo/` and runbooks should preserve canonical
+   `lotus-manage` service, image, and ingress identity while clearly labeling historical local-only
+   debug paths.
 
 ## Standards And RFCs That Govern This Repository
 
@@ -123,7 +126,9 @@ Most relevant current governance:
 5. this repo should stay operationally aligned with gateway and platform startup sequences,
 6. repo-local `wiki/` content should stay concise, operator-focused, and derived from repo truth
    rather than duplicating the full `docs/` tree,
-7. `make check` may refresh generated API vocabulary output; docs-only slices should inspect that
+7. enterprise audit and readiness surfaces must emit `lotus-manage` service identity rather than
+   stale split-era names,
+8. `make check` may refresh generated API vocabulary output; docs-only slices should inspect that
    diff and avoid committing timestamp-only churn when the semantic inventory is unchanged.
 
 ## Context Maintenance Rule

--- a/docs/demo/manual-validation-2026-02-20.md
+++ b/docs/demo/manual-validation-2026-02-20.md
@@ -198,7 +198,7 @@ Demo pack validation passed for http://127.0.0.1:8000
       both return `200`.
     - `GET /rebalance/idempotency/{idempotency_key}/history` returns `200` with two entries
       preserving run ids, correlation ids, and request hashes.
-  - Container run (`lotus-advise:latest`, `DPM_IDEMPOTENCY_REPLAY_ENABLED=false`,
+  - Container run (`lotus-manage:latest`, `DPM_IDEMPOTENCY_REPLAY_ENABLED=false`,
     `DPM_IDEMPOTENCY_HISTORY_APIS_ENABLED=true`, `DPM_SUPPORTABILITY_STORE_BACKEND=SQLITE`)
     on `http://127.0.0.1:8012`:
     - Two `POST /rebalance/simulate` calls with same idempotency key and different payload hash
@@ -209,7 +209,7 @@ Demo pack validation passed for http://127.0.0.1:8000
     - `GET /rebalance/lineage/{correlation_id}` returns `200` with `CORRELATION_TO_RUN`.
     - `GET /rebalance/lineage/{idempotency_key}` returns `200` with `IDEMPOTENCY_TO_RUN`.
     - `GET /rebalance/lineage/{operation_id}` returns `200` with `OPERATION_TO_CORRELATION`.
-  - Container run (`lotus-advise:latest` with `DPM_SUPPORTABILITY_STORE_BACKEND=SQLITE`)
+  - Container run (`lotus-manage:latest` with `DPM_SUPPORTABILITY_STORE_BACKEND=SQLITE`)
     on `http://127.0.0.1:8002`:
     - `POST /rebalance/simulate` succeeded (`200`).
     - `GET /rebalance/runs/{rebalance_run_id}` succeeded (`200`).
@@ -286,7 +286,7 @@ Demo pack validation passed for http://127.0.0.1:8000
       - history `decisions=[]`
     - `GET /rebalance/workflow/decisions?limit=20` returns workflow decisions across runs.
     - `GET /rebalance/workflow/decisions?actor_id=...&action=...&limit=...` returns filtered rows.
-  - Container runtime (`lotus-advise:latest` with `-e DPM_WORKFLOW_ENABLED=true`,
+  - Container runtime (`lotus-manage:latest` with `-e DPM_WORKFLOW_ENABLED=true`,
     published on `http://127.0.0.1:8002`):
     - `GET /rebalance/runs/by-correlation/{correlation_id}/workflow` returns `200`.
     - `GET /rebalance/runs/idempotency/{idempotency_key}/workflow` returns `200`.
@@ -300,7 +300,7 @@ Demo pack validation passed for http://127.0.0.1:8000
     - Idempotency-key workflow retrieval without prior action returns:
       - `workflow_status=PENDING_REVIEW`
       - history `decisions=[]`
-  - Container runtime (`lotus-advise:latest` with `-e DPM_WORKFLOW_ENABLED=true`,
+  - Container runtime (`lotus-manage:latest` with `-e DPM_WORKFLOW_ENABLED=true`,
     published on `http://127.0.0.1:8031`):
     - `POST /rebalance/simulate` returns `200`.
     - `POST /rebalance/runs/{rebalance_run_id}/workflow/actions` with `APPROVE` returns `200`.
@@ -308,7 +308,7 @@ Demo pack validation passed for http://127.0.0.1:8000
       returns `200` with one matching decision.
     - `GET /rebalance/workflow/decisions/by-correlation/corr-manual-wf-docker`
       returns `200` with decision history for the resolved run.
-  - Container runtime (`lotus-advise:latest` with `-e DPM_WORKFLOW_ENABLED=true`,
+  - Container runtime (`lotus-manage:latest` with `-e DPM_WORKFLOW_ENABLED=true`,
     published on `http://127.0.0.1:8034`):
     - `POST /rebalance/simulate` + one workflow `APPROVE` action succeeded.
     - `GET /rebalance/workflow/decisions/by-correlation/corr-manual-wf-corr-docker`
@@ -343,7 +343,7 @@ Demo pack validation passed for http://127.0.0.1:8000
   - `DPM_SUPPORTABILITY_STORE_BACKEND=POSTGRES`
   - `DPM_SUPPORTABILITY_POSTGRES_DSN=postgresql://dpm:dpm@postgres:5432/dpm_supportability`
   - Commands:
-    - `docker-compose --profile postgres up -d --build lotus-advise`
+    - `docker-compose --profile postgres up -d --build lotus-manage`
     - `.venv\Scripts\python scripts/run_demo_pack_live.py --base-url http://127.0.0.1:8000`
   - Observed result:
     - `Demo pack validation passed for http://127.0.0.1:8000`
@@ -542,7 +542,7 @@ Demo pack validation passed for http://127.0.0.1:8000
 
 - Docker startup validation (expected fail-fast):
   - Command:
-    - `docker run --rm -e APP_PERSISTENCE_PROFILE=PRODUCTION -e DPM_SUPPORTABILITY_STORE_BACKEND=IN_MEMORY -e PROPOSAL_STORE_BACKEND=POSTGRES lotus-advise:latest`
+    - `docker run --rm -e APP_PERSISTENCE_PROFILE=PRODUCTION -e DPM_SUPPORTABILITY_STORE_BACKEND=IN_MEMORY -e PROPOSAL_STORE_BACKEND=POSTGRES lotus-manage:latest`
   - Observed:
     - container exits at startup with `PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES`.
 

--- a/src/api/enterprise_readiness.py
+++ b/src/api/enterprise_readiness.py
@@ -11,7 +11,7 @@ logger = logging.getLogger("enterprise_readiness")
 MiddlewareNext = Callable[[Request], Awaitable[Response]]
 MiddlewareCallable = Callable[[Request, MiddlewareNext], Awaitable[Response]]
 
-_SERVICE_NAME = "lotus-advise"
+_SERVICE_NAME = "lotus-manage"
 _WRITE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 _REQUIRED_HEADERS = {"x-actor-id", "x-tenant-id", "x-role", "x-correlation-id"}
 _REDACT_FIELDS = {

--- a/tests/unit/api/test_enterprise_readiness.py
+++ b/tests/unit/api/test_enterprise_readiness.py
@@ -2,6 +2,7 @@ import json
 
 from src.api.enterprise_readiness import (
     authorize_write_request,
+    emit_audit_event,
     is_feature_enabled,
     redact_sensitive,
     validate_enterprise_runtime_config,
@@ -60,3 +61,18 @@ def test_validate_enterprise_runtime_config_reports_rotation_issue(monkeypatch):
     monkeypatch.setenv("ENTERPRISE_SECRET_ROTATION_DAYS", "120")
     issues = validate_enterprise_runtime_config()
     assert "secret_rotation_days_out_of_range" in issues
+
+
+def test_emit_audit_event_uses_manage_service_identity(caplog):
+    with caplog.at_level("INFO", logger="enterprise_readiness"):
+        emit_audit_event(
+            action="POST /rebalance/simulate",
+            actor_id="operator-1",
+            tenant_id="tenant-1",
+            role="operator",
+            correlation_id="corr-1",
+            metadata={"status_code": 200},
+        )
+
+    assert caplog.records
+    assert caplog.records[-1].audit["service"] == "lotus-manage"


### PR DESCRIPTION
## Summary
- fix enterprise audit events to emit the correct `lotus-manage` service identity
- add a regression test so stale split-era service names do not leak back into manage audit surfaces
- correct current operator evidence docs under `docs/demo/` so image and compose examples reference `lotus-manage`, not `lotus-advise`
- extend repo-local context with the new documentation and runtime-identity guardrails

## Validation
- `python -m pytest tests/unit/api/test_enterprise_readiness.py -q`
- `python -m pytest tests/unit/test_local_docker_runtime_contract.py tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py -q`
- `python -m mypy --config-file mypy.ini`
- `python scripts/openapi_quality_gate.py`