### PR TITLE
Harden DPM operating system RFCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ Current posture under RFC-0082:
 5. Solver-capable development and CI installs include the `solver` extra (`cvxpy` and `numpy`) so
    solver-mode target generation is validated instead of silently skipped.
 
+## Strategic DPM Roadmap
+
+RFC-0037 through RFC-0043 define the proposed revamp from a certified rebalance/supportability
+service into a discretionary mandate portfolio-management operating system.
+
+Those target-state RFCs cover mandate digital twins, health scoring, command-center workflows,
+advanced construction alternatives, pre-trade proof packs, decision timelines, CIO/model-change
+rebalance waves, post-trade outcome feedback, and governed AI PM support. They are not
+implementation-backed support claims until the owning RFC is implemented, certified, live-proven,
+and reflected in [wiki/Supported-Features.md](wiki/Supported-Features.md).
+
+The revamp is strategic-first: duplicate, stale, advisory-era, or poorly named APIs may be removed
+or redesigned rather than preserved for backward compatibility. Future gateway and Workbench
+integration should be rebuilt against the certified target contract.
+
 ## Architecture At A Glance
 
 Main runtime surfaces come from [src/api/main.py](src/api/main.py):

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -55,6 +55,9 @@ Current repository posture:
     `PortfolioTaxLotWindow:v1` through `/integration/portfolios/{portfolio_id}/tax-lots`,
     `MarketDataCoverageWindow:v1` through `/integration/market-data/coverage`, and
     `DpmSourceReadiness:v1` through `/integration/portfolios/{portfolio_id}/dpm-source-readiness`.
+11. RFC-0037 through RFC-0043 define the proposed strategic revamp into a DPM operating system.
+    These RFCs are target-state planning material until implementation-backed support, live proof,
+    and supported-feature promotion are completed.
 
 ## Architecture And Module Map
 
@@ -169,9 +172,13 @@ Most relevant current governance:
 9. `make check` may refresh generated API vocabulary output; docs-only slices should inspect that
    diff and avoid committing timestamp-only churn when the semantic inventory is unchanged,
 10. the current repo-native domain-data-product declaration intentionally records only governed
-   `PortfolioStateSnapshot` input consumption through caller-supplied management request payloads;
-   market-data and future stateful `portfolio_id` resolution must be added only after upstream
-   producer approval and an explicit source-data retrieval design.
+    `PortfolioStateSnapshot` input consumption through caller-supplied management request payloads;
+    market-data and future stateful `portfolio_id` resolution must be added only after upstream
+    producer approval and an explicit source-data retrieval design.
+11. target-state RFC-0037 through RFC-0043 work may redesign or remove stale manage APIs because
+    no production downstream dependency is assumed for the revamp surface. Any downstream usage
+    discovered during implementation should be documented and migrated to the certified target
+    contract rather than preserved through permanent compatibility aliases.
 
 ## Context Maintenance Rule
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -46,6 +46,11 @@ Governance boundary:
 | RFC-0042 | Post-Trade Outcome Feedback Loop | PROPOSED | RFC-0017, RFC-0019, RFC-0023, RFC-0036, RFC-0037, RFC-0038, RFC-0039, RFC-0040, RFC-0041 | `docs/rfcs/RFC-0042-post-trade-outcome-feedback-loop.md` |
 | RFC-0043 | Governed AI PM Copilot for DPM | PROPOSED | RFC-0037, RFC-0038, RFC-0039, RFC-0040, RFC-0041, RFC-0042 | `docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md` |
 
+Strategic RFC-0037 through RFC-0043 are pre-implementation target-state RFCs. They intentionally
+allow clean API redesign and endpoint removal where that produces a stronger enterprise DPM
+contract. Do not treat their features as supported until implementation, API certification, live
+evidence, wiki updates, and supported-feature promotion are complete.
+
 Review note:
 - RFC-0002, RFC-0007A, RFC-0021, RFC-0024, RFC-0025, and RFC-0028 were rebaselined on
   2026-05-03 against current lotus-manage DPM implementation evidence. RFC-0024 and RFC-0025

--- a/docs/rfcs/RFC-0037-dpm-operating-system-and-mandate-intelligence.md
+++ b/docs/rfcs/RFC-0037-dpm-operating-system-and-mandate-intelligence.md
@@ -82,6 +82,42 @@ This RFC also incorporates established portfolio-management concepts:
 | `lotus-gateway` | Experience API composition and partial-readiness-aware product boundary. |
 | `lotus-workbench` | Portfolio manager, advisor, operations, and leadership user experience. |
 
+### 1.4 Domain Vocabulary and Design Normalization
+
+This RFC family must use private-banking and institutional portfolio-management vocabulary. The
+implementation should not read like a generic task tracker wrapped around a rebalance API.
+
+Preferred language:
+
+| Domain concept | Preferred Lotus term | Avoid |
+| --- | --- | --- |
+| Client-authorized DPM scope | discretionary mandate, investment mandate, mandate policy statement | generic account settings |
+| Long-term policy allocation | strategic asset allocation, model portfolio, policy portfolio | target mix with no governance context |
+| Short-term CIO or PM tilt | tactical asset allocation, house-view tilt, CIO model change | manual adjustment |
+| Governed constraint set | mandate guidelines, investment restrictions, policy bands, hard/soft limits | arbitrary rules |
+| Ongoing supervision | mandate monitoring, exception surveillance, review cadence | background scan |
+| Rebalance decision | portfolio action, rebalance proposal, selected alternative | generated suggestion |
+| Analytical comparison | construction alternative, risk/return/tax/liquidity trade-off | option list |
+| Multi-currency control | reference currency, currency exposure, FX funding, hedge overlay | currency conversion only |
+| Evidence record | proof pack, source lineage, decision timeline, audit artifact | log dump |
+| Outcome review | expected-versus-realized review, post-trade feedback, execution-quality review | after-action note |
+| AI role | governed PM copilot, narrative assistant, evidence summarizer | autonomous decision agent |
+| Readiness posture | source readiness, supportability, degraded state, blocked state | success/failure flag |
+
+Methodology anchors:
+
+1. mandates should start from objectives, risk profile, time horizon, reference currency, liquidity
+   needs, tax position, regulatory constraints, sustainability preferences, and bespoke
+   restrictions,
+2. construction should distinguish strategic allocation discipline from tactical or dynamic tilts,
+3. construction and rebalancing must expose transaction cost, taxation, liquidity, risk, active
+   risk/tracking error, concentration, currency exposure, and operational readiness,
+4. scenario/stress analysis should be treated as a portfolio-construction and review control, not
+   as a decorative chart,
+5. portfolio memory should preserve decision rights, actor attribution, source lineage, and
+   expected-versus-realized outcome evidence,
+6. AI must consume structured evidence and never become the source of investment truth.
+
 ---
 
 ## 2. Problem Statement
@@ -170,6 +206,35 @@ evidence says, and what happened after action.
    `lotus-performance`.
 5. `lotus-manage` does not let AI choose trades. AI may summarize, explain, check, and prepare
    evidence, but deterministic domain services remain authoritative.
