### PR TITLE
Audit completed RFC36 and RFC38 WTBDs

### DIFF
--- a/docs/rfcs/RFC-0036-dpm-stateful-core-sourcing-and-endpoint-consolidation.md
+++ b/docs/rfcs/RFC-0036-dpm-stateful-core-sourcing-and-endpoint-consolidation.md
@@ -1578,6 +1578,117 @@ live validation, and the latest remote Feature Lane is green. No additional impl
 needed before integration through `lotus-gateway`; that future gateway work should consume the
 certified service surface rather than reintroducing advisory or monolithic context assumptions.
 
+## Post-Closure WTBD Integration Audit
+
+Assessment date: 2026-05-09
+
+This section incorporates the completed RFC36 WTBD follow-ons back into RFC-0036 so the durable
+implementation truth is not stranded only in `docs/rfcs/RFC-worktobedone.md`. The WTBD ledger
+remains the cross-RFC control and sequencing record; this RFC is now the primary narrative for the
+completed RFC36 downstream product realization.
+
+### Completed Follow-On WTBDs
+
+| WTBD | Status | Implementation-backed conclusion |
+| --- | --- | --- |
+| RFC36-WTBD-001 - Gateway integration rebuilt against canonical `/api/v1` manage APIs | Completed and merged | `lotus-gateway` PR #191 merged to `main` at `a68181b`. Gateway consumes the certified manage `/api/v1` routes for rebalance runs, supportability summary, capabilities, construction alternatives, outcome reviews, proof packs, portfolio memory, and waves. Regression coverage now rejects retired unversioned route families, platform capability aliases, and monolithic `dpm-execution-context` assumptions. |
+| RFC36-WTBD-002 - Workbench product surfaces over stateful manage execution | Completed and merged | `lotus-workbench` PR #152 merged to `main` at `c83ea7e`. Workbench presents Gateway-provided manage action-register supportability on `/workbench/{portfolioId}` without direct manage calls or browser-side source-readiness synthesis. The UI renders status, source support state, freshness, run/operation/decision counts, last-run identity, and explicit unknown/N/A posture when Gateway omits source context. |
+| RFC36-WTBD-003 - Portfolio-level DPM operation dashboards over stateful executions | Completed, merged, live-proven, and wiki-published | `lotus-gateway` PR #192 (`df428d6`), `lotus-workbench` PR #153 (`3cbc688`), and corrective `lotus-gateway` PR #193 (`8afa4d3`) completed the operations dashboard path. Gateway enriches the Workbench overview `rebalance_snapshot` from `/api/v1/rebalance/runs?portfolio_id=<portfolio>&limit=5` and `/api/v1/rebalance/supportability/summary`; Workbench renders recent-run counts, issue counts, latest run rows, workflow posture, error labels, and explicit no-runs posture. |
+
+### Cross-Repository Evidence Rechecked
+
+The 2026-05-09 audit re-ran focused evidence on current `main` state before recording this
+integration:
+
+1. `lotus-gateway` targeted regression proof:
+   `python -m pytest tests/unit/test_upstream_clients.py -k "dpm_client_uses_only_canonical_manage_api_v1_contracts or dpm_client_manage_routes or dpm_client_capabilities_uses_gateway_consumer_for_manage_contract" -q`
+   passed with 23 selected tests.
+2. `lotus-workbench` targeted UI proof:
+   `npm run test -- tests/unit/rebalance-status.test.tsx` passed with 3 tests.
+3. `lotus-manage` documentation current-state proof:
+   `python -m pytest tests/unit/test_documentation_current_state.py -q` passed with 14 tests after
+   this documentation movement.
+4. Canonical front-office proof was rerun through
+   `lotus-platform/automation/Invoke-Canonical-FrontOffice-QA.ps1 -BringUp -BuildImages
+   -ScreenshotDirectory output/front-office-qa/wtbd-rfc36-audit-20260509-214550` against
+   `PB_SG_GLOBAL_BAL_001`. The run completed with status `ok` and retained structured evidence in
+   `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260509-214551.json`, a
+   Markdown summary in `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260509-214551.md`,
+   and screenshots plus `live-validation-summary.json` under
+   `lotus-platform/output/front-office-qa/wtbd-rfc36-audit-20260509-214550`.
+
+### Critical Review
+
+The completed RFC36 follow-ons are production-ready for their stated first-wave scope:
+
+1. the browser product surface remains Gateway/BFF-only and does not call `lotus-manage` directly,
+2. Gateway uses canonical `/api/v1` manage contracts and has explicit route-regression protection,
+3. Workbench preserves missing source supportability as unknown/N/A rather than converting absence
+   into false zero-activity evidence,
+4. the operations dashboard was corrected from live evidence when supportability proved to come
+   from `/api/v1/rebalance/supportability/summary`, not the run-list payload,
+5. repo-local and published wiki truth in owning repositories had already been synchronized for the
+   completed follow-ons, and this `lotus-manage` RFC now carries the integrated source-of-truth
+   narrative.
+
+The live evidence also preserved two truthful degraded states that should not be misrepresented as
+RFC36 defects: the cross-platform performance evidence panel is `truthfully_degraded` under
+RFC-0079 ownership, and the manage action-register supportability summary is stale while the DPM
+command-center panel itself is `READY` and `COMPLETE`. These are recorded as operational truth and
+remain follow-on source-supportability work rather than blockers for the completed RFC36 first-wave
+Gateway/Workbench product path.
+
+The remaining RFC36 work is deliberately not reopened inside these completed WTBDs. Additional
+mesh-certified source products, richer upstream source-product depth, and any real downstream
+consumer migration for removed aliases remain separate work because they require producer-owned
+contracts, lineage semantics, and live proof.
+
+### Gold-Pass Reassessment
+
+What was truly completed:
+
+1. `lotus-manage` delivered the certified stateful core-sourced DPM API surface.
+2. `lotus-gateway` now consumes that surface through canonical versioned manage contracts.
+3. `lotus-workbench` presents stateful execution supportability and operations posture through the
+   governed Gateway product path.
+4. Portfolio-level DPM operations visibility is available for recent runs, issue posture,
+   workflow posture, source supportability, freshness, and missing-evidence states.
+
+Quality improvements made:
+
+1. downstream product code is guarded against stale route families and retired monolithic source
+   assumptions,
+2. UI state handling distinguishes ready, source-incomplete, no-runs, and unknown-supportability
+   states,
+3. documentation now places completed WTBD truth back into this RFC instead of leaving it only in
+   the WTBD ledger,
+4. wiki material now separates backend authority, Gateway composition, and Workbench product
+   realization for business, engineering, operations, sales, and client-demo use.
+
+Debt removed:
+
+1. stale Gateway assumptions about unversioned manage routes and platform capability aliases,
+2. browser-side temptation to infer manage source readiness locally,
+3. ledger-only durable truth for completed RFC36 product realization,
+4. ambiguous follow-on status for Gateway integration, Workbench realization, and the operations
+   dashboard.
+
+Testing and evidence:
+
+1. focused Gateway, Workbench, and `lotus-manage` documentation tests pass on current checked-out
+   sources,
+2. prior owning PR CI and wiki publication evidence remains recorded in the WTBD ledger,
+3. canonical front-office validation was rerun for this audit to capture current runtime evidence,
+4. the audit found no code gap requiring runtime implementation changes before this documentation
+   consolidation.
+
+Expected-standard decision:
+
+RFC-0036 and completed WTBD-001 through WTBD-003 have genuinely reached the expected standard for
+the certified backend surface and first-wave downstream product realization. The remaining RFC36
+items are not quality gaps in this completed scope; they are future producer/source-depth or
+conditional migration work that must be executed under their own evidence gates.
+
 ## Test Plan
 
 Minimum test coverage:
