### PR TITLE
Close RFC41 PM-book WTBD on mainline truth

### DIFF
--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -35,16 +35,15 @@ demo preparation. The wiki remains careful not to promote unfinished WTBDs as su
 
 ## Mainline WTBD Control Snapshot
 
-Snapshot basis: `main` after RFC41-WTBD-008 wave report materialization was merged across
-`lotus-manage`, `lotus-report`, `lotus-render`, and `lotus-archive`, CI-proven, and repo-local
-wiki source was published on 2026-05-07.
+Snapshot basis: `main` after RFC41-WTBD-001 source-owned PM-book wave discovery was merged to
+`lotus-manage`, CI-proven, and repo-local wiki source was published on 2026-05-07.
 
 | Control | Count | Meaning |
 | --- | ---: | --- |
 | Total WTBD items | 59 | RFC-0036 through RFC-0042 follow-up items tracked in this ledger. |
-| Done on merged/published truth | 24 | Implementation-backed items merged to owning `main` branches, validated, and published where wiki truth changed. |
+| Done on merged/published truth | 25 | Implementation-backed items merged to owning `main` branches, validated, and published where wiki truth changed. |
 | Partial / in progress | 3 | Items with meaningful implementation-backed progress but known source-owner or downstream gaps. |
-| Remaining / open | 32 | Items still deferred, proposed, conditional, unsupported, or awaiting ownership. |
+| Remaining / open | 31 | Items still deferred, proposed, conditional, unsupported, or awaiting ownership. |
 
 Partial / in-progress items:
 
@@ -58,11 +57,11 @@ Next bank-buyable product-readiness priorities:
 
 | Priority | WTBD | Why this is next | Promotion bar |
 | ---: | --- | --- | --- |
-| 1 | RFC41-WTBD-001 - Automatic PM-book / portfolio-manager cohort discovery | Replaces explicit portfolio-list operations with source-owned PM-book cohort selection when a certified owner exists. | Source-owned cohort product merged, consumed by manage, and proven without manage-local source fabrication. |
-| 2 | RFC41-WTBD-004 - Risk and performance aggregate enrichment for waves | Adds owning-service risk and performance impact to the explicit-list wave cockpit without manage-local approximations. | `lotus-risk` and `lotus-performance` contracts are consumed with supportability, lineage, degraded states, and live proof. |
-| 3 | RFC40-WTBD-006 - Broader risk and performance proof-pack enrichment | Adds richer source-owned proof-pack analytics without manage-local methodology cloning. | `lotus-risk` and `lotus-performance` proof-pack enrichment contracts are consumed with degraded states, lineage, tests, and wiki/demo proof. |
-| 4 | RFC40-WTBD-010 - Decision timeline and portfolio memory | Links mandate, exception, wave, proof-pack, handoff, and outcome evidence into portfolio memory without inventing source truth. | Manage/Gateway/Workbench event lineage is merged, source-owned, queryable, and live-proven with wiki/demo proof. |
-| 5 | RFC41-WTBD-009 - AI PM memo generation from wave evidence | Gives PMs a governed memo workflow over wave evidence without manage-local prompt or narrative generation. | `lotus-ai` owns memo generation from bounded wave evidence, with Gateway/Workbench posture, guardrails, provenance, tests, and live proof. |
+| 1 | RFC41-WTBD-004 - Risk and performance aggregate enrichment for waves | Adds owning-service risk and performance impact to the explicit-list and source-owned PM-book wave cockpit without manage-local approximations. | `lotus-risk` and `lotus-performance` contracts are consumed with supportability, lineage, degraded states, and live proof. |
+| 2 | RFC40-WTBD-006 - Broader risk and performance proof-pack enrichment | Adds richer source-owned proof-pack analytics without manage-local methodology cloning. | `lotus-risk` and `lotus-performance` proof-pack enrichment contracts are consumed with degraded states, lineage, tests, and wiki/demo proof. |
+| 3 | RFC40-WTBD-010 - Decision timeline and portfolio memory | Links mandate, exception, wave, proof-pack, handoff, and outcome evidence into portfolio memory without inventing source truth. | Manage/Gateway/Workbench event lineage is merged, source-owned, queryable, and live-proven with wiki/demo proof. |
+| 4 | RFC41-WTBD-009 - AI PM memo generation from wave evidence | Gives PMs a governed memo workflow over wave evidence without manage-local prompt or narrative generation. | `lotus-ai` owns memo generation from bounded wave evidence, with Gateway/Workbench posture, guardrails, provenance, tests, and live proof. |
+| 5 | RFC41-WTBD-002 - Automatic CIO model-change affected-mandate discovery | Lets CIO-approved model changes create source-owned affected-mandate waves without manual portfolio lists. | CIO/model authority owns an affected-cohort source product with approval lineage, reconciliation, degraded states, and live proof. |
 
 Execution rule:
 
@@ -2204,7 +2203,7 @@ downstream product-surface implementation, or owning-service materialization out
 
 | ID | Work item | Owner | Current status | Why it was not done in RFC-0041 |
 | --- | --- | --- | --- | --- |
