### PR TITLE
feat: adapt core cash realized outcome sources

### DIFF
--- a/docs/rfcs/RFC-0042-realized-source-adapters-slice5.md
+++ b/docs/rfcs/RFC-0042-realized-source-adapters-slice5.md
@@ -26,11 +26,15 @@ Slice 5 adds the source-owner realized evidence boundary:
 5. A follow-on WTBD-006 risk adapter in `src/core/outcomes/risk_sources.py` that wraps
    `lotus-risk` `RiskMetricsReport:v1` output into RFC-0042 realized `RISK_REDUCTION` evidence
    without recalculating risk methodology locally.
-6. Unit tests covering ready source evidence, missing execution evidence, missing risk/performance
+6. A follow-on WTBD-006 core cash adapter in `src/core/outcomes/core_sources.py` that wraps the
+   `lotus-core` `HoldingsAsOf:v1` cash total into RFC-0042 realized `CASH_RESIDUAL` evidence
+   without aggregating cash or tax/FX/transaction rows in manage.
+7. Unit tests covering ready source evidence, missing execution evidence, missing risk/performance
    contracts, stale source degradation, conflicting source values, malformed source blocking,
    performance source wrapping, degraded performance-source posture, malformed performance payload
    rejection, risk source wrapping, risk supportability preservation, permission-blocked risk
-   posture, and malformed risk payload rejection.
+   posture, malformed risk payload rejection, core cash source wrapping, degraded core cash posture,
+   and invalid core cash source payload rejection.
 
 ## Source-Owner Boundary
 
@@ -39,7 +43,7 @@ in this slice and does not calculate source-owner truth locally.
 
 | Source Owner | RFC-0042 First-Wave Posture |
 | --- | --- |
-| `lotus-core` | Can provide explicit realized snapshots for holdings drift, booked transaction cost, cash residual, tax, FX, and rule evidence when a certified source contract is supplied. Missing or malformed evidence blocks affected dimensions. |
+| `lotus-core` | First supported adapter consumes `HoldingsAsOf:v1` cash total evidence for `CASH_RESIDUAL`. It preserves source product metadata, as-of date, generated/evidence timestamp, data-quality posture, and source fingerprint. Missing or malformed evidence blocks affected dimensions. Tax, FX, transaction-cost, execution, and rule outcome adapters remain source-owner follow-on work until core exposes owned scalar totals or certified outcome contracts. |
 | execution/OMS owner | No certified first-wave fill/order contract is assumed. Missing execution evidence emits `EXECUTION_EVIDENCE_BLOCKED`. |
 | `lotus-risk` | First supported adapter consumes `RiskMetricsReport:v1` evidence from the `lotus-risk` risk-calculate response. It preserves request fingerprint, selected period, selected risk metric, source supportability, and source reason codes. Missing evidence still emits `RISK_OUTCOME_NOT_SUPPORTED`; unavailable evidence remains degraded as `RISK_SOURCE_UNAVAILABLE`. Historical attribution, rolling-risk, drawdown-report, and concentration-specific outcome adapters remain source-owner follow-on work. |
 | `lotus-performance` | First supported adapter consumes `WORKSPACE_SUMMARY_TWR_RETURN` evidence from the `lotus-performance` workspace-summary response. It performs only percentage-point to ratio unit conversion plus lineage wrapping. Missing evidence still emits `PERFORMANCE_OUTCOME_NOT_SUPPORTED`; unavailable evidence remains degraded as `PERFORMANCE_SOURCE_UNAVAILABLE`. Richer MWR, contribution, and attribution outcome adapters remain source-owner follow-on work. |
@@ -61,6 +65,33 @@ in this slice and does not calculate source-owner truth locally.
 | Unavailable `lotus-risk` risk metrics report source | `DEGRADED` with `RISK_SOURCE_UNAVAILABLE` plus the source-supplied reason code |
 | `lotus-performance` workspace-summary TWR source | `READY` when the source response includes the selected period, basis, measure, calculation id, and numeric base return |
 | Unavailable `lotus-performance` workspace-summary source | `DEGRADED` with `PERFORMANCE_SOURCE_UNAVAILABLE` plus the source-supplied reason code |
