### PR TITLE
docs: require RFC stranded truth reconciliation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,19 @@ Always:
 6. write meaningful, high-value tests and avoid superficial coverage,
 7. keep commits small, meaningful, and truthful,
 8. remove dead code, duplicate logic, and stale non-standard handling when encountered,
-9. ensure every UI feature is genuinely backed by supported backend functionality.
+9. ensure every UI feature is genuinely backed by supported backend functionality,
+10. ensure RFC/docs/wiki/context/contract closure truth is present on `main`, not stranded on an
+    unmerged side branch.
+
+For RFC, documentation, wiki, context, contract, supported-features, API-governance, migration, or
+CI-workflow changes, run stranded-truth reconciliation before starting implementation, before final
+closure, and before moving to the next RFC:
+
+1. `git fetch origin --prune`,
+2. `git branch -r --no-merged origin/main`,
+3. inspect unmerged branches that touch durable governance paths,
+4. classify each as `must-merge`, `cherry-pick`, `superseded`, `delete`, or `active`,
+5. merge, cherry-pick, explicitly supersede, or delete unique durable truth before claiming closure.
 
 ## Delivery Posture
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -207,6 +207,15 @@ Important validation expectations:
 6. current operational evidence docs under `docs/demo/` and runbooks should preserve canonical
    `lotus-manage` service, image, and ingress identity while clearly labeling historical local-only
    debug paths.
+7. RFC/docs/wiki/context work must include stranded-truth reconciliation before RFC start, final
+   closure, post-merge audit, and move-on to the next RFC. Run `git fetch origin --prune` and
+   `git branch -r --no-merged origin/main`, inspect unmerged branches touching `docs/rfcs/`,
+   `wiki/`, `README.md`, `REPOSITORY-ENGINEERING-CONTEXT.md`, `AGENTS.md`, contracts, standards,
+   OpenAPI/vocabulary, migrations, CI workflows, or supported-features material, and classify each
+   branch as `must-merge`, `cherry-pick`, `superseded`, `delete`, or `active`. This is mandatory
+   because RFC-0036 through RFC-0042 work previously exposed a failure mode where
+   `docs/rfcs/RFC-worktobedone.md` and an RFC-0041 post-closure documentation correction were
+   stranded on unmerged side branches instead of reaching `main`.
 
 ## Standards And RFCs That Govern This Repository
 
@@ -249,6 +258,10 @@ Most relevant current governance:
     no production downstream dependency is assumed for the revamp surface. Any downstream usage
     discovered during implementation should be documented and migrated to the certified target
     contract rather than preserved through permanent compatibility aliases.
+12. durable RFC control artifacts such as `docs/rfcs/RFC-worktobedone.md`, source maps, proof
+    indexes, and supported-feature ledgers must be referenced from stable navigation docs and pinned
+    by `tests/unit/test_documentation_current_state.py` or an equivalent docs/current-state test
+    whenever practical.
 
 ## Context Maintenance Rule
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -6,6 +6,16 @@ Standards for all current and future RFCs:
 Durable cross-RFC follow-up control:
 - `docs/rfcs/RFC-worktobedone.md`
 
+Mandatory branch hygiene for RFC work:
+- Before RFC tightening, implementation start, final closure, post-merge audit, or moving to the
+  next RFC, run stranded-truth reconciliation with `git fetch origin --prune` and
+  `git branch -r --no-merged origin/main`.
+- Inspect unmerged branches that touch `docs/rfcs/`, `wiki/`, README, repository engineering
+  context, AGENTS, contracts, standards, OpenAPI/vocabulary,
+  migrations, CI workflows, or supported-features material.
+- Classify each branch as `must-merge`, `cherry-pick`, `superseded`, `delete`, or `active`.
+  Closure truth that exists only on an unmerged side branch is not complete.
+
 Governance boundary:
 - Service-specific implementation RFCs belong in this repository.
 - Cross-cutting platform and multi-service RFCs belong in `https://github.com/sgajbi/lotus-platform`.

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -339,6 +339,7 @@ def test_rfc0041_slice0_source_map_guardrails_stay_truthful() -> None:
     wiki_index_normalized = " ".join(wiki_index.split())
     roadmap = (ROOT / "wiki" / "Roadmap.md").read_text(encoding="utf-8")
     supported_features = (ROOT / "wiki" / "Supported-Features.md").read_text(encoding="utf-8")
