### PR TITLE
Rebaseline lotus-manage foundation RFCs

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -39,3 +39,9 @@ Governance boundary:
 | RFC-0028 | lotus-manage Integration Capabilities Contract | IMPLEMENTED | RFC-0021, RFC-0022 | `docs/rfcs/RFC-0028-dpm-integration-capabilities-contract.md` |
 | RFC-0036 | lotus-manage Stateful Core Sourcing And Endpoint Consolidation | IMPLEMENTED | RFC-0013, RFC-0016, RFC-0017, RFC-0018, RFC-0021, RFC-0022, RFC-0023, RFC-0028 | `docs/rfcs/RFC-0036-dpm-stateful-core-sourcing-and-endpoint-consolidation.md` |
 
+Review note:
+- RFC-0002, RFC-0007A, RFC-0021, RFC-0024, RFC-0025, and RFC-0028 were rebaselined on
+  2026-05-03 against current lotus-manage DPM implementation evidence. RFC-0024 and RFC-0025
+  retain historical advisory migration notes only; active advisory proposal ownership is
+  `lotus-advise`, not `lotus-manage`.
+

--- a/docs/rfcs/RFC-0002-rebalance-simulation-mvp-hardening-enterprise-completeness.md
+++ b/docs/rfcs/RFC-0002-rebalance-simulation-mvp-hardening-enterprise-completeness.md
@@ -29,6 +29,31 @@ The focus of this phase is **Safety, Auditability, and Completeness**:
 4. PostgreSQL persistence and idempotency key store are not implemented.
 5. `Reconciliation` is implemented with `status: OK|MISMATCH` and mismatch blocks the run.
 
+### 0.2 Current Status Review (2026-05-03)
+
+RFC-0002 is a historical foundation RFC and remains **implemented** for current lotus-manage scope.
+Its core requirements are now delivered across the simulation engine, the canonical API, and later
+supportability RFCs. The dated implementation-alignment note above is preserved for traceability, but
+two statements have since evolved:
+
+1. Durable persistence and idempotency replay are no longer deferred; they are implemented through
+   RFC-0016, RFC-0017, RFC-0023, and RFC-0024.
+2. The test objective is governed by the current repository quality gate, which requires at least
+   99% coverage with meaningful unit, contract, integration, and live-validation tests rather than
+   a nominal 100% line-coverage target.
+
+| Original requirement | Current implementation evidence | Current status |
+| --- | --- | --- |
+| Canonical `POST /rebalance/simulate` audit bundle | `src/api/routers/rebalance.py`, `src/api/services/rebalance_simulation_service.py`, `src/core/models.py` | Implemented |
+| Before/after portfolio state, rule results, diagnostics, lineage | `src/core/rebalance/`, `src/core/models.py`, golden engine tests under `tests/unit/dpm/engine/` | Implemented |
+| Required idempotency key and replay protection | RFC-0016/RFC-0017 supportability services and tests under `tests/unit/dpm/supportability/` | Implemented by later RFCs |
+| Base-currency valuation and reconciliation | `src/core/valuation.py`, `tests/unit/dpm/engine/test_engine_valuation_service.py` | Implemented |
+| Shelf semantics and post-trade controls | `src/core/rebalance/universe.py`, `src/core/rebalance/rules.py`, golden data scenarios | Implemented |
+| RFC 7807-style HTTP validation for malformed requests | FastAPI/Pydantic request validation and API contract tests | Implemented for request validation; valid domain outcomes remain explicit result statuses |
+
+No new implementation slice is open under RFC-0002. Further capability changes should be raised
+against the focused RFC that owns the area, not reopened here.
+
 ---
 
 ## 1. Problem Statement

--- a/docs/rfcs/RFC-0007A-contract-tightening.md
+++ b/docs/rfcs/RFC-0007A-contract-tightening.md
@@ -28,6 +28,22 @@ Implemented:
 Pending:
 1. None.
 
