### PR TITLE
feat: adapt risk realized outcome sources

### DIFF
--- a/docs/rfcs/RFC-0042-realized-source-adapters-slice5.md
+++ b/docs/rfcs/RFC-0042-realized-source-adapters-slice5.md
@@ -23,10 +23,14 @@ Slice 5 adds the source-owner realized evidence boundary:
 4. A follow-on WTBD-006 performance adapter in `src/core/outcomes/performance_sources.py` that
    wraps `lotus-performance` workspace-summary TWR return output into RFC-0042 realized
    `PERFORMANCE` evidence without recalculating performance methodology locally.
-5. Unit tests covering ready source evidence, missing execution evidence, missing risk/performance
+5. A follow-on WTBD-006 risk adapter in `src/core/outcomes/risk_sources.py` that wraps
+   `lotus-risk` `RiskMetricsReport:v1` output into RFC-0042 realized `RISK_REDUCTION` evidence
+   without recalculating risk methodology locally.
+6. Unit tests covering ready source evidence, missing execution evidence, missing risk/performance
    contracts, stale source degradation, conflicting source values, malformed source blocking,
-   performance source wrapping, degraded performance-source posture, and malformed performance
-   payload rejection.
+   performance source wrapping, degraded performance-source posture, malformed performance payload
+   rejection, risk source wrapping, risk supportability preservation, permission-blocked risk
+   posture, and malformed risk payload rejection.
 
 ## Source-Owner Boundary
 
@@ -37,7 +41,7 @@ in this slice and does not calculate source-owner truth locally.
 | --- | --- |
 | `lotus-core` | Can provide explicit realized snapshots for holdings drift, booked transaction cost, cash residual, tax, FX, and rule evidence when a certified source contract is supplied. Missing or malformed evidence blocks affected dimensions. |
 | execution/OMS owner | No certified first-wave fill/order contract is assumed. Missing execution evidence emits `EXECUTION_EVIDENCE_BLOCKED`. |
-| `lotus-risk` | Existing risk APIs exist, but no RFC-0042-certified review-window outcome contract is assumed by manage. Missing risk evidence emits `RISK_OUTCOME_NOT_SUPPORTED`. |
+| `lotus-risk` | First supported adapter consumes `RiskMetricsReport:v1` evidence from the `lotus-risk` risk-calculate response. It preserves request fingerprint, selected period, selected risk metric, source supportability, and source reason codes. Missing evidence still emits `RISK_OUTCOME_NOT_SUPPORTED`; unavailable evidence remains degraded as `RISK_SOURCE_UNAVAILABLE`. Historical attribution, rolling-risk, drawdown-report, and concentration-specific outcome adapters remain source-owner follow-on work. |
 | `lotus-performance` | First supported adapter consumes `WORKSPACE_SUMMARY_TWR_RETURN` evidence from the `lotus-performance` workspace-summary response. It performs only percentage-point to ratio unit conversion plus lineage wrapping. Missing evidence still emits `PERFORMANCE_OUTCOME_NOT_SUPPORTED`; unavailable evidence remains degraded as `PERFORMANCE_SOURCE_UNAVAILABLE`. Richer MWR, contribution, and attribution outcome adapters remain source-owner follow-on work. |
 
 ## Degraded-State Mapping
@@ -51,8 +55,37 @@ in this slice and does not calculate source-owner truth locally.
 | Missing `EXECUTION_QUALITY` source | `BLOCKED` with `EXECUTION_EVIDENCE_BLOCKED` |
 | Missing `RISK_REDUCTION` source | `NOT_SUPPORTED` with `RISK_OUTCOME_NOT_SUPPORTED` |
 | Missing `PERFORMANCE` source | `NOT_SUPPORTED` with `PERFORMANCE_OUTCOME_NOT_SUPPORTED` |
+| `lotus-risk` risk metrics report source | `READY` when the source response includes the selected period, selected metric, request fingerprint, ready supportability, and numeric metric value |
+| Degraded `lotus-risk` risk metrics report source | `DEGRADED` when source supportability is stale/degraded/empty/error while preserving source reason posture |
+| Permission-blocked `lotus-risk` risk metrics report source | `BLOCKED` with source reason posture preserved and no ready value claim |
+| Unavailable `lotus-risk` risk metrics report source | `DEGRADED` with `RISK_SOURCE_UNAVAILABLE` plus the source-supplied reason code |
 | `lotus-performance` workspace-summary TWR source | `READY` when the source response includes the selected period, basis, measure, calculation id, and numeric base return |
 | Unavailable `lotus-performance` workspace-summary source | `DEGRADED` with `PERFORMANCE_SOURCE_UNAVAILABLE` plus the source-supplied reason code |