+
+### 3.4 Compatibility Posture
+
+This RFC family is a strategic revamp, not a backward-compatible extension of the current
+management API set.
+
+Current assumption:
+
+1. no downstream system is production-dependent on the target-state RFC-0037 through RFC-0043
+   surfaces,
+2. future `lotus-gateway` and `lotus-workbench` integration will be rebuilt against the certified
+   target contract,
+3. stale, duplicate, advisory-era, or misleading endpoints should be removed rather than wrapped,
+4. compatibility aliases should not be introduced unless a later downstream migration RFC proves a
+   real production dependency,
+5. the target contract should optimize for domain correctness, API quality, observability,
+   supportability, and evidence, not legacy payload shape preservation.
+
+Implementation rule:
+
+1. if downstream usage is discovered during implementation, document the consumer and migration
+   plan,
+2. prefer a short-lived migration issue over permanent compatibility code,
+3. keep the strategic endpoint vocabulary clean even when a downstream adapter is temporarily
+   required elsewhere,
+4. redesign current APIs where needed to create a coherent enterprise-grade contract,
+5. delete duplicate or poorly named endpoints instead of preserving them as aliases,
+6. certify the new contract through OpenAPI, tests, live evidence, and supported-feature updates
+   before gateway or Workbench integration is rebuilt.
 
 ---
 
@@ -1455,3 +1520,206 @@ first implementation RFC should be a smaller execution RFC for Slice 1 and Slice
 
 That follow-up RFC should include concrete API schemas, migrations, exact source-data contracts,
 OpenAPI examples, testing plan, and canonical demo data requirements.
+
+---
+
+## 19. Gold-Standard Execution Contract
+
+This section is the execution contract for RFC-0037 and the RFC-0038 through RFC-0043 delivery
+family. It exists to remove ambiguity before implementation begins.
+
+### 19.1 Supported-Features Ledger
+
+Target-state features must remain separate from implementation-backed features until live proof
+exists. Promotion requires API certification, tests, canonical evidence, and wiki/supported-feature
+updates.
+
+| Feature | Owning RFC | Initial support state | Promotion rule |
+| --- | --- | --- | --- |
+| Mandate digital twin | RFC-0038 | Proposed | Promote only after core sourcing, persistence, APIs, and live evidence are complete. |
+| Mandate health score | RFC-0038 | Proposed | Promote only after decomposed scoring, reason codes, tests, and command-center evidence exist. |
+| DPM command center | RFC-0038 | Proposed | Promote only after bounded portfolio-manager book summary APIs and gateway handoff are certified. |
+| CIO house-view propagation | RFC-0041 | Proposed | Promote only after model-change impact and wave preview are source-backed and audited. |
+| Advanced construction lab | RFC-0039 | Proposed | Promote only after alternatives are persisted, comparable, explainable, and solver posture is certified. |
+| Rebalance alternatives | RFC-0039 | Proposed | Promote only after selection, infeasibility, and fallback evidence are actor-attributed. |
+| Tax/liquidity/risk/ESG construction | RFC-0039 | Proposed | Promote only after each dimension has source supportability and degraded-state tests. |
+| Currency overlay and hedge governance | RFC-0039 | Proposed | Promote only after exposure, hedge-ratio, FX funding, and settlement evidence are complete. |
+| Regime and stress simulator | RFC-0039/RFC-0040 | Proposed | Promote only after scenario packs are sourced from risk-authoritative evidence. |
+| Pre-trade proof pack | RFC-0040 | Proposed | Promote only after durable JSON/Markdown/report/AI evidence artifacts are certified. |
+| Decision timeline and portfolio memory | RFC-0040 | Proposed | Promote only after mandate, exception, alternative, approval, wave, handoff, and outcome events link. |
+| Rebalance wave orchestration | RFC-0041 | Proposed | Promote only after multi-portfolio partial-readiness behavior is live-proven. |
+| Post-trade outcome feedback | RFC-0042 | Proposed | Promote only after expected-versus-realized review is linked to core, risk, and performance evidence. |
+| Governed PM copilot | RFC-0043 | Proposed | Promote only after `lotus-ai` workflow-pack guardrails and AI-unavailable fallbacks are proven. |
+| DPM sales/demo story | RFC-0037 plus wiki | Proposed | Promote only after implementation-backed demos are captured from the canonical stack. |
+
+### 19.2 Mandatory Delivery Slices
+
+The detailed RFCs may have feature-specific slices, but every implementation must also execute the
+following mandatory slices in order. Do not move to the next slice until the current slice has
+working code, tests, documentation posture, and evidence appropriate to its scope.
+
+#### Mandatory Slice A - Platform Automation and Scaffolding Improvement
+
+Run this slice before app-local implementation and again whenever repeated platform gaps appear.
+If no platform change is needed, record a deliberate no-change decision.
+
+Required checks:
+
+1. identify whether app scaffolding should already provide the needed API certification,
+   OpenAPI examples, health endpoints, structured logging, metrics, error models, migration smoke,
+   test scaffolding, CI defaults, documentation scaffolding, wiki source, and governance hooks,
+2. improve `lotus-platform` automation when a gap is repeatable across applications,
+3. keep app-local changes only where the concern is genuinely `lotus-manage` domain behavior,
+4. update central context, skills, or scaffolding docs when platform behavior changes.
+
+Exit evidence:
+
+1. list of platform gaps found,
+2. platform PR or explicit no-change decision,
+3. app-local implementation boundary recorded,
+4. impacted validators or templates documented.
+
+#### Mandatory Slice B - Cleanup and Structure
+
+Required checks:
+
+1. remove dead advisory leftovers, stale endpoints, duplicate RFC/documentation material, and
+   misleading target-state claims,
+2. simplify modules before adding new behavior,
+3. move long-lived operator and product material to wiki source where appropriate,
+4. avoid duplicating detailed RFC mechanics in the wiki,
+5. keep supported-features material implementation-backed.
+
+Exit evidence:
+
+1. dead-code and duplicate-doc review notes,
+2. updated repository structure when needed,
+3. wiki/source-doc split recorded,
+4. tests proving removed behavior is no longer exposed if endpoints are deleted.
+
+#### Mandatory Slice C - Implementation Proof
+
+Required checks:
+
+1. prove each endpoint and workflow against the RFC,
+2. capture full request/response evidence under non-git-tracked `output/`,
+3. validate every returned figure, readiness state, reason code, lineage ref, and degraded state,
+4. run canonical core/manage proof when source data is part of the feature,
+5. file or fix every gap discovered during evidence review.
+
+Exit evidence:
+
+1. live evidence folder path,
+2. request/response inventory,
+3. critical review notes,
+4. fixed-gap summary,
+5. remaining deferred items with owner and rationale.
+
+#### Mandatory Slice D - Second-Last Hardening and Review
+
+Required checks:
+
+1. perform a code review focused on bugs, architecture, duplication, dead code, and test quality,
+2. certify every touched API and error path,
+3. verify Swagger grouping, what/when/how guidance, request examples, response examples, and
+   field-level descriptions, types, and examples,
+4. verify data-mesh declarations, telemetry, structured logging, bounded metrics, health,
+   readiness, and platform governance,
+5. run repository-native checks and monitor GitHub lanes.
+
+Exit evidence:
+
+1. review findings and fixes,
+2. OpenAPI/API vocabulary certification,
+3. test-pyramid adequacy statement,
+4. local and GitHub check posture,
+5. no unresolved P0/P1 implementation gaps.
+
+#### Mandatory Slice E - Final Closure
+
+Required checks:
+
+1. update README, RFC, runbook, context, wiki source, and supported-features truth,
+2. publish wiki after merge when wiki truth changed,
+3. record whether skills, agent guidance, documentation workflow, or context should change,
+4. mark the RFC implementation status truthfully,
+5. clean branch state, PR state, and local generated artifacts.
+
+Exit evidence:
+
+1. final evidence summary,
+2. wiki source and publication posture,
+3. supported-features update,
+4. skills/context decision,
+5. branch hygiene and CI closure.
+
+### 19.3 Documentation-As-Product Standard
+
+Documentation must be suitable for business, engineering, sales, marketing, operations, and client
+demo preparation:
+
+1. README stays concise and command-accurate,
+2. wiki explains feature behavior, integrations, operational posture, and diagrams in
+   business-readable language,
+3. RFCs carry implementation detail, architecture, test and evidence requirements,
+4. supported-features separates implemented, gated, and proposed features,
+5. no sales or demo material may claim target-state behavior before implementation-backed proof.
+
+### 19.4 Enterprise, Data-Mesh, and Observability Baseline
+
+Every implementation RFC in this family inherits this baseline. A feature is not complete until it
+meets the relevant Lotus platform standards as well as its business acceptance criteria.
+
+Data-mesh requirements:
+
+1. declare every produced or consumed domain data product in repo-native contracts where applicable,
+2. keep `lotus-core`, `lotus-risk`, `lotus-performance`, `lotus-report`, and `lotus-ai` source
+   authority explicit,
+3. attach lineage, freshness, completeness, source-readiness, and supportability metadata to
+   cross-service evidence,
+4. update trust telemetry, SLO, access, and evidence-policy posture when a feature becomes a
+   governed product,
+5. validate with repo-native mesh and platform certification gates before promotion.
+
+API and contract requirements:
+
+1. use clean strategic `/api/v1` contracts; do not preserve poor legacy shapes for compatibility,
+2. certify every endpoint through OpenAPI quality, API vocabulary, no-alias, request/response
+   examples, error examples, and field-level descriptions/types/examples,
+3. expose bounded problem-details errors and deterministic reason codes,
+4. make partial readiness and degraded source states first-class response states,
+5. keep downstream Gateway/Workbench integration out of scope until the target API is certified.
+
+Observability and operations requirements:
+
+1. structured logs must carry service, operation, state, supportability reason, correlation id, and
+   trace context where available,
+2. metrics must use bounded, non-sensitive labels only,
+3. health, liveness, readiness, supportability, and operator diagnostics must distinguish app
+   health from source-data readiness,
+4. audit events must record actor, decision, state transition, reason codes, and artifact refs,
+5. telemetry must never expose client identifiers, holdings, raw requests/responses, proof-pack
+   sensitive payloads, trace ids, or correlation ids as metric labels,
+6. live proof must include logs/metrics/supportability posture, not only business responses.
+
+Delivery requirements:
+
+1. use repo-native checks first and GitHub lanes for asynchronous heavy proof,
+2. monitor Feature Lane and PR Merge Gate while continuing non-overlapping work,
+3. fix CI failures promptly,
+4. keep branch history small, meaningful, and truthful,
+5. leave no open P0/P1 architecture, API, data-mesh, observability, or test-quality gap before
+   closure.
+
+Feature-expansion rule:
+
+1. every new feature must strengthen the enterprise posture or include explicit compensating
+   controls,
+2. no feature may close if it increases endpoint sprawl, source-authority ambiguity, undocumented
+   states, unbounded telemetry labels, weak error handling, or superficial tests,
+3. new capabilities should reduce operational effort, improve auditability, improve decision
+   quality, or make source-readiness clearer,
+4. if a valuable feature introduces unavoidable complexity, the implementation must add modular
+   boundaries, supportability, observability, and tests that make the complexity operationally
+   manageable,
+5. final review must explicitly state how enterprise posture improved versus the pre-RFC baseline.