+### 0.2 Current Status Review (2026-05-03)
+
+RFC-0007A remains **implemented and aligned**. It is the contract-tightening baseline for the
+current lotus-manage API surface, including RFC-0036's consolidated stateful/stateless input model.
+
+| Original requirement | Current implementation evidence | Current status |
+| --- | --- | --- |
+| Keep one canonical simulation route | `src/api/routers/rebalance.py`; OpenAPI and live API validation tests assert current route inventory | Implemented |
+| Use discriminated execution intents | `src/core/models.py`; engine/golden tests assert `SECURITY_TRADE` and `FX_SPOT` intent shape | Implemented |
+| Make valuation policy explicit | `src/core/models.py`, `src/core/valuation.py`, `tests/unit/dpm/engine/test_engine_valuation_service.py` | Implemented |
+| Lock non-zero holdings and enforce shelf restrictions | `src/core/rebalance/universe.py`; golden scenarios for restricted, sell-only, suspended, and banned instruments | Implemented |
+| Avoid compatibility aliases for simulation | `tests/unit/test_validate_live_api.py` and OpenAPI certification checks ensure retired advisory/duplicate surfaces stay absent | Implemented |
+
+Design reasoning remains valid: lotus-manage now exposes one certified rebalance execution surface
+with explicit input mode selection, rather than multiple overlapping advisory-era routes.
+
 ---
 
 ## 1. Problem Statement

--- a/docs/rfcs/RFC-0021-dpm-openapi-contract-hardening.md
+++ b/docs/rfcs/RFC-0021-dpm-openapi-contract-hardening.md
@@ -11,6 +11,23 @@
 
 Harden lotus-manage OpenAPI contracts so request and response objects are explicitly separated, with complete field-level descriptions/examples and contract tests to prevent accidental schema drift.
 
+## 1.1 Current Status Review (2026-05-03)
+
+RFC-0021 is **implemented and extended** by the current API certification baseline. The RFC remains
+the OpenAPI quality foundation for lotus-manage, while later work added ecosystem-wide vocabulary,
+alias retirement, and endpoint-certification checks.
+
+| Requirement | Current implementation evidence | Current status |
+| --- | --- | --- |
+| Separate public request and response models | `src/api/schemas.py`, `src/core/models.py`, `tests/integration/test_openapi_certification_matrix.py` | Implemented |
+| Field-level descriptions and examples | `src/api/openapi_enrichment.py`, `tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py` | Implemented |
+| Contract tests over `/openapi.json` | `tests/integration/test_openapi_certification_matrix.py`, `tests/unit/test_validate_live_api.py` | Implemented |
+| Retired route and alias protection | `scripts/openapi_quality_gate.py`, `tests/unit/test_validate_live_api.py` | Implemented |
+| Endpoint certification evidence | `wiki/Endpoint-Certification.md`, live validation output under non-git-tracked `output/` when generated | Implemented |
+
+No additional route changes are owned by this RFC. New API certification work should update the
+endpoint-specific RFC or certification inventory and keep this RFC as the historical foundation.
+
 ## 2. Problem Statement
 
 Schema ambiguity and mixed request/response models reduce integrator confidence and make production support harder. Advisory APIs already use stricter schema discipline.

--- a/docs/rfcs/RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md
+++ b/docs/rfcs/RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md
@@ -1,11 +1,47 @@
-# RFC-0024: Unified PostgreSQL Persistence for lotus-manage and Advisory
+# RFC-0024: PostgreSQL Persistence for lotus-manage Supportability
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | COMPLETED (SLICE 19) |
+| **Status** | COMPLETED FOR LOTUS-MANAGE; ADVISORY PORTION SUPERSEDED BY LOTUS-ADVISE SPLIT |
 | **Created** | 2026-02-20 |
-| **Depends On** | RFC-0014G, RFC-0017, RFC-0018, RFC-0019, RFC-0020, RFC-0023 |
+| **Depends On** | RFC-0017, RFC-0018, RFC-0019, RFC-0020, RFC-0023 |
 | **Doc Location** | `docs/rfcs/RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md` |
