### PR TITLE
docs: tighten lotus-manage overview boundaries

### DIFF
--- a/docs/documentation/engine-know-how.md
+++ b/docs/documentation/engine-know-how.md
@@ -4,4 +4,10 @@ This documentation has been split by engine type:
 
 - Project Overview (Business + BA + Engineering): `docs/documentation/project-overview.md`
 - lotus-manage Rebalance Engine: `docs/documentation/engine-know-how-dpm.md`
-- Advisory Proposal Engine: `docs/documentation/engine-know-how-advisory.md`
+- Advisory Proposal Compatibility Surface: `docs/documentation/engine-know-how-advisory.md`
+
+Strategic ownership note:
+
+- new advisory workflow ownership lives in `lotus-advise`
+- the advisory document in this repository exists to explain remaining compatibility surfaces and
+  migration posture, not to define new advisory scope for `lotus-manage`

--- a/docs/documentation/project-overview.md
+++ b/docs/documentation/project-overview.md
@@ -1,104 +1,153 @@
 # Project Overview
 
-This document explains the system at a high level for three audiences:
+This document explains `lotus-manage` at a high level for:
+
 - business stakeholders,
-- business analysts (BAs),
-- developers.
+- business analysts,
+- engineers,
+- operators.
 
-## What This Platform Does
+It is intentionally deeper than the repo `README.md`, but it should still stay summary-oriented.
+Detailed engine mechanics, RFC decisions, and operational procedures belong in their own focused
+documents.
 
-The platform provides deterministic portfolio decisioning APIs for:
-- **lotus-manage rebalancing** (model-driven discretionary portfolio management),
-- **Advisory proposals** (advisor-entered cash flows and manual trades).
+## What This Service Does
 
-Architecture authority:
-- Platform-wide integration and architecture standards are maintained centrally in `https://github.com/sgajbi/lotus-platform`.
-- This repository documents service-local implementation details and service-specific RFCs only.
+`lotus-manage` provides deterministic management-side portfolio workflow APIs for:
 
-Both flows produce structured, auditable outputs with:
-- before/after portfolio states,
-- intent-level actions,
-- rules and diagnostics,
-- lineage identifiers and deterministic hashes.
+- discretionary rebalance simulation,
+- multi-scenario what-if analysis,
+- policy-pack-aware workflow gating,
+- async execution and polling,
+- run supportability, lineage, artifacts, and idempotency lookup.
+
+Platform-wide architecture authority remains in `lotus-platform`. This repository documents
+service-local behavior and service-specific RFCs only.
 
 ## Why It Matters
 
-For business and control functions, the platform is built for:
+For business and control functions, `lotus-manage` is built for:
+
 - reproducibility,
 - explainability,
 - policy-based controls,
-- workflow readiness.
+- supportability,
+- execution readiness.
 
-Domain outcomes are returned as:
+Domain outcomes remain explicit rather than inferred:
+
 - `READY`
 - `PENDING_REVIEW`
 - `BLOCKED`
 
-The API remains deterministic for identical inputs and options.
-
 ## Core Business Flows
 
-1. lotus-manage flow
-- Input: portfolio snapshot, market snapshot, model targets, shelf, options.
-- Output: optimized rebalance intents with controls (tax, turnover, settlement, constraints).
+### 1. Rebalance simulation
 
-2. Advisory flow
-- Input: portfolio snapshot, market snapshot, shelf, advisor cash/trade proposals, options.
-- Output: proposal simulation plus optional artifact package for client/reviewer workflow.
+Input:
 
-3. Workflow semantics (shared)
-- Gate decisions provide deterministic next-step semantics:
-  - blocked,
-  - risk review,
-  - compliance review,
-  - client consent,
-  - execution ready.
+- governed portfolio state,
+- market inputs,
+- model targets,
+- shelf constraints,
+- policy options.
 
