### PR TITLE
Add repo-native manage domain product declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard no-alias-gate openapi-gate api-vocabulary-gate format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down
+.PHONY: install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate no-alias-gate openapi-gate api-vocabulary-gate format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down
 
 COVERAGE_FAIL_UNDER ?= 92
 
@@ -70,10 +70,10 @@ ci-local-docker-down:
 check-all: lint typecheck test-all
 
 typecheck:
-	mypy --config-file mypy.ini
+	python -m mypy --config-file mypy.ini
 
 typecheck-tests-critical:
-	mypy tests/unit/core/test_capabilities.py tests/unit/dpm/engine/test_engine_workflow_gates.py
+	python -m mypy tests/unit/core/test_capabilities.py tests/unit/dpm/engine/test_engine_workflow_gates.py
 
 openapi-gate:
 	python scripts/openapi_quality_gate.py
@@ -97,6 +97,9 @@ lint:
 
 monetary-float-guard:
 	python scripts/check_monetary_float_usage.py
+
+domain-product-validate:
+	python scripts/validate_domain_data_product_contracts.py
 
 format:
 	python -m ruff format .

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -32,7 +32,9 @@ Current repository posture:
 2. canonical local host runtime uses port `8001` so it can coexist with `lotus-advise`,
 3. local CI and Docker parity are already standardized under the RFC-0072 lane model,
 4. upstream and source-data authority posture is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
-5. the service remains part of the canonical front-office validation path through `lotus-gateway`.
+5. it carries repo-native RFC-0084 consumer declarations for the governed core portfolio-state
+   product used by management execution request contracts,
+6. the service remains part of the canonical front-office validation path through `lotus-gateway`.
 
 ## Architecture And Module Map
 
@@ -48,6 +50,8 @@ Primary areas:
    canonical authored source for repository wiki publication and operator onboarding summaries.
 5. `tests/`
    unit, integration, and e2e validation.
+6. `contracts/domain-data-products/`
+   repo-native consumer declarations for governed upstream domain data products.
 
 ## Runtime And Integration Boundaries
 
@@ -83,6 +87,8 @@ Use these commands as the primary local contract:
    `make ci-local-docker`
 6. canonical host runtime
    `make run-canonical`
+7. domain-data-product contract validation
+   `make domain-product-validate`
 
 ## Validation And CI Expectations
 
@@ -129,7 +135,11 @@ Most relevant current governance:
 7. enterprise audit and readiness surfaces must emit `lotus-manage` service identity rather than
    stale split-era names,
 8. `make check` may refresh generated API vocabulary output; docs-only slices should inspect that
-   diff and avoid committing timestamp-only churn when the semantic inventory is unchanged.
+   diff and avoid committing timestamp-only churn when the semantic inventory is unchanged,
+9. the current repo-native domain-data-product declaration intentionally records only governed
+   `PortfolioStateSnapshot` input consumption through caller-supplied management request payloads;
+   market-data and future stateful `portfolio_id` resolution must be added only after upstream
+   producer approval and an explicit source-data retrieval design.
 
 ## Context Maintenance Rule
 

--- a/contracts/domain-data-products/README.md
+++ b/contracts/domain-data-products/README.md
@@ -1,0 +1,36 @@
+# Lotus Manage Domain Data Product Declarations
+
+This directory stores `lotus-manage` repo-native declarations for governed Lotus domain data
+products.
+
+`lotus-manage` owns discretionary portfolio-management execution and supportability. It does not
+own canonical portfolio ledger state, market-data source truth, performance analytics, risk
+analytics, advisory-only workflows, reporting, or UI composition.
+
+Current declarations:
+
+1. `lotus-manage-consumers.v1.json`
+   Consumer declaration for the governed `lotus-core` portfolio-state product used by management
+   execution workflows through the current request-payload contract.
+
+Local validation:
+
+```powershell
+python scripts/validate_domain_data_product_contracts.py
+```
+
+Make target:
+
+```powershell
+make domain-product-validate
+```
+
+Current watchlist:
+
+1. `lotus-manage` currently has no active outbound source-data client to `lotus-core`,
+   `lotus-performance`, or `lotus-risk`.
+2. `portfolio_id` stateful resolution must add an explicit governed API-read dependency before it
+   becomes runtime behavior.
+3. Market-data request payloads remain source-data-authority sensitive, but `MarketDataWindow` is not
+   currently approved for `lotus-manage` in the upstream producer declaration. Do not declare it here
+   until upstream approval and required trust metadata are explicit.

--- a/contracts/domain-data-products/lotus-manage-consumers.v1.json
+++ b/contracts/domain-data-products/lotus-manage-consumers.v1.json
@@ -1,0 +1,30 @@
+{
+  "contract_id": "domain-data-product-consumers",
+  "contract_version": "1.0.0",
+  "governed_by_rfc": "RFC-0084",
+  "consumer_repository": "lotus-manage",
+  "dependencies": [
+    {
+      "product_name": "PortfolioStateSnapshot",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "generated_at",
+        "as_of_date",
+        "reconciliation_status",
+        "data_quality_status",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "caller_supplied_contract_payload",
+      "business_purpose": "Run discretionary rebalance simulation and what-if analysis from a governed portfolio-state snapshot supplied through the current management request contract.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed"
+    }
+  ]
+}

