### PR TITLE
Tighten DPM target capability RFC coverage

### DIFF
--- a/docs/rfcs/RFC-0037-dpm-operating-system-and-mandate-intelligence.md
+++ b/docs/rfcs/RFC-0037-dpm-operating-system-and-mandate-intelligence.md
@@ -707,6 +707,70 @@ Demo rules:
 4. every business claim backed by source data and proof artifacts,
 5. demo data must include realistic DPM mandates, not only simple portfolios.
 
+### 6.13 Feature 13 - Currency Overlay and Hedge Governance
+
+Currency exposure is a first-class mandate dimension, not only a cash-conversion detail.
+
+Required capabilities:
+
+1. derive base-currency, local-currency, and settlement-currency exposure from `lotus-core`,
+2. compare unhedged, partially hedged, and fully hedged rebalance alternatives,
+3. support mandate-level hedge ratio bands by currency, asset class, sleeve, and instrument type,
+4. show expected cash, FX, cost, liquidity, and settlement effects before a plan is approved,
+5. identify when hedge instruments, FX rates, forward points, or settlement calendars are missing,
+6. distinguish strategic currency exposure from operational FX needed to fund trades,
+7. preserve deterministic reason codes for hedge suppression, hedge adjustment, and hedge breach.
+
+Business outcome:
+
+1. PMs can manage multi-currency mandates with clear risk, funding, and hedge evidence,
+2. operations can see settlement and funding readiness before trade staging,
+3. client-facing material can explain currency posture without reconstructing it from raw trades.
+
+### 6.14 Feature 14 - Market-Regime and Stress Simulator
+
+The platform must help a PM understand how a mandate behaves under plausible regime changes before
+action is taken.
+
+Required capabilities:
+
+1. consume stress, drawdown, concentration, and exposure data from `lotus-risk`,
+2. support named scenario packs such as rate shock, equity sell-off, credit widening, USD rally,
+   commodity shock, inflation surprise, liquidity freeze, and defensive-risk-off rotation,
+3. compare current, target, and alternative portfolios under the same scenario set,
+4. expose scenario loss, drawdown contribution, breached limits, and mitigation trades,
+5. allow CIO model-change waves to carry required scenario checks,
+6. mark results degraded when a scenario pack, risk model, or exposure dimension is unavailable,
+7. keep scenario evidence in proof packs and post-trade outcome reviews.
+
+Business outcome:
+
+1. investment-office users can demonstrate disciplined regime-aware construction,
+2. PMs can avoid alternatives that improve drift while worsening unacceptable tail exposure,
+3. risk and compliance reviewers can inspect scenario evidence before approval.
+
+### 6.15 Feature 15 - Portfolio Memory and Decision Timeline
+
+`lotus-manage` must remember why decisions were made, not only what the latest run produced.
+
+Required capabilities:
+
+1. maintain a portfolio-level timeline of mandate changes, monitoring exceptions, model-change
+   impacts, alternative sets, selected alternatives, proof packs, approvals, deferrals, wave states,
+   execution handoffs, and outcome reviews,
+2. link every timeline event to source lineage, actor, reason, status vocabulary, and artifacts,
+3. support PM, operations, compliance, CIO, and audit views over the same event record,
+4. distinguish automated observations from human decisions,
+5. expose decision memory to `lotus-ai` only through structured evidence packs,
+6. provide before/after and expected/realized context for future construction quality analysis,
+7. retain enough history to support client review, complaint handling, and internal supervision.
+
+Business outcome:
+
+1. PMs can explain the lifecycle of a mandate without manually stitching together run records,
+2. supervisors can review whether decisions were timely, disciplined, and mandate-consistent,
+3. future AI and analytics features have a governed memory substrate instead of inferred context.
+
 ---
 
 ## 7. Target Data Products
@@ -734,6 +798,11 @@ Additional target products likely required:
 8. `ClientRestrictionProfile:v1`
 9. `ModelChangeEvent:v1`
 10. `BenchmarkConstituentWindow:v1`
+11. `PortfolioCurrencyExposureWindow:v1`
+12. `CurrencyOverlayPolicy:v1`
+13. `HedgingInstrumentProfile:v1`
+14. `StressScenarioPack:v1`
+15. `MarketRegimeSignal:v1`
 
 ### 7.2 Required Inputs from lotus-risk
 
@@ -764,6 +833,9 @@ Potential governed data products:
 6. `DpmPortfolioActionRegister:v2`
 7. `DpmPostTradeOutcomeReview:v1`
 8. `DpmCioModelChangeImpact:v1`
+9. `DpmCurrencyOverlayPlan:v1`
+10. `DpmScenarioImpactRun:v1`
+11. `DpmDecisionTimeline:v1`
 
 ---
 
@@ -823,6 +895,33 @@ All public APIs must use `/api/v1`.
 2. `GET /api/v1/rebalance/proof-packs/{proof_pack_id}/pm-memo`
 
 These routes would call `lotus-ai` workflow-pack execution seams and persist returned run posture.
