### PR TITLE
feat(mesh): add management action data product

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -34,7 +34,9 @@ Current repository posture:
 4. upstream and source-data authority posture is classified under RFC-0082 in `docs/standards/RFC-0082-upstream-contract-family-map.md`,
 5. it carries repo-native RFC-0084 consumer declarations for the governed core portfolio-state
    product used by management execution request contracts,
-6. the service remains part of the canonical front-office validation path through `lotus-gateway`.
+6. it carries the RFC-0091 repo-native producer declaration and telemetry fixture for
+   `PortfolioActionRegister`,
+7. the service remains part of the canonical front-office validation path through `lotus-gateway`.
 
 ## Architecture And Module Map
 
@@ -51,7 +53,10 @@ Primary areas:
 5. `tests/`
    unit, integration, and e2e validation.
 6. `contracts/domain-data-products/`
-   repo-native consumer declarations for governed upstream domain data products.
+   repo-native producer and consumer declarations for governed upstream domain data products and
+   management workflow products.
+7. `contracts/trust-telemetry/`
+   repo-native RFC-0087/RFC-0091 trust telemetry snapshots for governed management products.
 
 ## Runtime And Integration Boundaries
 

--- a/contracts/domain-data-products/lotus-manage-products.v1.json
+++ b/contracts/domain-data-products/lotus-manage-products.v1.json
@@ -1,0 +1,70 @@
+{
+  "contract_id": "domain-data-products",
+  "contract_version": "1.0.0",
+  "governed_by_rfc": "RFC-0084",
+  "producer_repository": "lotus-manage",
+  "authoritative_domain": "portfolio_management_operations",
+  "products": [
+    {
+      "product_name": "PortfolioActionRegister",
+      "product_version": "v1",
+      "owner_repository": "lotus-manage",
+      "product_family": "portfolio_management_workflow",
+      "authoritative_domain": "portfolio_management_operations",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "tenant_id",
+        "generated_at",
+        "as_of_date",
+        "reconciliation_status",
+        "data_quality_status",
+        "lineage_bundle_id",
+        "source_batch_fingerprint",
+        "correlation_id"
+      ],
+      "serving_plane": "management_workflow_service",
+      "current_routes": [
+        "/manage/portfolio-actions/{portfolio_id}"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Portfolio action registers are refreshed from current management workflow state and governed portfolio-state inputs."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": false
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": true,
+        "lineage_bundle_class_ref": "customer_lineage_summary",
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-gateway"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "tenant_id",
+        "correlation_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    }
+  ]
+}

--- a/contracts/trust-telemetry/portfolio-action-register.telemetry.v1.json
+++ b/contracts/trust-telemetry/portfolio-action-register.telemetry.v1.json
@@ -1,0 +1,62 @@
+{
+  "contract_id": "lotus-domain-product-trust-telemetry-snapshot",
+  "contract_version": "1.0.0",
+  "governed_by_rfcs": [
+    "RFC-0087",
+    "RFC-0091"
+  ],
+  "emitted_at_utc": "2026-04-20T00:00:00Z",
+  "product_id": "lotus-manage:PortfolioActionRegister:v1",
+  "producer_repository": "lotus-manage",
+  "product_name": "PortfolioActionRegister",
+  "product_version": "v1",
+  "source_repository": "lotus-manage",
+  "runtime_source": {
+    "emission_mode": "deterministic_local_management_fixture",
+    "service_version": "rfc-0091",
+    "environment": "local"
+  },
+  "freshness": {
+    "freshness_class": "daily",
+    "freshness_state": "current",
+    "evaluated_at_utc": "2026-04-20T00:00:00Z",
+    "observed_at_utc": "2026-04-20T00:00:00Z",
+    "age_seconds": 0,
+    "max_allowed_age_seconds": 86400
+  },
+  "completeness_status": "complete",
+  "reconciliation_status": "reconciled",
+  "data_quality_status": "quality_passed",
+  "lineage": {
+    "lineage_materialized": true,
+    "lineage_bundle_id": "lineage:lotus-manage:portfolio-action-register:2026-04-20",
+    "evidence_access_class": "customer_consumable",
+    "evidence_uris": [
+      "lotus-manage://evidence/portfolio-action-register/PB_SG_GLOBAL_BAL_001/2026-04-20"
+    ]
+  },
+  "blocking": {
+    "blocked": false
+  },
+  "observed_trust_metadata": {
+    "product_name": "PortfolioActionRegister",
+    "product_version": "v1",
+    "tenant_id": "TENANT_PRIVATE_BANKING_DEMO",
+    "generated_at": "2026-04-20T00:00:00Z",
+    "as_of_date": "2026-04-20",
+    "reconciliation_status": "reconciled",
+    "data_quality_status": "quality_passed",
+    "lineage_bundle_id": "lineage:lotus-manage:portfolio-action-register:2026-04-20",
+    "source_batch_fingerprint": "sha256:portfolio-action-register-demo",
+    "correlation_id": "rfc-0091-lotus-manage-portfolio-action-register"
+  },
+  "evidence": {
+    "correlation_id": "rfc-0091-lotus-manage-portfolio-action-register",
+    "validation_lanes": [
+      "feature",
+      "pr-merge"
+    ],
+    "source_event_id": "source-event:lotus-manage:portfolio-action-register:2026-04-20",
+    "source_artifact_uri": "lotus-manage://contracts/trust-telemetry/portfolio-action-register.telemetry.v1.json"
+  }
+}

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -16,6 +16,9 @@ ROOT = Path(__file__).resolve().parents[2]
 CONSUMER_DECLARATION_PATH = (
     ROOT / "contracts" / "domain-data-products" / "lotus-manage-consumers.v1.json"
 )
+PRODUCT_DECLARATION_PATH = (
+    ROOT / "contracts" / "domain-data-products" / "lotus-manage-products.v1.json"
+)
 REQUEST_MODELS_PATH = ROOT / "src" / "api" / "request_models.py"
 UPSTREAM_FAMILY_MAP_PATH = ROOT / "docs" / "standards" / "RFC-0082-upstream-contract-family-map.md"
 DECLARATION_README_PATH = ROOT / "contracts" / "domain-data-products" / "README.md"
@@ -23,6 +26,10 @@ DECLARATION_README_PATH = ROOT / "contracts" / "domain-data-products" / "README.
 
 def _load_consumer_declaration() -> dict:
     return json.loads(CONSUMER_DECLARATION_PATH.read_text(encoding="utf-8"))
+
+
+def _load_product_declaration() -> dict:
+    return json.loads(PRODUCT_DECLARATION_PATH.read_text(encoding="utf-8"))
 
 
 def test_repo_native_domain_data_product_validation_passes_when_platform_is_available() -> None:
@@ -84,7 +91,25 @@ def test_manage_declaration_keeps_unapproved_market_data_on_the_watchlist() -> N
     assert "not currently approved for `lotus-manage`" in normalized_readme
 
 
-def test_manage_declaration_directory_is_consumer_only_until_manage_owns_a_data_product() -> None:
+def test_manage_declaration_directory_contains_consumer_and_owned_product_contracts() -> None:
     declaration_paths = sorted(path.name for path in LOCAL_DECLARATION_DIR.glob("*.json"))
 
-    assert declaration_paths == ["lotus-manage-consumers.v1.json"]
+    assert declaration_paths == [
+        "lotus-manage-consumers.v1.json",
+        "lotus-manage-products.v1.json",
+    ]
+
+
+def test_manage_product_declaration_publishes_portfolio_action_register() -> None:
+    payload = _load_product_declaration()
+    products = payload["products"]
+
+    assert payload["producer_repository"] == "lotus-manage"
+    assert [product["product_name"] for product in products] == ["PortfolioActionRegister"]
+
+    product = products[0]
+    assert product["product_version"] == "v1"
+    assert product["lifecycle_status"] == "active"
+    assert product["approved_consumers"] == ["lotus-gateway"]
+    assert product["lineage_policy"]["lineage_required"] is True
+    assert product["lineage_policy"]["lineage_bundle_class_ref"] == "customer_lineage_summary"


### PR DESCRIPTION
## Summary
- adds the repo-native lotus-manage:PortfolioActionRegister:v1 producer declaration
- adds RFC-0087/RFC-0091 trust telemetry fixture for the promoted management product
- updates manage repo context and contract tests so the repo is no longer treated as consumer-only

## Validation
- make domain-product-validate
- make check
- platform validator: python automation/validate_trust_telemetry.py ..\\lotus-manage\\contracts\\trust-telemetry

## RFC
- Supports RFC-0091 Slice 6 broader product rollout.