--- a/docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md
+++ b/docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md
@@ -801,3 +801,85 @@ RFC-0038 is complete only when:
 8. wiki/README/supported-features reflect actual implemented state,
 9. target-state claims remain separate from implemented claims,
 10. branch, PR, CI, and wiki publication are clean.
+
+---
+
+## 14. Gold-Standard Execution Contract
+
+RFC-0038 is the first implementation foundation for the DPM operating system. It must establish
+portfolio-manager trust in the mandate record before later construction, proof-pack, wave, outcome,
+or AI features build on it.
+
+### 14.1 Supported-Features Ledger
+
+| Feature | Support state before implementation | Promotion rule |
+| --- | --- | --- |
+| Mandate digital twin | Proposed | Promote only after source fields, derived fields, local overlays, versions, lineage, and APIs are certified. |
+| Mandate health score | Proposed | Promote only after decomposed dimensions, weights, thresholds, reason codes, and tests are complete. |
+| Monitoring exceptions | Proposed | Promote only after repeatable monitoring runs create bounded, actor-reviewable exceptions. |
+| DPM command center | Proposed | Promote only after book-level summaries, attention queues, and partial-readiness behavior are live-proven. |
+
+### 14.2 Architecture and Domain Direction
+
+Implementation must preserve these boundaries:
+
+1. `lotus-core` remains source authority for portfolio, mandate-binding, model, eligibility,
+   market-data, cash, tax-lot, and reference data,
+2. `lotus-manage` owns the DPM interpretation layer: mandate digital twin, health score,
+   monitoring exception, and command-center summary,
+3. `lotus-risk` and `lotus-performance` remain enrichment authorities; missing enrichment must
+   degrade health dimensions instead of inventing values,
+4. `lotus-gateway` and `lotus-workbench` must consume supported APIs rather than reconstructing
+   health or command-center truth client-side.
+
+### 14.3 Mandatory Delivery Slices
+
+These slices are mandatory in addition to the feature-specific slices in Section 9.
+
+#### Mandatory Slice A - Platform Automation and Scaffolding Improvement
+
+Check whether platform scaffolding already enforces health/readiness endpoints, OpenAPI examples,
+bounded problem-details errors, structured logging, no-sensitive metrics, documentation scaffolding,
+and API certification tests. Fix repeatable gaps in `lotus-platform`; otherwise record a deliberate
+no-change decision.
+
+#### Mandatory Slice B - Cleanup and Structure
+
+Remove stale advisory language, duplicate mandate documentation, unused local health abstractions,
+and any generic "score" naming that should be domain-specific. Keep long-lived operator and product
+truth in wiki source; keep scoring methodology and schema details in `docs/`.
+
+#### Mandatory Slice C - Implementation Proof
+
+Bring up core/manage with seeded discretionary mandate data. Capture request and response evidence
+for mandate lookup, mandate refresh, health snapshot, monitoring run, exceptions, and command-center
+summary. Review dimension scores, thresholds, reason codes, lineage, and degraded-source states.
+
+#### Mandatory Slice D - Second-Last Hardening and Review
+
+Perform a full review of source ownership, score transparency, OpenAPI field-level examples,
+metrics/logging labels, migration posture, repository boundaries, and tests. Every endpoint must be
+API-certified and every error path must have tests and Swagger examples.
+
+#### Mandatory Slice E - Final Closure
+
+Update README if orientation changes, update wiki with business-readable command-center behavior and
+diagrams, update supported-features only for proven support, update repository context if ownership
+or runtime truth changes, record skills/guidance decision, and leave branch/PR/CI clean.
+
+### 14.4 Evidence Expectations
+
+Closure evidence must include:
+
+1. field-by-field source map for the mandate twin,
+2. health-score worked example with source refs and reason codes,
+3. command-center response for a populated PM book and an empty/partial book,
+4. degraded-source proof,
+5. OpenAPI certification summary,
+6. local and GitHub check summary.
+
+### 14.5 Enterprise Baseline
+
+This RFC inherits RFC-0037 Section 19.4. Completion requires data-mesh posture, source-readiness
+lineage, structured logging, bounded metrics, supportability diagnostics, API certification, and
+GitHub lane evidence appropriate to every mandate, health, monitoring, and command-center endpoint.