--- a/scripts/validate_domain_data_product_contracts.py
+++ b/scripts/validate_domain_data_product_contracts.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCAL_DECLARATION_DIR = ROOT / "contracts" / "domain-data-products"
+PLATFORM_ROOT = ROOT.parent / "lotus-platform"
+PLATFORM_DECLARATION_DIR = PLATFORM_ROOT / "platform-contracts" / "domain-data-products"
+PLATFORM_VOCABULARY_DIR = PLATFORM_ROOT / "platform-contracts" / "domain-vocabulary"
+PLATFORM_VALIDATOR_PATH = PLATFORM_DECLARATION_DIR / "validate_domain_data_product_contracts.py"
+
+PRODUCT_PATTERN = "*-products.v1.json"
+CONSUMER_PATTERN = "*-consumers.v1.json"
+VOCABULARY_FILENAMES = (
+    "domain-data-product-semantics.v1.json",
+    "domain-data-product-trust-metadata.v1.json",
+)
+
+
+def _load_platform_validator():
+    if not PLATFORM_VALIDATOR_PATH.exists():
+        raise FileNotFoundError(
+            f"Platform validator not found at {PLATFORM_VALIDATOR_PATH}. "
+            "Ensure the sibling lotus-platform repository is available."
+        )
+
+    spec = importlib.util.spec_from_file_location(
+        "lotus_platform_domain_product_validator", PLATFORM_VALIDATOR_PATH
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load platform validator from {PLATFORM_VALIDATOR_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _collect_local_declaration_paths(source_directory: Path) -> list[Path]:
+    return sorted(source_directory.glob(PRODUCT_PATTERN)) + sorted(
+        source_directory.glob(CONSUMER_PATTERN)
+    )
+
+
+def _collect_required_upstream_product_paths(source_directory: Path) -> list[Path]:
+    required_repositories: set[str] = set()
+    local_producer_repositories: set[str] = set()
+
+    for path in sorted(source_directory.glob(PRODUCT_PATTERN)):
+        payload = _load_json(path)
+        producer_repository = payload.get("producer_repository")
+        if isinstance(producer_repository, str) and producer_repository:
+            local_producer_repositories.add(producer_repository)
+
+    for path in sorted(source_directory.glob(CONSUMER_PATTERN)):
+        payload = _load_json(path)
+        for dependency in payload.get("dependencies", []):
+            if not isinstance(dependency, dict):
+                continue
+            producer_repository = dependency.get("producer_repository")
+            if isinstance(producer_repository, str) and producer_repository:
+                required_repositories.add(producer_repository)
+
+    upstream_paths: list[Path] = []
+    for producer_repository in sorted(required_repositories - local_producer_repositories):
+        candidate = PLATFORM_DECLARATION_DIR / f"{producer_repository}-products.v1.json"
+        if not candidate.exists():
+            raise FileNotFoundError(
+                f"Required upstream producer declaration not found at {candidate}. "
+                "Machine-readable consumer coverage cannot validate until the upstream "
+                "producer declaration exists."
+            )
+        upstream_paths.append(candidate)
+
+    return upstream_paths
+
+
+def platform_validation_dependencies_available(
+    source_directory: Path = LOCAL_DECLARATION_DIR,
+) -> bool:
+    required_paths = [
+        PLATFORM_VALIDATOR_PATH,
+        *(PLATFORM_VOCABULARY_DIR / file_name for file_name in VOCABULARY_FILENAMES),
+    ]
+    try:
+        required_paths.extend(_collect_required_upstream_product_paths(source_directory))
+    except FileNotFoundError:
+        return False
+    return all(path.exists() for path in required_paths)
+
+
+def validate_repo_native_contracts(source_directory: Path = LOCAL_DECLARATION_DIR) -> list[str]:
+    source_directory = source_directory.resolve()
+    if not source_directory.exists():
+        return [f"{source_directory}: repo-native declaration directory does not exist"]
+
+    local_paths = _collect_local_declaration_paths(source_directory)
+    if not local_paths:
+        return [f"{source_directory}: no repo-native declaration files were found"]
+
+    validator = _load_platform_validator()
+    upstream_paths = _collect_required_upstream_product_paths(source_directory)
+
+    with tempfile.TemporaryDirectory(prefix="lotus-manage-domain-products-") as temp_dir_string:
+        temp_root = Path(temp_dir_string)
+        temp_declaration_dir = temp_root / "domain-data-products"
+        temp_vocabulary_dir = temp_root / "domain-vocabulary"
+        temp_declaration_dir.mkdir(parents=True, exist_ok=True)
+        temp_vocabulary_dir.mkdir(parents=True, exist_ok=True)
+
+        for declaration_path in local_paths:
+            shutil.copy2(declaration_path, temp_declaration_dir / declaration_path.name)
+
+        for upstream_path in upstream_paths:
+            shutil.copy2(upstream_path, temp_declaration_dir / upstream_path.name)
+
+        for vocabulary_file_name in VOCABULARY_FILENAMES:
+            shutil.copy2(
+                PLATFORM_VOCABULARY_DIR / vocabulary_file_name,
+                temp_vocabulary_dir / vocabulary_file_name,
+            )
+
+        return validator.validate_contract_directory(temp_declaration_dir)
+
+
+def main() -> int:
+    issues = validate_repo_native_contracts()
+    if issues:
+        for issue in issues:
+            print(issue)
+        return 1
+
+    producer_count = len(list(LOCAL_DECLARATION_DIR.glob(PRODUCT_PATTERN)))
+    consumer_count = len(list(LOCAL_DECLARATION_DIR.glob(CONSUMER_PATTERN)))
+    print(
+        "Validated "
+        f"{producer_count} repo-native producer declaration(s) and "
+        f"{consumer_count} repo-native consumer declaration(s) in {LOCAL_DECLARATION_DIR}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.validate_domain_data_product_contracts import (
+    LOCAL_DECLARATION_DIR,
+    platform_validation_dependencies_available,
+    validate_repo_native_contracts,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONSUMER_DECLARATION_PATH = (
+    ROOT / "contracts" / "domain-data-products" / "lotus-manage-consumers.v1.json"
+)
+REQUEST_MODELS_PATH = ROOT / "src" / "api" / "request_models.py"
+UPSTREAM_FAMILY_MAP_PATH = ROOT / "docs" / "standards" / "RFC-0082-upstream-contract-family-map.md"
+DECLARATION_README_PATH = ROOT / "contracts" / "domain-data-products" / "README.md"
+
+
+def _load_consumer_declaration() -> dict:
+    return json.loads(CONSUMER_DECLARATION_PATH.read_text(encoding="utf-8"))
+
+
+def test_repo_native_domain_data_product_validation_passes_when_platform_is_available() -> None:
+    if not platform_validation_dependencies_available(LOCAL_DECLARATION_DIR):
+        pytest.skip("sibling lotus-platform contract validator is not available")
+
+    assert validate_repo_native_contracts() == []
+
+
+def test_manage_consumer_declaration_tracks_current_portfolio_snapshot_input() -> None:
+    payload = _load_consumer_declaration()
+    dependencies = payload["dependencies"]
+
+    assert payload["consumer_repository"] == "lotus-manage"
+    assert dependencies == [
+        {
+            "product_name": "PortfolioStateSnapshot",
+            "producer_repository": "lotus-core",
+            "required_product_version": "v1",
+            "required_trust_metadata": [
+                "generated_at",
+                "as_of_date",
+                "reconciliation_status",
+                "data_quality_status",
+                "correlation_id",
+            ],
+            "migration_posture": {"status": "current"},
+            "consumption_mode": "caller_supplied_contract_payload",
+            "business_purpose": (
+                "Run discretionary rebalance simulation and what-if analysis from a governed "
+                "portfolio-state snapshot supplied through the current management request contract."
+            ),
+            "validation_lanes": ["feature", "pr-merge"],
+            "failure_posture": "fail_closed",
+        }
+    ]
+
+    request_models = REQUEST_MODELS_PATH.read_text(encoding="utf-8")
+    assert "portfolio_snapshot: PortfolioSnapshot" in request_models
+
+
+def test_manage_declaration_does_not_claim_live_source_data_api_reads() -> None:
+    payload = _load_consumer_declaration()
+    consumption_modes = {dependency["consumption_mode"] for dependency in payload["dependencies"]}
+    upstream_family_map = UPSTREAM_FAMILY_MAP_PATH.read_text(encoding="utf-8")
+
+    assert consumption_modes == {"caller_supplied_contract_payload"}
+    assert "does not contain an active outbound HTTP client" in upstream_family_map
+
+
+def test_manage_declaration_keeps_unapproved_market_data_on_the_watchlist() -> None:
+    dependencies = _load_consumer_declaration()["dependencies"]
+    product_names = {dependency["product_name"] for dependency in dependencies}
+    readme = DECLARATION_README_PATH.read_text(encoding="utf-8")
+    normalized_readme = " ".join(readme.split())
+
+    assert "MarketDataWindow" not in product_names
+    assert "`MarketDataWindow`" in readme
+    assert "not currently approved for `lotus-manage`" in normalized_readme
+
+
+def test_manage_declaration_directory_is_consumer_only_until_manage_owns_a_data_product() -> None:
+    declaration_paths = sorted(path.name for path in LOCAL_DECLARATION_DIR.glob("*.json"))
+
+    assert declaration_paths == ["lotus-manage-consumers.v1.json"]


### PR DESCRIPTION
## Summary
- add repo-native RFC-0084 consumer declaration for lotus-manage portfolio-state execution inputs
- add local domain-product validation wrapper and make target
- add unit coverage that keeps the declaration aligned with current request-payload behavior and source-data watchlists
- update repository engineering context with the new contract path and command
- make mypy Makefile targets use python -m for reliable local execution

## Validation
- python -m pytest tests/unit/test_domain_data_product_contracts.py -q
- python scripts/validate_domain_data_product_contracts.py
- make domain-product-validate
- make lint
- make check