+
+## 0. Current Status Review (2026-05-03)
+
+This RFC originally bundled lotus-manage DPM supportability persistence with advisory proposal
+persistence. That bundling is no longer the active architecture. Current lotus-manage is a
+discretionary mandate portfolio-management service; advisor-led proposal simulation, artifacts,
+consent, and lifecycle persistence belong in `lotus-advise`.
+
+The lotus-manage portion is complete and remains active:
+
+| Requirement | Current implementation evidence | Current status |
+| --- | --- | --- |
+| Durable DPM run repository | `src/infrastructure/rebalance_runs/postgres.py`, `tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py` | Implemented |
+| Idempotency, async operations, workflow decisions, lineage, artifacts | `src/api/routers/rebalance_runs.py`, `src/core/supportability/`, supportability tests | Implemented |
+| Forward-only Postgres migrations | `src/infrastructure/postgres_migrations.py`, `src/infrastructure/postgres_migrations/dpm/0001_baseline.sql`, migration tests | Implemented |
+| Postgres backend configuration and guardrails | `src/api/persistence_profile.py`, `src/api/production_cutover_contract.py`, `tests/unit/api/test_persistence_profile.py` | Implemented |
+| Repository parity and deterministic replay support | `tests/unit/dpm/supportability/`, integration and live API validation tests | Implemented |
+
+Historical advisory implementation notes in this file are retained only to explain why the RFC
+became broad during an earlier service-boundary phase. They are not current lotus-manage work
+items, and they must not be used as a reason to recreate proposal persistence, proposal environment
+variables, or advisory routes in this repository.
+
+## 0.1 Current lotus-manage Acceptance Criteria
+
+1. Production DPM supportability uses PostgreSQL with explicit DSN and driver guardrails.
+2. Migration tooling is forward-only, repeatable, and protected by advisory locks.
+3. Run, idempotency, async operation, workflow, lineage, artifact, and retention repositories have
+   deterministic tests and API coverage.
+4. Local development profiles remain available only where explicitly documented.
+5. No advisory proposal runtime surface is reintroduced in lotus-manage.
+
+## 0.2 Historical Scope Record
+
+Sections 1 onward preserve the original combined-scope RFC record. They are retained for audit and
+migration traceability; the active scope is the manage-only acceptance criteria above.
 
 ## 1. Executive Summary
 

--- a/docs/rfcs/RFC-0025-postgres-only-production-mode-cutover.md
+++ b/docs/rfcs/RFC-0025-postgres-only-production-mode-cutover.md
@@ -2,7 +2,7 @@
 
 | Metadata | Details |
 | --- | --- |
-| **Status** | COMPLETED |
+| **Status** | COMPLETED FOR LOTUS-MANAGE; ADVISORY PORTION SUPERSEDED BY LOTUS-ADVISE SPLIT |
 | **Created** | 2026-02-20 |
 | **Depends On** | RFC-0023, RFC-0024 |
 | **Doc Location** | `docs/rfcs/RFC-0025-postgres-only-production-mode-cutover.md` |
@@ -11,6 +11,39 @@
 
 Define a staged production cutover plan where lotus-manage/advisory persistence uses PostgreSQL-only
 backends in non-dev environments, while preserving in-memory/SQLite paths for local workflows.