--- a/docs/rfcs/RFC-0039-advanced-portfolio-construction-and-rebalance-alternatives.md
+++ b/docs/rfcs/RFC-0039-advanced-portfolio-construction-and-rebalance-alternatives.md
@@ -646,3 +646,90 @@ RFC-0039 is complete when:
 6. OpenAPI is complete,
 7. live proof shows a realistic discretionary mandate comparison,
 8. no AI or UI layer chooses the alternative on behalf of the PM.
+
+---
+
+## 13. Gold-Standard Execution Contract
+
+RFC-0039 must make portfolio construction explainable enough for a PM, CIO office, risk reviewer,
+tax specialist, and operations team to understand why one rebalance path is better than another.
+
+### 13.1 Supported-Features Ledger
+
+| Feature | Support state before implementation | Promotion rule |
+| --- | --- | --- |
+| Alternative set generation | Proposed | Promote only after alternatives are persisted, comparable, and reproducible. |
+| Solver-constrained construction | Proposed | Promote only after solver status, objective terms, constraints, relaxations, and fallback are exposed. |
+| Minimum-turnover construction | Proposed | Promote only after turnover, trade count, drift reduction, and cost trade-offs are tested. |
+| Tax-aware construction | Proposed | Promote only after lot availability, lot selection, tax budget, and degraded-source behavior are proven. |
+| Liquidity-aware construction | Proposed | Promote only after cash, settlement, liquidity, and cashflow-readiness evidence is complete. |
+| Risk/performance-aware construction | Proposed | Promote only after enrichment seams or live integrations degrade truthfully when unavailable. |
+| ESG/restriction-aware construction | Proposed | Promote only after restriction, sustainability, and eligibility evidence is complete. |
+| Currency-overlay construction | Proposed | Promote only after FX exposure, hedge-ratio, funding, settlement, and hedge-blocking evidence exists. |
+| Regime/stress-aware construction | Proposed | Promote only after scenario packs and stress contribution evidence are risk-authoritative. |
+
+### 13.2 Architecture and Domain Direction
+
+Implementation must use a portfolio-construction vocabulary:
+
+1. strategic asset allocation, policy bands, and model targets are the baseline,
+2. tactical tilts and house views are controlled deviations, not free-form target edits,
+3. objective terms and constraints must be explicit, versioned, and explainable,
+4. infeasible portfolios must return `BLOCKED` or `PENDING_REVIEW` with reason codes instead of
+   hidden relaxations,
+5. every alternative must expose expected drift, active risk/tracking error, turnover, cost, tax,
+   liquidity, cash, FX, ESG, and source-readiness posture where available.
+
+### 13.3 Mandatory Delivery Slices
+
+These slices are mandatory in addition to the feature-specific slices in Section 10.
+
+#### Mandatory Slice A - Platform Automation and Scaffolding Improvement
+
+Review whether platform scaffolding should provide reusable objective/constraint OpenAPI examples,
+solver-availability supportability fields, no-sensitive optimization traces, and standard
+calculation evidence fixtures. Improve platform automation for repeatable gaps; otherwise record a
+no-change decision.
+
+#### Mandatory Slice B - Cleanup and Structure
+
+Separate pure construction logic from API orchestration, persistence, and upstream enrichment. Remove
+duplicated heuristic rules, stale advisory proposal terms, and any generic "option" language that
+should be "construction alternative" or "selected alternative."
+
+#### Mandatory Slice C - Implementation Proof
+
+Capture full request/response evidence for at least one realistic mandate with do-nothing,
+heuristic, solver, tax-aware, liquidity-aware, currency-overlay, and degraded-source alternatives.
+Review every metric and reason code critically before promotion.
+
+#### Mandatory Slice D - Second-Last Hardening and Review
+
+Review numerical determinism, solver fallback, objective/constraint traceability, error handling,
+OpenAPI quality, performance, latency, and test-pyramid adequacy. Ensure Swagger explains when to
+use each method and every field has description, type, and example.
+
+#### Mandatory Slice E - Final Closure
+
+Update RFC evidence, README or wiki navigation if needed, supported-features promotion state,
+context/guidance decisions, and branch hygiene. Do not market a method as supported until canonical
+live evidence proves it.
+
+### 13.4 Evidence Expectations
+
+Closure evidence must include:
+
+1. alternative comparison matrix,
+2. objective and constraint trace sample,
+3. infeasible and fallback examples,
+4. source-unavailable degraded example,
+5. selected-alternative audit event,
+6. OpenAPI/API certification summary,
+7. local and GitHub check summary.
+
+### 13.5 Enterprise Baseline
+
+This RFC inherits RFC-0037 Section 19.4. Completion requires source-authority declarations,
+calculation lineage, solver/supportability telemetry, bounded objective/constraint traces,
+structured logs, API certification, and GitHub lane evidence for every construction and selection
+endpoint.

--- a/docs/rfcs/RFC-0040-pre-trade-proof-pack-and-evidence-fabric.md
+++ b/docs/rfcs/RFC-0040-pre-trade-proof-pack-and-evidence-fabric.md
@@ -432,3 +432,86 @@ RFC-0040 is complete when:
 6. canonical live evidence exists,
 7. Workbench can consume proof-pack truth through Gateway in a later UI slice without reconstructing
    evidence client-side.