+
+### 8.7 Currency Overlay
+
+1. `POST /api/v1/currency-overlays/simulate`
+2. `GET /api/v1/currency-overlays/{overlay_plan_id}`
+3. `POST /api/v1/currency-overlays/{overlay_plan_id}/select`
+
+These routes expose currency posture and hedge-governance evidence as part of construction and
+proof-pack workflows. They must not become independent FX-trading APIs.
+
+### 8.8 Regime and Stress Simulation
+
+1. `POST /api/v1/scenarios/impact-runs`
+2. `GET /api/v1/scenarios/impact-runs/{scenario_run_id}`
+3. `GET /api/v1/scenarios/packs`
+
+These routes consume risk-authoritative scenario packs and expose mandate-ready impact evidence for
+alternatives, waves, proof packs, and outcome reviews.
+
+### 8.9 Decision Timeline
+
+1. `GET /api/v1/portfolios/{portfolio_id}/decision-timeline`
+2. `GET /api/v1/mandates/{mandate_id}/decision-timeline`
+3. `GET /api/v1/decision-events/{decision_event_id}`
+
+These routes provide portfolio memory for PM, compliance, operations, CIO, report, and AI evidence
+workflows. Timeline APIs return decision facts and evidence refs, not AI-generated interpretation.
 
 ---
 

--- a/docs/rfcs/RFC-0039-advanced-portfolio-construction-and-rebalance-alternatives.md
+++ b/docs/rfcs/RFC-0039-advanced-portfolio-construction-and-rebalance-alternatives.md
@@ -85,7 +85,8 @@ This RFC targets the following business outcomes:
 1. Add first-class rebalance alternative generation.
 2. Support multiple construction methods:
    `HEURISTIC_EXPLAINABLE`, `SOLVER_CONSTRAINED`, `MIN_TURNOVER`, `TAX_AWARE`,
-   `LIQUIDITY_AWARE`, `RISK_AWARE`, `ESG_AWARE`, and `DO_NOTHING_BASELINE`.
+   `LIQUIDITY_AWARE`, `RISK_AWARE`, `ESG_AWARE`, `CURRENCY_OVERLAY`,
+   `REGIME_STRESS_AWARE`, and `DO_NOTHING_BASELINE`.
 3. Produce comparable metrics for each alternative.
 4. Persist alternative sets and selected alternatives.
 5. Expose solver status, objective terms, constraints, relaxations, infeasibility reasons, and
@@ -252,6 +253,45 @@ Purpose:
 3. prefer eligible sustainable instruments where mandate requires it,
 4. expose ESG degradation when source profiles are incomplete.
 
+### 4.9 CURRENCY_OVERLAY
+
+Purpose:
+
+1. compare unhedged, partially hedged, and fully hedged mandate outcomes,
+2. separate strategic currency exposure from operational trade funding,
+3. respect currency exposure bands and hedge-ratio bands from the mandate digital twin,
+4. avoid creating hedge trades when hedge instruments, FX rates, forward points, settlement
+   calendars, or eligibility evidence are missing.
+
+Required evidence:
+
+1. current currency exposure by currency, sleeve, and asset class,
+2. target currency exposure after cash funding and proposed trades,
+3. proposed hedge adjustments where permitted,
+4. residual exposure after hedge,
+5. hedge cost estimate and settlement readiness,
+6. reason codes for hedge created, hedge changed, hedge suppressed, hedge blocked, and hedge
+   degraded.
+
+### 4.10 REGIME_STRESS_AWARE
+
+Purpose:
+
+1. compare alternatives under named market-regime and stress packs,
+2. reject or downgrade alternatives that improve drift while materially worsening unacceptable
+   downside or concentration risk,
+3. support CIO-required scenario checks for model-change waves,
+4. expose degraded state when `lotus-risk` scenario packs or exposure inputs are incomplete.
+
+Required evidence:
+
+1. scenario pack id and version,
+2. current, target, and after-trade scenario impacts,
+3. breached scenario limits,
+4. main contributors to scenario loss,
+5. mitigation reason codes,
+6. risk-authoritative source refs from `lotus-risk`.
+
 ---
 
 ## 5. Objective Function
@@ -269,6 +309,8 @@ minimize:
   + w_liquidity * liquidity_penalty
   + w_esg * esg_penalty
   + w_concentration * concentration_penalty