+
+### 1.1 Current Status Review (2026-05-03)
+
+This RFC is complete for current lotus-manage DPM scope. The original text included advisory
+proposal persistence because the repository briefly carried advisory lifecycle responsibilities.
+That scope has been superseded by the `lotus-advise` service split. Current lotus-manage production
+cutover policy is:
+
+1. DPM supportability persistence must use PostgreSQL in production profiles.
+2. Policy-pack catalog persistence must use PostgreSQL in production profiles when catalog/admin
+   APIs are enabled.
+3. Local development may keep lightweight backends where explicitly allowed.
+4. Advisory proposal persistence is not an active lotus-manage production requirement.
+
+| Requirement | Current implementation evidence | Current status |
+| --- | --- | --- |
+| Production profile guardrails | `src/api/persistence_profile.py`, `tests/unit/api/test_persistence_profile.py` | Implemented |
+| Explicit cutover contract validation | `src/api/production_cutover_contract.py`, `scripts/production_cutover_check.py`, production cutover tests | Implemented |
+| Migration readiness checks | `src/infrastructure/postgres_migrations.py`, migration tests | Implemented |
+| Container/runtime Postgres profile | `docker-compose.yml`, `docker-compose.production.yml`, operations docs | Implemented |
+| Advisory proposal cutover controls | Historical only; current owner is `lotus-advise` | Superseded |
+
+The remaining sections preserve the original cutover record. Where they mention advisory controls,
+read them as historical implementation notes, not current lotus-manage acceptance criteria.
+
+### 1.2 Current lotus-manage Acceptance Criteria
+
+1. `APP_PERSISTENCE_PROFILE=PRODUCTION` fails fast unless DPM supportability is backed by Postgres.
+2. Production policy-pack catalog mode fails fast unless a Postgres backend and DSN are configured
+   when policy-pack catalog APIs are enabled.
+3. Cutover checks validate profile, environment, and migration readiness before production use.
+4. Local and test profiles remain explicit and cannot be confused with production posture.
+5. No advisory proposal runtime guardrail is required or advertised by lotus-manage.
 
 ## 2. Problem Statement
 

--- a/docs/rfcs/RFC-0028-dpm-integration-capabilities-contract.md
+++ b/docs/rfcs/RFC-0028-dpm-integration-capabilities-contract.md
@@ -1,30 +1,117 @@
-# RFC-0028 lotus-manage Integration Capabilities Contract
+# RFC-0028: lotus-manage Integration Capabilities Contract
 
-- Status: Accepted
-- Date: 2026-02-23
+| Metadata | Details |
+| --- | --- |
+| **Status** | IMPLEMENTED |
+| **Created** | 2026-02-23 |
+| **Depends On** | RFC-0021, RFC-0022 |
+| **Doc Location** | `docs/rfcs/RFC-0028-dpm-integration-capabilities-contract.md` |
 
-## Summary
+## 1. Executive Summary
 
-Add `GET /integration/capabilities` to expose backend-governed lotus-manage feature and workflow capability flags for lotus-gateway, lotus-core, and UI integration.
+Expose a backend-governed capabilities contract so upstream, gateway, UI, and operations tooling can
+discover which lotus-manage DPM features and workflows are enabled without hard-coding runtime
+assumptions.
 
-## Contract
+The implemented endpoint is:
 
-Inputs:
-- `consumer_system`
-- `tenant_id`
+`GET /api/v1/integration/capabilities`
 
-Outputs:
-- `contract_version`
-- `source_service`
-- `consumer_system`
-- `tenant_id`
-- `policy_version`
-- `supported_input_modes`
-- `features[]`
-- `workflows[]`
+## 2. Current Status Review (2026-05-03)
 
-## Rationale
+RFC-0028 is **implemented and aligned** with the current manage-only architecture. The original
+draft named an unversioned capabilities route; the certified public route now uses the standard
+versioned API prefix.
 