-| RFC41-WTBD-001 | Automatic PM-book / portfolio-manager cohort discovery | `lotus-core` source authority consumed by `lotus-manage` | Implemented on current governed branch; not complete by mainline definition until merge and wiki publication | `lotus-core` now owns `PortfolioManagerBookMembership:v1`; `lotus-manage` consumes it for `PM_BOOK_REVIEW` wave preview/create without caller-supplied portfolio fabrication. |
+| RFC41-WTBD-001 | Automatic PM-book / portfolio-manager cohort discovery | `lotus-core` source authority consumed by `lotus-manage` | Completed, merged, CI-proven, and wiki-published through `lotus-core` PR #339 and `lotus-manage` PR #126 | `lotus-core` now owns `PortfolioManagerBookMembership:v1`; `lotus-manage` consumes it for `PM_BOOK_REVIEW` wave preview/create without caller-supplied portfolio fabrication. |
 | RFC41-WTBD-002 | Automatic CIO model-change affected-mandate discovery | `lotus-core` or CIO model-event authority | Deferred with no support claim | Model targets and mandate bindings exist, but no certified source product returns all portfolios affected by a model-change event with lineage and reconciliation proof. |
 | RFC41-WTBD-003 | Tactical house-view, risk-event, and implicit bulk-campaign cohorts | CIO/risk/campaign source owners, with likely `lotus-risk` involvement for risk events | Deferred with no support claim | No governed scenario, risk-event, or campaign cohort authority exists for manage to consume. |
 | RFC41-WTBD-004 | Risk and performance aggregate enrichment for waves | `lotus-risk`, `lotus-performance`, consumed by `lotus-manage` and later `lotus-gateway` | Deferred unless owning-service contracts are consumed | RFC-0041 aggregate impact must not be calculated from manage-local approximations. Risk and performance figures need owning-service certified contracts. |
@@ -2246,11 +2245,14 @@ Support boundary:
 Promotion proof:
 
 1. source-owner foundation merged and wiki-published in `lotus-core` PR #339,
-2. manage focused tests prove source-product client, PM-book preview/create, invalid selector, and
-   incomplete dependency handling,
-3. README/wiki/supported-features updated to state the exact promoted trigger path,
-4. final definition of done still requires this manage branch to be merged to `main`, wiki
-   check-only to pass before merge, wiki publication after merge, and post-merge validation.
+2. manage implementation merged in PR #126 and CI-proven by Feature Lane and PR Merge Gate,
+3. manage focused tests prove source-product client, PM-book preview/create, invalid selector,
+   unavailable/incomplete/empty dependency handling, and source-owned empty-cohort validation,
+4. full local coverage proof passed with `make check-all`: 1173 tests passed and coverage reached
+   99.02%,
+5. repo-local wiki source was published after merge and `Sync-RepoWikis.ps1 -CheckOnly
+   -Repository lotus-manage` returned diff count 0,
+6. README/wiki/supported-features state the exact promoted trigger path.
 
 #### RFC41-WTBD-002 - Automatic CIO Model-Change Affected-Mandate Discovery
 

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -765,9 +765,9 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "RFC Work To Be Done Ledger" in work_to_be_done
     assert "## Mainline WTBD Control Snapshot" in work_to_be_done
     assert "| Total WTBD items | 59 |" in work_to_be_done
-    assert "| Done on merged/published truth | 24 |" in work_to_be_done
+    assert "| Done on merged/published truth | 25 |" in work_to_be_done
     assert "| Partial / in progress | 3 |" in work_to_be_done
