### PR TITLE
Harden Manage Docker readiness for canonical stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@ RUN adduser --disabled-password --gecos '' dpm-user
 # Set the working directory
 WORKDIR /app
 
-# Copy package metadata and source
+# Copy package metadata, source, and operational scripts
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
+COPY scripts/ ./scripts/
 
 # Install runtime dependencies only
 RUN pip install --upgrade pip && pip install .
@@ -28,9 +29,9 @@ USER dpm-user
 # Expose the port uvicorn will listen on
 EXPOSE 8000
 
-# Container-level healthcheck using Python stdlib (no curl dependency)
+# Container-level readiness check using Python stdlib (no curl dependency)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/docs', timeout=3)"
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health/ready', timeout=3)"
 
 # Command to run the application
 CMD ["python", "-m", "uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ Local Docker runtime does not publish the internal PostgreSQL port by default.
 `postgres:5432` remains internal to the Compose network, and only the application port `8000`
 is published for local API access.
 
+Docker startup applies the forward-only PostgreSQL migrations before `uvicorn` starts, and the
+container healthcheck uses `/health/ready` rather than `/docs`. In production profile,
+`/health/ready` validates persistence guardrails and applied migration versions so supportability
+APIs cannot look healthy while their backing store is missing or unmigrated.
+
 Operationally important truths:
 
 1. readiness and migration posture matter because supportability flows depend on persistence truth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     init: true
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      - "${LOTUS_MANAGE_HOST_PORT:-8000}:8000"
     environment:
       - ENVIRONMENT=production
       - APP_PERSISTENCE_PROFILE=${APP_PERSISTENCE_PROFILE:-PRODUCTION}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     image: lotus-manage:latest
     init: true
     restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
     ports:
       - "${LOTUS_MANAGE_HOST_PORT:-8000}:8000"
     environment:
@@ -23,7 +26,7 @@ services:
           "CMD",
           "python",
           "-c",
-          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/docs', timeout=3)"
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health/ready', timeout=3)"
         ]
       interval: 30s
       timeout: 5s
@@ -34,6 +37,12 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    command:
+      [
+        "sh",
+        "-lc",
+        "python scripts/postgres_migrate.py --target all && python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8000"
+      ]
 
   postgres:
     image: postgres:17.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
   "httpx>=0.28.0",
   "pydantic>=2.12.0",
   "pydantic-settings>=2.13.0",