+
+---
+
+## 11. Gold-Standard Execution Contract
+
+RFC-0040 is the DPM trust layer. It must produce evidence that is machine-readable, human-readable,
+audit-ready, and safe for downstream reporting and AI summarization.
+
+### 11.1 Supported-Features Ledger
+
+| Feature | Support state before implementation | Promotion rule |
+| --- | --- | --- |
+| Pre-trade proof pack JSON | Proposed | Promote only after all required sections, lineage, hashes, and retrieval APIs are certified. |
+| Human-readable Markdown summary | Proposed | Promote only after deterministic rendering and business-language review pass. |
+| Report input handoff | Proposed | Promote only after `lotus-report` payload contract tests and examples exist. |
+| AI evidence handoff | Proposed | Promote only after forbidden-field and structured-evidence guard tests pass. |
+| Decision timeline anchoring | Proposed | Promote only after mandate, exception, alternative, approval, wave, handoff, and outcome events link. |
+| Proof-pack audit and supportability | Proposed | Promote only after immutable hashes, source refs, supportability, and retention posture are complete. |
+
+### 11.2 Architecture and Domain Direction
+
+Implementation must treat the proof pack as a governed investment-decision artifact:
+
+1. it records the business rationale, mandate context, selected alternative, trade intent,
+   risk/tax/liquidity/currency/scenario evidence, source readiness, approvals, and operations state,
+2. it is not a replacement for `lotus-report`; it supplies report input,
+3. it is not an AI prompt; it supplies structured evidence to `lotus-ai`,
+4. it is not a log archive; it is a curated DPM evidence product,
+5. it must support PM, compliance, operations, CIO, audit, and demo use cases without exposing
+   sensitive raw telemetry or payload internals.
+
+### 11.3 Mandatory Delivery Slices
+
+These slices are mandatory in addition to the feature-specific slices in Section 8.
+
+#### Mandatory Slice A - Platform Automation and Scaffolding Improvement
+
+Review whether platform scaffolding should provide reusable evidence-artifact patterns, Markdown
+snapshot tests, report/AI handoff examples, OpenAPI artifact examples, and retention/governance
+checklists. Improve platform automation for repeatable gaps; otherwise record a no-change decision.
+
+#### Mandatory Slice B - Cleanup and Structure
+
+Consolidate overlapping artifact, support-bundle, lineage, and workflow evidence builders where it
+reduces duplication. Remove stale proof terminology that implies advisor consent or client proposal
+ownership.
+
+#### Mandatory Slice C - Implementation Proof
+
+Generate proof packs from both a direct rebalance run and a selected alternative. Save full JSON,
+Markdown, report-input, and AI-evidence request/response captures under `output/`. Review every
+section for unsupported claims, missing source refs, and degraded-state clarity.
+
+#### Mandatory Slice D - Second-Last Hardening and Review
+
+Review immutability, hashing, lineage, retention, OpenAPI field quality, error handling, no-sensitive
+AI/report handoff fields, Markdown readability, and test-pyramid depth. Every proof section must
+have positive and degraded tests.
+
+#### Mandatory Slice E - Final Closure
+
+Update README/wiki/supported-features only for proven evidence surfaces. Publish wiki after merge
+when proof-pack behavior or demo material changes. Record skills/context decisions and leave branch
+and PR posture clean.
+
+### 11.4 Evidence Expectations
+
+Closure evidence must include:
+
+1. proof-pack JSON example,
+2. Markdown summary example,
+3. report-input example,
+4. AI-evidence input example,
+5. missing-evidence degraded example,
+6. decision-timeline linkage example,
+7. OpenAPI/API certification summary,
+8. local and GitHub check summary.
+
+### 11.5 Enterprise Baseline
+
+This RFC inherits RFC-0037 Section 19.4. Completion requires proof-pack lineage, retention posture,
+audit events, no-sensitive report/AI handoff contracts, structured logging, bounded metrics,
+operator diagnostics, API certification, and GitHub lane evidence for every proof-pack endpoint.

--- a/docs/rfcs/RFC-0041-rebalance-wave-orchestration-and-cio-model-change-impact.md
+++ b/docs/rfcs/RFC-0041-rebalance-wave-orchestration-and-cio-model-change-impact.md
@@ -406,3 +406,83 @@ RFC-0041 is complete when:
 6. aggregate metrics are reproducible,
 7. APIs are certified,
 8. canonical live evidence shows a multi-portfolio wave.
+
+---
+
+## 12. Gold-Standard Execution Contract
+
+RFC-0041 turns single-portfolio decisions into managed investment-office execution waves. It must
+make book-level CIO and PM action safe, observable, partially executable, and audit-ready.
+
+### 12.1 Supported-Features Ledger
+
+| Feature | Support state before implementation | Promotion rule |
+| --- | --- | --- |
+| Wave creation | Proposed | Promote only after trigger, portfolio selection, state machine, and persistence are certified. |
+| CIO model-change impact | Proposed | Promote only after model-change source evidence and affected-mandate preview are complete. |
+| Wave source check | Proposed | Promote only after item-level readiness, blocked reasons, and partial execution posture are proven. |
+| Wave simulation | Proposed | Promote only after RFC-0039 alternatives can run per ready item and persist results. |
+| Wave approval and staging | Proposed | Promote only after actor attribution, state guards, and operations handoff are tested. |
+| Wave aggregate metrics | Proposed | Promote only after metrics are derived from item evidence and reproducible. |
+
+### 12.2 Architecture and Domain Direction
+
+Implementation must preserve book-level investment governance:
+
+1. CIO model changes are investment-office events with impact analysis and approval posture,
+2. PM waves can contain ready, pending-review, and blocked mandates without failing the whole wave,
+3. operations handoff prepares evidence and state; it does not execute external trades,
+4. aggregate metrics must reconcile to item-level evidence,
+5. wave APIs must expose partial readiness and supportability rather than hiding incomplete source
+   data.
+
+### 12.3 Mandatory Delivery Slices
+
+These slices are mandatory in addition to the feature-specific slices in Section 9.
+
+#### Mandatory Slice A - Platform Automation and Scaffolding Improvement
+
+Review whether platform scaffolding should provide reusable async/workflow state-machine examples,
+aggregate OpenAPI examples, operator-run supportability, and bounded metrics for multi-item
+workflows. Improve platform automation for repeatable gaps; otherwise record a no-change decision.
+
+#### Mandatory Slice B - Cleanup and Structure
+
+Keep wave orchestration separate from alternative construction. Remove duplicated state-transition
+logic and stale async-operation terminology that obscures the investment-office wave lifecycle.
+
+#### Mandatory Slice C - Implementation Proof
+
+Capture evidence for a CIO/model-change wave with at least one ready item, one pending-review item,
+and one blocked item. Review source readiness, aggregate metrics, item transitions, approval,
+staging, proof-pack refs, and operations handoff.
+
+#### Mandatory Slice D - Second-Last Hardening and Review
+
+Review state-machine correctness, idempotency, concurrency, partial readiness, OpenAPI quality,
+bounded metrics/logs, migration posture, error handling, and test-pyramid coverage.
+
+#### Mandatory Slice E - Final Closure
+
+Update wiki with wave diagrams and business-readable CIO/PM/operations flow. Update
+supported-features only after live evidence proves the wave lifecycle. Record context/skills
+decisions and leave branch/PR/CI clean.
+
+### 12.4 Evidence Expectations
+
+Closure evidence must include:
+
+1. wave creation request/response,
+2. affected-portfolio preview,
+3. source-check response with mixed readiness,
+4. wave simulation response,
+5. approval/stage/handoff transitions,
+6. aggregate metric reconciliation notes,
+7. OpenAPI/API certification summary,
+8. local and GitHub check summary.
+
+### 12.5 Enterprise Baseline
+
+This RFC inherits RFC-0037 Section 19.4. Completion requires wave lineage, item-level
+source-readiness metadata, actor-attributed audit events, bounded aggregate metrics, structured
+logs, operator diagnostics, API certification, and GitHub lane evidence for every wave endpoint.

--- a/docs/rfcs/RFC-0042-post-trade-outcome-feedback-loop.md
+++ b/docs/rfcs/RFC-0042-post-trade-outcome-feedback-loop.md
@@ -348,3 +348,82 @@ RFC-0042 is complete when:
 5. APIs are certified,
 6. live proof shows at least one post-trade feedback story,
 7. outcome feedback can feed future PM dashboards without recomputing domain truth in UI.
