### PR TITLE
Add WTBD product readiness control snapshot

### DIFF
--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -27,12 +27,47 @@ Governance rules:
 
 Wiki decision for this ledger update:
 
-The existing `wiki/Supported-Features.md`, `wiki/RFC-Index.md`, and `wiki/Roadmap.md` already state
-the RFC-0036 through RFC-0041 supported boundaries and the major unpromoted capabilities. This
-ledger is a repo-local planning/control artifact for follow-up sequencing, so no additional wiki
-source change is required for this slice. If this ledger later becomes the public cross-RFC backlog
-used for product planning or client roadmap discussion, add a wiki page and sidebar link in the
-same PR.
+The WTBD ledger is now used as a product-readiness control surface, not only an engineering
+planning artifact. `wiki/Supported-Features.md` is updated in this slice with an
+implementation-backed DPM product-readiness view, integration diagram, and next-priority WTBD
+sequence suitable for developers, operations, business stakeholders, sales/pre-sales, and client
+demo preparation. The wiki remains careful not to promote unfinished WTBDs as supported features.
+
+## Mainline WTBD Control Snapshot
+
+Snapshot basis: `main` after RFC38-WTBD-003 merged and repo-local wiki source was published on
+2026-05-07.
+
+| Control | Count | Meaning |
+| --- | ---: | --- |
+| Total WTBD items | 59 | RFC-0036 through RFC-0042 follow-up items tracked in this ledger. |
+| Done on merged/published truth | 16 | Implementation-backed items merged to owning `main` branches, validated, and published where wiki truth changed. |
+| Partial / in progress | 3 | Items with meaningful implementation-backed progress but known source-owner or downstream gaps. |
+| Remaining / open | 40 | Items still deferred, proposed, conditional, unsupported, or awaiting ownership. |
+
+Partial / in-progress items:
+
+| ID | Current partial scope | Remaining gap |
+| --- | --- | --- |
+| RFC37-WTBD-001 | `lotus-manage` RFC-0042 backend authority and first-wave outcome product path are implemented. | Complete richer downstream/source-owner realization across all outcome learning loops. |
+| RFC40-WTBD-009 | First-wave regime scenario evidence exists through RFC-0039 selected alternatives. | Direct proof-pack scenario contribution, CIO approval, and richer source-owner proof-pack enrichment remain future work. |
+| RFC42-WTBD-006 | Selected risk, performance, core tax/cash/FX/cashflow source-family adapters are implemented. | Aggregated risk/performance, tax, FX, cash movement, liquidity, and execution methodologies remain source-owner work. |
+
+Next bank-buyable product-readiness priorities:
+
+| Priority | WTBD | Why this is next | Promotion bar |
+| ---: | --- | --- | --- |
+| 1 | RFC40-WTBD-001 - Gateway proof-pack composition | Exposes manage-owned pre-trade evidence through the governed product API without reconstruction. | Gateway PR merged, route/OpenAPI tests green, no-reconstruction contract tests, wiki published. |
+| 2 | RFC40-WTBD-002 - Workbench proof-pack review UX | Turns pre-trade proof packs into a PM/CIO review surface suitable for demos and operating review. | Workbench BFF-only implementation, browser proof, screenshot evidence, accessible ready/degraded states, wiki published. |
+| 3 | RFC40-WTBD-003 - Full front-office proof-pack product realization | Converts backend proof-pack authority into an end-to-end product claim. | Priorities 1 and 2 merged, canonical front-office QA green, docs/wiki/client-demo material aligned. |
+| 4 | RFC41-WTBD-005 - Gateway wave composition | Starts converting explicit rebalance waves from backend authority into product APIs. | Gateway composition merged with supportability and no-reconstruction tests. |
+| 5 | RFC41-WTBD-006 - Workbench wave command center | Gives PMs an implementation-backed operating cockpit for explicit portfolio-list waves. | Workbench UX merged, canonical browser proof captured, wiki material useful for business, operations, and demos. |
+
+Execution rule:
+
+Do not open a new WTBD implementation slice until the current slice has passed local validation,
+GitHub required checks, PR merge, wiki publication where needed, final `git fetch origin --prune`
+plus `git branch -r --no-merged origin/main`, and clean branch/status hygiene.
 
 ## RFC-0036 - DPM Stateful Core Sourcing And Endpoint Consolidation
 