+
+## Risk Adapter Contract
+
+`realized_risk_source_from_risk_metrics_report` accepts a validated `lotus-risk`
+`RiskMetricsReport:v1` response and emits a `DpmRealizedSourceSnapshot` for `RISK_REDUCTION`.
+
+Implemented behavior:
+
+1. source owner remains `lotus-risk`,
+2. source type is `RISK_METRICS_REPORT`,
+3. default period/metric is `YTD` / `VOLATILITY`,
+4. source metric values are preserved in source units without local risk recalculation,
+5. `metadata.request_fingerprint`, selected period, selected metric, source supportability state,
+   supportability reason, and as-of date are preserved as lineage/supportability evidence,
+6. permission-blocked source responses become `BLOCKED` rather than degraded or ready claims,
+7. malformed source payloads or missing ready metric values raise `RiskOutcomeSourceError` and
+   cannot silently produce a ready outcome value.
+
+Out of scope for this adapter:
+
+1. calculating volatility, drawdown, VaR, Sharpe, Sortino, beta, tracking error, or information
+   ratio locally,
+2. deriving risk attribution or concentration outcome metrics,
+3. transforming signed VaR into a positive loss convention,
+4. fabricating missing source fingerprints, freshness, or observation timestamps.
 
 ## Performance Adapter Contract
 
@@ -84,6 +117,7 @@ Commands:
 ```powershell
 python -m pytest tests\unit\core\test_realized_outcome_sources.py -q
 python -m pytest tests\unit\core\test_performance_realized_outcome_sources.py tests\unit\core\test_realized_outcome_sources.py -q
+python -m pytest tests\unit\core\test_risk_realized_outcome_sources.py tests\unit\core\test_realized_outcome_sources.py -q
 python -m ruff check src\core\outcomes tests\unit\core\test_realized_outcome_sources.py
 ```
 
@@ -91,13 +125,15 @@ Observed result:
 
 1. `6 passed`
 2. `17 passed`
-3. `All checks passed!`
+3. `20 passed`
+4. `All checks passed!`
 
 ## Supported-Feature Decision
 
-The WTBD-006 performance adapter promotes only an implementation-backed source-integration
-capability inside manage: RFC-0042 can now mark `PERFORMANCE` ready when a certified
-`lotus-performance` workspace-summary TWR response is supplied to the realized-source boundary.
-It does not promote a full post-trade outcome-review product claim by itself. Runtime support still
-requires durable persistence, APIs, OpenAPI certification, live evidence, documentation publication,
-and downstream realization where surfaced.
+The WTBD-006 performance and risk adapters promote only implementation-backed source-integration
+capabilities inside manage: RFC-0042 can now mark `PERFORMANCE` ready when a certified
+`lotus-performance` workspace-summary TWR response is supplied, and `RISK_REDUCTION` ready when a
+certified `lotus-risk` `RiskMetricsReport:v1` response is supplied. They do not promote a full
+post-trade outcome-review product claim by themselves. Runtime support still requires durable
+persistence, APIs, OpenAPI certification, live evidence, documentation publication, and downstream
+realization where surfaced.

--- a/docs/rfcs/RFC-0042-source-map-and-gap-analysis.md
+++ b/docs/rfcs/RFC-0042-source-map-and-gap-analysis.md
@@ -121,6 +121,14 @@ The implementation records the first-wave boundary: missing execution evidence e
 `EXECUTION_EVIDENCE_BLOCKED`, missing risk evidence emits `RISK_OUTCOME_NOT_SUPPORTED`, and missing
 performance evidence emits `PERFORMANCE_OUTCOME_NOT_SUPPORTED`.
 
+The WTBD-006 risk follow-on adds the first source-owner adapter for `lotus-risk`
+`RiskMetricsReport:v1` output. `src/core/outcomes/risk_sources.py` wraps
+`RISK_METRICS_REPORT` evidence into RFC-0042 `RISK_REDUCTION` realized-source snapshots,
+preserving request fingerprint, selected period, selected risk metric, source supportability state,
+source supportability reason, and as-of date. The adapter preserves source metric values in source
+units; it does not compute volatility, drawdown, VaR, Sharpe, Sortino, beta, tracking error,
+information ratio, attribution, or concentration in manage.
+
 The WTBD-006 performance follow-on adds the first source-owner adapter for `lotus-performance`
 workspace-summary TWR output. `src/core/outcomes/performance_sources.py` wraps
 `WORKSPACE_SUMMARY_TWR_RETURN` evidence into RFC-0042 `PERFORMANCE` realized-source snapshots,