-  "prometheus-fastapi-instrumentator>=7.1.0"
+  "prometheus-fastapi-instrumentator>=7.1.0",
+  "psycopg[binary]>=3.2.0"
 ]
 
 [project.optional-dependencies]

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -16,6 +16,8 @@ from src.api.enterprise_readiness import (
 from src.api.observability import correlation_id_var, setup_observability
 from src.api.openapi_enrichment import enrich_openapi_schema
 from src.api.persistence_profile import validate_persistence_profile_guardrails
+from src.api.persistence_profile import app_persistence_profile_name
+from src.api.production_cutover_contract import validate_cutover_migrations_applied
 from src.api.routers.advisory_simulation import (
     build_proposal_artifact_endpoint,
     simulate_proposal,
@@ -170,6 +172,9 @@ def health_live() -> dict[str, str]:
 @app.get("/health/ready")
 @app.get("/api/v1/health/ready")
 def health_ready() -> dict[str, str]:
+    validate_persistence_profile_guardrails()
+    if app_persistence_profile_name() == "PRODUCTION":
+        validate_cutover_migrations_applied()
     return {"status": "ready"}
 
 

--- a/tests/unit/dpm/api/test_observability_api.py
+++ b/tests/unit/dpm/api/test_observability_api.py
@@ -2,6 +2,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from fastapi.testclient import TestClient
 
+import src.api.main as main_module
 from src.api.main import app
 
 
@@ -17,6 +18,20 @@ def test_health_endpoints_available():
     assert health.json() == {"status": "ok"}
     assert live.json() == {"status": "live"}
     assert ready.json() == {"status": "ready"}
+
+
+def test_health_ready_validates_cutover_migrations_in_production(monkeypatch):
+    called = {"migrations": 0}
+    monkeypatch.setattr(main_module, "app_persistence_profile_name", lambda: "PRODUCTION")
+    monkeypatch.setattr(main_module, "validate_persistence_profile_guardrails", lambda: None)
+    monkeypatch.setattr(
+        main_module,
+        "validate_cutover_migrations_applied",
+        lambda: called.__setitem__("migrations", called["migrations"] + 1),
+    )
+
+    assert main_module.health_ready() == {"status": "ready"}
+    assert called["migrations"] == 1
 
 
 def test_correlation_headers_are_exposed():

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -6,7 +6,20 @@ def test_local_docker_compose_does_not_publish_internal_postgres_port() -> None:
 
     assert "postgres:17.6" in compose_text
     assert '"5432:5432"' not in compose_text
-    assert '"8000:8000"' in compose_text
+    assert "${LOTUS_MANAGE_HOST_PORT:-8000}:8000" in compose_text
+
+
+def test_local_docker_runtime_applies_postgres_migrations_before_startup() -> None:
+    compose_text = Path("docker-compose.yml").read_text(encoding="utf-8")
+    dockerfile_text = Path("Dockerfile").read_text(encoding="utf-8")
+    pyproject_text = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert "depends_on:" in compose_text
+    assert "condition: service_healthy" in compose_text
+    assert "python scripts/postgres_migrate.py --target all" in compose_text
+    assert "urllib.request.urlopen('http://127.0.0.1:8000/health/ready'" in compose_text
+    assert "COPY scripts/ ./scripts/" in dockerfile_text
+    assert "psycopg[binary]" in pyproject_text
 
 
 def test_ci_local_docker_compose_does_not_publish_internal_postgres_port() -> None:

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -13,6 +13,9 @@
 - supportability flows depend on truthful run persistence, lineage, and idempotency history
 - capability discovery is backend-owned and should not be inferred by downstream callers
 - local Docker keeps PostgreSQL internal to the Compose network by default
+- Docker startup applies PostgreSQL migrations before serving traffic
+- `/health/ready` validates production persistence guardrails and applied migrations in production
+  profile, so container health is tied to supportability backing-store readiness instead of `/docs`
 
 ## RFC-0108 action register supportability
 
@@ -28,6 +31,20 @@
 - Capability consumers should gate this posture on
   `manage.observability.action_register_supportability` from `/integration/capabilities` or
   `/platform/capabilities`.
+
+## Docker production readiness
+
+- Compose waits for the internal PostgreSQL service to be healthy before starting
+  `lotus-manage`.
+- The application command runs `python scripts/postgres_migrate.py --target all` before `uvicorn`.
+- The runtime image includes the migration script and the `psycopg` runtime driver required for
+  Postgres-backed supportability stores.
+- A healthy container should have the `schema_migrations` table plus DPM and proposal persistence
+  tables. If `/rebalance/supportability/summary` returns a Postgres connection or migration error,
+  inspect the startup logs first for migration failures.
+- For canonical front-office proof, `GET /rebalance/supportability/summary` should return HTTP
+  `200`. An `empty` supportability state is acceptable for a freshly seeded stack with no recorded
+  management actions; HTTP `503` is not acceptable demo evidence.
 
 ## Key references
 

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -29,6 +29,17 @@ python -m pytest tests/unit/test_local_docker_runtime_contract.py -q
 
 That protects the local Docker runtime contract wording.
 
+When Docker readiness, migration startup, or supportability health behavior changes, include:
+
+```bash
+python -m pytest tests/unit/test_local_docker_runtime_contract.py tests/unit/dpm/api/test_observability_api.py tests/unit/shared/dependencies/test_production_cutover_contract.py -q
+docker compose config
+```
+
+For canonical front-office proof, rebuild with `LOTUS_MANAGE_HOST_PORT=8001`, verify that
+`/api/v1/rebalance/supportability/summary` returns HTTP `200`, and confirm Gateway overview no
+longer reports `MANAGE_REBALANCE_UNAVAILABLE`.
+
 When DPM supportability or OpenAPI-facing docs change, run:
 
 ```bash


### PR DESCRIPTION
## Summary
- runs PostgreSQL migrations before Manage Docker API startup
- switches Docker healthcheck to `/health/ready` and gates startup on healthy Postgres
- validates production readiness against persistence guardrails and cutover migrations
- documents Docker readiness expectations in README and repo-local wiki source

## Evidence
- `python -m pytest tests/unit/test_local_docker_runtime_contract.py tests/unit/dpm/api/test_observability_api.py tests/unit/shared/dependencies/test_production_cutover_contract.py -q` -> 21 passed
- `python -m ruff check src/api/main.py tests/unit/test_local_docker_runtime_contract.py tests/unit/dpm/api/test_observability_api.py` -> passed
- `docker compose config --quiet` -> passed
- Live canonical proof: `LOTUS_MANAGE_HOST_PORT=8001 docker compose up -d --build`; `manage.dev.lotus/health/ready` ready; supportability summary returned HTTP 200 on fresh stack

## Wiki
- Repo-local `wiki/Operations-Runbook.md` and `wiki/Validation-and-CI.md` updated.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` currently reports published wiki drift for these repo-authored pages; publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-manage`.