+
+---
+
+## 12. Gold-Standard Execution Contract
+
+RFC-0042 closes the investment feedback loop. It must compare what `lotus-manage` expected before
+trade with what actually happened after execution, using source-authoritative evidence rather than
+PM anecdotes or UI-side recomputation.
+
+### 12.1 Supported-Features Ledger
+
+| Feature | Support state before implementation | Promotion rule |
+| --- | --- | --- |
+| Outcome review creation | Proposed | Promote only after expected and realized data are reconciled with source refs. |
+| Variance decomposition | Proposed | Promote only after drift, cost, tax, FX, risk, performance, and execution-quality dimensions are tested. |
+| Source-degraded outcome review | Proposed | Promote only after missing core/risk/performance data is explicit and non-misleading. |
+| Searchable outcome memory | Proposed | Promote only after reviews are persisted, searchable, and linked to runs, waves, and proof packs. |
+| Feedback to future construction | Proposed | Promote only after feedback outputs are safe for future PM dashboards and construction quality review. |
+
+### 12.2 Architecture and Domain Direction
+
+Implementation must preserve source authority:
+
+1. `lotus-core` owns fills, transactions, cash movements, FX executions, holdings, and tax
+   realizations,
+2. `lotus-risk` owns post-trade risk and stress posture,
+3. `lotus-performance` owns post-trade returns, attribution, contribution, and benchmark context,
+4. `lotus-manage` owns expected-versus-realized decision review and PM workflow memory,
+5. no UI or AI layer may recompute outcome truth from partial evidence.
+
+### 12.3 Mandatory Delivery Slices
+
+These slices are mandatory in addition to the feature-specific slices in Section 9.
+
+#### Mandatory Slice A - Platform Automation and Scaffolding Improvement
+
+Review whether platform scaffolding should provide reusable outcome-review evidence patterns,
+source-degraded examples, post-trade telemetry fields, and OpenAPI examples for reconciliation
+surfaces. Improve platform automation for repeatable gaps; otherwise record a no-change decision.
+
+#### Mandatory Slice B - Cleanup and Structure
+
+Separate pure variance calculations from source clients, persistence, and API presentation. Remove
+any generic "review result" naming that should be outcome, variance, execution-quality, or
+expected-versus-realized terminology.
+
+#### Mandatory Slice C - Implementation Proof
+
+Capture evidence for at least one post-trade review linked to a proof pack and selected alternative.
+Review every expected value, realized value, tolerance, variance, classification, and degraded-source
+reason.
+
+#### Mandatory Slice D - Second-Last Hardening and Review
+
+Review numerical determinism, source staleness, tolerance policy, OpenAPI field examples, bounded
+metrics/logs, retention posture, error handling, and test-pyramid adequacy.
+
+#### Mandatory Slice E - Final Closure
+
+Update wiki with outcome-feedback behavior and business value, update supported-features only after
+live proof, update context/skills decisions, and leave branch/PR/CI clean.
+
+### 12.4 Evidence Expectations
+
+Closure evidence must include:
+
+1. outcome review creation request/response,
+2. source lineage for expected and realized values,
+3. variance/tolerance worked example,
+4. source-unavailable degraded example,
+5. search/filter example,
+6. OpenAPI/API certification summary,
+7. local and GitHub check summary.
+
+### 12.5 Enterprise Baseline
+
+This RFC inherits RFC-0037 Section 19.4. Completion requires expected-versus-realized lineage,
+source-readiness metadata, outcome audit events, bounded variance metrics, structured logs,
+operator diagnostics, API certification, and GitHub lane evidence for every outcome-review endpoint.

--- a/docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md
+++ b/docs/rfcs/RFC-0043-governed-ai-pm-copilot-for-dpm.md
@@ -397,3 +397,82 @@ RFC-0043 is complete when:
 6. OpenAPI is certified,
 7. live proof captures AI-ready and AI-unavailable behavior,
 8. docs clearly state that AI assists PMs but does not decide trades.
+
+---
+
+## 13. Gold-Standard Execution Contract
+
+RFC-0043 introduces AI-assisted PM productivity without weakening deterministic investment
+governance. The copilot must be useful for PMs, CIO, compliance, operations, and sales demos while
+remaining evidence-bound and non-decisioning.
+
+### 13.1 Supported-Features Ledger
+
+| Feature | Support state before implementation | Promotion rule |
+| --- | --- | --- |
+| PM memo from proof pack | Proposed | Promote only after `lotus-ai` workflow-pack execution, provenance, review state, and fallback are proven. |
+| Exception narrative | Proposed | Promote only after exception evidence is structured, bounded, and no unsupported claims are generated. |
+| CIO model-change brief | Proposed | Promote only after wave/model-change evidence is accepted by the workflow-pack contract. |
+| Operations handoff summary | Proposed | Promote only after handoff evidence is bounded and does not expose raw sensitive details. |
+| AI safety evaluation | Proposed | Promote only after forbidden-action, forbidden-claim, missing-evidence, and AI-unavailable tests pass. |
+
+### 13.2 Architecture and Domain Direction
+
+Implementation must preserve the AI boundary:
+
+1. `lotus-manage` supplies structured DPM evidence and persists narrative posture,
+2. `lotus-ai` owns workflow-pack execution, provider policy, model telemetry, and AI artifacts,
+3. AI may summarize rationale, exceptions, handoffs, and review notes,
+4. AI must not select trades, change approval state, create hidden weights, suppress rule breaches,
+   or invent missing source data,
+5. AI output must be reviewable, provenance-backed, and safe to omit when unavailable.
+
+### 13.3 Mandatory Delivery Slices
+
+These slices are mandatory in addition to the feature-specific slices in Section 10.
+
+#### Mandatory Slice A - Platform Automation and Scaffolding Improvement
+
+Review whether platform scaffolding should provide reusable AI-evidence handoff schemas,
+workflow-pack client examples, no-sensitive telemetry guards, AI-unavailable fallback examples, and
+OpenAPI safety annotations. Improve platform automation for repeatable gaps; otherwise record a
+no-change decision.
+
+#### Mandatory Slice B - Cleanup and Structure
+
+Remove any code or wording that implies AI ownership of investment decisions. Keep AI request
+assembly separate from domain services and persistence. Use PM memo, CIO brief, exception narrative,
+and operations handoff terminology instead of generic "AI text."
+
+#### Mandatory Slice C - Implementation Proof
+
+Capture evidence for AI-ready and AI-unavailable behavior. Review the source evidence input,
+workflow-pack request, bounded response, safety checks, review posture, and persisted provenance.
+
+#### Mandatory Slice D - Second-Last Hardening and Review
+
+Review no-domain-decision enforcement, no-sensitive content posture, OpenAPI examples, error
+handling, fallback behavior, structured logging, metrics labels, and test-pyramid adequacy.
+
+#### Mandatory Slice E - Final Closure
+
+Update wiki with AI boundary and business use cases, update supported-features only after proof,
+record context/skills decisions, and leave branch/PR/CI clean.
+
+### 13.4 Evidence Expectations
+
+Closure evidence must include:
+
+1. PM memo request/response,
+2. AI-unavailable fallback response,
+3. forbidden-action test evidence,
+4. forbidden-claim test evidence,
+5. no-sensitive telemetry proof,
+6. OpenAPI/API certification summary,
+7. local and GitHub check summary.
+
+### 13.5 Enterprise Baseline
+
+This RFC inherits RFC-0037 Section 19.4. Completion requires `lotus-ai` workflow-pack provenance,
+no-sensitive telemetry, bounded AI supportability states, actor review posture, structured logs,
+operator diagnostics, API certification, and GitHub lane evidence for every copilot endpoint.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -7,8 +7,9 @@
 - PostgreSQL-backed persistence and migrations under `src/infrastructure/`
 - consumed primarily through `lotus-gateway`
 - stateless execution is active and advertised
