### PR TITLE
feat: adapt performance realized outcome sources

### DIFF
--- a/docs/rfcs/RFC-0042-realized-source-adapters-slice5.md
+++ b/docs/rfcs/RFC-0042-realized-source-adapters-slice5.md
@@ -20,8 +20,13 @@ Slice 5 adds the source-owner realized evidence boundary:
    into comparable `DpmOutcomeMetricValue` entries.
 3. Degraded, blocked, missing, stale, unavailable, partial, malformed, conflicting, and not-supported
    source behavior.
-4. Unit tests covering ready source evidence, missing execution evidence, missing risk/performance
-   contracts, stale source degradation, conflicting source values, and malformed source blocking.
+4. A follow-on WTBD-006 performance adapter in `src/core/outcomes/performance_sources.py` that
+   wraps `lotus-performance` workspace-summary TWR return output into RFC-0042 realized
+   `PERFORMANCE` evidence without recalculating performance methodology locally.
+5. Unit tests covering ready source evidence, missing execution evidence, missing risk/performance
+   contracts, stale source degradation, conflicting source values, malformed source blocking,
+   performance source wrapping, degraded performance-source posture, and malformed performance
+   payload rejection.
 
 ## Source-Owner Boundary
 
@@ -33,7 +38,7 @@ in this slice and does not calculate source-owner truth locally.
 | `lotus-core` | Can provide explicit realized snapshots for holdings drift, booked transaction cost, cash residual, tax, FX, and rule evidence when a certified source contract is supplied. Missing or malformed evidence blocks affected dimensions. |
 | execution/OMS owner | No certified first-wave fill/order contract is assumed. Missing execution evidence emits `EXECUTION_EVIDENCE_BLOCKED`. |
 | `lotus-risk` | Existing risk APIs exist, but no RFC-0042-certified review-window outcome contract is assumed by manage. Missing risk evidence emits `RISK_OUTCOME_NOT_SUPPORTED`. |
-| `lotus-performance` | Existing performance APIs exist, but no RFC-0042-certified review-window outcome contract is assumed by manage. Missing performance evidence emits `PERFORMANCE_OUTCOME_NOT_SUPPORTED`. |
+| `lotus-performance` | First supported adapter consumes `WORKSPACE_SUMMARY_TWR_RETURN` evidence from the `lotus-performance` workspace-summary response. It performs only percentage-point to ratio unit conversion plus lineage wrapping. Missing evidence still emits `PERFORMANCE_OUTCOME_NOT_SUPPORTED`; unavailable evidence remains degraded as `PERFORMANCE_SOURCE_UNAVAILABLE`. Richer MWR, contribution, and attribution outcome adapters remain source-owner follow-on work. |
 
 ## Degraded-State Mapping
 
@@ -46,6 +51,31 @@ in this slice and does not calculate source-owner truth locally.
 | Missing `EXECUTION_QUALITY` source | `BLOCKED` with `EXECUTION_EVIDENCE_BLOCKED` |
 | Missing `RISK_REDUCTION` source | `NOT_SUPPORTED` with `RISK_OUTCOME_NOT_SUPPORTED` |
 | Missing `PERFORMANCE` source | `NOT_SUPPORTED` with `PERFORMANCE_OUTCOME_NOT_SUPPORTED` |
+| `lotus-performance` workspace-summary TWR source | `READY` when the source response includes the selected period, basis, measure, calculation id, and numeric base return |
+| Unavailable `lotus-performance` workspace-summary source | `DEGRADED` with `PERFORMANCE_SOURCE_UNAVAILABLE` plus the source-supplied reason code |
+
+## Performance Adapter Contract
+
+`realized_performance_source_from_workspace_summary` accepts a validated `lotus-performance`
+workspace-summary response and emits a `DpmRealizedSourceSnapshot` for `PERFORMANCE`.
+
+Implemented behavior:
+
+1. source owner remains `lotus-performance`,
+2. source type is `WORKSPACE_SUMMARY_TWR_RETURN`,
+3. default period/basis/measure is `YTD` / `net` / `cumulative_return`,
+4. values are converted from `lotus-performance` percentage-point units to RFC-0042 ratio units,
+5. `calculation_id`, `calculation_hash`, selected period, selected basis, selected measure, and
+   source reason codes are preserved as lineage/supportability evidence,
+6. malformed source payloads raise `PerformanceOutcomeSourceError` and cannot silently produce a
+   ready outcome value.
+
+Out of scope for this adapter:
+
+1. computing TWR locally,
+2. deriving benchmark-relative performance,
+3. calculating MWR, contribution, or attribution,
+4. fabricating missing source freshness or observation timestamps.
 
 ## Validation
 
