### PR TITLE
Add lotus-manage DPM execution roadmap RFCs

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -40,6 +40,11 @@ Governance boundary:
 | RFC-0036 | lotus-manage Stateful Core Sourcing And Endpoint Consolidation | IMPLEMENTED | RFC-0013, RFC-0016, RFC-0017, RFC-0018, RFC-0021, RFC-0022, RFC-0023, RFC-0028 | `docs/rfcs/RFC-0036-dpm-stateful-core-sourcing-and-endpoint-consolidation.md` |
 | RFC-0037 | lotus-manage DPM Operating System and Mandate Intelligence | PROPOSED | RFC-0001 through RFC-0013, RFC-0016 through RFC-0025, RFC-0028, RFC-0036, lotus-core RFC-0087 | `docs/rfcs/RFC-0037-dpm-operating-system-and-mandate-intelligence.md` |
 | RFC-0038 | Mandate Digital Twin, Health Score, and DPM Command Center Foundation | PROPOSED | RFC-0021, RFC-0022, RFC-0023, RFC-0024, RFC-0025, RFC-0028, RFC-0036, RFC-0037, lotus-core RFC-0087 | `docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md` |
+| RFC-0039 | Advanced Portfolio Construction and Rebalance Alternatives | PROPOSED | RFC-0008, RFC-0009, RFC-0010, RFC-0011, RFC-0012, RFC-0013, RFC-0022, RFC-0036, RFC-0037, RFC-0038 | `docs/rfcs/RFC-0039-advanced-portfolio-construction-and-rebalance-alternatives.md` |
+| RFC-0040 | Pre-Trade Proof Pack and DPM Evidence Fabric | PROPOSED | RFC-0017, RFC-0019, RFC-0020, RFC-0021, RFC-0023, RFC-0036, RFC-0037, RFC-0038, RFC-0039 | `docs/rfcs/RFC-0040-pre-trade-proof-pack-and-evidence-fabric.md` |
+| RFC-0041 | Rebalance Wave Orchestration and CIO Model Change Impact | PROPOSED | RFC-0018, RFC-0020, RFC-0023, RFC-0036, RFC-0037, RFC-0038, RFC-0039, RFC-0040 | `docs/rfcs/RFC-0041-rebalance-wave-orchestration-and-cio-model-change-impact.md` |
+| RFC-0042 | Post-Trade Outcome Feedback Loop | PROPOSED | RFC-0017, RFC-0019, RFC-0023, RFC-0036, RFC-0037, RFC-0038, RFC-0039, RFC-0040, RFC-0041 | `docs/rfcs/RFC-0042-post-trade-outcome-feedback-loop.md` |
+| RFC-0043 | Governed AI PM Copilot for DPM | PROPOSED | RFC-0037, RFC-0038, RFC-0039, RFC-0040, RFC-0041, RFC-0042 | `docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md` |
 
 Review note:
 - RFC-0002, RFC-0007A, RFC-0021, RFC-0024, RFC-0025, and RFC-0028 were rebaselined on

--- a/docs/rfcs/RFC-0037-dpm-operating-system-and-mandate-intelligence.md
+++ b/docs/rfcs/RFC-0037-dpm-operating-system-and-mandate-intelligence.md
@@ -108,6 +108,33 @@ support the full lifecycle:
 Without this broader operating-system layer, `lotus-manage` risks being perceived as a technical
 engine instead of a premium private-banking DPM product.
 
+## 2.5 Business Outcomes
+
+This RFC targets the following business outcomes:
+
+1. **Increase DPM scalability**
+   enable one portfolio manager to oversee a larger book through exception-based monitoring,
+   mandate health scoring, and wave orchestration instead of manual portfolio-by-portfolio review.
+2. **Improve investment discipline**
+   make every rebalance traceable to mandate objectives, CIO/model guidance, risk limits, tax and
+   liquidity constraints, and product eligibility.
+3. **Strengthen client and regulator trust**
+   produce evidence that explains why a discretionary action was proposed, approved, blocked, or
+   deferred.
+4. **Create a premium sales story**
+   demonstrate a full private-banking DPM lifecycle with real APIs, real evidence, and realistic
+   mandate scenarios.
+5. **Increase ecosystem pull-through**
+   make `lotus-core`, `lotus-risk`, `lotus-performance`, `lotus-report`, `lotus-ai`,
+   `lotus-gateway`, and `lotus-workbench` more valuable by orchestrating them into a coherent DPM
+   product.
+6. **Reduce operational risk**
+   replace spreadsheet-style exception tracking with governed workflows, supportability, lineage,
+   data-readiness states, and audit artifacts.
+7. **Improve decision quality over time**
+   use post-trade outcome feedback to compare expected versus realized results and improve future
+   construction and governance.
+
 ---
 
 ## 3. Product Vision

--- a/docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md
+++ b/docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md
@@ -48,6 +48,28 @@ Today, these answers are distributed across simulate/analyze responses, core rea
 supportability APIs, and future Workbench composition. RFC-0038 creates a first-class backend
 foundation for those answers.
 
+## 1.5 Business Outcomes
+
+This RFC targets the following business outcomes:
+
+1. **Daily PM book control**
+   give portfolio managers a single source of truth for which mandates are healthy, drifting,
+   blocked, stale, or ready for action.
+2. **Faster exception triage**
+   reduce time spent diagnosing whether an issue is caused by allocation drift, data readiness,
+   cash, tax, risk, restrictions, or workflow state.
+3. **Better mandate adherence**
+   make the mandate itself a machine-readable control object, so every downstream rebalance and
+   monitoring decision can be traced to client objectives and constraints.
+4. **Improved operating discipline**
+   allow operations and support teams to inspect source readiness and monitoring exceptions without
+   reconstructing state from individual simulation payloads.
+5. **A stronger Workbench product surface**
+   provide the backend truth needed for a sellable DPM command center in `lotus-workbench`.
+6. **Foundation for future automation**
+   create the mandate, health, and exception primitives needed by alternatives, proof packs, waves,
+   post-trade feedback, and AI summaries.
+
 ---
 
 ## 2. Goals and Non-Goals