-- stateful core-sourced execution is modeled, guarded, and intentionally disabled until upstream
-  resolver certification is complete
+- stateful core-sourced execution is implemented behind explicit runtime gates and advertised only
+  when core source-product readiness, stateful capability flags, and resolver configuration prove
+  the posture
 
 ```mermaid
 flowchart LR
@@ -31,17 +32,43 @@ flowchart TD
     Bundle --> Engine[DPM engine]
     Mode -->|stateful| Gate{Stateful sourcing enabled and core base URL configured?}
     Gate -->|no| Disabled[DPM_STATEFUL_INPUT_DISABLED or DPM_CORE_RESOLVER_UNAVAILABLE]
-    Gate -->|yes, future| Core[lotus-core DPM execution context]
+    Gate -->|yes| Core[lotus-core RFC-087 source products]
     Core --> Transform[Transform governed context to engine input]
     Transform --> Engine
     Engine --> Result[READY, PENDING_REVIEW, or BLOCKED]
     Result --> Supportability[Run record, artifact, lineage, workflow, metrics]
 ```
 
-The current implemented product mode is `stateless`. Stateful request models, resolver client,
-transformation helpers, and lineage fields are present so the integration boundary is explicit, but
-capabilities do not advertise stateful execution until the governed `lotus-core` source-data
-contract is live-certified.
+The default product mode is `stateless`. Stateful request models, resolver client, transformation
+helpers, and lineage fields are implemented behind explicit runtime gates. Capabilities advertise
+stateful execution only when `DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED`,
+`DPM_STATEFUL_CORE_SOURCING_ENABLED`, and `DPM_CORE_BASE_URL` prove a usable core-sourcing posture.
+
+## Target DPM Operating System Architecture
+
+```mermaid
+flowchart TD
+    Core[lotus-core<br/>portfolio, mandate, model, tax, cash, FX, eligibility]
+    Risk[lotus-risk<br/>risk, stress, concentration]
+    Perf[lotus-performance<br/>returns, attribution, outcome]
+    Manage[lotus-manage<br/>DPM operating system]
+    Report[lotus-report<br/>client, PM, audit packs]
+    AI[lotus-ai<br/>governed PM copilot]
+    Gateway[lotus-gateway]
+    Workbench[lotus-workbench]
+
+    Core --> Manage
+    Risk --> Manage
+    Perf --> Manage
+    Manage --> Report
+    Manage --> AI
+    Manage --> Gateway
+    Gateway --> Workbench
+```
+
+Target-state RFCs may redesign or delete existing manage APIs. The architecture preference is a
+clean, certified, domain-driven `/api/v1` contract rather than backward-compatible aliases for stale
+or poorly named endpoints.
 
 ## Evidence flow
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -20,6 +20,12 @@ This repo owns:
 - run artifacts, lineage, idempotency, and policy-pack supportability
 - management capability publication for gateway and platform consumers
 
+Strategic target-state RFCs now define the proposed revamp into a DPM operating system covering
+mandate digital twins, health scoring, command-center workflows, advanced construction alternatives,
+proof packs, rebalance waves, outcome feedback, and governed AI PM support. See
+[Roadmap](Roadmap) for the business-facing plan and [Supported Features](Supported-Features) for
+the separation between implementation-backed support and proposed target-state features.
+
 This repo does not own:
 
 - advisor-led proposal workflows

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -33,9 +33,9 @@ This repo does not own:
 - canonical host runtime on port `8001` so both services can coexist locally
 - explicit no-alias, OpenAPI, vocabulary, migration, and security governance in CI
 - proposal simulation, artifacts, consent, and lifecycle routes are owned by `lotus-advise`
-- stateless execution is the implemented and advertised runtime mode
-- stateful `portfolio_id` execution is modeled behind guardrails, but not promoted until
-  `lotus-core` exposes the RFC-087 certified composed DPM source-data products
+- stateless execution is the default implemented and advertised runtime mode
+- stateful `portfolio_id` execution is implemented behind explicit runtime gates and promoted only
+  when the canonical core/manage configuration proves RFC-087 source-product readiness
 
 ```mermaid
 flowchart LR
@@ -46,6 +46,25 @@ flowchart LR
     Core[lotus-core] -->|RFC-087 DPM source products| Manage
     Advise[lotus-advise] -. advisor-led proposal workflows .-> Gateway
 ```
+
+## Target Strategic Role
+
+RFC-0037 through RFC-0043 define the proposed revamp from a certified rebalance/supportability
+service into a discretionary mandate portfolio-management operating system.
+
+The target operating model adds:
+
+1. mandate digital twins and health scoring,
+2. portfolio-manager command center,
+3. advanced construction alternatives,
+4. pre-trade proof packs and decision timeline,
+5. CIO model-change and rebalance waves,
+6. post-trade outcome feedback,
+7. governed AI PM copilot.
+
+These are proposed target-state features until implementation and live evidence prove them. They
+may replace older manage APIs rather than preserving backward compatibility because there is no
+assumed production downstream dependency for the target revamp surface.
 
 ## Current Proof Posture
 

--- a/wiki/RFC-Index.md
+++ b/wiki/RFC-Index.md
@@ -44,6 +44,11 @@
 
 ## Strategic Target-State RFCs
 
+These RFCs are proposed roadmap and execution-guide material. They permit clean strategic API
+redesign and endpoint retirement because no production downstream dependency is assumed for the
+revamp surface. They become supported product claims only after implementation, certification, live
+evidence, and supported-feature promotion.
+
 - RFC-0037
   proposed DPM operating-system and mandate-intelligence roadmap intended to make
   `lotus-manage` the management-side crown jewel of the Lotus ecosystem, with the 15 target

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -1,12 +1,78 @@
 # Roadmap
 
-## Current direction
+## Direction
 
-- keep management-side execution and supportability boundaries clean after the service split
-- harden PostgreSQL-only runtime and migration posture
-- deepen integration and supportability validation without weakening deterministic contracts
+`lotus-manage` is being rebuilt as the discretionary mandate portfolio-management operating system
+for Lotus. The goal is not to preserve the old API shape. The goal is a clean, certified,
+enterprise-grade DPM service that can support portfolio managers, CIO offices, compliance,
+operations, sales, and client-demo teams with implementation-backed evidence.
 
-## Watchlist areas
+Current implementation-backed posture:
 