@@ -53,16 +83,21 @@ Commands:
 
 ```powershell
 python -m pytest tests\unit\core\test_realized_outcome_sources.py -q
+python -m pytest tests\unit\core\test_performance_realized_outcome_sources.py tests\unit\core\test_realized_outcome_sources.py -q
 python -m ruff check src\core\outcomes tests\unit\core\test_realized_outcome_sources.py
 ```
 
 Observed result:
 
 1. `6 passed`
-2. `All checks passed!`
+2. `17 passed`
+3. `All checks passed!`
 
 ## Supported-Feature Decision
 
-No supported feature is promoted by Slice 5. This slice proves source evidence translation and
-degraded-state handling only. Runtime support still requires durable persistence, APIs, OpenAPI
-certification, live evidence, documentation publication, and downstream realization where surfaced.
+The WTBD-006 performance adapter promotes only an implementation-backed source-integration
+capability inside manage: RFC-0042 can now mark `PERFORMANCE` ready when a certified
+`lotus-performance` workspace-summary TWR response is supplied to the realized-source boundary.
+It does not promote a full post-trade outcome-review product claim by itself. Runtime support still
+requires durable persistence, APIs, OpenAPI certification, live evidence, documentation publication,
+and downstream realization where surfaced.

--- a/docs/rfcs/RFC-0042-source-map-and-gap-analysis.md
+++ b/docs/rfcs/RFC-0042-source-map-and-gap-analysis.md
@@ -119,8 +119,15 @@ blocked, and not-supported source evidence without calculating source-owner trut
 
 The implementation records the first-wave boundary: missing execution evidence emits
 `EXECUTION_EVIDENCE_BLOCKED`, missing risk evidence emits `RISK_OUTCOME_NOT_SUPPORTED`, and missing
-performance evidence emits `PERFORMANCE_OUTCOME_NOT_SUPPORTED` until certified review-window
-contracts exist.
+performance evidence emits `PERFORMANCE_OUTCOME_NOT_SUPPORTED`.
+
+The WTBD-006 performance follow-on adds the first source-owner adapter for `lotus-performance`
+workspace-summary TWR output. `src/core/outcomes/performance_sources.py` wraps
+`WORKSPACE_SUMMARY_TWR_RETURN` evidence into RFC-0042 `PERFORMANCE` realized-source snapshots,
+preserving calculation id, calculation hash, selected period, selected basis, selected measure, and
+source reason codes. The adapter only converts source-owned percentage-point values into RFC-0042
+ratio units; it does not compute TWR, benchmark-relative performance, MWR, contribution, or
+attribution in manage.
 
 No supported feature is promoted by Slice 5.
 
@@ -269,7 +276,7 @@ can be claimed.
 | FX executions and currency exposures | `lotus-core` or treasury source owner | `FX_OUTCOME` | Source-owner required | Consume source product; no local treasury-depth reconstruction. |
 | Tax lots and realized tax | `lotus-core` or tax source owner | `TAX_OUTCOME` | Source-owner required | Consume source product; no manage-local tax-lot authority. |
 | Risk after execution | `lotus-risk` | `RISK_OUTCOME` | Supported only if endpoint supports review window and portfolio context | Consume risk owner output and supportability; otherwise mark not supported/degraded. |