+| `lotus-core` HoldingsAsOf cash total source | `READY` when the source response includes product identity, portfolio id, as-of date, selected cash total, and complete/ready data quality |
+| Degraded `lotus-core` HoldingsAsOf cash total source | `DEGRADED` when source data quality is incomplete, partial, stale, unavailable, or unknown |
+
+## Core Cash Adapter Contract
+
+`realized_cash_source_from_cash_balances_response` accepts a validated `lotus-core`
+`HoldingsAsOf:v1` cash-balance response and emits a `DpmRealizedSourceSnapshot` for
+`CASH_RESIDUAL`.
+
+Implemented behavior:
+
+1. source owner remains `lotus-core`,
+2. source type is `HOLDINGS_AS_OF_CASH_BALANCE`,
+3. default cash basis is the source-owned reporting-currency total,
+4. optional portfolio-currency basis uses the source-owned portfolio-currency total,
+5. `product_name`, `product_version`, `portfolio_id`, `as_of_date`, generated/evidence timestamp,
+   data-quality status, source batch fingerprint, snapshot id, and correlation id are preserved as
+   available,
+6. malformed source payloads or unsupported basis requests raise `CoreOutcomeSourceError` and
+   cannot silently produce a ready cash value.
+
+Out of scope for this adapter:
+
+1. aggregating cash-account rows locally,
+2. deriving tax, FX, transaction-cost, liquidity, execution, or rule outcomes from transaction rows,
+3. converting currencies locally,
+4. fabricating source fingerprints, evidence timestamps, or data-quality posture.
 
 ## Risk Adapter Contract
 
@@ -118,6 +149,7 @@ Commands:
 python -m pytest tests\unit\core\test_realized_outcome_sources.py -q
 python -m pytest tests\unit\core\test_performance_realized_outcome_sources.py tests\unit\core\test_realized_outcome_sources.py -q
 python -m pytest tests\unit\core\test_risk_realized_outcome_sources.py tests\unit\core\test_realized_outcome_sources.py -q