@@ -710,7 +745,7 @@ products, and canonical seed automation belonged to downstream or source-owning 
 | --- | --- | --- | --- | --- |
 | RFC38-WTBD-001 | Gateway DPM command-center composition | `lotus-gateway` | Completed, merged, CI-proven, and wiki-published through `lotus-gateway` PR #194 | Gateway now composes RFC-0038 mandate command-center, monitoring, exception, and mandate drill-down truth from manage without becoming mandate-health authority. |
 | RFC38-WTBD-002 | Workbench DPM cockpit panels | `lotus-workbench` | Completed, merged, CI-proven, live-proven, and wiki-published through `lotus-workbench` PR #154 | Workbench consumes Gateway/BFF command-center contracts only, renders manage-owned supportability/source readiness/health truth without recomputation, and originally recorded the canonical seed gap that RFC38-WTBD-003 later resolved for the populated governed portfolio. |
-| RFC38-WTBD-003 | Platform canonical seed automation for populated command-center proof | `lotus-platform` with source-app seeds | Completed locally, runtime-proven, pending PR publication | Platform canonical automation now refreshes the governed DPM mandate from core through manage, verifies Manage and Gateway mandate/health/summary reads, and runs canonical Workbench validation with `dpm.command_center` classified `ready`. Partial and empty command-center state automation remains future depth. |
+| RFC38-WTBD-003 | Platform canonical seed automation for populated command-center proof | `lotus-platform` with source-app seeds | Completed, merged, CI-proven, live-proven, and wiki-published through `lotus-platform` PR #304, `lotus-workbench` PR #155, and `lotus-manage` PR #113 | Platform canonical automation now refreshes the governed DPM mandate from core through manage, verifies Manage and Gateway mandate/health/summary reads, and runs canonical Workbench validation with `dpm.command_center` classified `ready`. Partial and empty command-center state automation remains future depth. |
 | RFC38-WTBD-004 | PM-book discovery for monitoring and command-center cohorts | `lotus-core` or future relationship-book authority | Deferred with no support claim | RFC-0038 supports caller-supplied mandate IDs and persisted monitoring runs. No certified PM-book membership source exists yet. |
 | RFC38-WTBD-005 | Mandate objective, benchmark, review cadence, and model-change source products | `lotus-core`, `lotus-performance`, CIO/model authority | Deferred source enrichment | MVP fields are source-backed, derived, or gap-coded. Dedicated source products are required before richer personalization can be claimed. |
 | RFC38-WTBD-006 | Client restriction, sustainability, and cashflow source products | `lotus-core` or dedicated client-governance/cashflow owners | Deferred source enrichment | Health dimensions preserve gaps rather than inventing restrictions, ESG preferences, or cashflow forecasts. |
@@ -853,8 +888,13 @@ for demo, QA, and regression proof.
 
 Closure status:
 
-Completed locally on 2026-05-07 through `lotus-platform` canonical automation and a small
-`lotus-workbench` validation-governance update. PR publication remains pending.
+Completed on 2026-05-07 through coordinated PRs:
+
+1. `lotus-platform` PR #304 merged to `main` as `cdbc489` and published
+   `lotus-platform.wiki` commit `fa3216a`,
+2. `lotus-workbench` PR #155 merged to `main` as `cad5302`,
+3. `lotus-manage` PR #113 merged to `main` as `7579a01` and published
+   `lotus-manage.wiki` commit `27b1071`.
 
 What was delivered:
 

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -761,6 +761,13 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
 
     work_to_be_done = (ROOT / "docs" / "rfcs" / "RFC-worktobedone.md").read_text(encoding="utf-8")
     assert "RFC Work To Be Done Ledger" in work_to_be_done