-| Returns series/TWR/MWR/contribution/attribution | `lotus-performance` | `PERFORMANCE_OUTCOME` | Supported only if endpoint supports review window and benchmark context | Consume performance owner output and supportability; otherwise mark not supported/degraded. |
+| Returns series/TWR/MWR/contribution/attribution | `lotus-performance` | `PERFORMANCE_OUTCOME` | Workspace-summary TWR return output is the first implemented adapter; broader review-window MWR, contribution, attribution, and benchmark-relative outcome contracts remain source-owner follow-on work. | Consume performance owner output and supportability; otherwise mark not supported/degraded. |
 | Report artifact | `lotus-report`, `lotus-render`, `lotus-archive` | Reports and archive | Downstream only | Manage emits `DpmOutcomeReportInput`; no artifact claim. |
 | AI memo/copilot output | `lotus-ai` | AI assistance | Downstream only | Manage emits `DpmOutcomeAiEvidenceInput`; no narrative claim. |
 | Product composition | `lotus-gateway` | Product API | Downstream RFC required | Gateway must preserve manage truth and source supportability. |
@@ -283,7 +290,7 @@ can be claimed.
 | --- | --- | --- |
 | `DRIFT_OUTCOME` | Expected target/current state plus post-trade holdings are source-backed. | `DRIFT_SOURCE_INCOMPLETE` if holdings or expected target is missing. |
 | `RISK_OUTCOME` | `lotus-risk` provides post-trade risk for the review window with supportability. | `RISK_OUTCOME_NOT_SUPPORTED` or `RISK_SOURCE_UNAVAILABLE`. |
-| `PERFORMANCE_OUTCOME` | `lotus-performance` provides returns/contribution/attribution for the review window. | `PERFORMANCE_OUTCOME_NOT_SUPPORTED` or `PERFORMANCE_SOURCE_UNAVAILABLE`. |
+| `PERFORMANCE_OUTCOME` | `lotus-performance` provides source-owned workspace-summary TWR return output for the selected period/basis/measure; richer contribution, attribution, MWR, and benchmark-relative evidence require future source-owner contracts. | `PERFORMANCE_OUTCOME_NOT_SUPPORTED` or `PERFORMANCE_SOURCE_UNAVAILABLE`. |
 | `TURNOVER_OUTCOME` | Booked transaction window is source-backed. | `TRANSACTION_SOURCE_INCOMPLETE`. |
 | `TRANSACTION_COST_OUTCOME` | Realized cost source is available and comparable to estimated cost basis. | `COST_SOURCE_INCOMPLETE`. |
 | `TAX_OUTCOME` | Realized tax/tax-lot evidence is source-backed. | `TAX_SOURCE_INCOMPLETE`. |

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -2257,7 +2257,7 @@ artifacts belong to report/render/archive services, and AI narrative execution b
 | RFC42-WTBD-003 | Full front-office post-trade outcome feedback product support | `lotus-gateway`, `lotus-workbench`, `lotus-manage` | Implemented and canonically proven for current Gateway/Workbench outcome-review product scope through `lotus-gateway` PR #186, `lotus-gateway` PR #187, `lotus-workbench` PR #146, `lotus-platform` PR #300, and `lotus-core` PR #336 | The full first-wave product path is now implementation-backed: manage owns authority, Gateway composes it, Workbench renders it, panel governance certifies it, and live canonical evidence proves it. Reporting, AI, OMS, source-owner methodology, and PM-scoring scope remain separate ledger items. |
 | RFC42-WTBD-004 | Rendered outcome reports and archive lifecycle | `lotus-report`, `lotus-render`, `lotus-archive`, `lotus-gateway`, `lotus-workbench` | Implemented, merged, CI-proven, and wiki-published through `lotus-render` PR #9, `lotus-archive` PR #21, `lotus-report` PR #88, `lotus-gateway` PR #188, and `lotus-workbench` PR #147 | Manage emits bounded report input only; downstream services now consume it to create deterministic outcome-review report artifacts, preserve archive posture, expose Gateway submission, and add the Workbench report request action without recomputing outcome truth. |
 | RFC42-WTBD-005 | Governed AI narrative/copilot over outcome evidence | `lotus-ai`, Gateway, Workbench, with manage as evidence authority | Implemented, merged, CI-proven, and wiki-published through `lotus-ai` PR #59/#60, `lotus-gateway` PR #189, and `lotus-workbench` PR #148 | Manage emits AI evidence input only; `lotus-ai` now owns guarded workflow-pack narrative execution, Gateway composes the evidence/narrative BFF, and Workbench exposes only a governed request action without prompt construction or autonomous decisioning. |
