### PR TITLE
Harden Manage supportability metric labels

### DIFF
--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -21,6 +21,41 @@ MANAGE_SUPPORTABILITY_TOTAL = Counter(
     ["surface", "supportability_state", "reason", "freshness_bucket"],
 )
 
+ACTION_REGISTER_SUPPORTABILITY_SURFACE = "rebalance/supportability/summary"
+UNKNOWN_ACTION_REGISTER_SURFACE = "unknown_surface"
+
+_ALLOWED_ACTION_REGISTER_SURFACES = frozenset({ACTION_REGISTER_SUPPORTABILITY_SURFACE})
+_ALLOWED_SUPPORTABILITY_STATES = frozenset(
+    {
+        "ready",
+        "stale",
+        "degraded",
+        "empty",
+        "error",
+        "permission_blocked",
+        "unsupported",
+    }
+)
+_ALLOWED_SUPPORTABILITY_REASONS = frozenset(
+    {
+        "supportability_summary_ready",
+        "supportability_summary_empty",
+        "supportability_summary_stale",
+        "supportability_summary_degraded",
+        "supportability_summary_error",
+        "permission_blocked",
+        "unsupported_surface",
+    }
+)
+_ALLOWED_FRESHNESS_BUCKETS = frozenset({"current", "same_day", "stale", "unknown"})
+
+
+def _safe_metric_label(value: str, *, allowed_values: frozenset[str], fallback: str) -> str:
+    candidate = value.strip()
+    if candidate in allowed_values:
+        return candidate
+    return fallback
+
 
 class JsonFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
@@ -104,8 +139,24 @@ def record_action_register_supportability(
     freshness_bucket: str,
 ) -> None:
     MANAGE_SUPPORTABILITY_TOTAL.labels(
-        surface=surface,
-        supportability_state=supportability_state,
-        reason=reason,
-        freshness_bucket=freshness_bucket,
+        surface=_safe_metric_label(
+            surface,
+            allowed_values=_ALLOWED_ACTION_REGISTER_SURFACES,
+            fallback=UNKNOWN_ACTION_REGISTER_SURFACE,
+        ),
+        supportability_state=_safe_metric_label(
+            supportability_state,
+            allowed_values=_ALLOWED_SUPPORTABILITY_STATES,
+            fallback="error",
+        ),
+        reason=_safe_metric_label(
+            reason,
+            allowed_values=_ALLOWED_SUPPORTABILITY_REASONS,
+            fallback="supportability_summary_error",
+        ),
+        freshness_bucket=_safe_metric_label(
+            freshness_bucket,
+            allowed_values=_ALLOWED_FRESHNESS_BUCKETS,
+            fallback="unknown",
+        ),
     ).inc()

--- a/src/api/routers/rebalance_runs.py
+++ b/src/api/routers/rebalance_runs.py
@@ -4,7 +4,10 @@ from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, status
 
-from src.api.observability import record_action_register_supportability
+from src.api.observability import (
+    ACTION_REGISTER_SUPPORTABILITY_SURFACE,
+    record_action_register_supportability,
+)
 from src.api.routers import rebalance_runs_config
 from src.api.routers.runtime_utils import assert_feature_enabled, normalize_backend_init_error
 from src.core.rebalance_runs import (
@@ -305,7 +308,7 @@ def get_dpm_supportability_summary(
         ),
     )
     record_action_register_supportability(
-        surface="rebalance/supportability/summary",
+        surface=ACTION_REGISTER_SUPPORTABILITY_SURFACE,
         supportability_state=response.supportability.state,
         reason=response.supportability.reason,
         freshness_bucket=response.supportability.freshness_bucket,

--- a/tests/unit/dpm/api/test_observability_api.py
+++ b/tests/unit/dpm/api/test_observability_api.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from fastapi.testclient import TestClient
 
 import src.api.main as main_module
+import src.api.observability as observability_module
 from src.api.main import app
 
 
@@ -51,6 +52,36 @@ def test_metrics_endpoint_available():
     response = client.get("/metrics")
     assert response.status_code == 200
     assert "http_requests_total" in response.text or "http_request_duration" in response.text
+
+
+def test_action_register_supportability_metric_labels_are_bounded(monkeypatch):
+    captured: dict[str, str] = {}
+
+    class _Counter:
+        def labels(self, **labels):
+            captured.update(labels)
+            return self
+
+        def inc(self):
+            return None
+
+    monkeypatch.setattr(observability_module, "MANAGE_SUPPORTABILITY_TOTAL", _Counter())
+
+    observability_module.record_action_register_supportability(
+        surface="rebalance/supportability/summary/PB_SG_GLOBAL_BAL_001",
+        supportability_state="ready",
+        reason="client_name:private-bank-client",
+        freshness_bucket="portfolio:PB_SG_GLOBAL_BAL_001",
+    )
+
+    assert captured == {
+        "surface": "unknown_surface",
+        "supportability_state": "ready",
+        "reason": "supportability_summary_error",
+        "freshness_bucket": "unknown",
+    }
+    assert "PB_SG_GLOBAL_BAL_001" not in captured.values()
+    assert "client_name:private-bank-client" not in captured.values()
 
 
 def test_traceparent_header_propagates_trace_id():

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -25,7 +25,9 @@
 - Operators should treat `empty` as no persisted run or operation evidence, `stale` as old
   supportability evidence, and `degraded` as failed async operation evidence.
 - `/metrics` exposes `lotus_manage_action_register_supportability_total` with only bounded
-  `surface`, `supportability_state`, `reason`, and `freshness_bucket` labels.
+  `surface`, `supportability_state`, `reason`, and `freshness_bucket` labels. The recorder
+  allowlists label values and falls back to `unknown_surface`, `supportability_summary_error`, or
+  `unknown` rather than emitting raw caller values.
 - Do not add portfolio ids, request hashes, idempotency keys, correlation ids, actor ids, or client
   content to supportability metric labels or log dimensions.
 - Capability consumers should gate this posture on


### PR DESCRIPTION
## Summary
- add allowlisted label sanitization around `lotus_manage_action_register_supportability_total`
- share the canonical supportability surface constant between the route and recorder
- add a regression test proving portfolio/client-like values fall back before reaching Prometheus labels
- update the operations wiki source with the metric fallback behavior

## Validation
- `python -m pytest tests\unit\dpm\api\test_observability_api.py tests\unit\dpm\supportability\test_dpm_run_support_service_coverage.py -q` passed: 12 tests
- `make lint` passed
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reported expected source/publication drift for `Operations-Runbook.md`

## RFC-0108 posture
This hardens the Manage action-register supportability metric boundary so future callers cannot accidentally emit portfolio ids, client text, request hashes, or unbounded reasons as metric labels.