### PR TITLE
Implement RFC-0108 manage supportability metrics

### DIFF
--- a/docs/documentation/engine-know-how-dpm.md
+++ b/docs/documentation/engine-know-how-dpm.md
@@ -111,6 +111,15 @@ Implementation scope:
   - run status distribution
   - async operation status distribution
   - oldest/newest created-at timestamps for runs and operations
+  - `supportability` posture with bounded `state`, `reason`, and `freshness_bucket`
+- Supportability states:
+  - `ready` when persisted supportability records are current and no failed async operation is present
+  - `empty` when no run or operation records exist
+  - `stale` when the newest run or operation timestamp is older than the freshness window
+  - `degraded` when failed async operation records are present
+- Metrics: each successful summary read records
+  `lotus_manage_action_register_supportability_total` with bounded `surface`,
+  `supportability_state`, `reason`, and `freshness_bucket` labels only.
 
 ### `GET /rebalance/policies/effective`
 - Purpose: resolve and return effective lotus-manage policy-pack selection for integration/support diagnostics.

--- a/docs/standards/RFC-0082-upstream-contract-family-map.md
+++ b/docs/standards/RFC-0082-upstream-contract-family-map.md
@@ -90,8 +90,21 @@ Existing tests that cover this posture include:
 11. `tests/integration/dpm/supportability/test_dpm_postgres_repository_integration.py`
 12. `tests/integration/dpm/supportability/test_dpm_policy_pack_postgres_repository_integration.py`
 
-This RFC-0082 documentation slice did not change runtime behavior, OpenAPI output, migrations, or
-upstream request/response contracts.
+RFC-0108 Slice 12 adds implementation-backed management supportability posture to
+`/rebalance/supportability/summary` and capability discovery:
+
+1. `GET /rebalance/supportability/summary` returns a `supportability` object with bounded
+   `state`, `reason`, `freshness_bucket`, and aggregate counts derived from persisted run,
+   operation, and workflow-decision records.
+2. `/integration/capabilities` and `/platform/capabilities` publish
+   `manage.observability.action_register_supportability` as the backend-owned feature key for
+   Gateway and Workbench gating.
+3. `/metrics` exposes `lotus_manage_action_register_supportability_total` with bounded
+   `surface`, `supportability_state`, `reason`, and `freshness_bucket` labels only. Portfolio ids,
+   request hashes, correlation ids, actor ids, and client content must not be emitted as metric
+   labels.
+4. This slice changes OpenAPI response shape for the summary endpoint but does not introduce
+   migrations or outbound upstream coupling.
 
 ## Gap Register
 

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-04-17T23:59:13.942986+00:00",
+  "generatedAt": "2026-04-29T08:33:06.767448+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.action",
@@ -1916,6 +1916,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.freshness_bucket",
+      "canonicalTerm": "freshness_bucket",
+      "preferredName": "freshness_bucket",
+      "description": "Freshness bucket derived from the latest persisted run or operation timestamp.",
+      "example": "current",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -4883,10 +4897,12 @@
       "example": null,
       "type": "object",
       "locations": [
-        "query"
+        "query",
+        "body"
       ],
       "observedTypes": [
-        "object"
+        "object",
+        "string"
       ]
     },
     {
@@ -5079,6 +5095,22 @@
       ],
       "observedTypes": [
         "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.supportability",
+      "canonicalTerm": "supportability",
+      "preferredName": "supportability",
+      "description": "Canonical supportability used by lotus-manage APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "DpmActionRegisterSupportability",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "DpmActionRegisterSupportability"
       ]
     },
     {
@@ -24089,6 +24121,62 @@
             "type": "object",
             "semanticId": "lotus.newest_operation_created_at",
             "attributeRef": "#/attributeCatalog/lotus.newest_operation_created_at"
+          },
+          {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmActionRegisterSupportability",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.state",
+            "attributeRef": "#/attributeCatalog/lotus.state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.freshness_bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.freshness_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
+          },
+          {
+            "name": "supportability.run_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.run_count",
+            "attributeRef": "#/attributeCatalog/lotus.run_count"
+          },
+          {
+            "name": "supportability.operation_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.operation_count",
+            "attributeRef": "#/attributeCatalog/lotus.operation_count"
+          },
+          {
+            "name": "supportability.workflow_decision_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.workflow_decision_count",
+            "attributeRef": "#/attributeCatalog/lotus.workflow_decision_count"
           }
         ]
       }
@@ -62222,6 +62310,62 @@
             "type": "object",
             "semanticId": "lotus.newest_operation_created_at",
             "attributeRef": "#/attributeCatalog/lotus.newest_operation_created_at"