@@ -275,7 +283,7 @@ can be claimed.
 | Cash movements | `lotus-core` | `CASH_OUTCOME` and MWR-related context | Source-owner required | Consume source product; missing source blocks cash outcome. |
 | FX executions and currency exposures | `lotus-core` or treasury source owner | `FX_OUTCOME` | Source-owner required | Consume source product; no local treasury-depth reconstruction. |
 | Tax lots and realized tax | `lotus-core` or tax source owner | `TAX_OUTCOME` | Source-owner required | Consume source product; no manage-local tax-lot authority. |
-| Risk after execution | `lotus-risk` | `RISK_OUTCOME` | Supported only if endpoint supports review window and portfolio context | Consume risk owner output and supportability; otherwise mark not supported/degraded. |
+| Risk after execution | `lotus-risk` | `RISK_OUTCOME` | RiskMetricsReport volatility and selected risk-metric output are the first implemented adapter; historical attribution, rolling-risk, drawdown-report, and concentration-specific outcome contracts remain source-owner follow-on work. | Consume risk owner output and supportability; otherwise mark not supported/degraded. |
 | Returns series/TWR/MWR/contribution/attribution | `lotus-performance` | `PERFORMANCE_OUTCOME` | Workspace-summary TWR return output is the first implemented adapter; broader review-window MWR, contribution, attribution, and benchmark-relative outcome contracts remain source-owner follow-on work. | Consume performance owner output and supportability; otherwise mark not supported/degraded. |
 | Report artifact | `lotus-report`, `lotus-render`, `lotus-archive` | Reports and archive | Downstream only | Manage emits `DpmOutcomeReportInput`; no artifact claim. |
 | AI memo/copilot output | `lotus-ai` | AI assistance | Downstream only | Manage emits `DpmOutcomeAiEvidenceInput`; no narrative claim. |
@@ -289,7 +297,7 @@ can be claimed.
 | Dimension | First-wave support condition | Blocked/not-supported posture |
 | --- | --- | --- |
 | `DRIFT_OUTCOME` | Expected target/current state plus post-trade holdings are source-backed. | `DRIFT_SOURCE_INCOMPLETE` if holdings or expected target is missing. |
-| `RISK_OUTCOME` | `lotus-risk` provides post-trade risk for the review window with supportability. | `RISK_OUTCOME_NOT_SUPPORTED` or `RISK_SOURCE_UNAVAILABLE`. |
+| `RISK_OUTCOME` | `lotus-risk` provides source-owned RiskMetricsReport output for the selected period/metric; richer attribution, rolling-risk, drawdown-report, and concentration-specific evidence require future source-owner contracts. | `RISK_OUTCOME_NOT_SUPPORTED` or `RISK_SOURCE_UNAVAILABLE`. |
 | `PERFORMANCE_OUTCOME` | `lotus-performance` provides source-owned workspace-summary TWR return output for the selected period/basis/measure; richer contribution, attribution, MWR, and benchmark-relative evidence require future source-owner contracts. | `PERFORMANCE_OUTCOME_NOT_SUPPORTED` or `PERFORMANCE_SOURCE_UNAVAILABLE`. |
 | `TURNOVER_OUTCOME` | Booked transaction window is source-backed. | `TRANSACTION_SOURCE_INCOMPLETE`. |
 | `TRANSACTION_COST_OUTCOME` | Realized cost source is available and comparable to estimated cost basis. | `COST_SOURCE_INCOMPLETE`. |

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -2257,7 +2257,7 @@ artifacts belong to report/render/archive services, and AI narrative execution b
 | RFC42-WTBD-003 | Full front-office post-trade outcome feedback product support | `lotus-gateway`, `lotus-workbench`, `lotus-manage` | Implemented and canonically proven for current Gateway/Workbench outcome-review product scope through `lotus-gateway` PR #186, `lotus-gateway` PR #187, `lotus-workbench` PR #146, `lotus-platform` PR #300, and `lotus-core` PR #336 | The full first-wave product path is now implementation-backed: manage owns authority, Gateway composes it, Workbench renders it, panel governance certifies it, and live canonical evidence proves it. Reporting, AI, OMS, source-owner methodology, and PM-scoring scope remain separate ledger items. |
 | RFC42-WTBD-004 | Rendered outcome reports and archive lifecycle | `lotus-report`, `lotus-render`, `lotus-archive`, `lotus-gateway`, `lotus-workbench` | Implemented, merged, CI-proven, and wiki-published through `lotus-render` PR #9, `lotus-archive` PR #21, `lotus-report` PR #88, `lotus-gateway` PR #188, and `lotus-workbench` PR #147 | Manage emits bounded report input only; downstream services now consume it to create deterministic outcome-review report artifacts, preserve archive posture, expose Gateway submission, and add the Workbench report request action without recomputing outcome truth. |
 | RFC42-WTBD-005 | Governed AI narrative/copilot over outcome evidence | `lotus-ai`, Gateway, Workbench, with manage as evidence authority | Implemented, merged, CI-proven, and wiki-published through `lotus-ai` PR #59/#60, `lotus-gateway` PR #189, and `lotus-workbench` PR #148 | Manage emits AI evidence input only; `lotus-ai` now owns guarded workflow-pack narrative execution, Gateway composes the evidence/narrative BFF, and Workbench exposes only a governed request action without prompt construction or autonomous decisioning. |