+python -m pytest tests\unit\core\test_core_realized_outcome_sources.py tests\unit\core\test_realized_outcome_sources.py -q
 python -m ruff check src\core\outcomes tests\unit\core\test_realized_outcome_sources.py
 ```
 
@@ -126,14 +158,16 @@ Observed result:
 1. `6 passed`
 2. `17 passed`
 3. `20 passed`
-4. `All checks passed!`
+4. `18 passed`
+5. `All checks passed!`
 
 ## Supported-Feature Decision
 
 The WTBD-006 performance and risk adapters promote only implementation-backed source-integration
 capabilities inside manage: RFC-0042 can now mark `PERFORMANCE` ready when a certified
 `lotus-performance` workspace-summary TWR response is supplied, and `RISK_REDUCTION` ready when a
-certified `lotus-risk` `RiskMetricsReport:v1` response is supplied. They do not promote a full
-post-trade outcome-review product claim by themselves. Runtime support still requires durable
-persistence, APIs, OpenAPI certification, live evidence, documentation publication, and downstream
-realization where surfaced.
+certified `lotus-risk` `RiskMetricsReport:v1` response is supplied. The WTBD-006 core cash adapter
+can mark `CASH_RESIDUAL` ready when a certified `lotus-core` `HoldingsAsOf:v1` cash total is
+supplied. They do not promote a full post-trade outcome-review product claim by themselves. Runtime
+support still requires durable persistence, APIs, OpenAPI certification, live evidence,
+documentation publication, and downstream realization where surfaced.

--- a/docs/rfcs/RFC-0042-source-map-and-gap-analysis.md
+++ b/docs/rfcs/RFC-0042-source-map-and-gap-analysis.md
@@ -129,6 +129,14 @@ source supportability reason, and as-of date. The adapter preserves source metri
 units; it does not compute volatility, drawdown, VaR, Sharpe, Sortino, beta, tracking error,
 information ratio, attribution, or concentration in manage.
 
+The WTBD-006 core cash follow-on adds the first source-owner adapter for `lotus-core`
+`HoldingsAsOf:v1` cash totals. `src/core/outcomes/core_sources.py` wraps
+`HOLDINGS_AS_OF_CASH_BALANCE` evidence into RFC-0042 `CASH_RESIDUAL` realized-source snapshots,
+preserving product identity, portfolio id, as-of date, generated/evidence timestamp, data-quality
+posture, and source fingerprint. The adapter consumes source-owned cash totals only; it does not
+aggregate cash-account rows, derive tax, FX, transaction-cost, execution, liquidity, or rule
+outcomes, or convert currencies in manage.
+
 The WTBD-006 performance follow-on adds the first source-owner adapter for `lotus-performance`
 workspace-summary TWR output. `src/core/outcomes/performance_sources.py` wraps
 `WORKSPACE_SUMMARY_TWR_RETURN` evidence into RFC-0042 `PERFORMANCE` realized-source snapshots,
@@ -280,7 +288,7 @@ can be claimed.
 | Booked transactions | `lotus-core` | Turnover, cost, cash, tax, execution reconciliation | Source-owner required | Consume certified product if available; otherwise block affected dimensions. |
 | Fill/order/execution detail | `lotus-core` or future execution/OMS owner | `EXECUTION_QUALITY` | Blocked until certified | Do not infer partial fills or slippage from manage intent. |
 | Post-trade holdings and positions | `lotus-core` | Drift, rule, cash/security residuals | Source-owner required | Consume source product with as-of date and lineage. |
-| Cash movements | `lotus-core` | `CASH_OUTCOME` and MWR-related context | Source-owner required | Consume source product; missing source blocks cash outcome. |
+| Cash movements | `lotus-core` | `CASH_OUTCOME` and MWR-related context | HoldingsAsOf cash totals are the first implemented adapter; cash movements, liquidity ladders, and MWR-related flow context remain source-owner follow-on work. | Consume source product; missing source blocks cash outcome. |
 | FX executions and currency exposures | `lotus-core` or treasury source owner | `FX_OUTCOME` | Source-owner required | Consume source product; no local treasury-depth reconstruction. |
 | Tax lots and realized tax | `lotus-core` or tax source owner | `TAX_OUTCOME` | Source-owner required | Consume source product; no manage-local tax-lot authority. |
 | Risk after execution | `lotus-risk` | `RISK_OUTCOME` | RiskMetricsReport volatility and selected risk-metric output are the first implemented adapter; historical attribution, rolling-risk, drawdown-report, and concentration-specific outcome contracts remain source-owner follow-on work. | Consume risk owner output and supportability; otherwise mark not supported/degraded. |
@@ -303,7 +311,7 @@ can be claimed.
 | `TRANSACTION_COST_OUTCOME` | Realized cost source is available and comparable to estimated cost basis. | `COST_SOURCE_INCOMPLETE`. |
 | `TAX_OUTCOME` | Realized tax/tax-lot evidence is source-backed. | `TAX_SOURCE_INCOMPLETE`. |
 | `FX_OUTCOME` | FX executions/currency exposures are source-backed. | `FX_SOURCE_INCOMPLETE`. |
-| `CASH_OUTCOME` | Post-trade cash movements and balances are source-backed. | `CASH_SOURCE_INCOMPLETE`. |
+| `CASH_OUTCOME` | `lotus-core` provides source-owned HoldingsAsOf cash total evidence; cash movements, liquidity ladders, and MWR flow context require future source-owner contracts. | `CASH_SOURCE_INCOMPLETE`. |
 | `EXECUTION_QUALITY` | Fill/order/execution source exists with partial, cancelled, unfilled, slippage, and timing evidence. | `EXECUTION_EVIDENCE_BLOCKED`. |
 | `RULE_OUTCOME` | Rule source and post-trade state source both exist. | `RULE_SOURCE_INCOMPLETE`. |
 | `SOURCE_DATA_OUTCOME` | Manage can classify completeness and supportability of all requested source families. | Always available as a classification, but never converts blocked dimensions to ready. |

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -2257,7 +2257,7 @@ artifacts belong to report/render/archive services, and AI narrative execution b
 | RFC42-WTBD-003 | Full front-office post-trade outcome feedback product support | `lotus-gateway`, `lotus-workbench`, `lotus-manage` | Implemented and canonically proven for current Gateway/Workbench outcome-review product scope through `lotus-gateway` PR #186, `lotus-gateway` PR #187, `lotus-workbench` PR #146, `lotus-platform` PR #300, and `lotus-core` PR #336 | The full first-wave product path is now implementation-backed: manage owns authority, Gateway composes it, Workbench renders it, panel governance certifies it, and live canonical evidence proves it. Reporting, AI, OMS, source-owner methodology, and PM-scoring scope remain separate ledger items. |
 | RFC42-WTBD-004 | Rendered outcome reports and archive lifecycle | `lotus-report`, `lotus-render`, `lotus-archive`, `lotus-gateway`, `lotus-workbench` | Implemented, merged, CI-proven, and wiki-published through `lotus-render` PR #9, `lotus-archive` PR #21, `lotus-report` PR #88, `lotus-gateway` PR #188, and `lotus-workbench` PR #147 | Manage emits bounded report input only; downstream services now consume it to create deterministic outcome-review report artifacts, preserve archive posture, expose Gateway submission, and add the Workbench report request action without recomputing outcome truth. |
 | RFC42-WTBD-005 | Governed AI narrative/copilot over outcome evidence | `lotus-ai`, Gateway, Workbench, with manage as evidence authority | Implemented, merged, CI-proven, and wiki-published through `lotus-ai` PR #59/#60, `lotus-gateway` PR #189, and `lotus-workbench` PR #148 | Manage emits AI evidence input only; `lotus-ai` now owns guarded workflow-pack narrative execution, Gateway composes the evidence/narrative BFF, and Workbench exposes only a governed request action without prompt construction or autonomous decisioning. |
-| RFC42-WTBD-006 | Source-owned realized risk/performance/tax/FX/cash outcome methodologies | `lotus-risk`, `lotus-performance`, `lotus-core`, future source owners | In progress source-family by source-family | RiskMetricsReport and performance workspace-summary TWR output now have manage adapters; richer risk/performance, tax, FX, cash, liquidity, and execution methodologies stay source-owner follow-on work. |
+| RFC42-WTBD-006 | Source-owned realized risk/performance/tax/FX/cash outcome methodologies | `lotus-risk`, `lotus-performance`, `lotus-core`, future source owners | In progress source-family by source-family | RiskMetricsReport, performance workspace-summary TWR output, and core HoldingsAsOf cash totals now have manage adapters; richer risk/performance, tax, FX, cash movements, liquidity, and execution methodologies stay source-owner follow-on work. |
 | RFC42-WTBD-007 | External execution/OMS integration and acknowledgements | Execution/OMS owner, `lotus-manage` consumer | Ownership not established | RFC-0042 can compare expected and realized evidence, but OMS integration needs a separate owner, controls, acknowledgements, and reconciliation contract. |
 | RFC42-WTBD-008 | PM quality scoring or behavioral analytics | Business owner, methodology owner, `lotus-ai` only if approved | Not supported | RFC-0042 intentionally avoids scoring PMs. Any future scoring requires business approval, auditable methodology, bias controls, and governance. |
 
@@ -2598,26 +2598,35 @@ Implementation-backed progress:
    `lotus-performance` workspace-summary TWR return evidence,
 2. `src/core/outcomes/risk_sources.py` adds the first WTBD-006 source-family adapter for
    `lotus-risk` `RiskMetricsReport:v1` evidence,
-3. the performance adapter consumes source-owned `WORKSPACE_SUMMARY_TWR_RETURN` output and converts
+3. `src/core/outcomes/core_sources.py` adds the first WTBD-006 `lotus-core` source-family adapter
+   for `HoldingsAsOf:v1` cash-total evidence,
+4. the performance adapter consumes source-owned `WORKSPACE_SUMMARY_TWR_RETURN` output and converts
    percentage-point return units to RFC-0042 ratio units without calculating performance locally,
-4. the risk adapter consumes source-owned `RISK_METRICS_REPORT` output and preserves selected
+5. the risk adapter consumes source-owned `RISK_METRICS_REPORT` output and preserves selected
    source metric values without calculating risk locally,
-5. performance source lineage is preserved through calculation id, calculation hash, selected period, selected
+6. the core cash adapter consumes source-owned `HOLDINGS_AS_OF_CASH_BALANCE` totals without
+   aggregating cash accounts or deriving tax/FX/transaction facts locally,
+7. performance source lineage is preserved through calculation id, calculation hash, selected period, selected
    basis, selected measure, source owner, source type, and reason codes,
-6. risk source lineage is preserved through request fingerprint, selected period, selected risk
+8. risk source lineage is preserved through request fingerprint, selected period, selected risk
    metric, source supportability state, source supportability reason, as-of date, source owner,
    source type, and reason codes,
-7. focused tests prove ready, missing, degraded/unavailable, permission-blocked, explicit metric,
+9. core cash source lineage is preserved through product identity, portfolio id, as-of date,
+   generated/evidence timestamp, data-quality posture, source fingerprint, source owner, source type,
+   and reason codes,
+10. focused tests prove ready, missing, degraded/unavailable, permission-blocked, explicit metric,
    source supportability, and malformed payload behavior,
-8. no broader methodology is claimed yet: risk attribution, rolling-risk, drawdown-report,
-   concentration, MWR, contribution, attribution, benchmark-relative performance analysis, and full
-   review-window source contracts remain source-owner follow-on scope.
+11. no broader methodology is claimed yet: tax, FX, transaction-cost, execution, cash movements,
+   liquidity ladders, risk attribution, rolling-risk, drawdown-report, concentration, MWR,
+   contribution, attribution, benchmark-relative performance analysis, and full review-window source
+   contracts remain source-owner follow-on scope.
 
 Why it cannot be done now:
 
-RFC-0042 intentionally avoided local calculation clones. The first risk and performance adapters are
-possible because `lotus-risk` publishes `RiskMetricsReport:v1` output and `lotus-performance`
-publishes workspace-summary TWR output. Remaining source-owner methods are surfaced as degraded,
+RFC-0042 intentionally avoided local calculation clones. The first risk, performance, and core cash
+adapters are possible because `lotus-risk` publishes `RiskMetricsReport:v1` output,
+`lotus-performance` publishes workspace-summary TWR output, and `lotus-core` publishes
+`HoldingsAsOf:v1` cash totals. Remaining source-owner methods are surfaced as degraded,
 unsupported, unavailable, malformed, conflicting, or blocked states until their owning applications
 publish certified contracts.
 

--- a/src/core/outcomes/__init__.py
+++ b/src/core/outcomes/__init__.py
@@ -4,6 +4,11 @@ from src.core.outcomes.comparison import (
     compare_outcome_dimension,
     compare_outcome_dimensions,
 )
+from src.core.outcomes.core_sources import (
+    CoreOutcomeSourceError,
+    realized_cash_source_from_cash_balances_response,
+    unavailable_core_cash_source,
+)
 from src.core.outcomes.models import (
     DpmExpectedOutcomeSnapshot,
     DpmOutcomeDimensionInput,
@@ -74,6 +79,7 @@ __all__ = [
     "DpmPostTradeOutcomeReview",
     "DpmRealizedOutcomeSnapshot",
     "DpmRealizedSourceSnapshot",
+    "CoreOutcomeSourceError",
     "OutcomeComparisonDirection",
     "OutcomeDimension",
     "OutcomeDimensionState",
@@ -90,8 +96,10 @@ __all__ = [
     "build_report_input",
     "compare_outcome_dimension",
     "compare_outcome_dimensions",
+    "realized_cash_source_from_cash_balances_response",
     "realized_performance_source_from_workspace_summary",
     "realized_risk_source_from_risk_metrics_report",
+    "unavailable_core_cash_source",
     "unavailable_performance_source",
     "unavailable_risk_source",
 ]

--- a/src/core/outcomes/core_sources.py
+++ b/src/core/outcomes/core_sources.py
@@ -1,0 +1,181 @@
+"""Source-owned lotus-core realized evidence adapters for RFC-0042."""
+
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal, TypedDict
+
+from src.core.outcomes.models import DpmRealizedSourceSnapshot
+
+
+class CoreOutcomeSourceError(ValueError):
+    """Raised when a lotus-core response cannot produce bounded outcome evidence."""
+
+
+class _CoreSourceMetadata(TypedDict):
+    product_name: str
+    product_version: str
+    as_of_date: str
+    observed_at: str | None
+    data_quality_status: str
+    content_hash: str | None
+
+
+def realized_cash_source_from_cash_balances_response(
+    response: dict[str, Any],
+    *,
+    currency_basis: str = "reporting",
+) -> DpmRealizedSourceSnapshot:
+    """Adapt lotus-core cash balance totals without recalculating cash truth locally."""
+
+    totals = _read_mapping(response.get("totals"))
+    metadata = _core_metadata(response)
+    if currency_basis == "portfolio":
+        value = _decimal_value(totals.get("total_balance_portfolio_currency"))
+        unit = _read_text(response.get("portfolio_currency")) or "portfolio_currency"
+    elif currency_basis == "reporting":
+        value = _decimal_value(totals.get("total_balance_reporting_currency"))
+        unit = _read_text(response.get("reporting_currency")) or "reporting_currency"
+    else:
+        raise CoreOutcomeSourceError(
+            "cash balance currency_basis must be 'portfolio' or 'reporting'"
+        )
+
+    source_id = _source_id(
+        product_name=metadata["product_name"],
+        product_version=metadata["product_version"],
+        portfolio_id=_read_required_text(response.get("portfolio_id"), "portfolio_id"),
+        as_of_date=metadata["as_of_date"],
+        basis=currency_basis,
+        fingerprint=metadata["content_hash"],
+    )
+    return DpmRealizedSourceSnapshot(
+        dimension="CASH_RESIDUAL",
+        source_system="lotus-core",
+        source_type="HOLDINGS_AS_OF_CASH_BALANCE",
+        source_id=source_id,
+        value=value,
+        unit=unit,
+        source_state=_source_state(metadata["data_quality_status"]),
+        quality=_source_quality(metadata["data_quality_status"]),
+        observed_at=metadata["observed_at"],
+        as_of_date=metadata["as_of_date"],
+        content_hash=metadata["content_hash"],
+        reason_codes=[
+            _primary_reason(metadata["data_quality_status"]),
+            f"CORE_PRODUCT_{metadata['product_name'].upper()}",
+            f"CORE_PRODUCT_VERSION_{metadata['product_version'].upper()}",
+            f"CASH_BASIS_{currency_basis.upper()}",
+            f"CORE_DATA_QUALITY_{metadata['data_quality_status'].upper()}",
+        ],
+    )
+
+
+def unavailable_core_cash_source(
+    *,
+    source_id: str,
+    reason_code: str,
+    as_of_date: str | None = None,
+) -> DpmRealizedSourceSnapshot:
+    """Return bounded unavailable cash evidence when lotus-core cannot serve truth."""
+
+    return DpmRealizedSourceSnapshot(
+        dimension="CASH_RESIDUAL",
+        source_system="lotus-core",
+        source_type="HOLDINGS_AS_OF_CASH_BALANCE",
+        source_id=source_id,
+        value=None,
+        unit="unknown",
+        source_state="DEGRADED",
+        quality="UNAVAILABLE",
+        observed_at=None,
+        as_of_date=as_of_date,
+        content_hash=None,
+        reason_codes=[reason_code],
+    )
+
+
+def _core_metadata(response: dict[str, Any]) -> _CoreSourceMetadata:
+    product_name = _read_required_text(response.get("product_name"), "product_name")
+    product_version = _read_required_text(response.get("product_version"), "product_version")
+    as_of_date = _read_required_text(
+        response.get("as_of_date") or response.get("resolved_as_of_date"),
+        "as_of_date",
+    )
+    generated_at = _read_text(response.get("generated_at"))
+    latest_evidence = _read_text(response.get("latest_evidence_timestamp"))
+    data_quality_status = (_read_text(response.get("data_quality_status")) or "UNKNOWN").upper()
+    content_hash = (
+        _read_text(response.get("source_batch_fingerprint"))
+        or _read_text(response.get("snapshot_id"))
+        or _read_text(response.get("correlation_id"))
+    )
+    return {
+        "product_name": product_name,
+        "product_version": product_version,
+        "as_of_date": as_of_date,
+        "observed_at": latest_evidence or generated_at,
+        "data_quality_status": data_quality_status,
+        "content_hash": content_hash,
+    }
+
+
+def _source_id(
+    *,
+    product_name: str,
+    product_version: str,
+    portfolio_id: str,
+    as_of_date: str,
+    basis: str,
+    fingerprint: str | None,
+) -> str:
+    suffix = fingerprint or "no-source-fingerprint"
+    return f"{product_name}:{product_version}:{portfolio_id}:{as_of_date}:{basis}:{suffix}"
+
+
+def _source_state(data_quality_status: str) -> Literal["READY", "DEGRADED"]:
+    if data_quality_status in {"COMPLETE", "READY", "OK"}:
+        return "READY"
+    if data_quality_status in {"UNAVAILABLE", "ERROR"}:
+        return "DEGRADED"
+    return "DEGRADED"
+
+
+def _source_quality(
+    data_quality_status: str,
+) -> Literal["COMPLETE", "STALE", "PARTIAL", "UNAVAILABLE"]:
+    if data_quality_status in {"COMPLETE", "READY", "OK"}:
+        return "COMPLETE"
+    if data_quality_status in {"STALE"}:
+        return "STALE"
+    if data_quality_status in {"PARTIAL", "INCOMPLETE"}:
+        return "PARTIAL"
+    return "UNAVAILABLE"
+
+
+def _primary_reason(data_quality_status: str) -> str:
+    if data_quality_status in {"COMPLETE", "READY", "OK"}:
+        return "CORE_SOURCE_READY"
+    return "CORE_SOURCE_DEGRADED"
+
+
+def _read_mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _read_text(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _read_required_text(value: Any, field_name: str) -> str:
+    text = _read_text(value)
+    if text is None:
+        raise CoreOutcomeSourceError(f"lotus-core cash response is missing {field_name}")
+    return text
+
+
+def _decimal_value(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError) as exc:
+        raise CoreOutcomeSourceError(
+            "lotus-core cash response contains a non-numeric cash balance total"
+        ) from exc

--- a/tests/unit/core/test_core_realized_outcome_sources.py
+++ b/tests/unit/core/test_core_realized_outcome_sources.py
@@ -1,0 +1,143 @@
+import pytest
+
+from src.core.outcomes import (
+    CoreOutcomeSourceError,
+    assemble_realized_outcome_snapshot,
+    realized_cash_source_from_cash_balances_response,
+    unavailable_core_cash_source,
+)
+from tests.unit.core.test_realized_outcome_sources import _window
+
+
+def _cash_balances_response() -> dict[str, object]:
+    return {
+        "product_name": "HoldingsAsOf",
+        "product_version": "v1",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "portfolio_currency": "USD",
+        "reporting_currency": "SGD",
+        "resolved_as_of_date": "2026-05-06",
+        "generated_at": "2026-05-06T01:12:00Z",
+        "as_of_date": "2026-05-06",
+        "data_quality_status": "COMPLETE",
+        "latest_evidence_timestamp": "2026-05-06T01:10:00Z",
+        "source_batch_fingerprint": "sha256:holdings-as-of-cash",
+        "snapshot_id": "pss_cash_001",
+        "totals": {
+            "cash_account_count": 2,
+            "total_balance_portfolio_currency": "152500.25",
+            "total_balance_reporting_currency": "205875.34",
+        },
+        "cash_accounts": [],
+    }
+
+
+def test_cash_balances_adapter_wraps_source_total_without_recalculation() -> None:
+    source = realized_cash_source_from_cash_balances_response(_cash_balances_response())
+
+    assert source.dimension == "CASH_RESIDUAL"
+    assert source.source_system == "lotus-core"
+    assert source.source_type == "HOLDINGS_AS_OF_CASH_BALANCE"
+    assert source.source_id == (
+        "HoldingsAsOf:v1:PB_SG_GLOBAL_BAL_001:2026-05-06:reporting:sha256:holdings-as-of-cash"
+    )
+    assert str(source.value) == "205875.34"
+    assert source.unit == "SGD"
+    assert source.observed_at == "2026-05-06T01:10:00Z"
+    assert source.content_hash == "sha256:holdings-as-of-cash"
+    assert source.reason_codes == [
+        "CORE_SOURCE_READY",
+        "CORE_PRODUCT_HOLDINGSASOF",
+        "CORE_PRODUCT_VERSION_V1",
+        "CASH_BASIS_REPORTING",
+        "CORE_DATA_QUALITY_COMPLETE",
+    ]
+
+
+def test_cash_balances_adapter_supports_portfolio_currency_basis() -> None:
+    source = realized_cash_source_from_cash_balances_response(
+        _cash_balances_response(),
+        currency_basis="portfolio",
+    )
+
+    assert str(source.value) == "152500.25"
+    assert source.unit == "USD"
+    assert source.source_id.endswith(":portfolio:sha256:holdings-as-of-cash")
+
+
+def test_cash_source_can_make_rfc42_cash_dimension_ready() -> None:
+    source = realized_cash_source_from_cash_balances_response(_cash_balances_response())
+
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[source],
+        required_dimensions=["CASH_RESIDUAL"],
+    )
+
+    cash = snapshot.realized_values["CASH_RESIDUAL"]
+    assert snapshot.supportability.state == "READY"
+    assert cash.value == source.value
+    assert cash.source_refs[0].source_system == "lotus-core"
+    assert cash.supportability.reason_codes[0] == "SOURCE_READY"
+
+
+def test_incomplete_cash_source_preserves_degraded_core_posture() -> None:
+    response = _cash_balances_response()
+    response["data_quality_status"] = "INCOMPLETE"
+
+    source = realized_cash_source_from_cash_balances_response(response)
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[source],
+        required_dimensions=["CASH_RESIDUAL"],
+    )
+
+    assert source.source_state == "DEGRADED"
+    assert source.quality == "PARTIAL"
+    assert snapshot.supportability.state == "DEGRADED"
+    assert snapshot.realized_values["CASH_RESIDUAL"].supportability.reason_codes[:2] == [
+        "SOURCE_EVIDENCE_INCOMPLETE",
+        "CORE_SOURCE_DEGRADED",
+    ]
+
+
+def test_unavailable_core_cash_source_preserves_degraded_owner_posture() -> None:
+    source = unavailable_core_cash_source(
+        source_id="core-down:cash",
+        reason_code="CORE_CASH_BALANCE_UNAVAILABLE",
+        as_of_date="2026-05-06",
+    )
+
+    snapshot = assemble_realized_outcome_snapshot(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=_window(),
+        source_snapshots=[source],
+        required_dimensions=["CASH_RESIDUAL"],
+    )
+
+    assert snapshot.supportability.state == "DEGRADED"
+    assert snapshot.realized_values["CASH_RESIDUAL"].value is None
+    assert snapshot.realized_values["CASH_RESIDUAL"].supportability.reason_codes[:2] == [
+        "SOURCE_EVIDENCE_INCOMPLETE",
+        "CORE_CASH_BALANCE_UNAVAILABLE",
+    ]
+
+
+def test_cash_adapter_rejects_local_aggregation_request() -> None:
+    with pytest.raises(CoreOutcomeSourceError, match="currency_basis"):
+        realized_cash_source_from_cash_balances_response(
+            _cash_balances_response(),
+            currency_basis="tax",
+        )
+
+
+def test_cash_adapter_rejects_missing_source_total() -> None:
+    malformed = _cash_balances_response()
+    totals = malformed["totals"]
+    assert isinstance(totals, dict)
+    del totals["total_balance_reporting_currency"]
+
+    with pytest.raises(CoreOutcomeSourceError, match="cash balance total"):
+        realized_cash_source_from_cash_balances_response(malformed)

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -620,8 +620,11 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "performance_sources.py" in realized_source_slice
     assert "RISK_METRICS_REPORT" in realized_source_slice
     assert "risk_sources.py" in realized_source_slice
+    assert "HOLDINGS_AS_OF_CASH_BALANCE" in realized_source_slice
+    assert "core_sources.py" in realized_source_slice
     assert "`17 passed`" in realized_source_slice
     assert "`20 passed`" in realized_source_slice
+    assert "`18 passed`" in realized_source_slice
 
     assert "Slice 6 - Persistence, Repository, Events, and Retention" in persistence_slice
     assert "Review body is immutable" in persistence_slice


### PR DESCRIPTION
## Summary
- add a source-owned `lotus-core` `HoldingsAsOf:v1` cash-total adapter for RFC-0042 realized `CASH_RESIDUAL` evidence
- preserve complete, degraded/incomplete, unavailable, malformed, and missing cash-source posture without aggregating cash rows or deriving tax/FX/transaction facts in manage
- update RFC-0042 source maps, Slice 5 evidence, documentation guard tests, and the WTBD ledger to reflect implemented core cash progress and remaining source-owner families

## Validation
- `python -m pytest tests/unit/core/test_core_realized_outcome_sources.py tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/core/test_performance_realized_outcome_sources.py tests/unit/core/test_realized_outcome_sources.py tests/unit/test_documentation_current_state.py -q` => 46 passed
- `python -m mypy --config-file mypy.ini src/core/outcomes/core_sources.py` => passed
- `python -m ruff check src/core/outcomes/core_sources.py src/core/outcomes/risk_sources.py src/core/outcomes/performance_sources.py src/core/outcomes/__init__.py tests/unit/core/test_core_realized_outcome_sources.py tests/unit/test_documentation_current_state.py` => passed
- `python -m ruff format --check src/core/outcomes/core_sources.py src/core/outcomes/risk_sources.py src/core/outcomes/performance_sources.py src/core/outcomes/__init__.py tests/unit/core/test_core_realized_outcome_sources.py tests/unit/test_documentation_current_state.py` => passed
- `git diff --check` => passed
- `make check` => passed, including lint, monetary float guard, no-alias, typecheck, OpenAPI, API vocabulary, mesh contract gates, and 868 unit tests
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` => DiffCount 0
- `git fetch origin --prune && git branch -r --no-merged origin/main` => no stranded remote branches

## Boundary
This adapter intentionally does not implement tax, FX, transaction-cost, execution, liquidity, or rule outcome derivation from transaction rows. Those still require source-owner scalar totals or certified source contracts.

## Wiki Decision
No repo-local wiki source change is required for this sub-slice. This is a manage source-adapter and RFC/ledger truth update, not a new product-facing supported-feature promotion.