--- a/docs/rfcs/RFC-0039-advanced-portfolio-construction-and-rebalance-alternatives.md
+++ b/docs/rfcs/RFC-0039-advanced-portfolio-construction-and-rebalance-alternatives.md
@@ -1,0 +1,601 @@
+# RFC-0039: Advanced Portfolio Construction and Rebalance Alternatives
+
+| Metadata | Details |
+| --- | --- |
+| **Status** | PROPOSED |
+| **Created** | 2026-05-03 |
+| **Depends On** | RFC-0008, RFC-0009, RFC-0010, RFC-0011, RFC-0012, RFC-0013, RFC-0022, RFC-0036, RFC-0037, RFC-0038 |
+| **Doc Location** | `docs/rfcs/RFC-0039-advanced-portfolio-construction-and-rebalance-alternatives.md` |
+
+---
+
+## 0. Executive Summary
+
+RFC-0039 turns `lotus-manage` from a single-result rebalance engine into a portfolio construction
+decision system. The target is to generate, compare, explain, and select multiple rebalance
+alternatives for a discretionary mandate, each with transparent trade-offs across drift, risk,
+turnover, tax, transaction cost, liquidity, FX, ESG, and mandate constraints.
+
+This is the core analytical differentiator for `lotus-manage`. Large private banks sell DPM as
+professional portfolio construction under mandate discipline. This RFC gives Lotus the backend
+foundation for that story.
+
+Primary outcome:
+
+1. a PM asks for alternatives for one mandate,
+2. `lotus-manage` produces a bounded `DpmRebalanceAlternativeSet`,
+3. each alternative has objective, constraints, trades, expected outcomes, reason codes, solver
+   trace, feasibility state, and evidence,
+4. the selected alternative can flow into proof-pack and workflow APIs in later RFCs.
+
+---
+
+## 1. Current Baseline
+
+Existing `lotus-manage` already has:
+
+1. deterministic rebalance simulation,
+2. explicit stateless/stateful execution envelopes,
+3. heuristic target generation,
+4. solver-capable target generation foundation,
+5. tax-lot support through core sourcing,
+6. turnover and transaction-cost controls,
+7. settlement awareness,
+8. what-if analysis,
+9. policy-pack configuration,
+10. supportability, lineage, idempotency, and artifacts.
+
+Current gaps:
+
+1. one execution request generally produces one primary result,
+2. alternatives are not a first-class API/product concept,
+3. solver objective and constraint trade-offs are not presented as comparable PM choices,
+4. tax, turnover, risk, liquidity, and ESG trade-offs are not normalized into a decision matrix,
+5. infeasible or relaxed constraint evidence is not rich enough for PM/CIO/compliance review,
+6. `lotus-risk` and `lotus-performance` enrichment is not yet part of construction comparison.
+
+## 1.5 Business Outcomes
+
+This RFC targets the following business outcomes:
+
+1. **Better PM decisions**
+   let portfolio managers compare multiple valid paths instead of accepting one generated trade
+   plan without understanding trade-offs.
+2. **More personalized DPM**
+   support different client/mandate priorities such as tax sensitivity, low turnover, liquidity,
+   ESG constraints, income needs, and risk reduction.
+3. **Higher investment quality**
+   bring solver-backed construction, objective functions, and constraint governance into the core
+   DPM decision process.
+4. **Improved review and approval quality**
+   expose why an alternative is selected, why another is rejected, and what constraints or
+   relaxations shaped the result.
+5. **Stronger client and sales narrative**
+   show sophisticated portfolio construction as a visible value proposition, not a hidden engine
+   detail.
+6. **Reduced unnecessary trading**
+   explicitly optimize and compare turnover, costs, tax, and liquidity impact before action.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. Add first-class rebalance alternative generation.
+2. Support multiple construction methods:
+   `HEURISTIC_EXPLAINABLE`, `SOLVER_CONSTRAINED`, `MIN_TURNOVER`, `TAX_AWARE`,
+   `LIQUIDITY_AWARE`, `RISK_AWARE`, `ESG_AWARE`, and `DO_NOTHING_BASELINE`.
+3. Produce comparable metrics for each alternative.
+4. Persist alternative sets and selected alternatives.
+5. Expose solver status, objective terms, constraints, relaxations, infeasibility reasons, and
+   fallback decisions.
+6. Preserve existing status vocabulary: `READY`, `PENDING_REVIEW`, `BLOCKED`.
+7. Prepare selected alternatives for RFC-0040 proof packs and RFC-0041 wave orchestration.
+
+### 2.2 Non-Goals
+
+1. Execute trades.
+2. Replace `lotus-risk` as the risk analytics authority.
+3. Replace `lotus-performance` as performance authority.
+4. Create client proposal or consent workflows.
+5. Allow AI to choose alternatives.
+6. Guarantee globally optimal portfolio outcomes under all constraints; infeasible and bounded
+   fallback behavior must be explicit.
+
+---
+
+## 3. Ownership and Boundaries
+
+`lotus-manage` owns:
+
+1. alternative set orchestration,
+2. construction objective registry,
+3. constraint registry and mapping to mandate/policy packs,
+4. solver invocation and fallback governance,
+5. alternative comparison metrics,
+6. selection workflow and evidence.
+
+External authorities:
+
+| Authority | Responsibility |
+| --- | --- |
+| `lotus-core` | portfolio state, tax lots, model targets, eligibility, prices, FX, market coverage, liquidity/reference data when available |
+| `lotus-risk` | risk impact, tracking error, concentration, stress, drawdown, factor risk when available |
+| `lotus-performance` | benchmark context, realized performance, attribution context |
+| `lotus-report` | downstream reporting package generation |
+| `lotus-ai` | narrative summaries only, not construction decisions |
+
+---
+
+## 4. Construction Methods
+
+### 4.1 DO_NOTHING_BASELINE
+
+Purpose:
+
+1. compare every action against no action,
+2. quantify current drift, risk, cash, tax, and restriction posture,
+3. avoid pretending action is always better.
+
+Output expectations:
+
+1. no trade intents,
+2. current state as after state,
+3. health and rule results preserved,
+4. expected drift reduction equals zero.
+
+### 4.2 HEURISTIC_EXPLAINABLE
+
+Purpose:
+
+1. preserve current deterministic baseline,
+2. give explainable target-difference logic,
+3. act as fallback when solver is unavailable.
+
+Rules:
+
+1. no hidden relaxations,
+2. no stochastic behavior,
+3. same input produces same output,
+4. reason codes must explain capping, suppression, funding, and blocking.
+
+### 4.3 SOLVER_CONSTRAINED
+
+Purpose:
+
+1. optimize against objective function,
+2. respect constraints,
+3. quantify trade-offs.
+
+Required solver trace:
+
+1. solver engine,
+2. solver version,
+3. objective terms,
+4. constraint set id,
+5. time budget,
+6. solve status,
+7. gap/tolerance where available,
+8. relaxed constraints,
+9. infeasible constraints,
+10. fallback method when used.
+
+### 4.4 MIN_TURNOVER
+
+Purpose:
+
+1. reduce drift while minimizing unnecessary trading,
+2. support fee-sensitive or low-activity mandates,
+3. reduce operational burden.
+
+Primary metrics:
+
+1. turnover weight,
+2. number of trades,
+3. drift reduction,
+4. expected tracking error after trade.
+
+### 4.5 TAX_AWARE
+
+Purpose:
+
+1. reduce realized gains within tax budget,
+2. use available tax-lot windows,
+3. flag missing tax lots explicitly.
+
+Lot-selection posture:
+
+1. `HIFO`
+2. `LIFO`
+3. `FIFO`
+4. `MIN_GAIN`
+5. `TAX_LOTS_UNAVAILABLE`
+
+No tax-aware alternative may be marked `READY` if required tax lots are missing and the mandate
+requires tax-aware execution.
+
+### 4.6 LIQUIDITY_AWARE
+
+Purpose:
+
+1. protect cash buffers,
+2. respect known cashflow needs,
+3. avoid illiquid trades where liquidity profile is weak,
+4. preserve settlement readiness.
+
+Inputs:
+
+1. current cash,
+2. settlement ladder,
+3. known cashflow forecast when available,
+4. instrument liquidity profile when available.
+
+### 4.7 RISK_AWARE
+
+Purpose:
+
+1. reduce or control tracking error,
+2. mitigate concentration,
+3. avoid increasing drawdown or stress posture beyond mandate limits,
+4. use `lotus-risk` enrichment where available.
+
+Risk-aware alternatives may be generated in degraded mode with local concentration metrics, but
+must clearly mark missing `lotus-risk` enrichment.
+
+### 4.8 ESG_AWARE
+
+Purpose:
+
+1. apply sustainability exclusions,
+2. avoid restricted sectors and issuers,
+3. prefer eligible sustainable instruments where mandate requires it,
+4. expose ESG degradation when source profiles are incomplete.
+
+---
+
+## 5. Objective Function
+
+The target solver objective is a weighted sum:
+
+```text
+minimize:
+    w_drift * drift_distance
+  + w_tracking_error * tracking_error
+  + w_turnover * turnover
+  + w_cost * transaction_cost
+  + w_tax * realized_tax
+  + w_cash * cash_band_penalty
+  + w_liquidity * liquidity_penalty
+  + w_esg * esg_penalty
+  + w_concentration * concentration_penalty
+```
+
+Objective weights come from:
+
+1. mandate digital twin,
+2. policy pack,
+3. construction method default,
+4. explicit request override where allowed.
+
+Every objective term must be exposed in the alternative trace.
+
+---
+
+## 6. Constraint Registry
+
+Initial constraint families:
+
+1. `ASSET_CLASS_BAND`
+2. `INSTRUMENT_WEIGHT_MAX`
+3. `ISSUER_WEIGHT_MAX`
+4. `SECTOR_WEIGHT_MAX`
+5. `REGION_WEIGHT_MAX`
+6. `CURRENCY_EXPOSURE_MAX`
+7. `TRACKING_ERROR_MAX`
+8. `TURNOVER_MAX`
+9. `TAX_REALIZATION_MAX`
+10. `CASH_BAND`
+11. `MIN_TRADE_NOTIONAL`
+12. `NO_SHORTING`
+13. `NO_OVERDRAFT`
+14. `SETTLEMENT_CASH_LADDER`
+15. `SHELF_ELIGIBILITY`
+16. `CLIENT_RESTRICTION`
+17. `SUSTAINABILITY_EXCLUSION`
+18. `LIQUIDITY_MINIMUM`
+
+Constraint severities:
+
+1. `HARD`: cannot be relaxed without `BLOCKED`,
+2. `SOFT`: may produce `PENDING_REVIEW`,
+3. `INFO`: evidence only.
+
+Relaxation rules:
+
+1. hard constraints cannot be silently relaxed,
+2. every soft relaxation must include reason, magnitude, actor or policy authority, and evidence,
+3. default target-state implementation should avoid relaxations unless explicitly configured.
+
+---
+
+## 7. Domain Models
+
+### 7.1 DpmRebalanceAlternativeSet
+
+Required fields:
+
+1. `alternative_set_id`
+2. `portfolio_id`
+3. `mandate_id`
+4. `as_of_date`
+5. `input_mode`
+6. `requested_methods`
+7. `generated_methods`
+8. `source_readiness`
+9. `alternatives`
+10. `comparison_summary`
+11. `recommended_alternative_id`
+12. `recommendation_basis`
+13. `lineage`
+14. `created_at`
+
+### 7.2 DpmRebalanceAlternative
+
+Required fields:
+
+1. `alternative_id`
+2. `alternative_type`
+3. `status`
+4. `construction_method`
+5. `objective_trace`
+6. `constraint_trace`
+7. `before`
+8. `target`
+9. `intents`
+10. `after_simulated`
+11. `rule_results`
+12. `diagnostics`
+13. `decision_metrics`
+14. `risk_impact`
+15. `tax_impact`
+16. `turnover_impact`
+17. `cost_impact`
+18. `liquidity_impact`
+19. `fx_impact`
+20. `explanation`
+21. `lineage`
+
+### 7.3 DpmAlternativeDecisionMetrics
+
+Required metrics:
+
+1. `drift_before`
+2. `drift_after`
+3. `drift_reduction`
+4. `turnover_weight`
+5. `trade_count`
+6. `estimated_transaction_cost_base`
+7. `estimated_realized_gain_base`
+8. `cash_after_weight`
+9. `risk_score_before`
+10. `risk_score_after`
+11. `tracking_error_before`
+12. `tracking_error_after`
+13. `restriction_breach_count`
+14. `source_readiness_state`
+
+---
+
+## 8. API Surface
+
+### 8.1 Generate Alternatives
+
+`POST /api/v1/rebalance/alternatives`
+
+Purpose:
+
+1. generate a bounded alternative set for one mandate/portfolio,
+2. support stateless or stateful source input,
+3. persist the alternative set and lineage.
+
+Request fields:
+
+1. `input_mode`
+2. `portfolio_id` or stateless input bundle,
+3. `as_of`
+4. `mandate_id`
+5. `requested_methods`
+6. `policy_pack_id`
+7. `max_alternatives`
+8. `include_risk_enrichment`
+9. `include_performance_context`
+10. `include_tax_impact`
+11. `solver_time_budget_ms`
+
+Response:
+
+1. full `DpmRebalanceAlternativeSet`,
+2. status per alternative,
+3. source readiness and degradation details.
+
+### 8.2 Retrieve Alternatives
+
+`GET /api/v1/rebalance/alternatives/{alternative_set_id}`
+
+Purpose:
+
+1. retrieve persisted alternative set,
+2. support Workbench comparison and proof-pack generation.
+
+### 8.3 Select Alternative
+
+`POST /api/v1/rebalance/alternatives/{alternative_set_id}/select`
+
+Purpose:
+
+1. mark selected alternative,
+2. persist actor, rationale, and timestamp,
+3. prepare for proof pack or workflow review.
+
+Rules:
+
+1. only one selected alternative per selection version,
+2. selecting `BLOCKED` alternative requires explicit override and remains `PENDING_REVIEW` or
+   `BLOCKED` according to policy,
+3. selection does not execute trades.
+
+---
+
+## 9. Persistence
+
+Tables:
+
+1. `dpm_alternative_sets`
+2. `dpm_rebalance_alternatives`
+3. `dpm_alternative_selection_events`
+
+Required indexes:
+
+1. `(portfolio_id, created_at desc)`
+2. `(mandate_id, created_at desc)`
+3. `(alternative_set_id)`
+4. `(selected_alternative_id)`
+5. `(status, created_at desc)`
+
+Retention:
+
+1. selected alternatives: 7 years,
+2. unselected alternatives: configurable, default 2 years,
+3. blocked alternatives linked to audit or compliance review: 7 years.
+
+---
+
+## 10. Implementation Slices
+
+### Slice 0 - Design Tightening and RFC Review
+
+1. validate current solver capabilities,
+2. map all constraints to existing engine/policy-pack fields,
+3. identify source-data gaps for risk, tax, liquidity, ESG, and costs,
+4. define minimum viable alternative methods.
+
+Exit evidence:
+
+1. field-by-field source map,
+2. gap list for `lotus-core`, `lotus-risk`, `lotus-performance`,
+3. agreed method list for first implementation.
+
+### Slice 1 - Domain Models and Pure Alternative Engine
+
+1. add alternative set models,
+2. add objective and constraint traces,
+3. wrap existing heuristic output as one alternative,
+4. add do-nothing baseline,
+5. add pure comparison metrics.
+
+Exit evidence:
+
+1. unit tests for model validation,
+2. deterministic comparison tests,
+3. no persistence required yet.
+
+### Slice 2 - Solver and Method Registry
+
+1. define method registry,
+2. expose solver availability posture,
+3. add solver trace,
+4. add fallback handling,
+5. add infeasibility classification.
+
+Exit evidence:
+
+1. solver success test,
+2. solver unavailable test,
+3. infeasible constraints test,
+4. fallback trace test.
+
+### Slice 3 - Tax, Turnover, Liquidity, and Cost Enrichment
+
+1. connect tax lots,
+2. calculate turnover and estimated cost,
+3. calculate liquidity/cash posture,
+4. classify missing inputs.
+
+Exit evidence:
+
+1. tax-lot present/missing tests,
+2. turnover budget tests,
+3. liquidity/cash buffer tests.
+
+### Slice 4 - Risk and Performance Context
+
+1. call or prepare seam for `lotus-risk`,
+2. call or prepare seam for `lotus-performance`,
+3. support degraded mode,
+4. include enrichment supportability.
+
+Exit evidence:
+
+1. mocked upstream tests,
+2. unavailable upstream tests,
+3. response examples with and without enrichment.
+
+### Slice 5 - Persistence and APIs
+
+1. add migrations and repositories,
+2. add generate/retrieve/select APIs,
+3. add OpenAPI docs and examples,
+4. add supportability.
+
+Exit evidence:
+
+1. repository parity tests,
+2. API tests,
+3. OpenAPI certification.
+
+### Slice 6 - Live Proof and Closure
+
+1. prove canonical portfolio alternatives,
+2. capture full request/response evidence,
+3. update README/wiki/supported-features,
+4. create follow-up RFCs or issues for gaps.
+
+Exit evidence:
+
+1. live evidence reviewed,
+2. CI green,
+3. docs and wiki current.
+
+---
+
+## 11. Testing Strategy
+
+Required tests:
+
+1. deterministic alternative generation,
+2. objective trace completeness,
+3. constraint trace completeness,
+4. solver success/failure/fallback,
+5. tax-aware lot selection,
+6. turnover budget enforcement,
+7. liquidity-aware cash preservation,
+8. risk/performance enrichment degraded behavior,
+9. selection event persistence,
+10. OpenAPI examples and field documentation,
+11. canonical live evidence.
+
+---
+
+## 12. Acceptance Criteria
+
+RFC-0039 is complete when:
+
+1. at least four alternative methods are implemented and certified,
+2. alternative sets are persisted and retrievable,
+3. every alternative includes comparable decision metrics,
+4. solver status and infeasibility are explainable,
+5. selected alternative is actor-attributed,
+6. OpenAPI is complete,
+7. live proof shows a realistic discretionary mandate comparison,
+8. no AI or UI layer chooses the alternative on behalf of the PM.