-| RFC42-WTBD-006 | Source-owned realized risk/performance/tax/FX/cash outcome methodologies | `lotus-risk`, `lotus-performance`, `lotus-core`, future source owners | In progress source-family by source-family | Performance workspace-summary TWR output now has a manage adapter; remaining risk, richer performance, tax, FX, cash, liquidity, and execution methodologies stay source-owner follow-on work. |
+| RFC42-WTBD-006 | Source-owned realized risk/performance/tax/FX/cash outcome methodologies | `lotus-risk`, `lotus-performance`, `lotus-core`, future source owners | In progress source-family by source-family | RiskMetricsReport and performance workspace-summary TWR output now have manage adapters; richer risk/performance, tax, FX, cash, liquidity, and execution methodologies stay source-owner follow-on work. |
 | RFC42-WTBD-007 | External execution/OMS integration and acknowledgements | Execution/OMS owner, `lotus-manage` consumer | Ownership not established | RFC-0042 can compare expected and realized evidence, but OMS integration needs a separate owner, controls, acknowledgements, and reconciliation contract. |
 | RFC42-WTBD-008 | PM quality scoring or behavioral analytics | Business owner, methodology owner, `lotus-ai` only if approved | Not supported | RFC-0042 intentionally avoids scoring PMs. Any future scoring requires business approval, auditable methodology, bias controls, and governance. |
 
@@ -2596,22 +2596,30 @@ Implementation-backed progress:
 
 1. `src/core/outcomes/performance_sources.py` adds the first WTBD-006 source-family adapter for
    `lotus-performance` workspace-summary TWR return evidence,
-2. the adapter consumes source-owned `WORKSPACE_SUMMARY_TWR_RETURN` output and converts
+2. `src/core/outcomes/risk_sources.py` adds the first WTBD-006 source-family adapter for
+   `lotus-risk` `RiskMetricsReport:v1` evidence,
+3. the performance adapter consumes source-owned `WORKSPACE_SUMMARY_TWR_RETURN` output and converts
    percentage-point return units to RFC-0042 ratio units without calculating performance locally,
-3. source lineage is preserved through calculation id, calculation hash, selected period, selected
+4. the risk adapter consumes source-owned `RISK_METRICS_REPORT` output and preserves selected
+   source metric values without calculating risk locally,
+5. performance source lineage is preserved through calculation id, calculation hash, selected period, selected
    basis, selected measure, source owner, source type, and reason codes,
-4. focused tests prove ready, missing, degraded/unavailable, explicit basis/measure, and malformed
-   payload behavior,
-5. no broader performance methodology is claimed yet: MWR, contribution, attribution,
-   benchmark-relative analysis, and full review-window performance contracts remain source-owner
-   follow-on scope.
+6. risk source lineage is preserved through request fingerprint, selected period, selected risk
+   metric, source supportability state, source supportability reason, as-of date, source owner,
+   source type, and reason codes,
+7. focused tests prove ready, missing, degraded/unavailable, permission-blocked, explicit metric,
+   source supportability, and malformed payload behavior,
+8. no broader methodology is claimed yet: risk attribution, rolling-risk, drawdown-report,
+   concentration, MWR, contribution, attribution, benchmark-relative performance analysis, and full
+   review-window source contracts remain source-owner follow-on scope.
 
 Why it cannot be done now:
 