+          },
+          {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmActionRegisterSupportability",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.state",
+            "attributeRef": "#/attributeCatalog/lotus.state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.freshness_bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.freshness_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
+          },
+          {
+            "name": "supportability.run_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.run_count",
+            "attributeRef": "#/attributeCatalog/lotus.run_count"
+          },
+          {
+            "name": "supportability.operation_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.operation_count",
+            "attributeRef": "#/attributeCatalog/lotus.operation_count"
+          },
+          {
+            "name": "supportability.workflow_decision_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.workflow_decision_count",
+            "attributeRef": "#/attributeCatalog/lotus.workflow_decision_count"
           }
         ]
       }

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -8,11 +8,18 @@ from typing import Awaitable, Callable
 from uuid import uuid4
 
 from fastapi import FastAPI, Request, Response
+from prometheus_client import Counter
 from prometheus_fastapi_instrumentator import Instrumentator
 
 correlation_id_var: ContextVar[str] = ContextVar("correlation_id", default="")
 request_id_var: ContextVar[str] = ContextVar("request_id", default="")
 trace_id_var: ContextVar[str] = ContextVar("trace_id", default="")
+
+MANAGE_SUPPORTABILITY_TOTAL = Counter(
+    "lotus_manage_action_register_supportability_total",
+    "lotus-manage action register supportability outcomes.",
+    ["surface", "supportability_state", "reason", "freshness_bucket"],
+)
 
 
 class JsonFormatter(logging.Formatter):
@@ -87,3 +94,18 @@ def setup_observability(app: FastAPI) -> None:
         response.headers["X-Trace-Id"] = trace_id
         response.headers["traceparent"] = f"00-{trace_id}-0000000000000001-01"
         return response
+
+
+def record_action_register_supportability(
+    *,
+    surface: str,
+    supportability_state: str,
+    reason: str,
+    freshness_bucket: str,
+) -> None:
+    MANAGE_SUPPORTABILITY_TOTAL.labels(
+        surface=surface,
+        supportability_state=supportability_state,
+        reason=reason,
+        freshness_bucket=freshness_bucket,
+    ).inc()

--- a/src/api/routers/integration_capabilities.py
+++ b/src/api/routers/integration_capabilities.py
@@ -189,6 +189,12 @@ async def get_integration_capabilities(
                 owner_service="lotus-manage",
                 description="lotus-manage lifecycle proposal and supportability workflows.",
             ),