-1. Keeps workflow/feature control in backend.
-2. Enables lotus-gateway/UI to drive behavior from capability contracts.
-3. Aligns lotus-manage with lotus-core and lotus-performance integration-governance direction.
+| Requirement | Current implementation evidence | Current status |
+| --- | --- | --- |
+| Backend-governed capability flags | `src/api/routers/integration_capabilities.py` | Implemented |
+| Consumer and tenant-aware contract shape | `src/api/routers/integration_capabilities.py`, API tests | Implemented |
+| Workflow capability publication | `src/core/capabilities.py`, integration capability tests | Implemented |
+| Stateful portfolio-id mode advertised only when core sourcing is truly enabled | `src/api/routers/integration_capabilities.py`, `tests/unit/api/test_integration_capabilities_api.py` | Implemented |
+| OpenAPI certified and documented | `tests/integration/test_openapi_certification_matrix.py`, `wiki/Endpoint-Certification.md` | Implemented |
+
+## 3. Problem Statement
+
+Downstream consumers should not infer lotus-manage behavior from environment variables, stale docs,
+or UI assumptions. Enterprise DPM integration needs a machine-readable control point that states:
+
+1. which input modes are currently available,
+2. which DPM features are enabled,
+3. which workflow surfaces are available, and
+4. whether stateful execution can safely source required data from lotus-core.
+
+## 4. Goals and Non-Goals
+
+### 4.1 Goals
+
+1. Publish the current lotus-manage DPM feature surface through one certified integration endpoint.
+2. Keep feature gating in the backend, where it can use runtime configuration and dependency state.
+3. Make stateful mode truthful: advertise it only when portfolio-id input, core sourcing, and core
+   base URL configuration are all enabled.
+4. Give lotus-gateway, lotus-workbench, operations tooling, and future consumers a stable discovery
+   contract.
+
+### 4.2 Non-Goals
+
+1. Replace endpoint-level OpenAPI documentation.
+2. Introduce advisory proposal capabilities into lotus-manage.
+3. Provide portfolio-specific eligibility decisions; those belong to execution/readiness endpoints.
+
+## 5. Contract
+
+### 5.1 Request
+
+Query parameters:
+
+| Parameter | Required | Description | Example |
+| --- | --- | --- | --- |
+| `consumer_system` | No | Calling system requesting capability truth. | `lotus-workbench` |
+| `tenant_id` | No | Tenant context used for policy-aware capability presentation. | `private-bank-sg` |
+
+### 5.2 Response
+
+Top-level fields:
+
+| Field | Description |
+| --- | --- |
+| `contract_version` | Version of the capabilities response contract. |
+| `source_service` | Always `lotus-manage`. |
+| `consumer_system` | Echoed consumer identifier or default value. |
+| `tenant_id` | Echoed tenant identifier when supplied. |
+| `generated_at` | Server timestamp for the generated contract. |
+| `as_of_date` | Business date used for policy presentation when available. |
+| `policy_version` | Effective policy version advertised to consumers. |
+| `supported_input_modes` | Available request modes, including stateless payload and portfolio-id mode when enabled. |
+| `features` | Feature flags and explanatory metadata. |
+| `workflows` | Workflow capabilities exposed by the service. |
+
+## 6. Design Reasoning
+
+This endpoint is intentionally descriptive rather than operational. It lets consumers render or route
+correctly before invoking execution APIs, while execution APIs remain the source of truth for actual
+portfolio-specific outcomes.
+
+The stateful capability is deliberately conservative. It is enabled only when:
+
+1. `DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED=true`,
+2. `DPM_STATEFUL_CORE_SOURCING_ENABLED=true`,
+3. `DPM_CORE_BASE_URL` is configured, and
+4. no retired monolithic execution-context route is configured.
+
+That prevents downstream systems from presenting a stateful workflow when lotus-manage cannot source
+the required DPM data products from lotus-core.
+
+## 7. Acceptance Criteria
+
+1. `GET /api/v1/integration/capabilities` returns a versioned contract.
+2. The contract includes input modes, features, and workflows with clear enabled/disabled semantics.
+3. Stateful portfolio-id mode is advertised only when all required core-sourcing controls are enabled.
+4. The route is included in OpenAPI and endpoint certification evidence.
+5. Tests cover default, tenant/consumer, disabled, and stateful-enabled capability presentations.
+
+## 8. Current Gap Assessment
+
+No active implementation gaps remain in RFC-0028. Future changes should update this RFC only when
+the capabilities contract itself changes; endpoint-specific behavior belongs in the owning endpoint
+RFC and OpenAPI certification evidence.

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -149,3 +149,36 @@ def test_endpoint_certification_wiki_covers_openapi_paths() -> None:
     missing = [path for path in sorted(app.openapi()["paths"]) if path not in certification]
 
     assert missing == []