+    development_workflow = (ROOT / "wiki" / "Development-Workflow.md").read_text(encoding="utf-8")
 
     required_sections = [
         "## 1. Critical Review of the Prior Draft",
@@ -486,6 +487,7 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     wiki_index = (ROOT / "wiki" / "RFC-Index.md").read_text(encoding="utf-8")
     roadmap = (ROOT / "wiki" / "Roadmap.md").read_text(encoding="utf-8")
     supported_features = (ROOT / "wiki" / "Supported-Features.md").read_text(encoding="utf-8")
+    development_workflow = (ROOT / "wiki" / "Development-Workflow.md").read_text(encoding="utf-8")
 
     required_sections = [
         "## 1. Critical Review of the Prior Draft",
@@ -692,6 +694,15 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "source map: `docs/rfcs/RFC-0042-source-map-and-gap-analysis.md`" in index
     assert "Durable cross-RFC follow-up control" in index
     assert "docs/rfcs/RFC-worktobedone.md" in index
+    assert "Mandatory branch hygiene for RFC work" in index
+    assert "git branch -r --no-merged origin/main" in index
+    assert "Closure truth that exists only on an unmerged side branch is not complete" in index
+    assert "stranded-truth reconciliation" in development_workflow
+    assert "git branch -r --no-merged origin/main" in development_workflow
+    assert (
+        "do not claim RFC closure while durable truth exists only on an unmerged side branch"
+        in (development_workflow)
+    )
     assert "gold-standard" in wiki_index
     assert "tightening on 2026-05-05" in wiki_index
     assert "Slice 3 pure domain comparison evidence" in wiki_index

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -339,7 +339,6 @@ def test_rfc0041_slice0_source_map_guardrails_stay_truthful() -> None:
     wiki_index_normalized = " ".join(wiki_index.split())
     roadmap = (ROOT / "wiki" / "Roadmap.md").read_text(encoding="utf-8")
     supported_features = (ROOT / "wiki" / "Supported-Features.md").read_text(encoding="utf-8")
-    development_workflow = (ROOT / "wiki" / "Development-Workflow.md").read_text(encoding="utf-8")
 
     required_sections = [
         "## 1. Critical Review of the Prior Draft",

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -5,6 +5,13 @@
 - branch from `main`
 - keep one branch per RFC or documentation slice
 - use PR-first delivery
+- before RFC tightening, implementation start, final closure, post-merge audit, or moving to the
+  next RFC, run stranded-truth reconciliation:
+  `git fetch origin --prune` and `git branch -r --no-merged origin/main`
+- classify every unmerged branch that touches RFC, wiki, README, context, AGENTS, contracts,
+  standards, OpenAPI/vocabulary, migrations, CI workflows, or supported-features truth as
+  `must-merge`, `cherry-pick`, `superseded`, `delete`, or `active`
+- do not claim RFC closure while durable truth exists only on an unmerged side branch
 
 ## Repo-native commands
 
@@ -23,3 +30,5 @@
 - keep `wiki/` as the authored wiki source
 - keep deep implementation detail in `docs/`
 - inspect generated API vocabulary diffs before committing docs-only slices
+- index durable control artifacts such as RFC ledgers and pin them with docs/current-state tests
+  when a test pack exists


### PR DESCRIPTION
## Summary

Adds a repo-local RFC branch hygiene rule so lotus-manage cannot repeat the RFC work-to-be-done ledger incident.

## Changes

- Syncs the updated Lotus AGENTS operating contract.
- Adds stranded-truth reconciliation to repo engineering context.
- Adds the rule to the RFC index/navigation page.
- Adds the rule to the wiki Development Workflow page.
- Pins the rule in `tests/unit/test_documentation_current_state.py`.
- Deleted stale remote branches `docs/rfc41-work-to-be-done-ledger` and `docs/rfc0042-gold-standard-tightening` after confirming their useful truth is now on `main`.

## Evidence

- `python -m ruff format --check tests\unit\test_documentation_current_state.py` -> passed after formatting
- `python -m pytest tests\unit\test_documentation_current_state.py -q` -> 13 passed
- `git diff --check` -> passed
- `git fetch origin --prune; git branch -r --no-merged origin/main` -> no unmerged remote branches after cleanup

## Wiki

Repo-authored wiki source changed (`wiki/Development-Workflow.md`). Publish after merge with `Sync-RepoWikis.ps1 -Publish -Repository lotus-manage`. `CheckOnly` currently reports expected drift for that page until publication.