-RFC-0042 intentionally avoided local calculation clones. The first performance adapter is possible
-because `lotus-performance` already publishes workspace-summary TWR output. Remaining source-owner
-methods are surfaced as degraded, unsupported, unavailable, malformed, conflicting, or blocked
-states until their owning applications publish certified contracts.
+RFC-0042 intentionally avoided local calculation clones. The first risk and performance adapters are
+possible because `lotus-risk` publishes `RiskMetricsReport:v1` output and `lotus-performance`
+publishes workspace-summary TWR output. Remaining source-owner methods are surfaced as degraded,
+unsupported, unavailable, malformed, conflicting, or blocked states until their owning applications
+publish certified contracts.
 
 Dependencies before implementation:
 

--- a/src/core/outcomes/__init__.py
+++ b/src/core/outcomes/__init__.py
@@ -36,6 +36,11 @@ from src.core.outcomes.performance_sources import (
     realized_performance_source_from_workspace_summary,
     unavailable_performance_source,
 )
+from src.core.outcomes.risk_sources import (
+    RiskOutcomeSourceError,
+    realized_risk_source_from_risk_metrics_report,
+    unavailable_risk_source,
+)
 from src.core.outcomes.handoffs import (
     OUTCOME_AI_EVIDENCE_REF_TYPE,
     OUTCOME_REPORT_INPUT_REF_TYPE,
@@ -77,6 +82,7 @@ __all__ = [
     "OUTCOME_AI_EVIDENCE_REF_TYPE",
     "OUTCOME_REPORT_INPUT_REF_TYPE",
     "PerformanceOutcomeSourceError",
+    "RiskOutcomeSourceError",
     "assemble_expected_outcome_snapshot",
     "assemble_realized_outcome_snapshot",
     "assert_no_ai_forbidden_fields",
@@ -85,5 +91,7 @@ __all__ = [
     "compare_outcome_dimension",
     "compare_outcome_dimensions",
     "realized_performance_source_from_workspace_summary",
+    "realized_risk_source_from_risk_metrics_report",
     "unavailable_performance_source",
+    "unavailable_risk_source",
 ]

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -1,0 +1,156 @@
+"""Source-owned risk realized evidence adapters for RFC-0042."""
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal
+
+from src.core.outcomes.models import DpmRealizedSourceSnapshot
+
+RiskOutcomeMeasure = Literal[
+    "VOLATILITY",
+    "DRAWDOWN",
+    "SHARPE",
+    "SORTINO",
+    "BETA",
+    "TRACKING_ERROR",
+    "INFORMATION_RATIO",
+    "VAR",
+]
+
+
+class RiskOutcomeSourceError(ValueError):
+    """Raised when a lotus-risk response cannot produce bounded outcome evidence."""
+
+
+def realized_risk_source_from_risk_metrics_report(
+    response: dict[str, Any],
+    *,
+    period: str = "YTD",
+    metric: RiskOutcomeMeasure = "VOLATILITY",
+) -> DpmRealizedSourceSnapshot:
+    """Adapt a lotus-risk RiskMetricsReport without recalculating risk truth locally."""
+
+    result = _read_mapping(_read_mapping(response.get("results")).get(period))
+    metric_result = _read_mapping(_read_mapping(result.get("metrics")).get(metric))
+    metadata = _read_mapping(response.get("metadata"))
+    scope = _read_mapping(response.get("scope"))
+    supportability = _read_mapping(metadata.get("calculation_supportability"))
+    request_fingerprint = _read_text(metadata.get("request_fingerprint"))
+    if request_fingerprint is None:
+        raise RiskOutcomeSourceError(
+            "lotus-risk metrics report is missing metadata.request_fingerprint"
+        )
+
+    supportability_state = _read_text(supportability.get("state")) or "ready"
+    supportability_reason = _read_text(supportability.get("reason")) or "calculation_complete"
+    value = (
+        _decimal_value(metric_result.get("value"))
+        if metric_result.get("value") is not None
+        else None
+    )
+    source_state, quality = _risk_source_posture(
+        supportability_state=supportability_state,
+        value=value,
+    )
+    if source_state == "READY" and value is None:
+        raise RiskOutcomeSourceError(
+            f"lotus-risk metrics report is missing a numeric {metric} value for {period}"
+        )
+
+    return DpmRealizedSourceSnapshot(
+        dimension="RISK_REDUCTION",
+        source_system="lotus-risk",
+        source_type="RISK_METRICS_REPORT",
+        source_id=f"{request_fingerprint}:{period}:{metric}",
+        value=value if source_state != "NOT_SUPPORTED" else None,
+        unit=_metric_unit(metric),
+        source_state=source_state,
+        quality=quality,
+        observed_at=None,
+        as_of_date=_read_text(scope.get("as_of_date")),
+        content_hash=request_fingerprint,
+        reason_codes=[
+            _primary_reason(source_state),
+            f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
+            f"RISK_REASON_{supportability_reason.upper()}",
+            f"RISK_PERIOD_{period}",
+            f"RISK_METRIC_{metric}",
+        ],
+    )
+
+
+def unavailable_risk_source(
+    *,
+    source_id: str,
+    reason_code: str,
+    as_of_date: str | None = None,
+) -> DpmRealizedSourceSnapshot:
+    """Return bounded unavailable risk evidence when lotus-risk cannot serve truth."""
+
+    return DpmRealizedSourceSnapshot(
+        dimension="RISK_REDUCTION",
+        source_system="lotus-risk",
+        source_type="RISK_METRICS_REPORT",
+        source_id=source_id,
+        value=None,
+        unit="ratio",
+        source_state="DEGRADED",
+        quality="UNAVAILABLE",
+        observed_at=None,
+        as_of_date=as_of_date,
+        content_hash=None,
+        reason_codes=[reason_code],
+    )
+
+
+def _risk_source_posture(
+    *,
+    supportability_state: str,
+    value: Decimal | None,
+) -> tuple[
+    Literal["READY", "DEGRADED", "BLOCKED", "NOT_SUPPORTED"],
+    Literal["COMPLETE", "STALE", "UNAVAILABLE", "PARTIAL", "MISSING", "NOT_SUPPORTED"],
+]:
+    if supportability_state == "unsupported":
+        return "NOT_SUPPORTED", "NOT_SUPPORTED"
+    if supportability_state == "permission_blocked":
+        return "BLOCKED", "MISSING"
+    if supportability_state == "stale":
+        return "DEGRADED", "STALE"
+    if supportability_state != "ready":
+        return "DEGRADED", "PARTIAL" if value is not None else "UNAVAILABLE"
+    return "READY", "COMPLETE"
+
+
+def _primary_reason(source_state: str) -> str:
+    if source_state == "READY":
+        return "RISK_SOURCE_READY"
+    if source_state == "NOT_SUPPORTED":
+        return "RISK_SOURCE_NOT_SUPPORTED"
+    if source_state == "BLOCKED":
+        return "RISK_SOURCE_BLOCKED"
+    return "RISK_SOURCE_DEGRADED"
+
+
+def _metric_unit(metric: RiskOutcomeMeasure) -> str:
+    if metric == "VAR":
+        return "percentage_point"
+    if metric in {"SHARPE", "SORTINO", "BETA", "INFORMATION_RATIO"}:
+        return "ratio"
+    return "ratio"
+
+
+def _read_mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _read_text(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _decimal_value(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError) as exc:
+        raise RiskOutcomeSourceError(
+            "lotus-risk metrics report contains a non-numeric risk metric value"
+        ) from exc

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -1,0 +1,221 @@
+import pytest
+
+from src.core.outcomes import (
+    RiskOutcomeSourceError,
+    assemble_realized_outcome_snapshot,
+    realized_risk_source_from_risk_metrics_report,
+    unavailable_risk_source,
+)
+from tests.unit.core.test_realized_outcome_sources import _window
+
+
+def _risk_metrics_report() -> dict[str, object]:
+    return {
+        "scope": {
+            "as_of_date": "2026-05-06",
+            "reporting_currency": "USD",
+            "net_or_gross": "NET",
+        },
+        "results": {
+            "YTD": {
+                "start_date": "2026-01-02",
+                "end_date": "2026-05-06",
+                "portfolio_observation_count": 64,
+                "benchmark_observation_count": 64,
+                "aligned_benchmark_observation_count": 61,
+                "metrics": {
+                    "VOLATILITY": {
+                        "value": 0.079885986,
+                        "details": {
+                            "observation_count": 64,
+                            "annualization_factor": 252,
+                        },
+                    },
+                    "VAR": {
+                        "value": -1.775,
+                        "details": {
+                            "method": "HISTORICAL",
+                            "confidence": 0.95,
+                            "horizon_days": 1,
+                        },
+                    },
+                },
+            }
+        },
+        "metadata": {
+            "contract_version": "v1",
+            "methodology_version": "risk.v1",
+            "request_fingerprint": "sha256:risk-metrics-request",
+            "source_services": ["lotus-risk", "lotus-performance"],
+            "upstream_request_fingerprints": {
+                "lotus-performance:/integration/returns/series": "sha256:returns-series"
+            },
+            "calculation_supportability": {
+                "state": "ready",
+                "reason": "calculation_complete",
+                "freshness_bucket": "current",
+                "degraded_metric_count": 0,
+                "empty_period_count": 0,
+                "evaluated_period_count": 1,
+            },
+        },
+    }
+
+
+def test_risk_metrics_report_adapter_wraps_source_truth_without_recalculation() -> None:
+    source = realized_risk_source_from_risk_metrics_report(_risk_metrics_report())
+
+    assert source.dimension == "RISK_REDUCTION"
+    assert source.source_system == "lotus-risk"
+    assert source.source_type == "RISK_METRICS_REPORT"
+    assert source.source_id == "sha256:risk-metrics-request:YTD:VOLATILITY"
+    assert str(source.value) == "0.079885986"
+    assert source.unit == "ratio"
+    assert source.content_hash == "sha256:risk-metrics-request"
+    assert source.reason_codes == [
+        "RISK_SOURCE_READY",
+        "RISK_SUPPORTABILITY_READY",
+        "RISK_REASON_CALCULATION_COMPLETE",
+        "RISK_PERIOD_YTD",
+        "RISK_METRIC_VOLATILITY",
+    ]
+
+
+def test_risk_metrics_report_adapter_supports_explicit_metric() -> None:
+    source = realized_risk_source_from_risk_metrics_report(
+        _risk_metrics_report(),
+        metric="VAR",
+    )
+
+    assert str(source.value) == "-1.775"
+    assert source.unit == "percentage_point"
+    assert source.source_id.endswith(":YTD:VAR")
+    assert "RISK_METRIC_VAR" in source.reason_codes
+
+
+def test_risk_source_can_make_rfc42_risk_dimension_ready() -> None:
+    source = realized_risk_source_from_risk_metrics_report(_risk_metrics_report())
+
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[source],
+        required_dimensions=["RISK_REDUCTION"],
+    )
+
+    risk = snapshot.realized_values["RISK_REDUCTION"]
+    assert snapshot.supportability.state == "READY"
+    assert risk.value == source.value
+    assert risk.source_refs[0].source_system == "lotus-risk"
+    assert risk.supportability.reason_codes[0] == "SOURCE_READY"
+
+
+def test_missing_risk_source_still_reports_not_supported_without_local_clone() -> None:
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[],
+        required_dimensions=["RISK_REDUCTION"],
+    )
+
+    assert snapshot.supportability.state == "NOT_SUPPORTED"
+    assert snapshot.realized_values["RISK_REDUCTION"].supportability.reason_codes == [
+        "RISK_OUTCOME_NOT_SUPPORTED"
+    ]
+
+
+def test_unavailable_risk_source_preserves_degraded_owner_posture() -> None:
+    source = unavailable_risk_source(
+        source_id="risk-down:YTD:VOLATILITY",
+        reason_code="RISK_METRICS_REPORT_UNAVAILABLE",
+        as_of_date="2026-05-06",
+    )
+
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[source],
+        required_dimensions=["RISK_REDUCTION"],
+    )
+
+    risk = snapshot.realized_values["RISK_REDUCTION"]
+    assert snapshot.supportability.state == "DEGRADED"
+    assert risk.value is None
+    assert risk.supportability.reason_codes[:2] == [
+        "RISK_SOURCE_UNAVAILABLE",
+        "RISK_METRICS_REPORT_UNAVAILABLE",
+    ]
+
+
+def test_degraded_risk_report_preserves_source_owner_supportability() -> None:
+    report = _risk_metrics_report()
+    metadata = report["metadata"]
+    assert isinstance(metadata, dict)
+    metadata["calculation_supportability"] = {
+        "state": "degraded",
+        "reason": "benchmark_unavailable",
+        "freshness_bucket": "current",
+    }
+
+    source = realized_risk_source_from_risk_metrics_report(report)
+
+    assert source.source_state == "DEGRADED"
+    assert source.quality == "PARTIAL"
+    assert source.value is not None
+    assert source.reason_codes[:3] == [
+        "RISK_SOURCE_DEGRADED",
+        "RISK_SUPPORTABILITY_DEGRADED",
+        "RISK_REASON_BENCHMARK_UNAVAILABLE",
+    ]
+
+
+def test_permission_blocked_risk_report_blocks_ready_claim() -> None:
+    report = _risk_metrics_report()
+    metadata = report["metadata"]
+    assert isinstance(metadata, dict)
+    metadata["calculation_supportability"] = {
+        "state": "permission_blocked",
+        "reason": "permission_blocked",
+        "freshness_bucket": "unknown",
+    }
+
+    source = realized_risk_source_from_risk_metrics_report(report)
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[source],
+        required_dimensions=["RISK_REDUCTION"],
+    )
+
+    assert source.source_state == "BLOCKED"
+    assert source.quality == "MISSING"
+    assert snapshot.supportability.state == "BLOCKED"
+    assert snapshot.realized_values["RISK_REDUCTION"].value is None
+    assert snapshot.realized_values["RISK_REDUCTION"].supportability.reason_codes[:2] == [
+        "SOURCE_EVIDENCE_INCOMPLETE",
+        "RISK_SOURCE_BLOCKED",
+    ]
+
+
+def test_risk_adapter_rejects_report_without_trust_fingerprint() -> None:
+    malformed = _risk_metrics_report()
+    metadata = malformed["metadata"]
+    assert isinstance(metadata, dict)
+    del metadata["request_fingerprint"]
+
+    with pytest.raises(RiskOutcomeSourceError, match="request_fingerprint"):
+        realized_risk_source_from_risk_metrics_report(malformed)
+
+
+def test_risk_adapter_rejects_missing_ready_metric_value() -> None:
+    malformed = _risk_metrics_report()
+    results = malformed["results"]
+    assert isinstance(results, dict)
+    ytd = results["YTD"]
+    assert isinstance(ytd, dict)
+    metrics = ytd["metrics"]
+    assert isinstance(metrics, dict)
+    metrics["VOLATILITY"] = {"value": None}
+
+    with pytest.raises(RiskOutcomeSourceError, match="numeric VOLATILITY value"):
+        realized_risk_source_from_risk_metrics_report(malformed)

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -618,7 +618,10 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "Missing `EXECUTION_QUALITY` source" in realized_source_slice
     assert "WORKSPACE_SUMMARY_TWR_RETURN" in realized_source_slice
     assert "performance_sources.py" in realized_source_slice
