### PR TITLE
RFC41 WTBD 006: expose DPM wave supportability

### DIFF
--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-06T03:22:28.088378+00:00",
+  "generatedAt": "2026-05-07T06:56:50.702625+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.action",
@@ -56200,6 +56200,126 @@
             "attributeRef": "#/attributeCatalog/lotus.durable"
           },
           {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
+          },
+          {
             "name": "idempotent_replay",
             "location": "body",
             "required": false,
@@ -56909,6 +57029,126 @@
             "type": "boolean",
             "semanticId": "lotus.durable",
             "attributeRef": "#/attributeCatalog/lotus.durable"
+          },
+          {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
           },
           {
             "name": "idempotent_replay",
@@ -58883,6 +59123,126 @@
             "attributeRef": "#/attributeCatalog/lotus.durable"
           },
           {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
+          },
+          {
             "name": "idempotent_replay",
             "location": "body",
             "required": false,
@@ -60146,6 +60506,126 @@
             "attributeRef": "#/attributeCatalog/lotus.durable"
           },
           {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
+          },
+          {
             "name": "idempotent_replay",
             "location": "body",
             "required": false,
@@ -60785,6 +61265,126 @@
             "attributeRef": "#/attributeCatalog/lotus.durable"
           },
           {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
+          },
+          {
             "name": "idempotent_replay",
             "location": "body",
             "required": false,
@@ -61398,6 +61998,126 @@
             "type": "boolean",
             "semanticId": "lotus.durable",
             "attributeRef": "#/attributeCatalog/lotus.durable"
+          },
+          {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
           },
           {
             "name": "idempotent_replay",
@@ -62015,6 +62735,126 @@
             "attributeRef": "#/attributeCatalog/lotus.durable"
           },
           {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
+          },
+          {
             "name": "idempotent_replay",
             "location": "body",
             "required": false,
@@ -62630,6 +63470,126 @@
             "attributeRef": "#/attributeCatalog/lotus.durable"
           },
           {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
+          },
+          {
             "name": "idempotent_replay",
             "location": "body",
             "required": false,
@@ -63243,6 +64203,126 @@
             "type": "boolean",
             "semanticId": "lotus.durable",
             "attributeRef": "#/attributeCatalog/lotus.durable"
+          },
+          {
+            "name": "supportability",
+            "location": "body",
+            "required": true,
+            "type": "DpmWaveSupportabilityResponse",
+            "semanticId": "lotus.supportability",
+            "attributeRef": "#/attributeCatalog/lotus.supportability"
+          },
+          {
+            "name": "supportability.wave_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_id",
+            "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "supportability.wave_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.wave_state",
+            "attributeRef": "#/attributeCatalog/lotus.wave_state"
+          },
+          {
+            "name": "supportability.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "supportability.item_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.item_count",
+            "attributeRef": "#/attributeCatalog/lotus.item_count"
+          },
+          {
+            "name": "supportability.issue_counts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.issue_counts",
+            "attributeRef": "#/attributeCatalog/lotus.issue_counts"
+          },
+          {
+            "name": "supportability.issues",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.issues",
+            "attributeRef": "#/attributeCatalog/lotus.issues"
+          },
+          {
+            "name": "supportability.issues[].support_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_ref",
+            "attributeRef": "#/attributeCatalog/lotus.support_ref"
+          },
+          {
+            "name": "supportability.issues[].item_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.item_state",
+            "attributeRef": "#/attributeCatalog/lotus.item_state"
+          },
+          {
+            "name": "supportability.issues[].severity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.severity",
+            "attributeRef": "#/attributeCatalog/lotus.severity"
+          },
+          {
+            "name": "supportability.issues[].source_owner",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_owner",
+            "attributeRef": "#/attributeCatalog/lotus.source_owner"
+          },
+          {
+            "name": "supportability.issues[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "supportability.issues[].remediation_route",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.remediation_route",
+            "attributeRef": "#/attributeCatalog/lotus.remediation_route"
+          },
+          {
+            "name": "supportability.operator_actions",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.operator_actions",
+            "attributeRef": "#/attributeCatalog/lotus.operator_actions"
           },
           {
             "name": "idempotent_replay",

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -201,6 +201,13 @@ class DpmWaveResponse(BaseModel):
     durable: bool = Field(
         description="Whether this response was durably persisted.", examples=[False]
     )
+    supportability: "DpmWaveSupportabilityResponse" = Field(
+        description=(
+            "Product-safe wave supportability derived by lotus-manage from item states. "
+            "Gateway and Workbench must preserve this authority-owned posture instead of "
+            "reconstructing readiness."
+        )
+    )
     idempotent_replay: bool = Field(
         default=False,
         description="True when create returned an already persisted wave for the idempotency key.",
@@ -461,6 +468,22 @@ router = APIRouter(prefix="/rebalance/waves", tags=["lotus-manage Rebalance Wave
 logger = logging.getLogger(__name__)
 
 
+def _wave_response(
+    *,
+    wave: DpmRebalanceWave,
+    durable: bool,
+    idempotent_replay: bool = False,
+) -> DpmWaveResponse:
+    return DpmWaveResponse(
+        wave=wave,
+        durable=durable,
+        supportability=DpmWaveSupportabilityResponse.model_validate(
+            wave_service.wave_supportability_payload(wave)
+        ),
+        idempotent_replay=idempotent_replay,
+    )
+
+
 @router.post(
     "/preview",
     response_model=DpmWaveResponse,
@@ -519,7 +542,7 @@ def preview_wave(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={"code": exc.code, "message": exc.message},
         ) from exc
-    return DpmWaveResponse(wave=wave, durable=False)
+    return _wave_response(wave=wave, durable=False)
 
 
 @router.post(
@@ -606,7 +629,7 @@ def create_wave(
             status_code=status_code,
             detail={"code": exc.code, "message": exc.message},
         ) from exc
-    return DpmWaveResponse(wave=wave, durable=True, idempotent_replay=replayed)
+    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.get(
@@ -870,7 +893,7 @@ def source_check_wave(
             status_code=status_code,
             detail={"code": exc.code, "message": exc.message},
         ) from exc
-    return DpmWaveResponse(wave=wave, durable=True, idempotent_replay=replayed)
+    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -930,7 +953,7 @@ def simulate_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return DpmWaveResponse(wave=wave, durable=True, idempotent_replay=replayed)
+    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -991,7 +1014,7 @@ def select_wave_item_alternative(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return DpmWaveResponse(wave=wave, durable=True)
+    return _wave_response(wave=wave, durable=True)
 
 
 @router.post(
@@ -1040,7 +1063,7 @@ def approve_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return DpmWaveResponse(wave=wave, durable=True, idempotent_replay=replayed)
+    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -1089,7 +1112,7 @@ def stage_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return DpmWaveResponse(wave=wave, durable=True, idempotent_replay=replayed)
+    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -1137,7 +1160,7 @@ def handoff_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return DpmWaveResponse(wave=wave, durable=True, idempotent_replay=replayed)
+    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -1188,7 +1211,7 @@ def cancel_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return DpmWaveResponse(wave=wave, durable=True, idempotent_replay=replayed)
+    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.get(

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -642,13 +642,17 @@ def cancel_wave(
     return cancelled, False
 
 
+def wave_supportability_payload(wave: DpmRebalanceWave) -> dict[str, object]:
+    return _wave_supportability_payload(wave)
+
+
 def wave_supportability(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    return _wave_supportability_payload(wave)
+    return wave_supportability_payload(wave)
 
 
 def search_waves(

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -313,6 +313,9 @@ def test_wave_preview_returns_source_backed_and_blocked_items_without_persistenc
     assert response.status_code == 200
     payload = response.json()
     assert payload["durable"] is False
+    assert payload["supportability"]["supportability_state"] == "blocked"
+    assert payload["supportability"]["reason"] == "wave_blocked_items"
+    assert payload["supportability"]["issue_counts"] == {"critical": 1, "warning": 0, "info": 1}
     assert payload["wave"]["state"] == "PREVIEWED"
     assert payload["wave"]["aggregate_metrics"]["state_counts"] == {
         "CANDIDATE": 1,
@@ -344,6 +347,8 @@ def test_wave_create_persists_and_replays_by_idempotency_key() -> None:
     first_payload = first.json()
     second_payload = second.json()
     assert first_payload["durable"] is True
+    assert first_payload["supportability"]["supportability_state"] == "blocked"
+    assert first_payload["supportability"]["reason"] == "wave_blocked_items"
     assert first_payload["idempotent_replay"] is False
     assert second_payload["idempotent_replay"] is True
     assert second_payload["wave"]["wave_id"] == first_payload["wave"]["wave_id"]

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -1628,6 +1628,9 @@ Functional coverage:
 - source-backed candidate selection from caller-supplied source refs,
 - source-backed candidate enrichment from an existing RFC-0038 mandate digital twin,
 - truthful `SOURCE_BLOCKED` item state when affected-portfolio evidence is missing,
+- preview, create, and workflow mutation responses include a manage-owned product-safe
+  `supportability` envelope derived from current item states, so Gateway and Workbench can
+  preserve source authority instead of reconstructing readiness,
 - unsupported trigger rejection with `NOT_SUPPORTED_TRIGGER`,
 - durable create with idempotent replay,
 - durable source-check from `CREATED` to `SOURCE_CHECKED`,


### PR DESCRIPTION
## Summary

Completes the Manage source-contract portion of RFC41-WTBD-006 for the Workbench Wave Command Center slice.

- returns source-owned DPM rebalance-wave supportability on preview, create, and workflow mutation responses
- reuses the existing supportability calculation path instead of letting downstream callers infer readiness
- updates endpoint certification wiki source to document the product-safe supportability envelope

## Validation

- `python -m pytest tests/unit/dpm/api/test_waves_api.py tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py -q` -> 40 passed
- `python -m pytest tests/unit/test_documentation_current_state.py -q` -> 13 passed
- `git diff --check` -> passed, normal LF-to-CRLF warnings only
- governed canonical live proof passed through Platform/Workbench after rebuilding Manage: `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260507-142715.json`

## Governance

- Repo-local wiki source changed: `wiki/Endpoint-Certification.md`
- Pre-merge wiki check-only reports expected drift until this PR is merged and wiki is published.
- Stranded-truth gate rerun; the two remaining RFC40 remote branches are classified as superseded because `git cherry -v origin/main` reports their commits as already represented on `origin/main`.