@@ -1687,9 +1798,15 @@ This RFC is complete only when:
 
 ## Follow-On Work
 
-1. Rebuild `lotus-gateway` integration against the canonical stateful `lotus-manage` API.
-2. Add Workbench product surfaces only through Gateway after Gateway integration is certified.
-3. Consider portfolio-level DPM operation dashboards after run/supportability APIs are certified
-   against stateful executions.
-4. Promote stateful DPM source-data products into platform mesh certification only after the
-   source-data lineage and supportability evidence is stable.
+1. Completed: rebuild `lotus-gateway` integration against the canonical stateful `lotus-manage`
+   API.
+2. Completed: add Workbench product surfaces only through Gateway after Gateway integration is
+   certified.
+3. Completed: add portfolio-level DPM operation dashboards after run/supportability APIs are
+   certified against stateful executions.
+4. Remaining: promote stateful DPM source-data products into platform mesh certification only after
+   the source-data lineage and supportability evidence is stable.
+5. Remaining: add further upstream source-product depth only through source-owner contracts,
+   retrieval design, supportability semantics, and live proof.
+6. Conditional: migrate real downstream consumers if production dependencies on removed aliases are
+   discovered; do not add permanent compatibility aliases without proven consumer need.

--- a/docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md
+++ b/docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md
@@ -1096,15 +1096,18 @@ Local and remote evidence:
 
 ### 16.5 Remaining Governed Follow-Up
 
-The implementation has reached the expected backend foundation standard for RFC-0038. Remaining
-work is explicitly downstream or deployment-refresh oriented:
+The implementation reached the expected backend foundation standard for RFC-0038. The original
+downstream follow-ups for Gateway composition, Workbench cockpit integration, and platform
+canonical seed automation are now complete and are integrated below as post-closure WTBD truth.
+Remaining work is source-owner enrichment rather than a gap in the completed command-center product
+path:
 