--- a/docs/rfcs/RFC-0040-pre-trade-proof-pack-and-evidence-fabric.md
+++ b/docs/rfcs/RFC-0040-pre-trade-proof-pack-and-evidence-fabric.md
@@ -1,0 +1,412 @@
+# RFC-0040: Pre-Trade Proof Pack and DPM Evidence Fabric
+
+| Metadata | Details |
+| --- | --- |
+| **Status** | PROPOSED |
+| **Created** | 2026-05-03 |
+| **Depends On** | RFC-0017, RFC-0019, RFC-0020, RFC-0021, RFC-0023, RFC-0036, RFC-0037, RFC-0038, RFC-0039 |
+| **Doc Location** | `docs/rfcs/RFC-0040-pre-trade-proof-pack-and-evidence-fabric.md` |
+
+---
+
+## 0. Executive Summary
+
+RFC-0040 creates the DPM pre-trade proof pack: a durable evidence artifact that explains why a
+portfolio action is being proposed, what it changes, what risks and constraints were evaluated, what
+source data was used, who reviewed it, and what downstream reports or narratives can be generated.
+
+This RFC is the trust layer for `lotus-manage`. It turns rebalance output into a complete PM,
+compliance, operations, investment-committee, sales-demo, and audit artifact.
+
+The proof pack must be structured enough for machines and readable enough for humans.
+
+---
+
+## 1. Current Baseline
+
+Existing foundations:
+
+1. deterministic run artifact contract,
+2. support bundle APIs,
+3. lineage APIs,
+4. workflow gate APIs,
+5. stateful core source lineage,
+6. OpenAPI certification,
+7. demo request/response evidence under non-git-tracked output folders when generated.
+
+Current gaps:
+
+1. no first-class pre-trade proof-pack aggregate,
+2. no normalized cross-section evidence for mandate, alternatives, risk, tax, liquidity, FX, and
+   source readiness,
+3. no report-ready package contract for `lotus-report`,
+4. no AI-ready structured evidence contract for `lotus-ai`,
+5. no Workbench-ready proof-pack summary contract through `lotus-gateway`.
+
+## 1.5 Business Outcomes
+
+This RFC targets the following business outcomes:
+
+1. **Trustworthy discretionary decisions**
+   give PMs, compliance, operations, and auditors one durable proof artifact explaining every
+   proposed action.
+2. **Faster approvals**
+   reduce approval friction by packaging mandate, risk, tax, liquidity, rule, trade, and source
+   evidence before review.
+3. **Higher-quality client and investment-committee material**
+   make DPM decisions report-ready and narrative-ready without manual reconstruction.
+4. **Lower operational support cost**
+   allow support teams to diagnose a decision from one proof pack instead of searching across run,
+   lineage, source, workflow, and log surfaces.
+5. **Safer AI usage**
+   provide `lotus-ai` with structured evidence rather than letting AI infer or invent business
+   context.
+6. **Differentiated sales demos**
+   show that Lotus can prove every DPM action end to end with source lineage and business-readable
+   evidence.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. Add `DpmPreTradeProofPack` as a first-class durable product artifact.
+2. Generate proof packs from selected alternatives or direct rebalance runs.
+3. Include mandate, source, before, target, after, trades, risk, tax, turnover, cost, liquidity, FX,
+   rules, workflow, and lineage evidence.
+4. Produce JSON artifact and Markdown summary.
+5. Provide adapter outputs for `lotus-report` and `lotus-ai`.
+6. Certify APIs and OpenAPI examples.
+7. Support Workbench display through Gateway without UI-side evidence reconstruction.
+
+### 2.2 Non-Goals
+
+1. Render PDF directly; `lotus-report` and `lotus-render` own rendering.
+2. Generate AI narrative directly inside `lotus-manage`; `lotus-ai` owns generation.
+3. Replace existing run artifacts immediately.
+4. Execute trades.
+5. Replace approval workflows; proof pack supplies evidence to them.
+
+---
+
+## 3. Proof Pack Sections
+
+Required sections:
+
+1. `decision_summary`
+2. `mandate_context`
+3. `source_readiness`
+4. `before_state`
+5. `target_state`
+6. `selected_alternative`
+7. `trade_intents`
+8. `after_state`
+9. `drift_impact`
+10. `risk_impact`
+11. `performance_context`
+12. `tax_impact`
+13. `turnover_and_cost`
+14. `liquidity_and_cash`
+15. `fx_funding_plan`
+16. `eligibility_and_restrictions`
+17. `sustainability_controls`
+18. `rule_results`
+19. `diagnostics`
+20. `approval_requirements`
+21. `operations_handoff`
+22. `lineage`
+23. `supportability`
+24. `reporting_refs`
+25. `ai_refs`
+
+Every section must include:
+
+1. `state`
+2. `summary`
+3. `evidence`
+4. `source_refs`
+5. `reason_codes`
+6. `generated_at`
+
+---
+
+## 4. Domain Models
+
+### 4.1 DpmPreTradeProofPack
+
+Required fields:
+
+1. `proof_pack_id`
+2. `proof_pack_version`
+3. `portfolio_id`
+4. `mandate_id`
+5. `rebalance_run_id`
+6. `alternative_set_id`
+7. `selected_alternative_id`
+8. `as_of_date`
+9. `status`
+10. `decision_summary`
+11. `sections`
+12. `approval_requirements`
+13. `operations_handoff`
+14. `lineage`
+15. `markdown_summary`
+16. `report_input_ref`
+17. `ai_evidence_ref`
+18. `created_at`
+19. `created_by`
+
+### 4.2 DpmProofPackSection
+
+Required fields:
+
+1. `section_id`
+2. `section_type`
+3. `state`
+4. `title`
+5. `summary`
+6. `facts`
+7. `metrics`
+8. `reason_codes`
+9. `evidence_refs`
+10. `source_supportability`
+
+### 4.3 DpmProofPackDecisionSummary
+
+Required fields:
+
+1. `decision_type`
+2. `recommended_action`
+3. `selected_alternative_type`
+4. `business_rationale`
+5. `expected_benefit`
+6. `main_tradeoffs`
+7. `top_risks`
+8. `approval_state`
+9. `operations_state`
+
+---
+
+## 5. API Surface
+
+### 5.1 Generate Proof Pack
+
+`POST /api/v1/rebalance/proof-packs`
+
+Purpose:
+
+1. generate a proof pack from selected alternative or run,
+2. persist the proof pack,
+3. return full JSON artifact and summary refs.
+
+Request fields:
+
+1. `source_type`: `REBALANCE_RUN` or `SELECTED_ALTERNATIVE`
+2. `rebalance_run_id`
+3. `alternative_set_id`
+4. `selected_alternative_id`
+5. `include_markdown`
+6. `include_report_input`
+7. `include_ai_evidence_input`
+8. `actor`
+9. `reason`
+
+### 5.2 Retrieve Proof Pack
+
+`GET /api/v1/rebalance/proof-packs/{proof_pack_id}`
+
+Purpose:
+
+1. retrieve durable proof pack,
+2. support Workbench evidence view and audit.
+
+### 5.3 Proof Pack Markdown
+
+`GET /api/v1/rebalance/proof-packs/{proof_pack_id}/summary.md`
+
+Purpose:
+
+1. return human-readable Markdown summary,
+2. support PM, operations, and report preview workflows.
+
+### 5.4 Proof Pack Report Input
+
+`GET /api/v1/rebalance/proof-packs/{proof_pack_id}/report-input`
+
+Purpose:
+
+1. return typed package for `lotus-report`,
+2. avoid report-side reconstruction of DPM decisions.
+
+### 5.5 Proof Pack AI Evidence Input
+
+`GET /api/v1/rebalance/proof-packs/{proof_pack_id}/ai-evidence-input`
+
+Purpose:
+
+1. return structured, bounded, no-decision AI input for `lotus-ai`,
+2. support RFC-0043 PM memo generation.
+
+---
+
+## 6. Persistence
+
+Tables:
+
+1. `dpm_pre_trade_proof_packs`
+2. `dpm_pre_trade_proof_pack_sections`
+3. `dpm_pre_trade_proof_pack_refs`
+
+Retention:
+
+1. proof packs tied to selected alternatives: 7 years,
+2. proof packs tied to blocked or rejected workflows: 7 years if audit-linked,
+3. draft proof packs: configurable, default 1 year.
+
+Integrity requirements:
+
+1. proof pack content hash,
+2. source run hash,
+3. source alternative hash,
+4. source-data lineage refs,
+5. immutable after creation except append-only refs.
+
+---
+
+## 7. Report and AI Handoff Contracts
+
+### 7.1 Report Input
+
+`DpmProofPackReportInput` must include:
+
+1. title,
+2. portfolio and mandate identifiers,
+3. decision summary,
+4. before/after allocation tables,
+5. trade table,
+6. risk/tax/cost/liquidity sections,
+7. rule and diagnostics sections,
+8. approval and operations sections,
+9. source lineage.
+
+### 7.2 AI Evidence Input
+
+`DpmProofPackAiEvidenceInput` must include only structured evidence:
+
+1. no raw prompt,
+2. no hidden calculations,
+3. no instruction to choose trades,
+4. no unsupported facts,
+5. bounded facts and metrics,
+6. explicit forbidden-action guardrails.
+
+---
+
+## 8. Implementation Slices
+
+### Slice 0 - Evidence Map and Artifact Design
+
+1. map existing run/artifact/support-bundle fields to proof-pack sections,
+2. identify missing evidence,
+3. decide minimum viable proof-pack sections.
+
+Exit evidence:
+
+1. section-to-source mapping,
+2. gap list,
+3. examples reviewed with business and engineering lens.
+
+### Slice 1 - Domain Models and Pure Proof Builder
+
+1. add proof-pack models,
+2. build proof pack from existing run result,
+3. build proof pack from selected alternative,
+4. generate deterministic content hash.
+
+Exit evidence:
+
+1. unit tests for every section,
+2. deterministic hash tests,
+3. missing-section degraded tests.
+
+### Slice 2 - Markdown Summary and Human Readability
+
+1. add Markdown renderer,
+2. add section ordering,
+3. add PM-friendly language without unsupported claims,
+4. add snapshot tests.
+
+Exit evidence:
+
+1. Markdown examples,
+2. no broken tables,
+3. no target-state claims for missing evidence.
+
+### Slice 3 - Persistence and APIs
+
+1. add migrations and repository,
+2. add generate/retrieve/markdown APIs,
+3. add OpenAPI examples,
+4. add supportability fields.
+
+Exit evidence:
+
+1. migration smoke,
+2. API tests,
+3. OpenAPI certification.
+
+### Slice 4 - Report and AI Handoff Adapters
+
+1. add report-input contract,
+2. add AI evidence-input contract,
+3. add downstream mock tests,
+4. add no-domain-truth AI guard tests.
+
+Exit evidence:
+
+1. report payload example,
+2. AI payload example,
+3. forbidden-field tests.
+
+### Slice 5 - Live Proof and Docs
+
+1. generate proof pack from canonical stateful portfolio,
+2. save request/response evidence under `output/`,
+3. update wiki and README,
+4. update supported-features after proof.
+
+Exit evidence:
+
+1. live proof artifact,
+2. reviewed evidence notes,
+3. docs and wiki current.
+
+---
+
+## 9. Testing Requirements
+
+1. proof-pack section completeness tests,
+2. content hash determinism tests,
+3. missing evidence degradation tests,
+4. Markdown rendering tests,
+5. report-input contract tests,
+6. AI evidence guardrail tests,
+7. repository persistence tests,
+8. API and OpenAPI tests,
+9. canonical live proof.
+
+---
+
+## 10. Acceptance Criteria
+
+RFC-0040 is complete when:
+
+1. proof packs can be generated from a selected alternative or run,
+2. every proof pack is durable, hashed, lineage-backed, and retrievable,
+3. Markdown summary is readable and deterministic,
+4. report and AI handoff payloads are bounded and certified,
+5. OpenAPI is complete,
+6. canonical live evidence exists,
+7. Workbench can consume proof-pack truth through Gateway in a later UI slice without reconstructing
+   evidence client-side.