-| RFC42-WTBD-006 | Source-owned realized risk/performance/tax/FX/cash outcome methodologies | `lotus-risk`, `lotus-performance`, `lotus-core`, future source owners | Source-owner follow-on | RFC-0042 preserves missing/unsupported/degraded source states instead of cloning calculations in manage. |
+| RFC42-WTBD-006 | Source-owned realized risk/performance/tax/FX/cash outcome methodologies | `lotus-risk`, `lotus-performance`, `lotus-core`, future source owners | In progress source-family by source-family | Performance workspace-summary TWR output now has a manage adapter; remaining risk, richer performance, tax, FX, cash, liquidity, and execution methodologies stay source-owner follow-on work. |
 | RFC42-WTBD-007 | External execution/OMS integration and acknowledgements | Execution/OMS owner, `lotus-manage` consumer | Ownership not established | RFC-0042 can compare expected and realized evidence, but OMS integration needs a separate owner, controls, acknowledgements, and reconciliation contract. |
 | RFC42-WTBD-008 | PM quality scoring or behavioral analytics | Business owner, methodology owner, `lotus-ai` only if approved | Not supported | RFC-0042 intentionally avoids scoring PMs. Any future scoring requires business approval, auditable methodology, bias controls, and governance. |
 
@@ -2592,10 +2592,26 @@ Target business outcome:
 Outcome reviews can compare richer realized evidence across risk, performance, tax, FX, cash,
 liquidity, and execution dimensions using source-owner methodologies and certified contracts.
 
+Implementation-backed progress:
+
+1. `src/core/outcomes/performance_sources.py` adds the first WTBD-006 source-family adapter for
+   `lotus-performance` workspace-summary TWR return evidence,
+2. the adapter consumes source-owned `WORKSPACE_SUMMARY_TWR_RETURN` output and converts
+   percentage-point return units to RFC-0042 ratio units without calculating performance locally,
+3. source lineage is preserved through calculation id, calculation hash, selected period, selected
+   basis, selected measure, source owner, source type, and reason codes,
+4. focused tests prove ready, missing, degraded/unavailable, explicit basis/measure, and malformed
+   payload behavior,
+5. no broader performance methodology is claimed yet: MWR, contribution, attribution,
+   benchmark-relative analysis, and full review-window performance contracts remain source-owner
+   follow-on scope.
+
 Why it cannot be done now:
 
-RFC-0042 intentionally avoided local calculation clones. Missing source-owner methods are surfaced
-as degraded, unsupported, unavailable, malformed, conflicting, or blocked states.
+RFC-0042 intentionally avoided local calculation clones. The first performance adapter is possible
+because `lotus-performance` already publishes workspace-summary TWR output. Remaining source-owner
+methods are surfaced as degraded, unsupported, unavailable, malformed, conflicting, or blocked
+states until their owning applications publish certified contracts.
 
 Dependencies before implementation:
 

--- a/src/core/outcomes/__init__.py
+++ b/src/core/outcomes/__init__.py
@@ -31,6 +31,11 @@ from src.core.outcomes.snapshots import (
     assemble_expected_outcome_snapshot,
 )
 from src.core.outcomes.realized_sources import assemble_realized_outcome_snapshot
