### PR TITLE
Replay DPM proof packs by source identity

### DIFF
--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -15,6 +15,8 @@ from src.core.proof_packs import (
     build_proof_pack_from_run,
     build_proof_pack_from_selected_alternative,
     build_report_input,
+    proof_pack_id_for_rebalance_run,
+    proof_pack_id_for_selected_alternative,
 )
 from src.core.proof_packs.handoffs import DpmProofPackAiEvidenceInput, DpmProofPackReportInput
 from src.core.proof_packs.models import (
@@ -57,6 +59,11 @@ def generate_proof_pack_from_run(
         )
         if existing is not None:
             return existing
+    existing = proof_pack_repository.get_proof_pack(
+        proof_pack_id=proof_pack_id_for_rebalance_run(rebalance_run_id=rebalance_run_id)
+    )
+    if existing is not None:
+        return existing
     run = run_service.get_run_record(rebalance_run_id=rebalance_run_id)
     mandate_twin, mandate_health, mandate_evidence_gap_codes = _resolve_mandate_evidence(
         mandate_id=mandate_id,
@@ -104,6 +111,14 @@ def generate_proof_pack_from_selected_alternative(
         )
         if existing is not None:
             return existing
+    existing = proof_pack_repository.get_proof_pack(
+        proof_pack_id=proof_pack_id_for_selected_alternative(
+            alternative_set_id=alternative_set_id,
+            selected_alternative_id=selected_alternative_id,
+        )
+    )
+    if existing is not None:
+        return existing
     alternative_set = construction_repository.get_alternative_set(
         alternative_set_id=alternative_set_id
     )

--- a/src/core/proof_packs/__init__.py
+++ b/src/core/proof_packs/__init__.py
@@ -3,6 +3,8 @@ from src.core.proof_packs.builder import (
     ProofPackSourceValidationError,
     build_proof_pack_from_run,
     build_proof_pack_from_selected_alternative,
+    proof_pack_id_for_rebalance_run,
+    proof_pack_id_for_selected_alternative,
 )
 from src.core.proof_packs.handoffs import (
     AI_EVIDENCE_REF_TYPE,
@@ -57,5 +59,7 @@ __all__ = [
     "build_proof_pack_from_run",
     "build_proof_pack_from_selected_alternative",
     "build_report_input",
+    "proof_pack_id_for_rebalance_run",
+    "proof_pack_id_for_selected_alternative",
     "render_proof_pack_markdown",
 ]

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -60,6 +60,17 @@ _SECTION_TITLES: dict[ProofPackSectionType, str] = {
     "ai_refs": "AI Evidence References",
 }
 
+
+def proof_pack_id_for_rebalance_run(*, rebalance_run_id: str) -> str:
+    return rebalance_run_id.replace("rr_", "dpp_", 1)
+
+
+def proof_pack_id_for_selected_alternative(
+    *, alternative_set_id: str, selected_alternative_id: str
+) -> str:
+    return f"dpp_{alternative_set_id}_{selected_alternative_id}"
+
+
 _SECTION_ORDER: list[ProofPackSectionType] = list(_SECTION_TITLES)
 
 
@@ -1047,11 +1058,14 @@ def _proof_pack_id(
     selected_alternative: ConstructionAlternative | None,
 ) -> str:
     if source_type == "REBALANCE_RUN" and run is not None:
-        return run.rebalance_run_id.replace("rr_", "dpp_", 1)
+        return proof_pack_id_for_rebalance_run(rebalance_run_id=run.rebalance_run_id)
     if (
         source_type == "SELECTED_ALTERNATIVE"
         and alternative_set is not None
         and selected_alternative is not None
     ):
-        return f"dpp_{alternative_set.alternative_set_id}_{selected_alternative.alternative_id}"
+        return proof_pack_id_for_selected_alternative(
+            alternative_set_id=alternative_set.alternative_set_id,
+            selected_alternative_id=selected_alternative.alternative_id,
+        )
     raise ProofPackSourceValidationError("DPM_PROOF_PACK_SOURCE_MISSING")

--- a/tests/unit/dpm/proof_packs/test_proof_pack_service.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_service.py
@@ -27,9 +27,9 @@ CREATED_AT = datetime(2026, 5, 3, 9, 30, tzinfo=timezone.utc)
 
 
 class _RunService:
-    def __init__(self, *, missing: bool = False) -> None:
+    def __init__(self, *, missing: bool = False, run=None) -> None:
         self.missing = missing
-        self.run = _run_record()
+        self.run = run or _run_record()
 
     def get_run_record(self, *, rebalance_run_id: str):
         if self.missing:
@@ -112,6 +112,70 @@ def test_selected_alternative_service_replays_idempotent_existing_pack() -> None
         mandate_id="mandate_service",
         idempotency_key="idem-service-proof",
         construction_repository=repository,
+        run_service=_RunService(missing=True),
+        mandate_repository=_mandate_repository(),
+        proof_pack_repository=proof_repository,
+    )
+
+    assert replay == first
+
+
+def test_run_service_replays_existing_pack_by_source_identity() -> None:
+    proof_repository = InMemoryDpmProofPackRepository()
+    run = _run_record()
+
+    first = proof_pack_service.generate_proof_pack_from_run(
+        rebalance_run_id=run.rebalance_run_id,
+        actor_id="pm_service",
+        reason="Initial proof.",
+        correlation_id="corr-service-proof",
+        mandate_id=None,
+        idempotency_key="idem-service-proof",
+        run_service=_RunService(run=run),
+        mandate_repository=None,
+        proof_pack_repository=proof_repository,
+    )
+    replay = proof_pack_service.generate_proof_pack_from_run(
+        rebalance_run_id=run.rebalance_run_id,
+        actor_id="pm_service",
+        reason="Changed proof reason should replay existing immutable source proof.",
+        correlation_id="corr-service-proof-replay",
+        mandate_id=None,
+        idempotency_key="different-idem-service-proof",
+        run_service=_RunService(missing=True),
+        mandate_repository=None,
+        proof_pack_repository=proof_repository,
+    )
+
+    assert replay == first
+
+
+def test_selected_alternative_service_replays_existing_pack_by_source_identity() -> None:
+    repository, alternative_set_id, selected_alternative_id = _construction_repository()
+    proof_repository = InMemoryDpmProofPackRepository()
+
+    first = proof_pack_service.generate_proof_pack_from_selected_alternative(
+        alternative_set_id=alternative_set_id,
+        selected_alternative_id=selected_alternative_id,
+        actor_id="pm_service",
+        reason="Initial proof.",
+        correlation_id="corr-service-proof",
+        mandate_id="mandate_service",
+        idempotency_key="idem-service-proof",
+        construction_repository=repository,
+        run_service=_RunService(),
+        mandate_repository=_mandate_repository(),
+        proof_pack_repository=proof_repository,
+    )
+    replay = proof_pack_service.generate_proof_pack_from_selected_alternative(
+        alternative_set_id=alternative_set_id,
+        selected_alternative_id=selected_alternative_id,
+        actor_id="pm_service",
+        reason="Changed proof reason should replay existing immutable source proof.",
+        correlation_id="corr-service-proof-replay",
+        mandate_id="mandate_service",
+        idempotency_key="different-idem-service-proof",
+        construction_repository=InMemoryConstructionRepository(),
         run_service=_RunService(missing=True),
         mandate_repository=_mandate_repository(),
         proof_pack_repository=proof_repository,


### PR DESCRIPTION
## Summary
- expose deterministic proof-pack identity helpers for rebalance-run and selected-alternative sources
- replay an existing immutable proof pack by source identity before rebuilding
- add regression coverage for repeat generation with a different idempotency key

## Evidence
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_service.py tests/unit/dpm/proof_packs/test_proof_pack_repository.py tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py tests/unit/dpm/api/test_proof_pack_api.py -q` -> 29 passed
- `git diff --check` -> passed with normal LF-to-CRLF warnings

## Slice Context
Supports RFC40-WTBD-003 governed Workbench proof-pack live validation by making pre-trade proof generation repeatable against persistent immutable proof-pack storage.