### PR TITLE
Pin portfolio memory PM scoring boundary

### DIFF
--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -4710,6 +4710,15 @@ RFC-0042 explicitly supports outcome review, not PM scoring. Scoring requires bu
 methodology, controls, explainability, fairness review, and governance that do not exist in this
 RFC.
 
+2026-05-12 boundary-hardening result:
+
+`lotus-manage` portfolio memory already publishes `pm_scoring` as
+`DEFERRED_SOURCE_OWNER`. The audit strengthened regression proof so the deferred family is locked
+as `future-pm-scoring-owner`, has no event types, has no route, and carries
+`PM_SCORING_SOURCE_EVENTS_NOT_SUPPORTED`. OpenAPI schema assertions now pin the
+source-event-family posture wording so consumers do not infer hidden PM-scoring or behavioral
+analytics functionality from portfolio memory.
+
 Dependencies before implementation:
 
 1. named business owner,
@@ -4729,6 +4738,14 @@ Promotion proof:
 3. governance approval evidence,
 4. README/wiki/supported-feature updates with strict wording,
 5. client-facing material reviewed for appropriate claims.
+
+Boundary-hardening proof:
+
+1. `python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py -q`,
+2. portfolio-memory API regression proves `pm_scoring` remains a deferred source-owner family with
+   no route and no event types,
+3. OpenAPI regression proves the source-event-family posture describes hidden-truth prevention and
+   PM-scoring no-claim boundaries.
 
 ### Suggested Sequencing
 

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -274,7 +274,13 @@ def test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events() 
     assert family_posture["generated_document_archive"].source_system == "lotus-archive"
     assert family_posture["external_oms_execution"].support_status == "DEFERRED_SOURCE_OWNER"
     assert family_posture["external_oms_execution"].event_types == []
+    assert family_posture["pm_scoring"].source_system == "future-pm-scoring-owner"
+    assert family_posture["pm_scoring"].owner == "future PM scoring methodology owner"
+    assert family_posture["pm_scoring"].support_status == "DEFERRED_SOURCE_OWNER"
+    assert family_posture["pm_scoring"].event_types == []
+    assert family_posture["pm_scoring"].route is None
     assert family_posture["pm_scoring"].reason_code == "PM_SCORING_SOURCE_EVENTS_NOT_SUPPORTED"
+    assert "approved methodology" in family_posture["pm_scoring"].summary
     mandate_events = {
         event.event_type: event
         for event in memory.events
@@ -345,6 +351,19 @@ def test_portfolio_memory_api_returns_queryable_source_backed_memory() -> None:
         ),
     }
     assert family_posture["pm_scoring"]["support_status"] == "DEFERRED_SOURCE_OWNER"
+    assert family_posture["pm_scoring"] == {
+        "family_key": "pm_scoring",
+        "source_system": "future-pm-scoring-owner",
+        "owner": "future PM scoring methodology owner",
+        "support_status": "DEFERRED_SOURCE_OWNER",
+        "event_types": [],
+        "route": None,
+        "reason_code": "PM_SCORING_SOURCE_EVENTS_NOT_SUPPORTED",
+        "summary": (
+            "No PM quality-scoring events are projected until an approved methodology, controls, "
+            "and source owner exist."
+        ),
+    }
     assert all(event["event_identity"] for event in payload["events"])
     assert all(event["redaction_policy"] == "NO_RAW_PAYLOADS" for event in payload["events"])
     assert any(event["event_type"] == "OUTCOME_REVIEW_EVENT" for event in payload["events"])
@@ -353,3 +372,11 @@ def test_portfolio_memory_api_returns_queryable_source_backed_memory() -> None:
     assert "/api/v1/rebalance/portfolio-memory/{portfolio_id}" in openapi_json["paths"]
     memory_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemory"]
     assert "source_event_family_posture" in memory_schema["properties"]
+    posture_schema = openapi_json["components"]["schemas"][
+        "DpmPortfolioMemorySourceEventFamilyPosture"
+    ]
+    assert "hidden portfolio-memory truth" in posture_schema["properties"]["summary"]["description"]
+    assert (
+        "PM-scoring no-claim boundaries"
+        in memory_schema["properties"]["source_event_family_posture"]["description"]
+    )

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -1878,6 +1878,8 @@ Functional behavior:
   `CLIENT_CONFIDENTIAL_INTERNAL`, and `AUDIT_READ_AND_EXPORT`,
 - publishes `source_event_family_posture` for supported manage, report, AI, and archive families
   plus explicit `DEFERRED_SOURCE_OWNER` posture for external OMS execution and PM scoring,
+  with no route or event types for deferred families until owning products publish governed source
+  contracts,
 - derives event counts, source-system coverage, aggregate reason codes, and a deterministic
   content hash for the returned view,
 - returns `EMPTY` supportability when no persisted source events exist for the portfolio,
@@ -1891,7 +1893,8 @@ Non-functional posture:
 - Does not claim external execution; wave handoff nodes preserve `external_execution_claimed=false`
   when present.
 - Future OMS execution and PM-scoring products remain source-owner roadmap scope and are visible as
-  deferred posture entries rather than hidden portfolio-memory functionality.
+  deferred posture entries rather than hidden portfolio-memory functionality. `pm_scoring` remains
+  pinned as `PM_SCORING_SOURCE_EVENTS_NOT_SUPPORTED` with no projected events or route.
 
 ```mermaid
 flowchart LR

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -509,7 +509,9 @@ Current supported behavior:
 Current boundaries:
 
 1. external OMS execution and acknowledgements are not supported,
-2. PM quality scoring and behavioral analytics are not supported,
+2. PM quality scoring and behavioral analytics are not supported; portfolio memory publishes this
+   as `pm_scoring` with `DEFERRED_SOURCE_OWNER`, no route, no event types, and
+   `PM_SCORING_SOURCE_EVENTS_NOT_SUPPORTED`,
 3. client communication execution remains future downstream scope,
 4. aggregated tax, FX, client income-needs planning, and execution methodologies
    remain source-owner follow-on work.


### PR DESCRIPTION
## Summary
- pin portfolio-memory `pm_scoring` as a deferred source-owner family with no route and no event types
- add OpenAPI assertions so the no-claim posture remains visible to API consumers
- update WTBD and wiki source to document the PM-scoring/behavioral-analytics boundary without claiming support

## Evidence
- `python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py tests/unit/test_documentation_current_state.py tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py tests/integration/test_openapi_certification_matrix.py -q` -> 114 passed
- `python -m ruff check tests/unit/dpm/api/test_portfolio_memory_api.py` -> passed
- `python -m ruff format --check tests/unit/dpm/api/test_portfolio_memory_api.py` -> passed after formatting
- `python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py -q` -> 2 passed
- `git diff --check` -> passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> expected pre-merge drift: Endpoint-Certification.md, Supported-Features.md

## Boundary
This does not implement PM scoring or behavioral analytics. It locks the current no-claim posture so portfolio memory cannot be mistaken for a scoring source.