-1. complete Gateway composition in
-   [sgajbi/lotus-gateway#180](https://github.com/sgajbi/lotus-gateway/issues/180),
-2. complete Workbench cockpit integration in
-   [sgajbi/lotus-workbench#140](https://github.com/sgajbi/lotus-workbench/issues/140),
-3. extend platform canonical seed automation in
-   [sgajbi/lotus-platform#294](https://github.com/sgajbi/lotus-platform/issues/294).
+1. richer mandate objective, benchmark, review-cadence, and model-change source products,
+2. client-restriction, sustainability, cashflow, and income-need source products where they affect
+   health scoring,
+3. broader risk and performance health enrichment only through certified source owners,
+4. degraded, blocked, and permission-denied canonical command-center fixtures once source owners
+   publish durable fixture support.
 
 Skills and context decision: no new local Codex skill is required for this RFC. The existing
 `lotus-backend-delivery-governance`, `lotus-endpoint-certification-loop`, and
@@ -1112,3 +1115,104 @@ Skills and context decision: no new local Codex skill is required for this RFC. 
 context and RFC/wiki wording so the current backend foundation, published wiki state, and remaining
 downstream product-surface work are explicitly separated. Gateway, Workbench, and platform context
 should be updated in the owning repositories when those implementations land.
+
+## 17. Post-Closure WTBD Integration Audit
+
+Assessment date: 2026-05-09
+
+This section incorporates completed RFC38 WTBD follow-ons back into RFC-0038 so the command-center
+product truth lives with the originating RFC rather than only in
+`docs/rfcs/RFC-worktobedone.md`.
+
+### 17.1 Completed Follow-On WTBDs
+
+| WTBD | Status | Implementation-backed conclusion |
+| --- | --- | --- |
+| RFC38-WTBD-001 - Gateway DPM command-center composition | Completed and merged | `lotus-gateway` PR #194 merged to `main` at `ee2d806`. Gateway exposes the `/api/v1/dpm/command-center` route family, composes manage-owned mandate, health, monitoring, exception, and drill-down truth, and keeps mandate health and PM-book source authority outside the BFF. |
+| RFC38-WTBD-002 - Workbench DPM cockpit panels | Completed, merged, and live-proven | `lotus-workbench` PR #154 merged to `main` at `2fbfac5`. Workbench consumes Gateway/BFF command-center contracts only and renders health distribution, source readiness, attention queue, active exceptions, mandate health dimensions, monitoring action posture, and bounded observability without browser-side health or source-readiness calculation. |
+| RFC38-WTBD-003 - Platform canonical seed automation | Completed, merged, live-proven, and wiki-published | `lotus-platform` PR #304, `lotus-workbench` PR #155, and `lotus-manage` PR #113 added the governed command-center seed path for `PB_SG_GLOBAL_BAL_001`, `MANDATE_PB_SG_GLOBAL_BAL_001`, `PM_SG_DPM_001`, and `BOOK_SG_BALANCED_DPM`, including Manage and Gateway mandate/health/summary checks plus canonical Workbench screenshot registration. |
+| RFC38-WTBD-004 - PM-book discovery for monitoring and command-center cohorts | Completed for populated source-owned PM-book monitoring cohorts | `lotus-core` owns `PortfolioManagerBookMembership:v1`; `lotus-manage` consumes it when monitoring run-once receives a portfolio-manager selector without explicit mandate ids; Gateway passes the body through; Workbench now triggers the source-owned path rather than sending a single-mandate fallback. |
+
+### 17.2 Evidence Rechecked
+
+The 2026-05-09 audit rechecked current source and runtime evidence:
+
+1. Manage command-center, mandate, health, monitoring, and repository proof:
+   `python -m pytest tests/unit/dpm/core/test_mandate_health.py tests/unit/dpm/api/test_mandates_api.py tests/unit/dpm/api/test_monitoring_api.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py -q`
+   passed with 61 tests.
+2. Manage PM-book core-sourcing proof:
+   `python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client.py -k "pm_book or PortfolioManagerBookMembership or cio_model_change" -q`
+   passed with 1 selected PM-book test.
+3. Static command-center proof:
+   `python -m ruff check src/api/routers/monitoring.py src/api/services/mandate_service.py src/infrastructure/core_sourcing/client.py tests/unit/dpm/api/test_monitoring_api.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py`
+   passed.
+4. Canonical front-office proof:
+   `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260509-214551.json` passed
+   with DPM command-center seed status `ok`.
+5. The same canonical proof classified `dpm.command_center` as `ready`, with
+   `supportabilityState=READY`, `dataCompletenessState=COMPLETE`, and screenshot evidence under
+   `lotus-platform/output/front-office-qa/wtbd-rfc36-audit-20260509-214550/dpm-command-center-live.png`.
+6. The DPM command-center seed evidence captured populated `ready`, selector-driven `partial`
+   (`PM_BOOK_DISCOVERY_NOT_YET_SOURCED`), and empty-date `empty` posture checks in
+   `lotus-platform/output/front-office-qa/dpm-command-center-seed-20260509-220332.json`.
+
+### 17.3 Critical Review
+
+The completed RFC38 command-center path is production-ready for its first-wave scope:
+
+1. manage remains mandate-health, monitoring, and command-center authority,
+2. Gateway composes but does not recalculate mandate health, source readiness, exceptions, or
+   PM-book membership,
+3. Workbench consumes Gateway/BFF contracts and preserves bounded supportability, health, attention,
+   and exception state without local reconstruction,
+4. canonical seed automation now proves the populated command-center path with current runtime
+   evidence and captures explicit partial and empty postures,
+5. PM-book monitoring cohort discovery fails closed on missing selectors, source unavailability,
+   incomplete source supportability, empty memberships, and missing refreshed mandate twins.
+
+The audit did not find a code gap requiring implementation changes in this slice. The main gap was
+documentation drift: the RFC still described Gateway/Workbench/platform follow-ups as outstanding
+after they had already merged. This section closes that durable-truth drift.
+
+### 17.4 Gold-Pass Reassessment
+
+What was truly completed:
+
+1. the manage backend mandate twin, health, monitoring, exception, and command-center authority,
+2. Gateway command-center composition over manage-owned truth,
+3. Workbench cockpit panels over the Gateway/BFF product contract,
+4. platform canonical seed automation and current live command-center screenshot evidence,
+5. populated PM-book monitoring cohort discovery through `PortfolioManagerBookMembership:v1`.
+
+Quality improvements made:
+
+1. source authority boundaries are now explicit across manage, Gateway, Workbench, and platform
+   automation,
+2. tests prove command-center behavior, selected-run exception scoping, PM-book dependency
+   handling, and PM-book source-client parsing,
+3. canonical evidence preserves ready, partial, and empty states rather than collapsing them into a
+   single success label,
+4. this RFC now owns completed WTBD truth instead of pointing readers to obsolete downstream issue
+   links.
+
+Debt removed:
+
+1. stale follow-up wording for already completed Gateway, Workbench, and platform seed work,
+2. ambiguity between manage backend foundation and full first-wave product realization,
+3. the risk of treating populated command-center screenshots as proof without machine-readable seed
+   and panel-classification evidence.
+
+Testing and evidence:
+
+1. 61 manage RFC38 tests passed in this audit,
+2. PM-book core-sourcing focused proof passed,
+3. Ruff static checks passed for the command-center and core-sourcing files,
+4. governed canonical front-office QA passed with command-center seed status `ok`,
+5. screenshot and `live-validation-summary.json` evidence prove the populated Workbench panel.
+
+Expected-standard decision:
+
+RFC-0038 and completed WTBD-001 through WTBD-004 have genuinely reached the expected first-wave
+standard for backend authority, Gateway composition, Workbench command-center product realization,
+platform seed automation, and PM-book monitoring cohort discovery. Remaining source-product,
+degraded-fixture, and richer health-enrichment work should remain separate WTBD scope.

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -93,6 +93,12 @@ supportability, certified the implemented APIs, proved live `manage.dev.lotus` p
 `core-control.dev.lotus` / `core-query.dev.lotus`, published wiki truth, and kept stateful
 capability publication behind explicit runtime gates.
 
+2026-05-09 gold-pass audit update: completed RFC36-WTBD-001 through RFC36-WTBD-003 have been moved
+back into `docs/rfcs/RFC-0036-dpm-stateful-core-sourcing-and-endpoint-consolidation.md` as
+implemented follow-on truth. This WTBD ledger remains the control register, closure evidence
+index, and sequencing view; RFC-0036 is now the durable narrative for the completed Gateway,
+Workbench, and operations-dashboard product realization.
+
 Closure evidence:
 
 | Evidence | Location |
@@ -297,6 +303,63 @@ repo-local plus published wiki material reflects the implementation-backed capab
 level aggregation, operations drill-down pages, alerting, and report/AI materialization remain
 future product depth and should be tracked under later command-center/reporting WTBDs rather than
 reopening this first-wave operations dashboard slice.
+
+### RFC36 Gold-Pass Audit And RFC Reintegration - 2026-05-09
+
+Current decision:
+
+RFC36-WTBD-001, RFC36-WTBD-002, and RFC36-WTBD-003 remain complete after slice-by-slice audit.
+Their implementation truth has been incorporated into RFC-0036 so completed work is not stranded
+only in this WTBD ledger.
+
+What was truly completed:
+
+1. Gateway integration was rebuilt and guarded against stale manage aliases through canonical
+   `/api/v1` route tests.
+2. Workbench renders stateful DPM supportability and rebalance status only through Gateway/BFF
+   data.
+3. Portfolio-level DPM operations dashboard visibility is available for source supportability,
+   freshness, recent runs, run issues, workflow posture, no-runs posture, and missing-supportability
+   posture.
+
+Quality improvements made:
+
+1. Current targeted Gateway, Workbench, and documentation tests were rerun during this audit before
+   claiming completion.
+2. Completed WTBD truth was moved into RFC-0036, reducing durable-truth fragmentation.
+3. Wiki source was enriched with current-state feature behavior, integration flow, audience-specific
+   usage, and non-functional controls for the RFC36 product path.
+
+Debt removed:
+
+1. ledger-only closure truth for the completed downstream RFC36 follow-ons,
+2. ambiguous follow-on status inside RFC-0036,
+3. outdated impression that Gateway integration, Workbench realization, or the operations dashboard
+   remained merely future considerations.
+
+Testing and evidence:
+
+1. `lotus-gateway` targeted proof passed: 23 selected tests in
+   `tests/unit/test_upstream_clients.py`.
+2. `lotus-workbench` targeted proof passed: 3 tests in
+   `tests/unit/rebalance-status.test.tsx`.
+3. `lotus-manage` documentation current-state proof passed: 14 tests in
+   `tests/unit/test_documentation_current_state.py`.
+4. Canonical front-office QA was rerun through the governed platform wrapper against
+   `PB_SG_GLOBAL_BAL_001`; the generated summary is retained at
+   `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260509-214551.json` and the
+   screenshot evidence is retained under
+   `lotus-platform/output/front-office-qa/wtbd-rfc36-audit-20260509-214550`.
+5. Evidence review confirmed the DPM command-center, proof-pack, outcome-review, portfolio-memory,
+   and wave command-center panels are demo-ready. It also confirmed `performance.evidence` remains
+   truthfully degraded under RFC-0079 ownership and manage action-register supportability remains
+   stale; those are follow-on source-supportability truths, not hidden completion claims.
+
+Expected-standard decision:
+
+The completed RFC36 WTBDs have genuinely reached the expected first-wave standard. No code change
+was required by this audit; the remaining action was documentation closure so RFC, WTBD, and wiki
+truth align with merged implementation and live validation evidence.
 
 #### RFC36-WTBD-004 - Additional Stateful Source Products In Mesh Certification
 
@@ -1017,6 +1080,65 @@ seed hardening now proves populated ready, selector-driven partial, and empty pl
 postures. It still does not claim degraded, blocked, or permission-denied PM-book fixtures because those require
 source-owner fixture support, Workbench browser assertions, and screenshot/evidence registration
 beyond the populated command-center path.
+
+### RFC38 Gold-Pass Audit And RFC Reintegration - 2026-05-09
+
+Current decision:
+
+RFC38-WTBD-001, RFC38-WTBD-002, RFC38-WTBD-003, and RFC38-WTBD-004 remain complete after
+slice-by-slice audit. Their implementation truth has been incorporated into RFC-0038 so the
+completed command-center product path is not stranded only in this WTBD ledger.
+
+What was truly completed:
+
+1. Gateway composes the manage-owned DPM command-center route family without becoming mandate,
+   source-readiness, or monitoring authority.
+2. Workbench renders the DPM command-center cockpit through Gateway/BFF only, including health
+   distribution, attention queue, active exceptions, mandate-health dimensions, and monitoring
+   action posture.
+3. Platform canonical seed automation proves the populated command-center path and records
+   ready, partial, and empty seed posture checks.
+4. Manage PM-book monitoring can resolve populated cohorts from lotus-core
+   `PortfolioManagerBookMembership:v1` instead of requiring caller-supplied mandate lists.
+
+Quality improvements made:
+
+1. RFC-0038 now reflects completed Gateway, Workbench, platform seed, and PM-book follow-ons
+   instead of pointing to stale downstream issue links.
+2. Wiki source now contains an audience-aware command-center flow diagram, current feature
+   behavior, non-functional controls, and demo boundaries.
+3. The documentation regression guard now pins RFC38 WTBD reintegration, exact canonical evidence
+   artifacts, and wiki command-center material.
+
+Debt removed:
+
+1. stale RFC wording that treated merged downstream command-center work as open,
+2. ambiguity between backend-only RFC closure and full first-wave product realization,
+3. screenshot-only proof risk by tying demo readiness to machine-readable seed and panel evidence.
+
+Testing and evidence:
+
+1. `lotus-manage` RFC38 focused proof passed: 61 tests across mandate health, mandates API,
+   monitoring API, and mandate repository supportability tests.
+2. `lotus-manage` PM-book core-sourcing proof passed: 1 selected PM-book test in
+   `tests/unit/dpm/infrastructure/test_core_sourcing_client.py`.
+3. Ruff static proof passed for command-center routers/services, core-sourcing client, and related
+   tests.
+4. Canonical front-office QA passed at
+   `lotus-platform/output/front-office-qa/canonical-front-office-qa-20260509-214551.json` with
+   DPM command-center seed status `ok`.
+5. Screenshot evidence is retained at
+   `lotus-platform/output/front-office-qa/wtbd-rfc36-audit-20260509-214550/dpm-command-center-live.png`.
+6. Seed evidence is retained at
+   `lotus-platform/output/front-office-qa/dpm-command-center-seed-20260509-220332.json` and proves
+   populated ready, selector-driven partial, and empty-date command-center postures.
+
+Expected-standard decision:
+
+The completed RFC38 WTBDs have genuinely reached the expected first-wave standard for backend
+authority, Gateway composition, Workbench command-center product realization, platform seed
+automation, and PM-book cohort discovery. Remaining source-product, degraded-fixture,
+permission-denied fixture, and richer health-enrichment work stays separate WTBD scope.
 
 #### RFC38-WTBD-005 - Mandate Objective, Benchmark, Review Cadence, And Model-Change Sources
 

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -112,6 +112,77 @@ def test_architecture_review_control_docs_stay_present() -> None:
     assert missing_findings == []
 
 
+def test_rfc0036_completed_wtbd_truth_is_integrated_into_rfc_and_wiki() -> None:
+    rfc = (
+        ROOT / "docs" / "rfcs" / "RFC-0036-dpm-stateful-core-sourcing-and-endpoint-consolidation.md"
+    ).read_text(encoding="utf-8")
+    wtbd = (ROOT / "docs" / "rfcs" / "RFC-worktobedone.md").read_text(encoding="utf-8")
+    supported_features = (ROOT / "wiki" / "Supported-Features.md").read_text(encoding="utf-8")
+
+    assert "## Post-Closure WTBD Integration Audit" in rfc
+    assert (
+        "RFC36-WTBD-001 - Gateway integration rebuilt against canonical `/api/v1` manage APIs"
+        in rfc
+    )
+    assert "RFC36-WTBD-002 - Workbench product surfaces over stateful manage execution" in rfc
+    assert (
+        "RFC36-WTBD-003 - Portfolio-level DPM operation dashboards over stateful executions" in rfc
+    )
+    assert "canonical-front-office-qa-20260509-214551.json" in rfc
+    assert "wtbd-rfc36-audit-20260509-214550" in rfc
+    assert "truthfully_degraded" in rfc
+    assert "Expected-standard decision" in rfc
+    assert "Completed: rebuild `lotus-gateway` integration" in rfc
+    assert "Remaining: promote stateful DPM source-data products" in rfc
+
+    assert "RFC36 Gold-Pass Audit And RFC Reintegration - 2026-05-09" in wtbd
+    assert "Their implementation truth has been incorporated into RFC-0036" in wtbd
+    assert "canonical-front-office-qa-20260509-214551.json" in wtbd
+    assert "wtbd-rfc36-audit-20260509-214550" in wtbd
+    assert (
+        "The completed RFC36 WTBDs have genuinely reached the expected first-wave standard" in wtbd
+    )
+
+    assert "## RFC-0036 Stateful Execution Product Path" in supported_features
+    assert "lotus-gateway Workbench overview BFF" in supported_features
+    assert "Missing supportability is rendered as unknown/N/A" in supported_features
+    assert "| Contract governance |" in supported_features
+    assert (
+        "Client demos should claim first-wave supportability and operations visibility only"
+        in supported_features
+    )
+
+
+def test_rfc0038_completed_wtbd_truth_is_integrated_into_rfc_and_wiki() -> None:
+    rfc = (
+        ROOT / "docs" / "rfcs" / "RFC-0038-mandate-digital-twin-health-and-command-center.md"
+    ).read_text(encoding="utf-8")
+    wtbd = (ROOT / "docs" / "rfcs" / "RFC-worktobedone.md").read_text(encoding="utf-8")
+    supported_features = (ROOT / "wiki" / "Supported-Features.md").read_text(encoding="utf-8")
+
+    assert "## 17. Post-Closure WTBD Integration Audit" in rfc
+    assert "RFC38-WTBD-001 - Gateway DPM command-center composition" in rfc
+    assert "RFC38-WTBD-002 - Workbench DPM cockpit panels" in rfc
+    assert "RFC38-WTBD-003 - Platform canonical seed automation" in rfc
+    assert "RFC38-WTBD-004 - PM-book discovery for monitoring and command-center cohorts" in rfc
+    assert "canonical-front-office-qa-20260509-214551.json" in rfc
+    assert "dpm-command-center-seed-20260509-220332.json" in rfc
+    assert "supportabilityState=READY" in rfc
+    assert "Expected-standard decision" in rfc
+
+    assert "RFC38 Gold-Pass Audit And RFC Reintegration - 2026-05-09" in wtbd
+    assert "Their implementation truth has been incorporated into RFC-0038" in wtbd
+    assert "dpm-command-center-live.png" in wtbd
+    assert (
+        "populated ready, selector-driven partial, and empty-date command-center postures" in wtbd
+    )
+
+    assert "## RFC-0038 DPM Command Center Product Path" in supported_features
+    assert "lotus-core PortfolioManagerBookMembership:v1" in supported_features
+    assert "| Failure behavior |" in supported_features
+    assert "daily discretionary mandate control surface" in supported_features
+
+
 def test_wiki_sidebar_links_resolve_to_authored_pages() -> None:
     sidebar = (ROOT / "wiki" / "_Sidebar.md").read_text(encoding="utf-8")
     missing: list[str] = []

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -47,6 +47,128 @@ Current first-wave product posture:
 | Post-trade outcome feedback | Manage backend, Gateway/Workbench first-wave product path, rendered reports, archive lifecycle, and governed AI narrative request path are implemented in owning repos. | First-wave product path is implementation-backed; remaining source-owner methodology depth and OMS/PM-scoring work are not supported claims. |
 | Canonical DPM demo story | Platform owns the governed cross-app canonical DPM demo story for `PB_SG_GLOBAL_BAL_001`, with deep docs, wiki landing page, diagrams, audience-specific talk track, canonical contract links, Workbench panel registry links, platform QA command, and explicit unsupported-claim boundaries. | `lotus-platform` PR #310 and wiki publication commit `884bec3` make the demo story implementation-backed and publishable for business users, operations, engineering, sales/pre-sales, and client demos. It does not claim external OMS execution, PM scoring, client-communication lineage, autonomous AI decisioning, or local Workbench recomputation. |
 
+## RFC-0036 Stateful Execution Product Path
+
+RFC-0036 is no longer only a backend cleanup record. The certified manage API surface now has a
+completed first-wave downstream product path through Gateway and Workbench for canonical stateful
+DPM execution supportability and operations visibility.
+
+```mermaid
+flowchart LR
+    CoreProducts[lotus-core RFC-087 source products]
+    ManageStateful[lotus-manage stateful DPM execution and supportability]
+    GatewayBff[lotus-gateway Workbench overview BFF]
+    WorkbenchStatus[lotus-workbench rebalance status panel]
+    WorkbenchOps[lotus-workbench DPM operations dashboard]
+    Evidence[Canonical front-office QA evidence]
+
+    CoreProducts --> ManageStateful
+    ManageStateful -->|/api/v1/rebalance/runs| GatewayBff
+    ManageStateful -->|/api/v1/rebalance/supportability/summary| GatewayBff
+    GatewayBff --> WorkbenchStatus
+    GatewayBff --> WorkbenchOps
+    WorkbenchStatus --> Evidence
+    WorkbenchOps --> Evidence
+```
+
+Current functional behavior:
+
+1. Gateway reads manage only through canonical `/api/v1` contracts and preserves manage-owned
+   source supportability.
+2. Workbench displays source support state, freshness, run count, operation count, workflow
+   decision count, last-run identity, and reason posture on `/workbench/{portfolioId}`.
+3. The operations dashboard displays recent manage rebalance runs, issue count, workflow posture,
+   run status, timestamp, and explicit no-runs posture.
+4. Missing supportability is rendered as unknown/N/A instead of false readiness or false zero
+   activity.
+
+Non-functional controls:
+
+| Control area | Current implementation-backed posture |
+| --- | --- |
+| Contract governance | Gateway tests prove manage consumption remains on `/api/v1` route families and rejects retired aliases. |
+| Source ownership | Workbench does not calculate manage supportability, source readiness, freshness, or run posture locally. |
+| Observability | UI and Gateway evidence use bounded supportability and state labels rather than portfolio-sensitive metric labels. |
+| Operational diagnosis | PM and operations users can distinguish ready, action-required, stale, no-runs, and unknown-supportability states. |
+| Demo readiness | Canonical proof uses governed `PB_SG_GLOBAL_BAL_001` evidence and must be captured through the front-office runtime before screenshots are treated as demo-ready. |
+
+Audience use:
+
+1. Business and sales users can describe this as a discretionary portfolio management operating
+   surface that shows whether stateful execution evidence is ready for review.
+2. Operations users can use the same panel to spot source-readiness gaps, failed runs, stale
+   supportability, and missing upstream evidence.
+3. Engineering users can trace the feature from Workbench to Gateway to the manage `/api/v1`
+   contracts and RFC-087 core source products.
+4. Client demos should claim first-wave supportability and operations visibility only; richer
+   book-level aggregation, alerting, external OMS execution, and additional source-product depth
+   remain future work.
+
+## RFC-0038 DPM Command Center Product Path
+
+RFC-0038 now has a complete first-wave product path for mandate health and command-center
+visibility. The backend authority, Gateway composition, Workbench cockpit, canonical seed
+automation, and PM-book cohort discovery are implementation-backed for the governed populated
+portfolio.
+
+```mermaid
+flowchart LR
+    CoreBook[lotus-core PortfolioManagerBookMembership:v1]
+    CoreMandate[lotus-core mandate, model, eligibility, tax-lot, and market-data products]
+    ManageTwin[lotus-manage mandate digital twin]
+    ManageHealth[lotus-manage mandate health and monitoring]
+    ManageCommand[lotus-manage command-center summary]
+    GatewayCommand[lotus-gateway DPM command-center BFF]
+    WorkbenchCockpit[lotus-workbench DPM command-center cockpit]
+    PlatformSeed[lotus-platform canonical command-center seed]
+    EvidencePack[Canonical QA summary and screenshots]
+
+    CoreBook --> ManageHealth
+    CoreMandate --> ManageTwin
+    ManageTwin --> ManageHealth
+    ManageHealth --> ManageCommand
+    ManageCommand --> GatewayCommand
+    GatewayCommand --> WorkbenchCockpit
+    PlatformSeed --> ManageTwin
+    PlatformSeed --> GatewayCommand
+    WorkbenchCockpit --> EvidencePack
+```
+
+Current functional behavior:
+
+1. Manage owns mandate digital twins, mandate health scores, monitoring runs, active exceptions,
+   and the command-center summary.
+2. PM-book monitoring can resolve the populated cohort from lotus-core
+   `PortfolioManagerBookMembership:v1` instead of relying on caller-supplied mandate lists.
+3. Gateway exposes the command-center route family without recalculating mandate health or
+   becoming source authority.
+4. Workbench renders health distribution, attention queue, active exceptions, mandate health
+   dimensions, source-readiness posture, and monitoring action state through the Gateway/BFF only.
+5. Platform seed automation verifies ready, partial, and empty command-center postures before the
+   screenshot pack is treated as demo-ready evidence.
+
+Non-functional controls:
+
+| Control area | Current implementation-backed posture |
+| --- | --- |
+| Source authority | Core owns PM-book membership and source products; manage owns mandate health interpretation; Gateway and Workbench do not reconstruct either layer. |
+| Failure behavior | Missing selector, unavailable PM-book source, incomplete supportability, empty membership, and missing refreshed mandate twins fail closed with bounded error or non-ready posture. |
+| Observability | Command-center and monitoring surfaces use bounded supportability, reason, and state vocabulary instead of sensitive portfolio, mandate, run, or exception labels. |
+| Auditability | Monitoring filters retain PM, book, tenant, booking center, source product, source version, supportability, snapshot id, and source content hash. |
+| Demo readiness | `canonical-front-office-qa-20260509-214551.json` proves command-center seed status `ok`; `dpm-command-center-live.png` is demo-ready for the populated canonical portfolio. |
+
+Audience use:
+
+1. Business users can describe the cockpit as the daily discretionary mandate control surface for
+   source readiness, health, and exception triage.
+2. Operations teams can use it to separate ready mandates from partial source selectors, empty
+   filters, stale source posture, and active exception queues.
+3. Sales and pre-sales teams can show populated command-center evidence for
+   `PB_SG_GLOBAL_BAL_001` while avoiding claims about degraded/blocked fixtures that are still
+   source-owner follow-up.
+4. Engineers can trace the flow from core source products through manage health and monitoring,
+   Gateway BFF composition, Workbench rendering, and platform QA evidence.
+
 ## WTBD Product-Readiness Roadmap
 
 `docs/rfcs/RFC-worktobedone.md` is the governed WTBD ledger. As of the current mainline snapshot it


### PR DESCRIPTION
## Summary
- integrates completed RFC36 and RFC38 WTBD truth into the originating RFCs
- adds gold-pass WTBD assessments with current live canonical evidence references
- enriches Supported Features wiki source with RFC36 and RFC38 product-path diagrams and audience-aware controls
- pins the durable RFC/WTBD/wiki truth in documentation current-state tests

## Validation
- python -m pytest tests/unit/test_documentation_current_state.py -q
- python -m pytest tests/unit/dpm/core/test_mandate_health.py tests/unit/dpm/api/test_mandates_api.py tests/unit/dpm/api/test_monitoring_api.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py -q
- python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client.py -k "pm_book or PortfolioManagerBookMembership or cio_model_change" -q
- python -m ruff check src/api/routers/monitoring.py src/api/services/mandate_service.py src/infrastructure/core_sourcing/client.py tests/unit/dpm/api/test_monitoring_api.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py
- git diff --check
- python automation/validate_engineering_context_system.py (lotus-platform)
- python automation/validate_lotus_skill_alignment.py (lotus-platform)
- powershell -ExecutionPolicy Bypass -File automation/Sync-AgentOperatingContract.ps1 -AllRepoRoots -IncludeDeployedTarget (lotus-platform)
- powershell -ExecutionPolicy Bypass -File automation/Invoke-Canonical-FrontOffice-QA.ps1 -BringUp -BuildImages -ScreenshotDirectory output/front-office-qa/wtbd-rfc36-audit-20260509-214550 (lotus-platform, status ok)

## Wiki
- Repo-local wiki source changed: wiki/Supported-Features.md
- Check-only currently reports expected drift until this PR merges and the wiki is published from repo-local source.