+    assert "RISK_METRICS_REPORT" in realized_source_slice
+    assert "risk_sources.py" in realized_source_slice
     assert "`17 passed`" in realized_source_slice
+    assert "`20 passed`" in realized_source_slice
 
     assert "Slice 6 - Persistence, Repository, Events, and Retention" in persistence_slice
     assert "Review body is immutable" in persistence_slice


### PR DESCRIPTION
## Summary
- add a source-owned `lotus-risk` `RiskMetricsReport:v1` adapter for RFC-0042 realized `RISK_REDUCTION` evidence
- preserve ready, degraded, unavailable, permission-blocked, malformed, and missing risk-source posture without calculating risk truth in manage
- update RFC-0042 source maps, Slice 5 evidence, documentation guard tests, and the WTBD ledger to reflect implemented risk progress and remaining source-owner families

## Validation
- `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/core/test_performance_realized_outcome_sources.py tests/unit/core/test_realized_outcome_sources.py tests/unit/test_documentation_current_state.py -q` => 39 passed
- `python -m ruff check src/core/outcomes/risk_sources.py src/core/outcomes/__init__.py tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/test_documentation_current_state.py` => passed
- `python -m ruff format --check src/core/outcomes/risk_sources.py src/core/outcomes/__init__.py tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/test_documentation_current_state.py` => passed
- `git diff --check` => passed
- `make check` => passed, including lint, monetary float guard, no-alias, typecheck, OpenAPI, API vocabulary, mesh contract gates, and 861 unit tests
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` => DiffCount 0
- `git fetch origin --prune && git branch -r --no-merged origin/main` => no stranded remote branches

## Wiki Decision
No repo-local wiki source change is required for this sub-slice. This is a manage source-adapter and RFC/ledger truth update, not a new product-facing supported-feature promotion.