-- `portfolio_id` stateful-mode implementation depth against governed `lotus-core` contracts
-- gateway capability-consumer alignment on canonical snake_case query parameters
+1. management-side rebalance execution and what-if analysis are supported,
+2. run supportability, artifacts, lineage, idempotency, workflow gates, policy packs, and
+   PostgreSQL-backed operational evidence are supported or feature-gated as documented in
+   [Supported Features](Supported-Features),
+3. stateful `portfolio_id` execution is implemented behind explicit runtime gates and composes
+   governed `lotus-core` RFC-087 source products when the canonical core/manage stack is configured,
+4. advisory proposal workflows remain outside this repository and belong to `lotus-advise`.
+
+Strategic posture:
+
+1. no production downstream dependency is assumed for the target RFC-0037 through RFC-0043 surfaces,
+2. duplicate, advisory-era, poorly named, or misleading manage endpoints may be deleted rather than
+   kept for backward compatibility,
+3. future gateway and Workbench integration should be rebuilt against the certified target contract,
+4. every feature must improve enterprise posture through better source authority, auditability,
+   observability, supportability, tests, and documentation.
+
+## Strategic Roadmap
+
+```mermaid
+flowchart TD
+    Foundation[RFC-0038<br/>Mandate digital twin, health score, command center]
+    Construction[RFC-0039<br/>Advanced construction and rebalance alternatives]
+    Evidence[RFC-0040<br/>Pre-trade proof pack and decision timeline]
+    Waves[RFC-0041<br/>CIO model-change impact and rebalance waves]
+    Feedback[RFC-0042<br/>Post-trade outcome feedback]
+    Copilot[RFC-0043<br/>Governed AI PM copilot]
+    Crown[RFC-0037<br/>DPM operating system]
+
+    Foundation --> Construction
+    Construction --> Evidence
+    Evidence --> Waves
+    Waves --> Feedback
+    Evidence --> Copilot
+    Feedback --> Crown
+    Copilot --> Crown
+```
+
+| RFC | Business outcome | Enterprise posture raised by |
+| --- | --- | --- |
+| RFC-0038 | PMs see mandate state, health, exceptions, and book attention queues. | Source-lineage-backed mandate twin, deterministic scoring, certified command-center APIs. |
+| RFC-0039 | PMs compare construction alternatives with visible risk, tax, liquidity, FX, ESG, and cost trade-offs. | Objective/constraint traces, solver supportability, degraded-source handling, certified alternative APIs. |
+| RFC-0040 | PMs, compliance, operations, CIO, and audit can inspect one pre-trade evidence artifact. | Durable proof packs, decision timeline, report/AI handoff contracts, lineage and retention posture. |
+| RFC-0041 | CIO and PM teams can orchestrate book-level model-change and rebalance waves. | Item-level readiness, state-machine governance, actor-attributed approvals, bounded aggregate metrics. |
+| RFC-0042 | PMs learn from expected-versus-realized outcomes after execution. | Source-authoritative realized evidence, variance decomposition, searchable outcome memory. |
+| RFC-0043 | AI assists PM productivity without owning investment truth. | Structured evidence input, forbidden-action guardrails, no-sensitive telemetry, AI-unavailable fallback. |
+
+## Business Value Themes
+
+1. scale PM capacity through exception-based monitoring and wave orchestration,
+2. improve investment discipline through mandate, policy, CIO, risk, tax, liquidity, currency, and
+   ESG controls,
+3. improve trust through proof packs, lineage, decision timelines, and outcome reviews,
+4. strengthen sales and demo material through implementation-backed DPM stories,
+5. raise Lotus ecosystem value by orchestrating `lotus-core`, `lotus-risk`, `lotus-performance`,
+   `lotus-report`, `lotus-ai`, `lotus-gateway`, and `lotus-workbench`.
+
+## Non-Negotiable Delivery Rules
+
+1. target-state features remain `Proposed` until live evidence proves them,
+2. OpenAPI must explain what each endpoint is for, when to use it, how to call it, and every
+   request/response/error field,
+3. every endpoint must expose source-readiness and degraded states rather than hiding missing data,
+4. every implementation must satisfy data-mesh, structured logging, metrics, health, readiness,
+   audit, and supportability standards,
+5. documentation is part of the product and must serve business, engineering, sales, marketing,
+   operations, and client-demo preparation.

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -89,3 +89,26 @@ Final proof is not complete if the validator reports stale OpenAPI certification
 missing request, response, or error examples, even when business execution probes pass. Stateful
 execution is not complete unless the RFC-087 `lotus-core` product-specific source APIs pass
 canonical live proof and manage live proof shows READY stateful source lineage.
+
+## Target-State Roadmap Features
+
+The following are proposed strategic features. They are not supported-feature claims until the
+owning RFC is implemented, certified, live-proven, and this page is updated with implementation
+evidence.
+
+| Proposed capability | Owning RFC | Promotion requirement |
+| --- | --- | --- |
+| Mandate digital twin | RFC-0038 | Source lineage, versioning, persistence, APIs, and live core/manage proof. |
+| Mandate health score | RFC-0038 | Decomposed scoring, reason codes, thresholds, tests, and command-center evidence. |
+| DPM command center | RFC-0038 | Bounded PM-book summary, attention queues, partial-readiness behavior, and certified APIs. |
+| Advanced construction alternatives | RFC-0039 | Persisted comparable alternatives with objective/constraint traces and solver posture. |
+| Tax, liquidity, risk, ESG, currency, and regime-aware construction | RFC-0039 | Source supportability, degraded behavior, field-level OpenAPI, and live proof for each dimension. |
+| Pre-trade proof pack | RFC-0040 | Durable JSON, Markdown, report-input, AI-evidence input, lineage, and hash evidence. |
+| Decision timeline and portfolio memory | RFC-0040 | Linked mandate, exception, alternative, approval, wave, handoff, and outcome events. |
+| CIO model-change and rebalance waves | RFC-0041 | Multi-portfolio wave proof with ready, pending-review, and blocked items. |
+| Post-trade outcome feedback | RFC-0042 | Expected-versus-realized review sourced from core, risk, and performance evidence. |
+| Governed AI PM copilot | RFC-0043 | `lotus-ai` workflow-pack integration, guardrail tests, provenance, and AI-unavailable fallback. |
+
+Target-state features may replace or remove older manage APIs where the new strategic contract is
+cleaner. No backward compatibility adapter should be added unless a later downstream migration RFC
+proves a real production dependency.


### PR DESCRIPTION
## Summary
- Tighten RFC-0037 through RFC-0043 into implementation-ready, gold-standard execution guides.
- Add domain-vocabulary normalization, business/architecture posture, clean strategic API redesign posture, and no-backward-compatibility default for the revamp surface.
- Add supported-feature ledgers, mandatory platform/cleanup/proof/hardening/final-closure slices, evidence expectations, and enterprise data-mesh/observability baselines.
- Refresh README, repository context, and wiki source with implementation-backed current state, target-state roadmap, diagrams, and demo/client-prep posture.

## Validation
- python -m pytest tests\\unit\\test_documentation_current_state.py tests\\unit\\test_local_docker_runtime_contract.py tests\\unit\\dpm\\contracts\\test_contract_openapi_supportability_docs.py -q
- git diff --check
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage

## Wiki
- Repo-local wiki source changed intentionally.
- CheckOnly currently reports expected drift for Architecture.md, Home.md, Overview.md, RFC-Index.md, Roadmap.md, and Supported-Features.md until this PR is merged and the wiki is published.