### PR TITLE
fix: harden RFC-0041 unsupported trigger boundaries

### DIFF
--- a/docs/rfcs/RFC-0041-rebalance-wave-orchestration-and-cio-model-change-impact.md
+++ b/docs/rfcs/RFC-0041-rebalance-wave-orchestration-and-cio-model-change-impact.md
@@ -205,16 +205,19 @@ defer that feature from supported status.
 
 ## 6. Trigger Contract
 
-Supported trigger types:
+Implementation-backed trigger types:
 
-1. `CIO_MODEL_CHANGE`
-2. `TACTICAL_HOUSE_VIEW`
-3. `PM_BOOK_REVIEW`
-4. `RISK_BREACH_REMEDIATION`
-5. `CASH_DRAG_CAMPAIGN`
-6. `TAX_YEAR_END_REVIEW`
-7. `ESG_RESTRICTION_UPDATE`
-8. `EXPLICIT_PORTFOLIO_LIST`
+1. `EXPLICIT_PORTFOLIO_LIST`
+2. `PM_BOOK_REVIEW`
+3. `CIO_MODEL_CHANGE`
+4. `RISK_EVENT`
+
+Target-state trigger families that remain unsupported until a source owner publishes governed
+cohort membership are:
+
+1. `TACTICAL_HOUSE_VIEW`
+2. `BULK_REVIEW_CAMPAIGN`
+3. any future cash-drag, tax-year-end, ESG/restriction, or other thematic campaign trigger family
 
 Every trigger must record:
 
@@ -232,15 +235,21 @@ Every trigger must record:
 12. `correlation_id`
 
 First implementation supported only `EXPLICIT_PORTFOLIO_LIST`. Later source-owner slices promoted
-`PM_BOOK_REVIEW` through lotus-core `PortfolioManagerBookMembership:v1` and `CIO_MODEL_CHANGE`
-through lotus-core `CioModelChangeAffectedCohort:v1`. Other trigger types remain unsupported until
-an owning source product or approved manifest governance is implemented and proven. Unsupported
-trigger types must be rejected or returned as `NOT_SUPPORTED`; they must not appear as supported
-features.
+`PM_BOOK_REVIEW` through lotus-core `PortfolioManagerBookMembership:v1`, `CIO_MODEL_CHANGE`
+through lotus-core `CioModelChangeAffectedCohort:v1`, and bounded `RISK_EVENT` through
+lotus-risk `RiskEventAffectedCohort:v1`. Other trigger families remain unsupported until an
+owning source product or approved manifest governance is implemented and proven. Unsupported
+source-owner trigger types must be rejected with `NOT_SUPPORTED_TRIGGER`; they must not appear as
+supported features.
 
 Promoted source-owned trigger selectors are intentionally narrow: `PM_BOOK_REVIEW` requires
-`portfolio_manager_id`, while `CIO_MODEL_CHANGE` requires `model_portfolio_id`. Both reject
-caller-supplied portfolio lists so cohort authority remains in the owning source product.
+`portfolio_manager_id`, `CIO_MODEL_CHANGE` requires `model_portfolio_id`, and `RISK_EVENT` requires
+`risk_event_id`, candidate portfolios, and source-supplied exposure weights. PM-book and CIO
+model-change waves reject caller-supplied portfolio lists so cohort authority remains in the
+owning source product. Tactical house-view waves require a governed CIO or risk house-view cohort
+source product before manage can preview or create them; bulk review campaign waves require a
+governed campaign membership source product with review, approval, expiry, and entitlement
+controls before manage can preview or create them.
 
 ---
 

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -954,7 +954,11 @@ def _resolve_risk_event_portfolios(
                     "example": {
                         "detail": {
                             "code": "NOT_SUPPORTED_TRIGGER",
-                            "message": "Trigger type CIO_MODEL_CHANGE is not supported.",
+                            "message": (
+                                "Trigger type TACTICAL_HOUSE_VIEW is not supported. Tactical "
+                                "house-view waves require a governed CIO or risk house-view "
+                                "cohort source product before manage can preview or create them."
+                            ),
                         }
                     }
                 }
@@ -1036,7 +1040,12 @@ def preview_wave(
                     "example": {
                         "detail": {
                             "code": "NOT_SUPPORTED_TRIGGER",
-                            "message": "Trigger type PM_BOOK_REVIEW is not supported.",
+                            "message": (
+                                "Trigger type BULK_REVIEW_CAMPAIGN is not supported. Bulk review "
+                                "campaign waves require a governed campaign membership source "
+                                "product with review, approval, expiry, and entitlement controls "
+                                "before manage can preview or create them."
+                            ),
                         }
                     }
                 }

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -54,6 +54,18 @@ SUPPORTED_CREATE_TRIGGER_TYPES = {
     "RISK_EVENT",
 }
 
+UNSUPPORTED_SOURCE_OWNER_TRIGGER_TYPES = {
+    "TACTICAL_HOUSE_VIEW": (
+        "Tactical house-view waves require a governed CIO or risk house-view cohort source "
+        "product before manage can preview or create them."
+    ),
+    "BULK_REVIEW_CAMPAIGN": (
+        "Bulk review campaign waves require a governed campaign membership source product with "
+        "review, approval, expiry, and entitlement controls before manage can preview or create "
+        "them."
+    ),
+}
+
 
 class DpmWaveValidationError(ValueError):
     def __init__(self, code: str, message: str) -> None:
@@ -1679,6 +1691,12 @@ def _event(
 
 def _validate_trigger(trigger_type: str, *, portfolios: list[dict[str, object]]) -> None:
     if trigger_type not in SUPPORTED_CREATE_TRIGGER_TYPES:
+        source_owner_reason = UNSUPPORTED_SOURCE_OWNER_TRIGGER_TYPES.get(trigger_type)
+        if source_owner_reason is not None:
+            raise DpmWaveValidationError(
+                "NOT_SUPPORTED_TRIGGER",
+                f"Trigger type {trigger_type} is not supported. {source_owner_reason}",
+            )
         raise DpmWaveValidationError(
             "NOT_SUPPORTED_TRIGGER",
             f"Trigger type {trigger_type} is not supported for RFC-0041 Slice 4.",

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -2932,15 +2932,39 @@ def test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_postur
     assert missing.json()["detail"]["code"] == "DPM_WAVE_NOT_FOUND"
 
 
-def test_wave_preview_rejects_unsupported_trigger_without_fallback() -> None:
+def test_wave_preview_and_create_reject_source_owner_triggers_without_fallback() -> None:
     with _client(InMemoryDpmMandateRepository(), InMemoryDpmWaveRepository()) as client:
-        response = client.post(
+        tactical_preview = client.post(
             "/api/v1/rebalance/waves/preview",
             json={**_request(), "trigger_type": "TACTICAL_HOUSE_VIEW"},
         )
+        campaign_preview = client.post(
+            "/api/v1/rebalance/waves/preview",
+            json={**_request(), "trigger_type": "BULK_REVIEW_CAMPAIGN"},
+        )
+        tactical_create = client.post(
+            "/api/v1/rebalance/waves",
+            headers={"Idempotency-Key": "tactical-wave-unsupported"},
+            json={**_request(), "trigger_type": "TACTICAL_HOUSE_VIEW"},
+        )
+        campaign_create = client.post(
+            "/api/v1/rebalance/waves",
+            headers={"Idempotency-Key": "campaign-wave-unsupported"},
+            json={**_request(), "trigger_type": "BULK_REVIEW_CAMPAIGN"},
+        )
 
-    assert response.status_code == 422
-    assert response.json()["detail"]["code"] == "NOT_SUPPORTED_TRIGGER"
+    for response in [tactical_preview, campaign_preview, tactical_create, campaign_create]:
+        assert response.status_code == 422
+        assert response.json()["detail"]["code"] == "NOT_SUPPORTED_TRIGGER"
+
+    assert (
+        "governed CIO or risk house-view cohort source product"
+        in (tactical_preview.json()["detail"]["message"])
+    )
+    assert (
+        "governed campaign membership source product"
+        in (campaign_preview.json()["detail"]["message"])
+    )
 
 
 def test_wave_openapi_documents_preview_and_create() -> None:
@@ -2981,6 +3005,38 @@ def test_wave_openapi_documents_preview_and_create() -> None:
     )
     assert "422" in preview["responses"]
     assert "409" in create["responses"]
+    assert (
+        "TACTICAL_HOUSE_VIEW"
+        in (
+            preview["responses"]["422"]["content"]["application/json"]["example"]["detail"][
+                "message"
+            ]
+        )
+    )
+    assert (
+        "governed CIO or risk house-view cohort source product"
+        in (
+            preview["responses"]["422"]["content"]["application/json"]["example"]["detail"][
+                "message"
+            ]
+        )
+    )
+    assert (
+        "BULK_REVIEW_CAMPAIGN"
+        in (
+            create["responses"]["422"]["content"]["application/json"]["example"]["detail"][
+                "message"
+            ]
+        )
+    )
+    assert (
+        "governed campaign membership source product"
+        in (
+            create["responses"]["422"]["content"]["application/json"]["example"]["detail"][
+                "message"
+            ]
+        )
+    )
     assert "durable RFC-0041 waves" in search["description"]
     assert "does not regenerate downstream" in detail["description"]
     assert "without UI-side recomputation" in items["description"]

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -1633,7 +1633,8 @@ Functional coverage:
 - preview, create, and workflow mutation responses include a manage-owned product-safe
   `supportability` envelope derived from current item states, so Gateway and Workbench can
   preserve source authority instead of reconstructing readiness,
-- unsupported trigger rejection with `NOT_SUPPORTED_TRIGGER`,
+- unsupported tactical house-view and bulk review campaign trigger rejection with
+  `NOT_SUPPORTED_TRIGGER` and source-owner gap reasons,
 - durable create with idempotent replay,
 - durable source-check from `CREATED` to `SOURCE_CHECKED`,
 - item classification as `SOURCE_READY`, `SOURCE_DEGRADED`, `REVIEW_REQUIRED`, or


### PR DESCRIPTION
## Summary
- make unsupported RFC-0041 tactical house-view and bulk review campaign triggers fail closed with source-owner-specific `NOT_SUPPORTED_TRIGGER` reasons
- correct OpenAPI examples so supported PM-book/CIO triggers are not shown as unsupported
- update RFC-0041 and endpoint-certification wiki truth to separate implemented triggers from target-state cohort families

## Validation
- `python -m pytest tests/unit/dpm/api/test_waves_api.py -q` PASS, 63 passed
- `python -m pytest tests/unit/test_documentation_current_state.py tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py tests/integration/test_openapi_certification_matrix.py -q` PASS, 112 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` PASS
- `git diff --check` PASS
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` EXPECTED DRIFT before merge/publication: `Endpoint-Certification.md`

## Governance
- Stranded-truth scan before commit: `git fetch origin --prune`; `git branch -r --no-merged origin/main` returned no unmerged remote branches in `lotus-manage`.
- Wiki source changed and must be published after merge.