--- a/docs/rfcs/RFC-0041-rebalance-wave-orchestration-and-cio-model-change-impact.md
+++ b/docs/rfcs/RFC-0041-rebalance-wave-orchestration-and-cio-model-change-impact.md
@@ -1,0 +1,408 @@
+# RFC-0041: Rebalance Wave Orchestration and CIO Model Change Impact
+
+| Metadata | Details |
+| --- | --- |
+| **Status** | PROPOSED |
+| **Created** | 2026-05-03 |
+| **Depends On** | RFC-0018, RFC-0020, RFC-0023, RFC-0036, RFC-0037, RFC-0038, RFC-0039, RFC-0040 |
+| **Doc Location** | `docs/rfcs/RFC-0041-rebalance-wave-orchestration-and-cio-model-change-impact.md` |
+
+---
+
+## 0. Executive Summary
+
+RFC-0041 adds multi-portfolio DPM orchestration. It lets a CIO/model change, tactical house view, or
+PM book action create a rebalance wave, determine affected mandates, check source readiness,
+simulate alternatives, route exceptions, stage selected actions, and prepare execution handoff
+evidence.
+
+This is how `lotus-manage` scales from one-portfolio analysis to real discretionary portfolio
+management across a PM book.
+
+---
+
+## 1. Problem Statement
+
+Single-portfolio simulation is necessary but insufficient. A private-bank DPM desk needs to answer:
+
+1. Which portfolios are affected by a model or house-view change?
+2. Which portfolios are ready to rebalance?
+3. Which are blocked by data, policy, tax, liquidity, or workflow?
+4. How much aggregate notional will be traded?
+5. Which currencies require funding?
+6. Which securities create liquidity or concentration issues?
+7. Which PM/CIO/compliance approvals are required?
+8. What can operations safely stage?
+
+Without a wave aggregate, PMs and operations must stitch together many independent runs manually.
+
+## 1.5 Business Outcomes
+
+This RFC targets the following business outcomes:
+
+1. **Scale DPM operations**
+   move from individual portfolio actions to coordinated PM-book and CIO-driven rebalance waves.
+2. **Improve CIO implementation control**
+   show how model changes and house views affect mandates before trading begins.
+3. **Reduce operational bottlenecks**
+   separate ready, blocked, review-required, staged, and handoff-ready portfolios in one governed
+   workflow.
+4. **Improve risk and liquidity planning**
+   aggregate expected trade notional, FX needs, liquidity warnings, and blocked cohorts before
+   execution handoff.
+5. **Increase governance quality**
+   preserve actor-attributed approval, staging, cancellation, and retry decisions at both wave and
+   item level.
+6. **Create a premium management dashboard story**
+   enable Workbench to show CIO/PM wave progress with real backend state, not UI-only summaries.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. Add `DpmRebalanceWave` aggregate.
+2. Add CIO model-change impact analysis.
+3. Identify affected mandates from model, risk profile, region, currency, PM book, or explicit list.
+4. Run source-readiness checks across the wave.
+5. Generate alternatives per wave item.
+6. Allow item-level review and selection.
+7. Stage approved items for handoff.
+8. Persist wave, wave items, state transitions, and supportability.
+9. Expose wave APIs and command-center integration.
+
+### 2.2 Non-Goals
+
+1. Actual OMS/EMS execution.
+2. Client consent workflows.
+3. Replacing report batch scheduler.
+4. Replacing core transaction booking.
+5. Solving all portfolios as one global optimization problem. First-wave scope is coordinated
+   orchestration with item-level construction.
+
+---
+
+## 3. Wave Triggers
+
+Supported trigger types:
+
+1. `CIO_MODEL_CHANGE`
+2. `TACTICAL_HOUSE_VIEW`
+3. `PM_BOOK_REVIEW`
+4. `RISK_BREACH_REMEDIATION`
+5. `CASH_DRAG_CAMPAIGN`
+6. `TAX_YEAR_END_REVIEW`
+7. `ESG_RESTRICTION_UPDATE`
+8. `MANUAL_PORTFOLIO_LIST`
+
+Each trigger must record:
+
+1. trigger id,
+2. trigger type,
+3. source system,
+4. source event id,
+5. effective date,
+6. created by,
+7. rationale,
+8. affected model ids,
+9. affected mandate filters,
+10. lineage.
+
+---
+
+## 4. Wave State Machine
+
+Wave states:
+
+1. `DRAFT`
+2. `SOURCE_CHECK`
+3. `SIMULATING`
+4. `REVIEWING`
+5. `APPROVED`
+6. `STAGED`
+7. `HANDOFF_READY`
+8. `HANDOFF_SENT`
+9. `PARTIALLY_COMPLETED`
+10. `COMPLETED`
+11. `CANCELLED`
+12. `FAILED`
+
+Wave item states:
+
+1. `PENDING_SOURCE_CHECK`
+2. `SOURCE_BLOCKED`
+3. `READY_TO_SIMULATE`
+4. `SIMULATION_BLOCKED`
+5. `ALTERNATIVES_READY`
+6. `REVIEW_REQUIRED`
+7. `SELECTED`
+8. `APPROVED`
+9. `STAGED`
+10. `HANDOFF_READY`
+11. `HANDOFF_SENT`
+12. `COMPLETED`
+13. `CANCELLED`
+14. `FAILED`
+
+State rules:
+
+1. a wave can be `PARTIALLY_COMPLETED` if at least one item completed and at least one item is
+   blocked, failed, or cancelled,
+2. item-level `BLOCKED` simulation outcomes do not fail the whole wave,
+3. wave transitions are actor-attributed,
+4. every state transition is append-only.
+
+---
+
+## 5. Domain Models
+
+### 5.1 DpmRebalanceWave
+
+Required fields:
+
+1. `wave_id`
+2. `wave_name`
+3. `trigger`
+4. `state`
+5. `as_of_date`
+6. `portfolio_manager_id`
+7. `tenant_id`
+8. `selection_criteria`
+9. `items`
+10. `aggregate_metrics`
+11. `source_readiness_summary`
+12. `approval_summary`
+13. `handoff_summary`
+14. `lineage`
+15. `created_at`
+16. `updated_at`
+
+### 5.2 DpmRebalanceWaveItem
+
+Required fields:
+
+1. `wave_item_id`
+2. `wave_id`
+3. `portfolio_id`
+4. `mandate_id`
+5. `state`
+6. `source_readiness_state`
+7. `alternative_set_id`
+8. `selected_alternative_id`
+9. `proof_pack_id`
+10. `rebalance_run_id`
+11. `blocking_reasons`
+12. `approval_state`
+13. `handoff_state`
+14. `lineage`
+
+### 5.3 DpmCioModelChangeImpact
+
+Required fields:
+
+1. `impact_id`
+2. `model_change_event_id`
+3. `affected_model_ids`
+4. `affected_portfolio_count`
+5. `affected_mandate_count`
+6. `estimated_trade_count`
+7. `estimated_turnover_base`
+8. `estimated_fx_by_currency`
+9. `source_blocked_count`
+10. `policy_blocked_count`
+11. `approval_required_count`
+12. `top_exposures`
+13. `lineage`
+
+---
+
+## 6. API Surface
+
+### 6.1 Create Wave
+
+`POST /api/v1/rebalance/waves`
+
+Purpose:
+
+1. create wave from trigger and selection criteria,
+2. persist draft wave and candidate items.
+
+### 6.2 Preview Affected Portfolios
+
+`POST /api/v1/rebalance/waves/preview`
+
+Purpose:
+
+1. estimate affected portfolios without creating durable wave,
+2. support CIO and PM planning.
+
+### 6.3 Source Check
+
+`POST /api/v1/rebalance/waves/{wave_id}/source-check`
+
+Purpose:
+
+1. call core readiness for each item,
+2. classify item readiness,
+3. update wave source summary.
+
+### 6.4 Simulate Wave
+
+`POST /api/v1/rebalance/waves/{wave_id}/simulate`
+
+Purpose:
+
+1. generate alternatives for ready items,
+2. preserve blocked item reasons,
+3. update aggregate metrics.
+
+### 6.5 Approve Wave or Items
+
+`POST /api/v1/rebalance/waves/{wave_id}/approve`
+
+Purpose:
+
+1. approve all eligible items or selected item ids,
+2. preserve actor/rationale,
+3. fail safely for blocked items.
+
+### 6.6 Stage and Handoff
+
+1. `POST /api/v1/rebalance/waves/{wave_id}/stage`
+2. `POST /api/v1/rebalance/waves/{wave_id}/handoff`
+
+Purpose:
+
+1. prepare operations handoff package,
+2. mark handoff state,
+3. do not execute externally.
+
+### 6.7 Search and Inspect
+
+1. `GET /api/v1/rebalance/waves`
+2. `GET /api/v1/rebalance/waves/{wave_id}`
+3. `GET /api/v1/rebalance/waves/{wave_id}/items`
+4. `GET /api/v1/rebalance/waves/{wave_id}/proof-pack`
+
+---
+
+## 7. Persistence
+
+Tables:
+
+1. `dpm_rebalance_waves`
+2. `dpm_rebalance_wave_items`
+3. `dpm_rebalance_wave_events`
+4. `dpm_cio_model_change_impacts`
+
+Indexes:
+
+1. `(state, updated_at desc)`
+2. `(portfolio_manager_id, created_at desc)`
+3. `(trigger_type, created_at desc)`
+4. `(wave_id, state)`
+5. `(portfolio_id, created_at desc)`
+
+Retention:
+
+1. completed waves: 7 years,
+2. cancelled drafts with no approvals: 1 year,
+3. failed waves with operational incident refs: 7 years.
+
+---
+
+## 8. Aggregate Metrics
+
+Wave aggregate metrics:
+
+1. portfolio count,
+2. mandate count,
+3. ready count,
+4. blocked count,
+5. review required count,
+6. approved count,
+7. staged count,
+8. estimated trade count,
+9. estimated turnover,
+10. estimated cost,
+11. estimated realized tax,
+12. FX buy/sell by currency,
+13. top instruments by notional,
+14. liquidity warnings,
+15. risk warnings.
+
+All aggregate metrics must be derived from item evidence and reproducible.
+
+---
+
+## 9. Implementation Slices
+
+### Slice 0 - Model-Change and Wave Design
+
+1. define wave trigger inputs,
+2. map model-change source gaps,
+3. define first-wave selection filters,
+4. define item state machine.
+
+### Slice 1 - Wave Domain and Repository
+
+1. add wave models,
+2. add event model,
+3. add repository and migrations,
+4. add state transition guards.
+
+### Slice 2 - Affected Portfolio Preview
+
+1. identify candidate mandates from existing source products,
+2. generate preview response,
+3. support empty and partial-source states.
+
+### Slice 3 - Source Check and Simulation
+
+1. source-check all items,
+2. call RFC-0039 alternatives for ready items,
+3. persist item outcomes.
+
+### Slice 4 - Approval, Staging, and Handoff
+
+1. approve item or wave,
+2. stage selected alternatives,
+3. generate handoff package,
+4. preserve no-external-execution boundary.
+
+### Slice 5 - Supportability, Proof, and Docs
+
+1. wave proof pack,
+2. supportability APIs,
+3. live evidence,
+4. docs/wiki/supported-features.
+
+---
+
+## 10. Testing Requirements
+
+1. state machine tests,
+2. affected portfolio selection tests,
+3. source-check partial readiness tests,
+4. item simulation tests,
+5. aggregate metrics tests,
+6. approval/staging/handoff tests,
+7. repository parity tests,
+8. OpenAPI certification,
+9. live canonical model-change wave proof.
+
+---
+
+## 11. Acceptance Criteria
+
+RFC-0041 is complete when:
+
+1. a wave can be created from a CIO/model trigger or explicit portfolio list,
+2. source readiness is evaluated per item,
+3. alternatives are generated per ready item,
+4. blocked items retain reasons without failing the whole wave,
+5. wave approval/staging/handoff states are persisted and actor-attributed,
+6. aggregate metrics are reproducible,
+7. APIs are certified,
+8. canonical live evidence shows a multi-portfolio wave.