+
+
+def test_foundation_rfcs_are_rebaselined_to_current_dpm_scope() -> None:
+    reviewed_rfcs = [
+        "RFC-0002-rebalance-simulation-mvp-hardening-enterprise-completeness.md",
+        "RFC-0007A-contract-tightening.md",
+        "RFC-0021-dpm-openapi-contract-hardening.md",
+        "RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md",
+        "RFC-0025-postgres-only-production-mode-cutover.md",
+        "RFC-0028-dpm-integration-capabilities-contract.md",
+    ]
+    missing_review = [
+        rfc
+        for rfc in reviewed_rfcs
+        if "Current Status Review (2026-05-03)"
+        not in (ROOT / "docs" / "rfcs" / rfc).read_text(encoding="utf-8")
+    ]
+
+    assert missing_review == []
+
+    rfc_0028 = (
+        ROOT / "docs" / "rfcs" / "RFC-0028-dpm-integration-capabilities-contract.md"
+    ).read_text(encoding="utf-8")
+    assert "`GET /api/v1/integration/capabilities`" in rfc_0028
+    assert "`GET /integration/capabilities`" not in rfc_0028
+
+    for rfc in [
+        "RFC-0024-unified-postgresql-persistence-for-dpm-and-advisory.md",
+        "RFC-0025-postgres-only-production-mode-cutover.md",
+    ]:
+        text = (ROOT / "docs" / "rfcs" / rfc).read_text(encoding="utf-8")
+        assert "ADVISORY PORTION SUPERSEDED BY LOTUS-ADVISE SPLIT" in text
+        assert "not current lotus-manage" in text

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -13,6 +13,11 @@
 
 - RFC-0001 to RFC-0013
   core rebalance simulation, controls, optimization, and what-if analysis foundation
+- RFC-0002
+  implemented enterprise hardening baseline; durable idempotency and persistence are now delivered
+  by later supportability RFCs rather than deferred work
+- RFC-0007A
+  implemented contract-tightening baseline for the canonical rebalance execution surface
 - RFC-0016
   idempotency replay contract
 - RFC-0017
@@ -24,13 +29,13 @@
 - RFC-0020
   workflow gate API and persistence
 - RFC-0021
-  OpenAPI hardening and request/response model separation
+  OpenAPI hardening, request/response model separation, and current certification evidence
 - RFC-0022
   policy-pack configuration model
 - RFC-0023
   persistent supportability store and lineage APIs
 - RFC-0028
-  integration capabilities contract
+  implemented `GET /api/v1/integration/capabilities` backend-governed capabilities contract
 
 ## Active And Recently Completed RFCs
 
@@ -47,6 +52,14 @@
 
 - Advisor-led proposal simulation, artifacts, consent, and lifecycle RFCs are no longer active
   `lotus-manage` scope. They belong in `lotus-advise`.
+
+## Rebaselined foundation RFCs
+
+- RFC-0002, RFC-0007A, RFC-0021, RFC-0024, RFC-0025, and RFC-0028 were reviewed against current
+  implementation evidence on 2026-05-03.
+- RFC-0024 and RFC-0025 are complete for current lotus-manage DPM supportability and production
+  cutover scope. Historical advisory migration notes remain in the RFC files for audit traceability
+  only.
 
 ## Full local RFC inventory
 


### PR DESCRIPTION
## Summary
- Rebaseline RFC-0002, RFC-0007A, RFC-0021, RFC-0024, RFC-0025, and RFC-0028 against current lotus-manage DPM implementation evidence
- Clarify that RFC-0024 and RFC-0025 are complete for manage supportability/production cutover while advisory proposal scope is superseded by lotus-advise
- Upgrade RFC-0028 from a thin accepted draft to the implemented `/api/v1/integration/capabilities` contract
- Update repo-authored wiki RFC index and add a governance test to prevent drift back to stale foundation RFC wording

## Validation
- `python -m pytest tests\unit\test_documentation_current_state.py -q` -> 8 passed
- `git diff --check` -> passed
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> reports expected branch drift on `RFC-Index.md` because repo-authored wiki source changed and must be published after merge

## Wiki
Repo-authored wiki source is updated in this PR. Publish after merge with:
`..\lotus-platform\automation\Sync-RepoWikis.ps1 -Publish -Repository lotus-manage`