### PR TITLE
Align live core validation with source-ready stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ live-api-validate:
 	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://127.0.0.1:8001}
 
 live-api-validate-core:
-	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://manage.dev.lotus} --skip-demo-pack --core-base-url $${LOTUS_CORE_CONTROL_BASE_URL:-http://core-control.dev.lotus} --core-base-url $${LOTUS_CORE_QUERY_BASE_URL:-http://core-query.dev.lotus} --expect-core-dpm-route $${LOTUS_MANAGE_EXPECT_CORE_DPM_ROUTE:-absent} --expect-stateful-core-sourcing $${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-disabled} --portfolio-id $${LOTUS_MANAGE_CANONICAL_PORTFOLIO_ID:-PB_SG_GLOBAL_BAL_001} --as-of $${LOTUS_MANAGE_CANONICAL_AS_OF:-2026-04-10}
+	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://manage.dev.lotus} --skip-demo-pack --core-base-url $${LOTUS_CORE_CONTROL_BASE_URL:-http://core-control.dev.lotus} --core-base-url $${LOTUS_CORE_QUERY_BASE_URL:-http://core-query.dev.lotus} --expect-core-dpm-route $${LOTUS_MANAGE_EXPECT_CORE_DPM_ROUTE:-absent} --expect-stateful-core-sourcing $${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-available} --portfolio-id $${LOTUS_MANAGE_CANONICAL_PORTFOLIO_ID:-PB_SG_GLOBAL_BAL_001} --as-of $${LOTUS_MANAGE_CANONICAL_AS_OF:-2026-04-10}
 
 migration-smoke:
 	python -m pytest tests/unit/shared/dependencies/test_postgres_migrations.py tests/unit/shared/dependencies/test_production_cutover_contract.py -q

--- a/README.md
+++ b/README.md
@@ -229,8 +229,10 @@ Repo-native gate mapping:
   live API evidence against a running `lotus-manage` instance
 - `make live-api-validate-core`
   live API evidence against `lotus-manage` plus current `lotus-core` DPM source-product posture;
-  set `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=available` when RFC-087 source products and
-  stateful manage gates are active
+  the canonical source-ready stack defaults to `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=available`
+  because RFC-087 source products and stateful manage gates are active. Set
+  `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=disabled` only when deliberately validating a
+  non-source-ready local runtime.
 - `make mesh-contract-validate`
   repo-native domain product, trust telemetry, and observability monitoring contract validation
   against Lotus platform governance
@@ -284,8 +286,9 @@ Operationally important truths:
    canonical snake_case query parameters
 3. advisory proposal routes should be served by `lotus-advise`, not reintroduced here
 4. stateful DPM promotion requires `make live-api-validate-core` to pass with
-   `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=available` after `lotus-core` exposes the
-   RFC-087 certified source-data products and canonical data is seeded. The live proof now includes
+   `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=available`, which is the repo-native default for the
+   canonical source-ready stack after `lotus-core` exposes the RFC-087 certified source-data
+   products and canonical data is seeded. The live proof now includes
    stateful source-backed construction over `TransactionCostCurve:v1`,
    `PortfolioCashflowProjection:v1`, `ClientRestrictionProfile:v1`, and
    `SustainabilityPreferenceProfile:v1`, not only stateful simulate lineage.

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -89,8 +89,7 @@ def test_manage_core_live_validation_has_repo_native_command_and_docs() -> None:
         makefile_text
     )
     assert (
-        "--expect-stateful-core-sourcing "
-        "$${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-available}"
+        "--expect-stateful-core-sourcing $${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-available}"
     ) in makefile_text
     assert "`make live-api-validate-core`" in readme_text
     assert "RFC-087 certified source-data" in readme_text

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -88,7 +88,14 @@ def test_manage_core_live_validation_has_repo_native_command_and_docs() -> None:
     assert "--expect-core-dpm-route $${LOTUS_MANAGE_EXPECT_CORE_DPM_ROUTE:-absent}" in (
         makefile_text
     )
+    assert (
+        "--expect-stateful-core-sourcing "
+        "$${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-available}"
+    ) in makefile_text
     assert "`make live-api-validate-core`" in readme_text
-    assert "RFC-087 certified source-data products" in readme_text
+    assert "RFC-087 certified source-data" in readme_text
+    assert "products and canonical data is seeded" in readme_text
+    assert "non-source-ready local runtime" in readme_text
     assert "make live-api-validate-core" in validation_wiki_text
     assert "RFC-087 certified composed DPM source-data products" in validation_wiki_text
+    assert "canonical source-ready stack defaults" in validation_wiki_text

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -21,7 +21,10 @@
 - `make live-api-validate`
   live API evidence against a running `lotus-manage` instance
 - `make live-api-validate-core`
-  live API evidence against `lotus-manage` plus current `lotus-core` DPM source-product posture
+  live API evidence against `lotus-manage` plus current `lotus-core` DPM source-product posture.
+  The canonical source-ready stack defaults to
+  `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=available`; set it to `disabled` only for a
+  deliberately non-source-ready local runtime.
 
 ## Live API evidence
 
@@ -50,7 +53,6 @@ python scripts/validate_live_api.py --base-url http://127.0.0.1:8001 --json-outp
 Use this before claiming manage/core integration readiness with stateful sourcing enabled:
 
 ```bash
-LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=available \
 make live-api-validate-core
 ```
 


### PR DESCRIPTION
## Summary
- Default `make live-api-validate-core` to the canonical source-ready stateful sourcing expectation.
- Update README and wiki validation guidance for source-ready vs deliberately non-source-ready runtimes.
- Strengthen the local runtime contract test so the repo-native command and docs stay aligned.

## Evidence
- `python -m ruff check tests/unit/test_local_docker_runtime_contract.py tests/unit/test_validate_live_api.py`
- `python -m pytest tests/unit/test_local_docker_runtime_contract.py tests/unit/test_validate_live_api.py -q`
- `make live-api-validate-core` against the running canonical stack: 14 checks, 0 failures
- `git diff --check`
- `docker logs lotus-manage-lotus-manage-1 --since 10m` filtered for ERROR/CRITICAL/Traceback/5xx: no matches

## Wiki
- Repo-authored `wiki/Validation-and-CI.md` changed.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` is expected to report drift until this PR is merged and the wiki is published from repo source.