+from src.core.outcomes.performance_sources import (
+    PerformanceOutcomeSourceError,
+    realized_performance_source_from_workspace_summary,
+    unavailable_performance_source,
+)
 from src.core.outcomes.handoffs import (
     OUTCOME_AI_EVIDENCE_REF_TYPE,
     OUTCOME_REPORT_INPUT_REF_TYPE,
@@ -71,6 +76,7 @@ __all__ = [
     "OutcomeReviewState",
     "OUTCOME_AI_EVIDENCE_REF_TYPE",
     "OUTCOME_REPORT_INPUT_REF_TYPE",
+    "PerformanceOutcomeSourceError",
     "assemble_expected_outcome_snapshot",
     "assemble_realized_outcome_snapshot",
     "assert_no_ai_forbidden_fields",
@@ -78,4 +84,6 @@ __all__ = [
     "build_report_input",
     "compare_outcome_dimension",
     "compare_outcome_dimensions",
+    "realized_performance_source_from_workspace_summary",
+    "unavailable_performance_source",
 ]

--- a/src/core/outcomes/performance_sources.py
+++ b/src/core/outcomes/performance_sources.py
@@ -1,0 +1,110 @@
+"""Source-owned performance realized evidence adapters for RFC-0042."""
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal
+
+from src.core.outcomes.models import DpmRealizedSourceSnapshot
+
+PerformanceReturnMeasure = Literal["period_return", "cumulative_return", "annualized_return"]
+PerformanceBasis = Literal["net", "gross"]
+
+
+class PerformanceOutcomeSourceError(ValueError):
+    """Raised when a lotus-performance response cannot produce bounded outcome evidence."""
+
+
+def realized_performance_source_from_workspace_summary(
+    response: dict[str, Any],
+    *,
+    period: str = "YTD",
+    basis: PerformanceBasis = "net",
+    return_measure: PerformanceReturnMeasure = "cumulative_return",
+) -> DpmRealizedSourceSnapshot:
+    """Adapt lotus-performance workspace-summary output without recalculating performance truth.
+
+    lotus-performance publishes return values in percentage-point units. RFC-0042 outcome
+    comparisons use ratio units, so this adapter performs only a unit conversion and lineage
+    wrapping; it does not compute returns, benchmark effects, or portfolio economics locally.
+    """
+
+    period_result = _read_mapping(_read_mapping(response.get("results_by_period")).get(period))
+    portfolio_twr = _read_mapping(period_result.get("portfolio_twr"))
+    basis_block = _read_mapping(portfolio_twr.get(basis))
+    summary = _read_mapping(basis_block.get("summary"))
+    return_value = _read_mapping(summary.get(return_measure))
+    base_return = _decimal_from_percentage_points(return_value.get("base"))
+    meta = _read_mapping(response.get("meta"))
+    diagnostics = _read_mapping(response.get("diagnostics"))
+    periods = _read_mapping(meta.get("periods"))
+    calculation_id = _read_text(response.get("calculation_id")) or _read_text(
+        meta.get("calculation_id")
+    )
+    if calculation_id is None:
+        raise PerformanceOutcomeSourceError(
+            "lotus-performance workspace summary is missing calculation_id"
+        )
+
+    calculation_hash = _read_text(meta.get("calculation_hash"))
+    source_id = f"{calculation_id}:{period}:{basis}:{return_measure}"
+    reason_codes = [
+        "PERFORMANCE_SOURCE_READY",
+        f"PERFORMANCE_PERIOD_{period}",
+        f"PERFORMANCE_BASIS_{basis.upper()}",
+        f"PERFORMANCE_MEASURE_{return_measure.upper()}",
+    ]
+    return DpmRealizedSourceSnapshot(
+        dimension="PERFORMANCE",
+        source_system="lotus-performance",
+        source_type="WORKSPACE_SUMMARY_TWR_RETURN",
+        source_id=source_id,
+        value=base_return,
+        unit="ratio",
+        source_state="READY",
+        quality="COMPLETE",
+        observed_at=None,
+        as_of_date=_read_text(periods.get("master_end"))
+        or _read_text(diagnostics.get("effective_period_start")),
+        content_hash=calculation_hash,
+        reason_codes=reason_codes,
+    )
+
+
+def unavailable_performance_source(
+    *,
+    source_id: str,
+    reason_code: str,
+    as_of_date: str | None = None,
+) -> DpmRealizedSourceSnapshot:
+    """Return bounded unavailable performance evidence when lotus-performance cannot serve truth."""
+
+    return DpmRealizedSourceSnapshot(
+        dimension="PERFORMANCE",
+        source_system="lotus-performance",
+        source_type="WORKSPACE_SUMMARY_TWR_RETURN",
+        source_id=source_id,
+        value=None,
+        unit="ratio",
+        source_state="DEGRADED",
+        quality="UNAVAILABLE",
+        observed_at=None,
+        as_of_date=as_of_date,
+        content_hash=None,
+        reason_codes=[reason_code],
+    )
+
+
+def _read_mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _read_text(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _decimal_from_percentage_points(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value)) / Decimal("100")
+    except (InvalidOperation, TypeError) as exc:
+        raise PerformanceOutcomeSourceError(
+            "lotus-performance workspace summary is missing a numeric base return"
+        ) from exc

--- a/tests/unit/core/test_performance_realized_outcome_sources.py
+++ b/tests/unit/core/test_performance_realized_outcome_sources.py
@@ -1,0 +1,139 @@
+import pytest
+
+from src.core.outcomes import (
+    PerformanceOutcomeSourceError,
+    assemble_realized_outcome_snapshot,
+    realized_performance_source_from_workspace_summary,
+    unavailable_performance_source,
+)
+from tests.unit.core.test_realized_outcome_sources import _window
+
+
+def _workspace_summary() -> dict[str, object]:
+    return {
+        "calculation_id": "0d000003-1111-4222-8333-abcdefabcdef",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "input_mode": "stateful",
+        "results_by_period": {
+            "YTD": {
+                "portfolio_twr": {
+                    "net": {
+                        "summary": {
+                            "period_return": {"base": 2.41, "local": 2.12, "fx": 0.29},
+                            "cumulative_return": {"base": 3.41, "local": 3.18, "fx": 0.23},
+                            "annualized_return": {"base": 3.41, "local": 3.18, "fx": 0.23},
+                        },
+                        "breakdowns": {},
+                    },
+                    "gross": {
+                        "summary": {
+                            "period_return": {"base": 2.44, "local": 2.15, "fx": 0.29},
+                            "cumulative_return": {"base": 3.44, "local": 3.21, "fx": 0.23},
+                            "annualized_return": {"base": 3.44, "local": 3.21, "fx": 0.23},
+                        },
+                        "breakdowns": {},
+                    },
+                }
+            }
+        },
+        "meta": {
+            "calculation_id": "0d000003-1111-4222-8333-abcdefabcdef",
+            "calculation_hash": "sha256:workspace-summary",
+            "periods": {"master_start": "2026-01-02", "master_end": "2026-05-06"},
+        },
+        "diagnostics": {"effective_period_start": "2026-01-02", "notes": []},
+        "audit": {"counts": {"input_rows": 64}},
+    }
+
+
+def test_performance_workspace_summary_adapter_wraps_source_truth_without_recalculation() -> None:
+    source = realized_performance_source_from_workspace_summary(_workspace_summary())
+
+    assert source.dimension == "PERFORMANCE"
+    assert source.source_system == "lotus-performance"
+    assert source.source_type == "WORKSPACE_SUMMARY_TWR_RETURN"
+    assert source.source_id == "0d000003-1111-4222-8333-abcdefabcdef:YTD:net:cumulative_return"
+    assert str(source.value) == "0.0341"
+    assert source.unit == "ratio"
+    assert source.content_hash == "sha256:workspace-summary"
+    assert source.reason_codes == [
+        "PERFORMANCE_SOURCE_READY",
+        "PERFORMANCE_PERIOD_YTD",
+        "PERFORMANCE_BASIS_NET",
+        "PERFORMANCE_MEASURE_CUMULATIVE_RETURN",
+    ]
+
+
+def test_performance_workspace_summary_adapter_supports_explicit_basis_and_measure() -> None:
+    source = realized_performance_source_from_workspace_summary(
+        _workspace_summary(),
+        basis="gross",
+        return_measure="period_return",
+    )
+
+    assert str(source.value) == "0.0244"
+    assert source.source_id.endswith(":YTD:gross:period_return")
+    assert "PERFORMANCE_BASIS_GROSS" in source.reason_codes
+    assert "PERFORMANCE_MEASURE_PERIOD_RETURN" in source.reason_codes
+
+
+def test_performance_source_can_make_rfc42_performance_dimension_ready() -> None:
+    source = realized_performance_source_from_workspace_summary(_workspace_summary())
+
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[source],
+        required_dimensions=["PERFORMANCE"],
+    )
+
+    performance = snapshot.realized_values["PERFORMANCE"]
+    assert snapshot.supportability.state == "READY"
+    assert performance.value == source.value
+    assert performance.source_refs[0].source_system == "lotus-performance"
+    assert performance.supportability.reason_codes[0] == "SOURCE_READY"
+
+
+def test_missing_performance_source_still_reports_not_supported_without_local_clone() -> None:
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[],
+        required_dimensions=["PERFORMANCE"],
+    )
+
+    assert snapshot.supportability.state == "NOT_SUPPORTED"
+    assert snapshot.realized_values["PERFORMANCE"].supportability.reason_codes == [
+        "PERFORMANCE_OUTCOME_NOT_SUPPORTED"
+    ]
+
+
+def test_unavailable_performance_source_preserves_degraded_owner_posture() -> None:
+    source = unavailable_performance_source(
+        source_id="performance-down:YTD:net:cumulative_return",
+        reason_code="PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE",
+        as_of_date="2026-05-06",
+    )
+
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[source],
+        required_dimensions=["PERFORMANCE"],
+    )
+
+    performance = snapshot.realized_values["PERFORMANCE"]
+    assert snapshot.supportability.state == "DEGRADED"
+    assert performance.value is None
+    assert performance.supportability.reason_codes[:2] == [
+        "PERFORMANCE_SOURCE_UNAVAILABLE",
+        "PERFORMANCE_WORKSPACE_SUMMARY_UNAVAILABLE",
+    ]
+
+
+def test_performance_adapter_rejects_malformed_source_payload() -> None:
+    malformed = _workspace_summary()
+    del malformed["results_by_period"]
+
+    with pytest.raises(PerformanceOutcomeSourceError, match="numeric base return"):
+        realized_performance_source_from_workspace_summary(malformed)

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -616,7 +616,9 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     )
     assert "does not calculate source-owner truth locally" in realized_source_slice
     assert "Missing `EXECUTION_QUALITY` source" in realized_source_slice