+  + w_currency_overlay * currency_overlay_penalty
+  + w_scenario_loss * scenario_loss_penalty
 ```
 
 Objective weights come from:
@@ -304,6 +346,11 @@ Initial constraint families:
 16. `CLIENT_RESTRICTION`
 17. `SUSTAINABILITY_EXCLUSION`
 18. `LIQUIDITY_MINIMUM`
+19. `CURRENCY_HEDGE_RATIO_BAND`
+20. `FX_FORWARD_ELIGIBILITY`
+21. `SCENARIO_LOSS_MAX`
+22. `REGIME_POLICY_BAND`
+23. `STRESS_CONTRIBUTION_MAX`
 
 Constraint severities:
 

--- a/docs/rfcs/RFC-0040-pre-trade-proof-pack-and-evidence-fabric.md
+++ b/docs/rfcs/RFC-0040-pre-trade-proof-pack-and-evidence-fabric.md
@@ -74,7 +74,7 @@ This RFC targets the following business outcomes:
 1. Add `DpmPreTradeProofPack` as a first-class durable product artifact.
 2. Generate proof packs from selected alternatives or direct rebalance runs.
 3. Include mandate, source, before, target, after, trades, risk, tax, turnover, cost, liquidity, FX,
-   rules, workflow, and lineage evidence.
+   currency overlay, scenario, rules, workflow, decision timeline, and lineage evidence.
 4. Produce JSON artifact and Markdown summary.
 5. Provide adapter outputs for `lotus-report` and `lotus-ai`.
 6. Certify APIs and OpenAPI examples.
@@ -109,16 +109,19 @@ Required sections:
 13. `turnover_and_cost`
 14. `liquidity_and_cash`
 15. `fx_funding_plan`
-16. `eligibility_and_restrictions`
-17. `sustainability_controls`
-18. `rule_results`
-19. `diagnostics`
-20. `approval_requirements`
-21. `operations_handoff`
-22. `lineage`
-23. `supportability`
-24. `reporting_refs`
-25. `ai_refs`
+16. `currency_overlay_evidence`
+17. `scenario_and_regime_evidence`
+18. `eligibility_and_restrictions`
+19. `sustainability_controls`
+20. `rule_results`
+21. `diagnostics`
+22. `approval_requirements`
+23. `operations_handoff`
+24. `decision_timeline`
+25. `lineage`
+26. `supportability`
+27. `reporting_refs`
+28. `ai_refs`
 
 Every section must include:
 
@@ -150,12 +153,31 @@ Required fields:
 11. `sections`
 12. `approval_requirements`
 13. `operations_handoff`
-14. `lineage`
-15. `markdown_summary`
-16. `report_input_ref`
-17. `ai_evidence_ref`
-18. `created_at`
-19. `created_by`
+14. `decision_timeline`
+15. `lineage`
+16. `markdown_summary`
+17. `report_input_ref`
+18. `ai_evidence_ref`
+19. `created_at`
+20. `created_by`
+
+### 4.1.1 Decision Timeline Requirements
+
+The proof pack must be able to anchor itself in portfolio memory.
+
+Required timeline evidence:
+
+1. most recent mandate version event,
+2. current monitoring exception events that triggered or influenced the action,
+3. model-change, tactical house-view, or PM-initiated event where applicable,
+4. generated alternative set event,
+5. selected alternative event,
+6. approval or deferral event,
+7. wave inclusion event when applicable,
+8. downstream execution handoff and post-trade outcome refs when available.
+
+Each timeline event must include `event_id`, `event_type`, `event_time`, `actor`, `source_system`,
+`reason_codes`, `status`, and `artifact_refs`.
 
 ### 4.2 DpmProofPackSection
 

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -46,14 +46,16 @@
 
 - RFC-0037
   proposed DPM operating-system and mandate-intelligence roadmap intended to make
-  `lotus-manage` the management-side crown jewel of the Lotus ecosystem
+  `lotus-manage` the management-side crown jewel of the Lotus ecosystem, with the 15 target
+  capability themes explicitly accounted for as implementation slices or dependent RFCs
 - RFC-0038
   proposed first implementation foundation for mandate digital twins, mandate health scoring,
   monitoring exceptions, and the DPM command-center API
 - RFC-0039
-  proposed advanced portfolio construction and rebalance alternatives roadmap
+  proposed advanced portfolio construction and rebalance alternatives roadmap, including tax,
+  turnover, liquidity, ESG, risk, currency-overlay, and regime-stress-aware construction methods
 - RFC-0040
-  proposed pre-trade proof-pack and DPM evidence-fabric roadmap
+  proposed pre-trade proof-pack, decision-timeline, and DPM evidence-fabric roadmap
 - RFC-0041
   proposed rebalance-wave orchestration and CIO model-change impact roadmap
 - RFC-0042


### PR DESCRIPTION
## Summary
- Explicitly account for all 15 DPM target capability themes in RFC-0037.
- Add first-class currency overlay, market-regime stress simulation, and portfolio memory / decision timeline scope.
- Tighten RFC-0039 construction methods and RFC-0040 proof-pack evidence sections so the roadmap is implementation-accounted instead of implied.
- Update wiki RFC index source to reflect the expanded target-state coverage.

## Validation
- python -m pytest tests\\unit\\test_documentation_current_state.py -q
- git diff --check

## Wiki
- Repo-local wiki source updated. Publish after merge with Sync-RepoWikis.ps1.