+            FeatureCapability(
+                key="manage.observability.action_register_supportability",
+                enabled=True,
+                owner_service="lotus-manage",
+                description="Source-backed action register and supportability summary posture with bounded states, reasons, and metrics.",
+            ),
         ],
         workflows=[
             WorkflowCapability(

--- a/src/api/routers/rebalance_runs.py
+++ b/src/api/routers/rebalance_runs.py
@@ -4,6 +4,7 @@ from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 
+from src.api.observability import record_action_register_supportability
 from src.api.routers import rebalance_runs_config
 from src.api.routers.runtime_utils import assert_feature_enabled, normalize_backend_init_error
 from src.core.rebalance_runs import (
@@ -297,12 +298,19 @@ def get_dpm_supportability_summary(
     _assert_support_apis_enabled()
     _assert_supportability_summary_apis_enabled()
     _reject_unexpected_query_params(request, allowed_params=set())
-    return service.get_supportability_summary(
+    response = service.get_supportability_summary(
         store_backend=_supportability_store_backend_name(),
         retention_days=rebalance_runs_config.env_non_negative_int(
             "DPM_SUPPORTABILITY_RETENTION_DAYS", 0
         ),
     )
+    record_action_register_supportability(
+        surface="rebalance/supportability/summary",
+        supportability_state=response.supportability.state,
+        reason=response.supportability.reason,
+        freshness_bucket=response.supportability.freshness_bucket,
+    )
+    return response
 
 
 @router.get(

--- a/src/core/rebalance_runs/__init__.py
+++ b/src/core/rebalance_runs/__init__.py
@@ -1,4 +1,5 @@
 from src.core.rebalance_runs.models import (
+    DpmActionRegisterSupportability,
     DpmAsyncAcceptedResponse,
     DpmAsyncOperationListResponse,
     DpmAsyncOperationStatusResponse,
@@ -24,6 +25,7 @@ from src.core.rebalance_runs.service import (
 )
 
 __all__ = [
+    "DpmActionRegisterSupportability",
     "DpmAsyncAcceptedResponse",
     "DpmAsyncOperationListResponse",
     "DpmAsyncOperationStatusResponse",

--- a/src/core/rebalance_runs/models.py
+++ b/src/core/rebalance_runs/models.py
@@ -10,6 +10,25 @@ DpmAsyncOperationStatus = Literal["PENDING", "RUNNING", "SUCCEEDED", "FAILED"]
 DpmWorkflowStatus = Literal["NOT_REQUIRED", "PENDING_REVIEW", "APPROVED", "REJECTED"]
 DpmWorkflowActionType = Literal["APPROVE", "REJECT", "REQUEST_CHANGES"]
 DpmLineageEdgeType = Literal["CORRELATION_TO_RUN", "IDEMPOTENCY_TO_RUN", "OPERATION_TO_CORRELATION"]
+DpmSupportabilityState = Literal[
+    "ready",
+    "stale",
+    "degraded",
+    "empty",
+    "error",
+    "permission_blocked",
+    "unsupported",
+]
+DpmSupportabilityReason = Literal[
+    "supportability_summary_ready",
+    "supportability_summary_empty",
+    "supportability_summary_stale",
+    "supportability_summary_degraded",
+    "supportability_summary_error",
+    "permission_blocked",
+    "unsupported_surface",
+]
+DpmFreshnessBucket = Literal["current", "same_day", "stale", "unknown"]
 
 
 class DpmRunRecord(BaseModel):
@@ -196,6 +215,36 @@ class DpmSupportabilitySummaryData(BaseModel):
     )
 
 
+class DpmActionRegisterSupportability(BaseModel):
+    state: DpmSupportabilityState = Field(
+        description="Bounded supportability state for management action register surfaces.",
+        examples=["ready"],
+    )
+    reason: DpmSupportabilityReason = Field(
+        description="Bounded product-safe reason for the supportability state.",
+        examples=["supportability_summary_ready"],
+    )
+    freshness_bucket: DpmFreshnessBucket = Field(
+        description="Freshness bucket derived from the latest persisted run or operation timestamp.",
+        examples=["current"],
+    )
+    run_count: int = Field(
+        ge=0,
+        description="Total persisted run records considered for this posture.",
+        examples=[128],
+    )
+    operation_count: int = Field(
+        ge=0,
+        description="Total persisted async operation records considered for this posture.",
+        examples=[42],
+    )
+    workflow_decision_count: int = Field(
+        ge=0,
+        description="Total persisted workflow decisions considered for this posture.",
+        examples=[16],
+    )
+
+
 class DpmSupportabilitySummaryResponse(BaseModel):
     store_backend: str = Field(
         description="Configured supportability storage backend.",
@@ -260,6 +309,12 @@ class DpmSupportabilitySummaryResponse(BaseModel):
         default=None,
         description="Newest persisted operation creation timestamp (UTC ISO8601).",
         examples=["2026-02-20T12:10:00+00:00"],
+    )
+    supportability: DpmActionRegisterSupportability = Field(
+        description=(
+            "Source-backed supportability posture for management action register and "
+            "supportability summary surfaces."
+        )
     )
 
 

--- a/src/core/rebalance_runs/service.py
+++ b/src/core/rebalance_runs/service.py
@@ -4,11 +4,13 @@ from typing import Any, Optional
 
 from src.core.rebalance_runs.artifact import build_dpm_run_artifact
 from src.core.rebalance_runs.models import (
+    DpmActionRegisterSupportability,
     DpmAsyncAcceptedResponse,
     DpmAsyncOperationListItemResponse,
     DpmAsyncOperationListResponse,
     DpmAsyncOperationRecord,
     DpmAsyncOperationStatusResponse,
+    DpmFreshnessBucket,
     DpmLineageEdgeRecord,
     DpmLineageEdgeType,
     DpmLineageEdgeResponse,
@@ -29,6 +31,8 @@ from src.core.rebalance_runs.models import (
     DpmRunWorkflowResponse,
     DpmSupportabilitySummaryData,
     DpmSupportabilitySummaryResponse,
+    DpmSupportabilityReason,
+    DpmSupportabilityState,
     DpmWorkflowActionType,
     DpmWorkflowDecisionListResponse,
     DpmWorkflowStatus,
@@ -411,6 +415,7 @@ class DpmRunSupportService:
         self._cleanup_expired_operations()
         self._cleanup_expired_supportability()
         summary: DpmSupportabilitySummaryData = self._repository.get_supportability_summary()
+        supportability = _resolve_action_register_supportability(summary=summary)
         return DpmSupportabilitySummaryResponse(
             store_backend=store_backend,
             retention_days=retention_days,
@@ -442,6 +447,7 @@ class DpmRunSupportService:
                 if summary.newest_operation_created_at is not None
                 else None
             ),
+            supportability=supportability,
         )
 
     def get_run_support_bundle(
@@ -924,6 +930,58 @@ class DpmRunSupportService:
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _resolve_action_register_supportability(
+    *,
+    summary: DpmSupportabilitySummaryData,
+) -> DpmActionRegisterSupportability:
+    freshness_bucket = _resolve_freshness_bucket(summary=summary)
+    has_records = summary.run_count > 0 or summary.operation_count > 0
+    state: DpmSupportabilityState
+    reason: DpmSupportabilityReason
+    if not has_records:
+        state = "empty"
+        reason = "supportability_summary_empty"
+    elif freshness_bucket == "stale":
+        state = "stale"
+        reason = "supportability_summary_stale"
+    elif summary.operation_status_counts.get("FAILED", 0) > 0:
+        state = "degraded"
+        reason = "supportability_summary_degraded"
+    else:
+        state = "ready"
+        reason = "supportability_summary_ready"
+    return DpmActionRegisterSupportability(
+        state=state,
+        reason=reason,
+        freshness_bucket=freshness_bucket,
+        run_count=summary.run_count,
+        operation_count=summary.operation_count,
+        workflow_decision_count=summary.workflow_decision_count,
+    )
+
+
+def _resolve_freshness_bucket(*, summary: DpmSupportabilitySummaryData) -> DpmFreshnessBucket:
+    candidates = [
+        value
+        for value in (
+            summary.newest_run_created_at,
+            summary.newest_operation_created_at,
+        )
+        if value is not None
+    ]
+    if not candidates:
+        return "unknown"
+    newest = max(candidates)
+    if newest.tzinfo is None:
+        newest = newest.replace(tzinfo=timezone.utc)
+    age_days = (_utc_now().date() - newest.astimezone(timezone.utc).date()).days
+    if age_days <= 0:
+        return "current"
+    if age_days <= 1:
+        return "same_day"
+    return "stale"
 
 
 def _lineage_cursor(edge: DpmLineageEdgeRecord) -> str:

--- a/tests/unit/dpm/api/test_api_rebalance.py
+++ b/tests/unit/dpm/api/test_api_rebalance.py
@@ -627,6 +627,22 @@ def test_dpm_supportability_summary_endpoint(client):
     assert body["newest_run_created_at"] is not None
     assert body["oldest_operation_created_at"] is not None
     assert body["newest_operation_created_at"] is not None
+    assert body["supportability"] == {
+        "state": "ready",
+        "reason": "supportability_summary_ready",
+        "freshness_bucket": "current",
+        "run_count": 1,
+        "operation_count": 1,
+        "workflow_decision_count": 0,
+    }
+
+    metrics = client.get("/metrics")
+    assert metrics.status_code == 200
+    assert "lotus_manage_action_register_supportability_total" in metrics.text
+    assert 'surface="rebalance/supportability/summary"' in metrics.text
+    assert 'supportability_state="ready"' in metrics.text
+    assert 'reason="supportability_summary_ready"' in metrics.text
+    assert 'freshness_bucket="current"' in metrics.text
 
 
 def test_dpm_supportability_summary_endpoint_disabled(client, monkeypatch):

--- a/tests/unit/dpm/api/test_integration_capabilities_api.py
+++ b/tests/unit/dpm/api/test_integration_capabilities_api.py
@@ -21,6 +21,7 @@ def test_integration_capabilities_default_contract():
     feature_keys = {item["key"] for item in body["features"]}
     assert "dpm.execution.stateful_portfolio_id" in feature_keys
     assert "dpm.execution.stateless_inline_bundle" in feature_keys
+    assert "manage.observability.action_register_supportability" in feature_keys
 
 
 def test_integration_capabilities_env_overrides(monkeypatch):

--- a/tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py
+++ b/tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -144,3 +144,55 @@ def test_service_persisted_artifact_mode_backfills_missing_persisted_artifact():
     artifact = service.get_run_artifact(rebalance_run_id=result.rebalance_run_id)
     assert artifact.rebalance_run_id == result.rebalance_run_id
     assert repository.get_run_artifact(rebalance_run_id=result.rebalance_run_id) is not None
+
+
+def test_supportability_summary_posture_empty_ready_stale_and_degraded():
+    empty_service = _build_service()
+    empty = empty_service.get_supportability_summary(store_backend="INMEMORY", retention_days=0)
+    assert empty.supportability.state == "empty"
+    assert empty.supportability.reason == "supportability_summary_empty"
+    assert empty.supportability.freshness_bucket == "unknown"
+
+    ready_service = _build_service()
+    ready_service.record_run(
+        result=_sample_result(),
+        request_hash="sha256:req-supportability-ready",
+        portfolio_id="pf_service_artifact_1",
+        idempotency_key=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    ready = ready_service.get_supportability_summary(store_backend="INMEMORY", retention_days=0)
+    assert ready.supportability.state == "ready"
+    assert ready.supportability.reason == "supportability_summary_ready"
+    assert ready.supportability.freshness_bucket == "current"
+
+    stale_service = _build_service()
+    stale_service.record_run(
+        result=_sample_result(),
+        request_hash="sha256:req-supportability-stale",
+        portfolio_id="pf_service_artifact_1",
+        idempotency_key=None,
+        created_at=datetime.now(timezone.utc) - timedelta(days=3),
+    )
+    stale = stale_service.get_supportability_summary(store_backend="INMEMORY", retention_days=0)
+    assert stale.supportability.state == "stale"
+    assert stale.supportability.reason == "supportability_summary_stale"
+    assert stale.supportability.freshness_bucket == "stale"
+
+    degraded_service = _build_service()
+    accepted = degraded_service.submit_analyze_async(
+        correlation_id="corr-supportability-degraded",
+        request_json={"scenarios": {"baseline": {"options": {}}}},
+    )
+    degraded_service.complete_operation_failure(
+        operation_id=accepted.operation_id,
+        code="FAILED_TEST",
+        message="failed",
+    )
+    degraded = degraded_service.get_supportability_summary(
+        store_backend="INMEMORY",
+        retention_days=0,
+    )
+    assert degraded.supportability.state == "degraded"
+    assert degraded.supportability.reason == "supportability_summary_degraded"
+    assert degraded.supportability.freshness_bucket == "current"

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -14,6 +14,21 @@
 - capability discovery is backend-owned and should not be inferred by downstream callers
 - local Docker keeps PostgreSQL internal to the Compose network by default
 
+## RFC-0108 action register supportability
+
+- `GET /rebalance/supportability/summary` returns `supportability.state`,
+  `supportability.reason`, and `supportability.freshness_bucket` for management action register
+  surfaces.
+- Operators should treat `empty` as no persisted run or operation evidence, `stale` as old
+  supportability evidence, and `degraded` as failed async operation evidence.
+- `/metrics` exposes `lotus_manage_action_register_supportability_total` with only bounded
+  `surface`, `supportability_state`, `reason`, and `freshness_bucket` labels.
+- Do not add portfolio ids, request hashes, idempotency keys, correlation ids, actor ids, or client
+  content to supportability metric labels or log dimensions.
+- Capability consumers should gate this posture on
+  `manage.observability.action_register_supportability` from `/integration/capabilities` or
+  `/platform/capabilities`.
+
 ## Key references
 
 - [docs/documentation/project-overview.md](../docs/documentation/project-overview.md)


### PR DESCRIPTION
## Summary
- add supportability posture to /rebalance/supportability/summary
- expose lotus_manage_action_register_supportability_total with bounded labels only
- publish manage.observability.action_register_supportability through capabilities
- update manage docs/wiki source for Slice 12 operator posture

## Validation
- python -m pytest tests\unit\dpm\supportability\test_dpm_run_support_service_coverage.py tests\unit\dpm\api\test_integration_capabilities_api.py tests\unit\dpm\api\test_api_rebalance.py::test_dpm_supportability_summary_endpoint tests\unit\dpm\contracts\test_contract_openapi_supportability_docs.py -q
- python -m ruff check src\api\observability.py src\api\routers\rebalance_runs.py src\api\routers\integration_capabilities.py src\core\rebalance_runs\models.py src\core\rebalance_runs\service.py src\core\rebalance_runs\__init__.py tests\unit\dpm\supportability\test_dpm_run_support_service_coverage.py tests\unit\dpm\api\test_integration_capabilities_api.py tests\unit\dpm\api\test_api_rebalance.py
- python -m mypy src\api\observability.py src\api\routers\rebalance_runs.py src\api\routers\integration_capabilities.py src\core\rebalance_runs\models.py src\core\rebalance_runs\service.py src\core\rebalance_runs\__init__.py
- git diff --check

## Wiki
- repo-local wiki source updated: wiki/Operations-Runbook.md
- Sync-RepoWikis.ps1 -CheckOnly currently reports expected drift until this branch is merged and the wiki is published