-    assert "| Remaining / open | 32 |" in work_to_be_done
+    assert "| Remaining / open | 31 |" in work_to_be_done
     assert "RFC40-WTBD-001 - Gateway Proof-Pack Composition" in work_to_be_done
     assert "Completed, merged, CI-proven, and wiki-published through `lotus-gateway` PR #195" in (
         work_to_be_done
@@ -841,13 +841,19 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "Workbench must consume Gateway/BFF only" in work_to_be_done
     assert "PM quality scoring" in work_to_be_done
     assert "pending PR publication" not in work_to_be_done
-    assert "not complete by mainline definition until merge and wiki publication" in work_to_be_done
+    assert "Completed, merged, CI-proven, and wiki-published through `lotus-core` PR #339" in (
+        work_to_be_done
+    )
+    assert "and `lotus-manage` PR #126" in work_to_be_done
+    assert "not complete by mainline definition until merge and wiki publication" not in (
+        work_to_be_done
+    )
 
     assert "## Product Readiness At A Glance" in supported_features
     assert "## WTBD Product-Readiness Roadmap" in supported_features
     assert "flowchart LR" in supported_features
     assert "developers, business users, operations, sales/pre-sales" in supported_features
-    assert "59 WTBD items: 24 done on merged/published truth" in supported_features
+    assert "59 WTBD items: 25 done on merged/published truth" in supported_features
     assert "Explicit portfolio-list waves" in supported_features
     assert "governed rebalance-wave report materialization in report/render/archive" in (
         supported_features

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -48,17 +48,17 @@ Current first-wave product posture:
 ## WTBD Product-Readiness Roadmap
 
 `docs/rfcs/RFC-worktobedone.md` is the governed WTBD ledger. As of the current mainline snapshot it
-tracks 59 WTBD items: 24 done on merged/published truth, 3 partial or in progress, and 32 remaining
+tracks 59 WTBD items: 25 done on merged/published truth, 3 partial or in progress, and 31 remaining
 or open. The next execution wave should focus on product surfaces that materially improve
 bank-buyable demo and operating value without inventing unsupported source truth.
 
 | Priority | WTBD | Business value | Required proof before support claim |
 | ---: | --- | --- | --- |
-| 1 | RFC41-WTBD-001 - Automatic PM-book / portfolio-manager cohort discovery | Replaces explicit portfolio-list operations with source-owned PM-book cohort selection when a certified owner exists. | Source-owned cohort product merged, consumed by manage, and proven without manage-local source fabrication. |
-| 2 | RFC41-WTBD-004 - Risk and performance aggregate enrichment for waves | Adds owning-service risk and performance impact to the explicit-list wave cockpit without manage-local approximations. | `lotus-risk` and `lotus-performance` contracts are consumed with supportability, lineage, degraded states, and live proof. |
-| 3 | RFC40-WTBD-006 - Broader risk and performance proof-pack enrichment | Adds richer source-owned proof-pack analytics without manage-local methodology cloning. | `lotus-risk` and `lotus-performance` proof-pack enrichment contracts are consumed with degraded states, lineage, tests, and wiki/demo proof. |
-| 4 | RFC40-WTBD-010 - Decision timeline and portfolio memory | Links mandate, exception, wave, proof-pack, handoff, and outcome evidence into portfolio memory without inventing source truth. | Manage/Gateway/Workbench event lineage is merged, source-owned, queryable, and live-proven with wiki/demo proof. |
-| 5 | RFC41-WTBD-009 - AI PM memo generation from wave evidence | Gives PMs a governed memo workflow over wave evidence without manage-local prompt or narrative generation. | `lotus-ai` owns memo generation from bounded wave evidence, with Gateway/Workbench posture, guardrails, provenance, tests, and live proof. |
+| 1 | RFC41-WTBD-004 - Risk and performance aggregate enrichment for waves | Adds owning-service risk and performance impact to the explicit-list and source-owned PM-book wave cockpit without manage-local approximations. | `lotus-risk` and `lotus-performance` contracts are consumed with supportability, lineage, degraded states, and live proof. |
+| 2 | RFC40-WTBD-006 - Broader risk and performance proof-pack enrichment | Adds richer source-owned proof-pack analytics without manage-local methodology cloning. | `lotus-risk` and `lotus-performance` proof-pack enrichment contracts are consumed with degraded states, lineage, tests, and wiki/demo proof. |
+| 3 | RFC40-WTBD-010 - Decision timeline and portfolio memory | Links mandate, exception, wave, proof-pack, handoff, and outcome evidence into portfolio memory without inventing source truth. | Manage/Gateway/Workbench event lineage is merged, source-owned, queryable, and live-proven with wiki/demo proof. |
+| 4 | RFC41-WTBD-009 - AI PM memo generation from wave evidence | Gives PMs a governed memo workflow over wave evidence without manage-local prompt or narrative generation. | `lotus-ai` owns memo generation from bounded wave evidence, with Gateway/Workbench posture, guardrails, provenance, tests, and live proof. |
+| 5 | RFC41-WTBD-002 - Automatic CIO model-change affected-mandate discovery | Lets CIO-approved model changes create source-owned affected-mandate waves without manual portfolio lists. | CIO/model authority owns an affected-cohort source product with approval lineage, reconciliation, degraded states, and live proof. |
 
 Roadmap boundaries:
 


### PR DESCRIPTION
## Summary
- update the WTBD control snapshot after RFC41-WTBD-001 was merged and wiki-published
- mark RFC41-WTBD-001 completed on mainline truth through lotus-core PR #339 and lotus-manage PR #126
- move the next-priority WTBD queue to the next open bank-buyable slices
- pin the updated counts in documentation regression tests

## Proof
- python -m pytest tests/unit/test_documentation_current_state.py -q: 13 passed
- make check: 977 unit tests passed plus lint, format, monetary-float guard, no-alias guard, mypy, OpenAPI quality, API vocabulary, domain-data-product, trust telemetry, and observability contract checks
- git diff --check: passed, normal LF-to-CRLF warnings only

## Governance
- Stranded truth before slice: origin/wtbd-rfc40-proof-pack-product-closure and origin/wtbd-rfc40-proof-pack-source-identity-replay classified superseded by git cherry patch-equivalence to origin/main
- Wiki check-only before merge is expected to show drift for wiki/Supported-Features.md; publish after merge with Sync-RepoWikis.ps1 -Publish -Repository lotus-manage