--- a/docs/rfcs/RFC-0042-post-trade-outcome-feedback-loop.md
+++ b/docs/rfcs/RFC-0042-post-trade-outcome-feedback-loop.md
@@ -1,0 +1,350 @@
+# RFC-0042: Post-Trade Outcome Feedback Loop
+
+| Metadata | Details |
+| --- | --- |
+| **Status** | PROPOSED |
+| **Created** | 2026-05-03 |
+| **Depends On** | RFC-0017, RFC-0019, RFC-0023, RFC-0036, RFC-0037, RFC-0038, RFC-0039, RFC-0040, RFC-0041 |
+| **Doc Location** | `docs/rfcs/RFC-0042-post-trade-outcome-feedback-loop.md` |
+
+---
+
+## 0. Executive Summary
+
+RFC-0042 closes the DPM decision loop. After a rebalance is approved and execution records arrive
+from `lotus-core`, `lotus-manage` should compare expected versus realized outcomes across drift,
+risk, performance, turnover, cost, tax, FX, cash, and execution quality.
+
+This creates a feedback system for PMs, CIO teams, operations, risk oversight, and sales demos. It
+proves not only what the engine proposed, but whether the decision achieved its intended outcome.
+
+---
+
+## 1. Problem Statement
+
+Without outcome feedback:
+
+1. expected drift reduction is not compared to realized drift reduction,
+2. expected risk improvement is not compared to realized risk,
+3. transaction cost and tax estimates are not checked,
+4. execution slippage and partial fills are not measured,
+5. PMs cannot learn which construction method performed best,
+6. CIO teams cannot see whether model-change waves were implemented effectively,
+7. audit evidence stops before the outcome.
+
+## 1.5 Business Outcomes
+
+This RFC targets the following business outcomes:
+
+1. **Close the discretionary management loop**
+   prove whether approved actions achieved their intended drift, risk, liquidity, tax, and cost
+   outcomes.
+2. **Improve PM accountability**
+   give PMs and leaders evidence on expected versus realized impact without relying on manual
+   post-trade analysis.
+3. **Improve model and construction quality**
+   reveal which construction methods produce better realized outcomes under different mandate
+   conditions.
+4. **Strengthen governance and audit**
+   connect pre-trade proof, execution evidence, risk/performance outcomes, and post-trade review in
+   one traceable chain.
+5. **Reduce future errors**
+   identify recurring slippage, partial-fill, tax, cash, source-data, or risk variance patterns.
+6. **Create high-value reporting content**
+   provide outcome review material for client reports, PM reviews, CIO reviews, and sales demos.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. Add post-trade outcome review model and APIs.
+2. Compare expected versus realized outcomes.
+3. Integrate with `lotus-core` execution/transaction records.
+4. Integrate with `lotus-risk` for post-trade risk.
+5. Integrate with `lotus-performance` for post-trade returns and attribution.
+6. Link outcome review to proof packs, alternatives, waves, and runs.
+7. Persist outcome evidence and supportability.
+8. Produce PM quality and method quality metrics.
+
+### 2.2 Non-Goals
+
+1. Book transactions.
+2. Calculate authoritative performance or risk locally.
+3. Replace operations break management.
+4. Trigger client communications directly.
+5. Use AI to judge PM quality.
+
+---
+
+## 3. Outcome Dimensions
+
+Required dimensions:
+
+1. `DRIFT_OUTCOME`
+2. `RISK_OUTCOME`
+3. `PERFORMANCE_OUTCOME`
+4. `TURNOVER_OUTCOME`
+5. `TRANSACTION_COST_OUTCOME`
+6. `TAX_OUTCOME`
+7. `FX_OUTCOME`
+8. `CASH_OUTCOME`
+9. `EXECUTION_QUALITY`
+10. `RULE_OUTCOME`
+11. `SOURCE_DATA_OUTCOME`
+
+Each dimension includes:
+
+1. expected value,
+2. realized value,
+3. variance,
+4. tolerance,
+5. state,
+6. reason code,
+7. source refs.
+
+---
+
+## 4. Outcome Classification
+
+Outcome states:
+
+1. `READY`: outcome is within expected tolerance or positive,
+2. `PENDING_REVIEW`: variance exceeds soft tolerance or requires PM explanation,
+3. `BLOCKED`: source evidence is incomplete or outcome breach requires formal review.
+
+Reason codes:
+
+1. `DRIFT_REDUCTION_ACHIEVED`
+2. `DRIFT_REDUCTION_SHORTFALL`
+3. `RISK_REDUCTION_ACHIEVED`
+4. `RISK_INCREASED`
+5. `COST_ABOVE_ESTIMATE`
+6. `TAX_ABOVE_BUDGET`
+7. `SLIPPAGE_ABOVE_TOLERANCE`
+8. `PARTIAL_FILL_IMPACT`
+9. `FX_RESIDUAL_VARIANCE`
+10. `CASH_RESIDUAL_OUT_OF_BAND`
+11. `PERFORMANCE_BELOW_EXPECTATION`
+12. `SOURCE_EVIDENCE_INCOMPLETE`
+
+---
+
+## 5. Domain Models
+
+### 5.1 DpmPostTradeOutcomeReview
+
+Required fields:
+
+1. `outcome_review_id`
+2. `portfolio_id`
+3. `mandate_id`
+4. `rebalance_run_id`
+5. `alternative_set_id`
+6. `selected_alternative_id`
+7. `wave_id`
+8. `proof_pack_id`
+9. `review_window_start`
+10. `review_window_end`
+11. `overall_state`
+12. `dimension_results`
+13. `expected_snapshot`
+14. `realized_snapshot`
+15. `variance_summary`
+16. `source_lineage`
+17. `created_at`
+
+### 5.2 DpmOutcomeDimensionResult
+
+Required fields:
+
+1. `dimension`
+2. `state`
+3. `reason_code`
+4. `expected`
+5. `realized`
+6. `variance`
+7. `tolerance`
+8. `explanation`
+9. `source_refs`
+
+### 5.3 DpmExecutionQualitySummary
+
+Required fields:
+
+1. `expected_trade_count`
+2. `executed_trade_count`
+3. `cancelled_trade_count`
+4. `partial_fill_count`
+5. `estimated_cost_base`
+6. `realized_cost_base`
+7. `estimated_tax_base`
+8. `realized_tax_base`
+9. `slippage_base`
+10. `residual_cash_base`
+
+---
+
+## 6. API Surface
+
+### 6.1 Create Outcome Review
+
+`POST /api/v1/rebalance/outcome-reviews`
+
+Purpose:
+
+1. create outcome review for a run, alternative, or wave item,
+2. source realized evidence,
+3. persist review.
+
+Request fields:
+
+1. `rebalance_run_id`
+2. `alternative_set_id`
+3. `selected_alternative_id`
+4. `wave_id`
+5. `wave_item_id`
+6. `review_window_start`
+7. `review_window_end`
+8. `include_risk`
+9. `include_performance`
+10. `actor`
+
+### 6.2 Retrieve Outcome Review
+
+`GET /api/v1/rebalance/outcome-reviews/{outcome_review_id}`
+
+### 6.3 Find Outcome Review By Run
+
+`GET /api/v1/rebalance/runs/{rebalance_run_id}/outcome-review`
+
+### 6.4 Search Outcome Reviews
+
+`GET /api/v1/rebalance/outcome-reviews`
+
+Filters:
+
+1. `portfolio_id`
+2. `mandate_id`
+3. `wave_id`
+4. `overall_state`
+5. `reason_code`
+6. `from`
+7. `to`
+
+---
+
+## 7. Source Integrations
+
+`lotus-core`:
+
+1. transaction/fill window,
+2. post-trade holdings,
+3. cash movements,
+4. FX executions,
+5. tax-lot realization data.
+
+`lotus-risk`:
+
+1. risk after execution,
+2. risk before/after comparison,
+3. concentration and stress posture.
+
+`lotus-performance`:
+
+1. return since rebalance,
+2. contribution and attribution,
+3. benchmark-relative impact.
+
+If any source is unavailable, the outcome review must degrade explicitly.
+
+---
+
+## 8. Persistence
+
+Tables:
+
+1. `dpm_outcome_reviews`
+2. `dpm_outcome_dimension_results`
+3. `dpm_outcome_source_refs`
+
+Indexes:
+
+1. `(rebalance_run_id)`
+2. `(portfolio_id, created_at desc)`
+3. `(mandate_id, created_at desc)`
+4. `(wave_id, created_at desc)`
+5. `(overall_state, created_at desc)`
+
+Retention:
+
+1. 7 years for selected/approved rebalance outcomes,
+2. 3 years for diagnostic-only reviews not tied to execution,
+3. legal/audit hold support must be compatible with future archive policy.
+
+---
+
+## 9. Implementation Slices
+
+### Slice 0 - Source Evidence Mapping
+
+1. map expected fields from proof pack and alternatives,
+2. map realized fields from core/risk/performance,
+3. identify gaps,
+4. define first-wave review window semantics.
+
+### Slice 1 - Pure Outcome Comparison
+
+1. add domain models,
+2. compare expected vs realized from provided fixtures,
+3. implement variance and tolerance logic,
+4. add reason codes.
+
+### Slice 2 - Persistence and APIs
+
+1. add migrations,
+2. add repositories,
+3. add create/retrieve/search APIs,
+4. add OpenAPI docs.
+
+### Slice 3 - Core/Risk/Performance Integration
+
+1. add source clients or seams,
+2. add degraded-source handling,
+3. add supportability and lineage.
+
+### Slice 4 - Live Proof and Reporting Handoff
+
+1. generate outcome review from canonical executed example,
+2. link proof pack and report evidence,
+3. update docs/wiki.
+
+---
+
+## 10. Testing Requirements
+
+1. pure variance calculations,
+2. tolerance thresholds,
+3. source-unavailable degradation,
+4. partial fills,
+5. slippage,
+6. tax variance,
+7. risk/performance enrichment,
+8. repository persistence,
+9. API and OpenAPI,
+10. live canonical evidence.
+
+---
+
+## 11. Acceptance Criteria
+
+RFC-0042 is complete when:
+
+1. outcome review can be generated from a selected rebalance,
+2. expected versus realized metrics are decomposed,
+3. degraded source behavior is explicit,
+4. reviews are persisted and searchable,
+5. APIs are certified,
+6. live proof shows at least one post-trade feedback story,
+7. outcome feedback can feed future PM dashboards without recomputing domain truth in UI.