+    assert "## Mainline WTBD Control Snapshot" in work_to_be_done
+    assert "| Total WTBD items | 59 |" in work_to_be_done
+    assert "| Done on merged/published truth | 16 |" in work_to_be_done
+    assert "| Partial / in progress | 3 |" in work_to_be_done
+    assert "| Remaining / open | 40 |" in work_to_be_done
+    assert "RFC40-WTBD-001 - Gateway proof-pack composition" in work_to_be_done
+    assert "RFC41-WTBD-006 - Workbench wave command center" in work_to_be_done
     assert "## RFC-0042 - Post-Trade Outcome Feedback Loop" in work_to_be_done
     assert "RFC42-WTBD-001" in work_to_be_done
     assert "RFC42-WTBD-008" in work_to_be_done
@@ -781,3 +788,12 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "relative `--output-root`" in work_to_be_done
     assert "Workbench must consume Gateway/BFF only" in work_to_be_done
     assert "PM quality scoring" in work_to_be_done
+    assert "pending PR publication" not in work_to_be_done
+
+    assert "## Product Readiness At A Glance" in supported_features
+    assert "## WTBD Product-Readiness Roadmap" in supported_features
+    assert "flowchart LR" in supported_features
+    assert "developers, business users, operations, sales/pre-sales" in supported_features
+    assert "59 WTBD items: 16 done on merged/published truth" in supported_features
+    assert "RFC40-WTBD-002 - Workbench proof-pack review UX" in supported_features
+    assert "A WTBD is not complete until merged to `main`" in supported_features

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -1,7 +1,72 @@
 # Supported Features
 
 This page summarizes implementation-backed `lotus-manage` capabilities after the advisory cleanup.
