### PR TITLE
Record issuer active-risk WTBD proof

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -166,7 +166,13 @@ Current repository posture:
     internal handoff refs, and RFC-0042 outcome-review events into a deterministic, source-backed,
     hashable timeline without reconstructing mandate health, risk, performance, execution, tax,
     cash, FX, or source-owner methodology. RFC42-WTBD-006 source-owner methodology depth now
-    includes the merged and wiki-published `lotus-core`
+    includes merged and wiki-published issuer active-risk source truth through `lotus-performance`
+    PR #165 (`191a405`, wiki `46a9124`) and `lotus-risk` PR #138 (`8ae3e4a`, wiki
+    `616a10c`): performance owns benchmark issuer exposure context from lotus-core index-catalog
+    issuer labels, and risk owns stateful `ACTIVE_RISK + ISSUER` historical attribution
+    consumption. Manage records the proof posture only and does not reconstruct benchmark issuer
+    exposure, covariance, tracking-error, or issuer attribution locally. It also includes the
+    merged and wiki-published `lotus-core`
     `HoldingsAsOf:v1` methodology slice from PR #348
     (`0a8785e0a4be7ea737b40eded07bd9c7f8002f25`, wiki `2a428eb`), which pins booked holdings,
     explicit as-of holdings, projected-inclusive holdings, cash-balance reads,

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -5399,6 +5399,34 @@ Latest WTBD-006 performance RFC-046 TWR live-audit proof:
    source-owned portfolio-level `currency_attribution_totals` for the implemented performance
    attribution path.
 
+Latest WTBD-006 risk/performance issuer active-risk proof:
+
+1. `lotus-performance` PR #165 was merged to `main` as `191a405` and published wiki commit
+   `46a9124`; it ungates `ISSUER` for `POST /integration/benchmarks/exposure-context`, maps
+   issuer rows from lotus-core index-catalog `classification_labels.issuer_id` and `issuer_name`,
+   updates integration capability copy and API vocabulary, and keeps lotus-core as the benchmark
+   composition/classification system of record,
+2. performance local proof passed `make lint`, `make typecheck`, `make openapi-gate`,
+   `make api-vocabulary-gate`, `make domain-product-validate`, `make no-alias-gate`, focused
+   endpoint/doc tests with `88` passed, and `make test-unit` with `1270` passed; GitHub Feature
+   Lane and PR Merge Gate were green before merge,
+3. `lotus-risk` PR #138 was merged to `main` as `8ae3e4a` and published wiki commit `616a10c`;
+   it enables stateful `ACTIVE_RISK + ISSUER` historical attribution by consuming
+   lotus-performance benchmark exposure context issuer rows and publishes an empty
+   `stateful_active_risk_gated_grouping_dimensions` list,
+4. risk local proof passed `make lint`, `make no-alias-gate`, `make typecheck`,
+   `make openapi-gate`, `make api-vocabulary-gate`, `make domain-data-product-gate`,
+   `make test-unit` with `358` passed, `make test-integration` with `80` passed and `14`
+   skipped, `make test-e2e` with `24` passed, `make test-pyramid-gate`, and the final GitHub
+   Feature Lane and PR Merge Gate were green before merge,
+5. manage consumes this as source-owner truth for outcome-review and proof-pack posture only: no
+   benchmark issuer exposure, active-risk decomposition, covariance, tracking-error,
+   issuer-enrichment, or benchmark classification logic is implemented or duplicated in manage,
+6. this advances RFC42-WTBD-006 but does not close it: broader FX methodology beyond
+   performance-owned Karnosky-Singer totals, predictive execution, OMS acknowledgements,
+   income-needs planning, financial-planning advice, tax advice, tax optimization, and broader
+   live portfolio-archetype validation remain source-owner or future-RFC work.
+
 #### RFC42-WTBD-007 - External Execution / OMS Integration And Acknowledgements
 
 Target business outcome:

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -1778,6 +1778,15 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "signed cash movement bucket evidence" in work_to_be_done
     assert "latest-cashflow-row selection per transaction" in work_to_be_done
     assert "cashflow forecasting" in work_to_be_done
+    assert "Latest WTBD-006 risk/performance issuer active-risk proof" in work_to_be_done
+    assert "`lotus-performance` PR #165" in work_to_be_done
+    assert "`191a405`" in work_to_be_done
+    assert "`46a9124`" in work_to_be_done
+    assert "`lotus-risk` PR #138" in work_to_be_done
+    assert "`8ae3e4a`" in work_to_be_done
+    assert "`616a10c`" in work_to_be_done
+    assert "stateful `ACTIVE_RISK + ISSUER` historical attribution" in work_to_be_done
+    assert "benchmark issuer exposure, active-risk decomposition, covariance" in work_to_be_done
     assert "Latest WTBD-006 core transaction-cost-curve methodology proof" in work_to_be_done
     assert "`lotus-core` PR #345" in work_to_be_done
     assert "`83d791d0e599f06a2c0caab6eaba647f717d4658`" in work_to_be_done
@@ -1870,6 +1879,12 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
         supported_features
     )
     assert "`TransactionCostCurve:v1` methodology truth through `lotus-core` PR #345" in (
+        supported_features
+    )
+    assert "`lotus-performance` PR #165 (`191a405`, wiki `46a9124`)" in supported_features
+    assert "`lotus-risk` PR #138 (`8ae3e4a`, wiki `616a10c`)" in supported_features
+    assert "stateful\n`ACTIVE_RISK + ISSUER` historical attribution" in supported_features
+    assert "performs no local benchmark issuer exposure, covariance, tracking-error" in (
         supported_features
     )
     assert (

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -343,6 +343,13 @@ legal versus ultimate-parent grouping, issuer-enrichment precedence, determinist
 driver selection, issuer coverage/supportability posture, and isolation from `risk_proxy.hhi_*` and
 `single_position_concentration.*` outputs rather than recomputing concentration locally.
 
+Current risk/performance issuer active-risk source-owner proof additionally includes
+`lotus-performance` PR #165 (`191a405`, wiki `46a9124`) for benchmark exposure context `ISSUER`
+grouping and `lotus-risk` PR #138 (`8ae3e4a`, wiki `616a10c`) for stateful
+`ACTIVE_RISK + ISSUER` historical attribution. Manage treats those outputs as source-owner
+evidence only and performs no local benchmark issuer exposure, covariance, tracking-error, or
+issuer-attribution calculation.
+
 Roadmap boundaries:
 
 1. Unsupported source products remain explicit gaps; do not fill them with local placeholders.


### PR DESCRIPTION
## Summary
- record lotus-performance PR #165 issuer benchmark exposure context proof for RFC42-WTBD-006
- record lotus-risk PR #138 stateful ACTIVE_RISK + ISSUER proof and manage no-recalculation boundary
- update supported-features wiki source and documentation drift assertions

## Validation
- make lint
- make typecheck
- python -m pytest tests\\unit\\test_documentation_current_state.py -q
- make test-unit
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- pwsh -NoProfile -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected pre-merge drift: Supported-Features.md)