-    assert "`6 passed`" in realized_source_slice
+    assert "WORKSPACE_SUMMARY_TWR_RETURN" in realized_source_slice
+    assert "performance_sources.py" in realized_source_slice
+    assert "`17 passed`" in realized_source_slice
 
     assert "Slice 6 - Persistence, Repository, Events, and Retention" in persistence_slice
     assert "Review body is immutable" in persistence_slice


### PR DESCRIPTION
## Summary
- add a source-owned `lotus-performance` workspace-summary TWR adapter for RFC-0042 realized `PERFORMANCE` evidence
- preserve missing and unavailable performance source behavior without calculating performance truth in manage
- update RFC-0042 source maps, Slice 5 evidence, and the WTBD ledger to reflect implemented performance progress and remaining source-owner families

## Validation
- `python -m pytest tests/unit/core/test_performance_realized_outcome_sources.py tests/unit/core/test_realized_outcome_sources.py tests/unit/test_documentation_current_state.py -q` => 30 passed
- `make lint` => passed
- `make typecheck` => passed
- `make test-unit` => 839 passed, 13 skipped, 2 warnings
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` => DiffCount 0
- `git branch -r --no-merged origin/main` => no stranded remote branches
- `make check` => passed, including lint, no-alias, typecheck, OpenAPI, API vocabulary, mesh contracts, and 852 unit tests

## Wiki Decision
No repo-local wiki source change is required for this slice. This is a manage source-adapter and RFC/ledger truth update, not a new product-facing supported-feature promotion.