-It is intentionally a navigation and demo-prep page; deep mechanics stay in `docs/`.
+It is intentionally a navigation and demo-prep page; deep mechanics stay in `docs/`. The page is
+written for developers, business users, operations, sales/pre-sales, and client-demo preparation, so
+it distinguishes supported capabilities from product-roadmap WTBD items that still need owning-app
+implementation and proof.
+
+## Product Readiness At A Glance
+
+`lotus-manage` is implementation-backed today as the discretionary portfolio management execution
+and evidence authority. It can support private-banking demos and operating review for the backend
+capabilities listed below, but full front-office product claims require the governed
+`lotus-gateway` and `lotus-workbench` realization path to be implemented, validated, merged, and
+published.
+
+```mermaid
+flowchart LR
+    Core[lotus-core<br/>portfolio, mandate, tax-lot, cashflow, market-data sources]
+    Risk[lotus-risk<br/>risk and scenario authority]
+    Performance[lotus-performance<br/>returns, contribution, attribution authority]
+    Manage[lotus-manage<br/>DPM workflow and evidence authority]
+    Gateway[lotus-gateway<br/>product API / BFF composition]
+    Workbench[lotus-workbench<br/>PM and CIO product surface]
+    Report[lotus-report / lotus-render / lotus-archive<br/>report and archive lifecycle]
+    AI[lotus-ai<br/>guarded narrative workflows]
+
+    Core --> Manage
+    Risk --> Manage
+    Performance --> Manage
+    Manage --> Gateway
+    Gateway --> Workbench
+    Manage --> Report
+    Manage --> AI
+```
+
+Current first-wave product posture:
+
+| Product area | Implementation-backed state | Product/demo posture |
+| --- | --- | --- |
+| Stateful DPM source execution | Manage composes governed `lotus-core` source products behind explicit runtime gates. | Backend and integration proof are suitable for technical demos when source gates are enabled. |
+| DPM command center foundation | Manage command-center APIs, Gateway composition, Workbench cockpit rendering, and populated canonical seed proof are merged and live-proven. | First-wave populated command-center demo path is implementation-backed; PM-book discovery and partial/empty seed fixtures remain future scope. |
+| Construction alternatives | Manage alternative generation/read/selection is implemented, with first-wave Gateway/Workbench realization for generated alternatives. | Suitable for demos of generated alternatives and selection posture; richer lifecycle choreography remains roadmap. |
+| Pre-trade proof packs | Manage owns durable proof-pack JSON, Markdown, report input, AI evidence input, hashes, lineage, and supportability states. | Backend proof is demoable; full front-office review UX is the next bank-buyable product-readiness priority. |
+| Explicit portfolio-list waves | Manage owns explicit wave preview/create/source-check/simulate/select/approve/stage/handoff supportability. | Backend authority is proven; Gateway and Workbench product realization remain next-wave work. |
+| Post-trade outcome feedback | Manage backend, Gateway/Workbench first-wave product path, rendered reports, archive lifecycle, and governed AI narrative request path are implemented in owning repos. | First-wave product path is implementation-backed; remaining source-owner methodology depth and OMS/PM-scoring work are not supported claims. |
+
+## WTBD Product-Readiness Roadmap
+
+`docs/rfcs/RFC-worktobedone.md` is the governed WTBD ledger. As of the current mainline snapshot it
+tracks 59 WTBD items: 16 done on merged/published truth, 3 partial or in progress, and 40 remaining
+or open. The next execution wave should focus on product surfaces that materially improve
+bank-buyable demo and operating value without inventing unsupported source truth.
+
+| Priority | WTBD | Business value | Required proof before support claim |
+| ---: | --- | --- | --- |
+| 1 | RFC40-WTBD-001 - Gateway proof-pack composition | Makes pre-trade evidence consumable through the governed product API. | Gateway composition merged, no-reconstruction tests, OpenAPI evidence, wiki publication. |
+| 2 | RFC40-WTBD-002 - Workbench proof-pack review UX | Gives PMs/CIOs a reviewable proof-pack surface for decision meetings and demos. | Workbench BFF-only implementation, ready/degraded/error states, browser proof, screenshot pack, wiki publication. |
+| 3 | RFC40-WTBD-003 - Full proof-pack product realization | Converts manage backend proof-pack authority into a bank-ready front-office product claim. | Gateway and Workbench proof-pack slices merged, canonical front-office QA green, audience-ready docs/wiki. |
+| 4 | RFC41-WTBD-005 - Gateway wave composition | Exposes explicit rebalance-wave authority without making Gateway the workflow owner. | Gateway route, contract, supportability, and no-reconstruction tests. |
+| 5 | RFC41-WTBD-006 - Workbench wave command center | Creates a PM operating cockpit for explicit portfolio-list waves. | Workbench UX, browser proof, canonical screenshots, operations/sales/client-demo wiki material. |
+
+Roadmap boundaries:
+
+1. Unsupported source products remain explicit gaps; do not fill them with local placeholders.
+2. Gateway and Workbench must consume supported backend APIs through the governed product path.
+3. README, RFC, wiki, and supported-feature updates are part of implementation, not post-work notes.
+4. A WTBD is not complete until merged to `main`, validated, wiki-published where needed, and branch
+   hygiene confirms no durable truth remains stranded.
 
 ## Functional Capabilities
 


### PR DESCRIPTION
## Summary

Adds a mainline WTBD control snapshot and implementation-backed wiki product-readiness view so the remaining WTBD execution queue is governed, prioritized, and useful for engineering, operations, business, sales/pre-sales, and client-demo preparation.

## Scope

- Updates `docs/rfcs/RFC-worktobedone.md` with current mainline counts: 59 total, 16 done, 3 partial/in-progress, 40 remaining/open.
- Corrects stale RFC38-WTBD-003 wording now that platform, Workbench, and manage PRs are merged and wiki publication completed where needed.
- Adds a prioritized bank-buyable WTBD execution sequence focused on proof-pack and wave product realization.
- Enriches `wiki/Supported-Features.md` with product-readiness posture, upstream/downstream integration diagram, first-wave product posture table, and WTBD roadmap boundaries.
- Adds documentation regression assertions so stale pending-publication wording and missing roadmap/wiki controls are caught.

## Evidence

- `python -m pytest tests/unit/test_documentation_current_state.py -q` -> 13 passed.
- `git diff --check` passed with only normal LF-to-CRLF warnings.
- `git fetch origin --prune && git branch -r --no-merged origin/main` was clean before this branch was pushed.

## Wiki

Repo-local wiki source changed. `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reports expected pre-publication drift for `Supported-Features.md`. Publish only after merge to `main`.