--- a/docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md
+++ b/docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md
@@ -1,0 +1,399 @@
+# RFC-0043: Governed AI PM Copilot for DPM
+
+| Metadata | Details |
+| --- | --- |
+| **Status** | PROPOSED |
+| **Created** | 2026-05-03 |
+| **Depends On** | RFC-0037, RFC-0038, RFC-0039, RFC-0040, RFC-0041, RFC-0042 |
+| **Doc Location** | `docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md` |
+
+---
+
+## 0. Executive Summary
+
+RFC-0043 adds a governed PM copilot for discretionary mandate management. The copilot summarizes
+evidence, drafts PM memos, explains exceptions, prepares investment-committee notes, and converts
+proof packs into business-readable narratives.
+
+The copilot must not make trade decisions, alter domain outputs, hide missing data, or replace PM,
+CIO, compliance, risk, or operations approval.
+
+The target architecture routes AI work through `lotus-ai` workflow packs. `lotus-manage` owns the
+business evidence and workflow authority; `lotus-ai` owns prompt, provider, safety, evaluation,
+async, and AI run posture.
+
+---
+
+## 1. Problem Statement
+
+DPM evidence can be rich but dense. PMs, CIO teams, operations, advisors, and sales teams need
+clear explanations:
+
+1. why this mandate needs attention,
+2. what changed,
+3. which alternative was selected,
+4. what risks and trade-offs exist,
+5. what approvals are required,
+6. what the client-safe story is,
+7. what operations should watch.
+
+Manual writing is slow and inconsistent. Uncontrolled AI would be dangerous. RFC-0043 defines a
+bounded AI assistant that uses structured proof only.
+
+## 1.5 Business Outcomes
+
+This RFC targets the following business outcomes:
+
+1. **Increase PM productivity**
+   reduce time spent drafting memos, exception summaries, operations notes, and committee briefs.
+2. **Improve communication quality**
+   produce consistent, evidence-backed narratives for PMs, CIO teams, operations, advisors, and
+   client-facing stakeholders.
+3. **Make proof packs usable by humans**
+   convert dense structured evidence into readable summaries without weakening the underlying
+   audit trail.
+4. **Differentiate Lotus demos**
+   show governed AI as a safe assistant layered on top of deterministic DPM evidence.
+5. **Reduce AI risk**
+   ensure AI does not own trades, approvals, calculations, source truth, or workflow state.
+6. **Increase ecosystem value**
+   connect `lotus-manage` evidence with `lotus-ai` workflow-pack governance instead of building
+   one-off local AI behavior.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. Add PM memo generation from proof packs.
+2. Add exception narrative generation from command-center exceptions.
+3. Add CIO model-change summary generation from rebalance waves.
+4. Add operations handoff summary generation.
+5. Persist AI run posture and generated narrative refs.
+6. Enforce no-domain-decision guardrails.
+7. Route all AI execution through `lotus-ai`.
+8. Support degraded behavior when AI is unavailable.
+
+### 2.2 Non-Goals
+
+1. AI-generated trades.
+2. AI-selected alternatives.
+3. AI rule or risk calculations.
+4. AI-generated source data.
+5. AI approval decisions.
+6. Direct provider calls from `lotus-manage`.
+7. Raw prompts or model outputs in logs/metrics.
+
+---
+
+## 3. Allowed Copilot Use Cases
+
+### 3.1 PM Memo
+
+Input:
+
+1. proof pack,
+2. selected alternative,
+3. mandate health,
+4. rule results,
+5. source readiness.
+
+Output:
+
+1. concise PM memo,
+2. key rationale,
+3. trade-offs,
+4. approval checklist,
+5. caveats.
+
+### 3.2 Exception Narrative
+
+Input:
+
+1. command-center exception,
+2. mandate health snapshot,
+3. relevant source readiness,
+4. latest simulation/proof refs if available.
+
+Output:
+
+1. exception summary,
+2. likely cause,
+3. next action,
+4. owner suggestion,
+5. missing evidence list.
+
+### 3.3 CIO Model-Change Brief
+
+Input:
+
+1. wave impact summary,
+2. affected mandates,
+3. aggregate exposures,
+4. blocked counts,
+5. approval workload.
+
+Output:
+
+1. model-change impact brief,
+2. implementation risk summary,
+3. key blocked cohorts,
+4. PM workload summary.
+
+### 3.4 Operations Handoff Summary
+
+Input:
+
+1. proof pack,
+2. wave item state,
+3. operations handoff checklist,
+4. trade and FX requirements.
+
+Output:
+
+1. operations summary,
+2. execution prerequisites,
+3. blocking conditions,
+4. support references.
+
+---
+
+## 4. Forbidden AI Behaviors
+
+The copilot must never:
+
+1. create or modify order intents,
+2. choose selected alternative,
+3. change run status,
+4. change rule result,
+5. change approval state,
+6. hide data-quality issues,
+7. invent missing source data,
+8. call external providers directly,
+9. log raw prompt,
+10. log raw model output,
+11. emit portfolio/client/security ids as metric labels,
+12. present target-state features as implemented.
+
+Tests must enforce these guardrails.
+
+---
+
+## 5. Workflow-Pack Families
+
+Initial `lotus-ai` workflow-pack families:
+
+1. `dpm_pm_memo.pack`
+2. `dpm_exception_summary.pack`
+3. `dpm_cio_model_change_brief.pack`
+4. `dpm_operations_handoff_summary.pack`
+
+Each pack registration must include:
+
+1. owner app: `lotus-manage`,
+2. workflow surface,
+3. input schema ref,
+4. output schema ref,
+5. safety policy,
+6. review posture,
+7. artifact refs,
+8. retention policy,
+9. disabled/unavailable behavior.
+
+---
+
+## 6. Domain Models
+
+### 6.1 DpmAiNarrativeRequest
+
+Required fields:
+
+1. `narrative_type`
+2. `source_artifact_type`
+3. `source_artifact_id`
+4. `portfolio_id_hash`
+5. `mandate_id_hash`
+6. `tenant_id`
+7. `audience`
+8. `tone`
+9. `max_length`
+10. `include_caveats`
+11. `actor`
+
+Use hashed or internal refs where possible. Raw sensitive identifiers must not enter telemetry.
+
+### 6.2 DpmAiNarrativeResponse
+
+Required fields:
+
+1. `narrative_id`
+2. `narrative_type`
+3. `state`
+4. `source_artifact_id`
+5. `workflow_pack_run_id`
+6. `review_state`
+7. `summary`
+8. `sections`
+9. `caveats`
+10. `forbidden_claims_checked`
+11. `lineage`
+12. `created_at`
+
+### 6.3 DpmAiNarrativeSection
+
+Required fields:
+
+1. `section_type`
+2. `title`
+3. `body`
+4. `evidence_refs`
+5. `caveats`
+
+---
+
+## 7. API Surface
+
+### 7.1 Generate PM Memo
+
+`POST /api/v1/rebalance/proof-packs/{proof_pack_id}/pm-memo`
+
+Purpose:
+
+1. submit proof-pack evidence to `lotus-ai`,
+2. persist AI workflow-pack run posture,
+3. return bounded narrative response.
+
+### 7.2 Retrieve PM Memo
+
+`GET /api/v1/rebalance/proof-packs/{proof_pack_id}/pm-memo`
+
+### 7.3 Generate Exception Summary
+
+`POST /api/v1/dpm/exceptions/{exception_id}/summary`
+
+### 7.4 Generate Wave Brief
+
+`POST /api/v1/rebalance/waves/{wave_id}/cio-brief`
+
+### 7.5 Generate Operations Summary
+
+`POST /api/v1/rebalance/proof-packs/{proof_pack_id}/operations-summary`
+
+---
+
+## 8. Safety and Evaluation
+
+Required checks:
+
+1. input schema validation,
+2. proof-pack evidence completeness,
+3. forbidden action check,
+4. forbidden claim check,
+5. missing evidence disclosure,
+6. no raw sensitive telemetry,
+7. no unsupported recommendation,
+8. no domain field mutation.
+
+Evaluation set:
+
+1. successful ready rebalance,
+2. blocked rebalance,
+3. stale source data,
+4. restricted instrument,
+5. tax-sensitive alternative,
+6. risk-breach alternative,
+7. partial wave,
+8. AI unavailable fallback.
+
+---
+
+## 9. Persistence
+
+Tables:
+
+1. `dpm_ai_narratives`
+2. `dpm_ai_narrative_events`
+3. `dpm_ai_narrative_source_refs`
+
+Persist:
+
+1. narrative metadata,
+2. workflow-pack run id,
+3. review state,
+4. bounded output summary,
+5. source artifact refs,
+6. safety check results.
+
+Do not persist:
+
+1. raw provider request if it contains sensitive evidence,
+2. raw model output unless governed by `lotus-ai` artifact policy,
+3. high-cardinality telemetry fields.
+
+---
+
+## 10. Implementation Slices
+
+### Slice 0 - AI Boundary and Workflow-Pack Design
+
+1. define pack families,
+2. align with `lotus-ai`,
+3. create input/output schemas,
+4. define forbidden claims.
+
+### Slice 1 - Proof-Pack PM Memo
+
+1. add PM memo request/response models,
+2. call `lotus-ai` workflow-pack seam,
+3. persist run posture,
+4. support unavailable fallback.
+
+### Slice 2 - Exception, Wave, and Operations Narratives
+
+1. add exception summary,
+2. add CIO brief,
+3. add operations summary,
+4. reuse safety checks.
+
+### Slice 3 - Review and Governance
+
+1. review actions,
+2. narrative state transitions,
+3. safety evaluation evidence,
+4. supportability APIs.
+
+### Slice 4 - Live Proof and Docs
+
+1. run canonical proof-pack memo,
+2. capture evidence,
+3. update wiki,
+4. update supported-features only after implementation.
+
+---
+
+## 11. Testing Requirements
+
+1. no-domain-decision mutation tests,
+2. forbidden claim tests,
+3. AI unavailable fallback tests,
+4. workflow-pack client tests,
+5. safety/eval fixture tests,
+6. persistence tests,
+7. API and OpenAPI tests,
+8. live proof through `lotus-ai` where configured.
+
+---
+
+## 12. Acceptance Criteria
+
+RFC-0043 is complete when:
+
+1. PM memo generation works from proof packs,
+2. exception, wave, and operations summaries are implemented or explicitly deferred,
+3. all AI calls go through `lotus-ai`,
+4. generated narratives carry run posture and provenance,
+5. guardrail tests prove AI cannot change domain truth,
+6. OpenAPI is certified,
+7. live proof captures AI-ready and AI-unavailable behavior,
+8. docs clearly state that AI assists PMs but does not decide trades.

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -50,6 +50,17 @@
 - RFC-0038
   proposed first implementation foundation for mandate digital twins, mandate health scoring,
   monitoring exceptions, and the DPM command-center API