-## API Surface
+Output:
+
+- deterministic rebalance intents,
+- diagnostics and workflow posture,
+- before and after portfolio states,
+- lineage identifiers and supportability evidence.
+
+### 2. What-if and async execution support
+
+Input:
+
+- rebalance scenarios or analysis requests,
+- execution mode and correlation context.
+
+Output:
+
+- synchronous analysis or async acceptance,
+- durable operation lookup,
+- run artifacts and lineage references,
+- supportability summaries for investigation workflows.
+
+### 3. Capability and policy supportability
+
+Input:
+
+- tenant or consumer capability queries,
+- policy or workflow supportability lookups.
+
+Output:
+
+- backend-owned capability posture,
+- policy-pack supportability summaries,
+- workflow-gate visibility for downstream consumers.
+
+## Current Boundary Posture
+
+`lotus-manage` is the management-side service after the split from `lotus-advise`.
+
+That means:
+
+- management-side execution and supportability stay here,
+- advisor-led proposal ownership stays in `lotus-advise`,
+- `lotus-core` remains source-data authority for core-referenced portfolio, market-data, price,
+  and FX inputs.
+
+Some advisory proposal routes still remain in this repository as compatibility surfaces during
+cleanup. They should not be treated as a mandate to grow new advisory scope here.
+
+For compatibility-surface details, use:
+
+- `docs/documentation/engine-know-how-advisory.md`
+
+## API Surface Summary
+
+Primary management surfaces:
 
 - `POST /rebalance/simulate`
 - `POST /rebalance/analyze`
-- `POST /rebalance/proposals/simulate`
-- `POST /rebalance/proposals/artifact`
+- `POST /rebalance/analyze/async`
+- `/rebalance/runs/*`
+- `/rebalance/operations/*`
+- `/rebalance/lineage/*`
+- `/rebalance/idempotency/*`
+- `/rebalance/policies/*`
+- `/integration/capabilities`
+- `/platform/capabilities`
+
+For grouped route documentation, use the repo wiki and router-level docs rather than extending this
+overview into an endpoint catalog.
 
 ## Architecture Summary
 
-- `src/api/`: FastAPI contracts and endpoint orchestration.
-- `src/core/rebalance/`: lotus-manage-specific engine modules.
-- `src/core/advisory/`: Advisory-specific modules (artifact, funding, intents, ids).
-- `src/core/common/`: Shared logic (simulation primitives, diagnostics, drift, suitability, canonical hashing, workflow gates).
-- `src/core/models.py`: shared request/response contracts and options.
+Key module areas:
 
-## Test Strategy
+- `src/api/`
+  FastAPI contracts, readiness, observability, and endpoint orchestration
+- `src/core/dpm/`
+  rebalance engine and management-side simulation logic
+- `src/core/dpm_runs/`
+  async operation, workflow, artifact, and supportability services
+- `src/core/proposals/`
+  compatibility proposal-lifecycle modules still present after the split
+- `src/infrastructure/`
+  PostgreSQL migrations, repository backends, and policy-pack persistence
 
-Tests are organized by responsibility:
-- `tests/unit/dpm/`: lotus-manage API, engine, and lotus-manage golden tests.
-- `tests/unit/advisory/`: advisory API, engine, contracts, and advisory golden tests.
-- `tests/unit/shared/`: shared contracts/compliance/dependencies tests.
-- `tests/e2e/`: end-to-end workflow/demo scenario tests.
-- `tests/shared/`: shared test helpers (factories/assertions).
+## Document Map
 
-Golden fixtures are split by domain:
-- `tests/unit/dpm/golden_data/`
-- `tests/unit/advisory/golden_data/`
+Use the focused documents for detail:
 
-CI test execution model:
-- runs `tests/unit`, `tests/integration`, and `tests/e2e` in parallel matrix jobs,
-- combines per-suite coverage artifacts,
-- enforces a single repository-wide `99%` coverage gate.
-
-## Governance and RFCs
-
-- RFCs under `docs/rfcs/` define scope and acceptance.
-- Advisory refinement RFCs are under:
-  - `docs/rfcs/advisory pack/refine/`
-- Current implementation status is tracked in RFC metadata (`Status`, `Implemented In`).
-
-## Current Delivery Principle
-
-Keep lotus-manage and advisory behavior separated by business logic, while sharing:
-- vocabulary,
-- control semantics,
-- deterministic primitives,
-- test and audit standards.
-
+- management engine detail:
+  `docs/documentation/engine-know-how-dpm.md`
+- compatibility advisory surface detail:
+  `docs/documentation/engine-know-how-advisory.md`
+- migration rollout:
+  `docs/documentation/postgres-migration-rollout-runbook.md`
+- service operations:
+  `docs/runbooks/service-operations.md`
+- RFC index:
+  `docs/rfcs/README.md`


### PR DESCRIPTION
## Summary
- tighten `docs/documentation/project-overview.md` so the management-service boundary, operating model, and workflow vocabulary read more cleanly
- align `docs/documentation/engine-know-how.md` to the refined overview language so the repo-level narrative stays consistent

## Validation
- `python -m pytest tests/unit/test_local_docker_runtime_contract.py tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py -q`