+- RFC-0039
+  proposed advanced portfolio construction and rebalance alternatives roadmap
+- RFC-0040
+  proposed pre-trade proof-pack and DPM evidence-fabric roadmap
+- RFC-0041
+  proposed rebalance-wave orchestration and CIO model-change impact roadmap
+- RFC-0042
+  proposed post-trade outcome feedback-loop roadmap
+- RFC-0043
+  proposed governed AI PM copilot roadmap using `lotus-ai` without transferring domain decision
+  ownership to AI
 
 ## Removed local RFC sprawl
 


### PR DESCRIPTION
## Summary
- Add RFC-0039 through RFC-0043 as focused execution RFCs for advanced portfolio construction, proof packs/evidence fabric, rebalance waves/CIO impact, post-trade outcome feedback, and governed AI PM copilot
- Add explicit business outcome sections across RFC-0037 and RFC-0038 as well as the new execution RFCs
- Update repo RFC inventory and repo-authored wiki source to cover the full RFC-0037 through RFC-0043 roadmap

## Validation
- `python -m pytest tests\unit\test_documentation_current_state.py -q` -> 8 passed
- `git diff --check` -> passed

## Notes
- These RFCs remain PROPOSED and do not claim implementation exists yet.
- Repo-authored wiki source changed and should be published after merge with `..\lotus-platform\automation\Sync-RepoWikis.ps1 -Publish -Repository lotus-manage`.