### PR TITLE
Extract campaign discovery read model

### DIFF
--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -35,11 +35,13 @@ from src.core.rebalance_runs.service import DpmRunSupportService
 from src.core.waves import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionConflictError,
+    DpmBulkReviewCampaignDiscoveryPage,
     DpmBulkReviewCampaignDefinitionRepository,
     DpmRebalanceWave,
     DpmWaveReportInput,
     DpmWaveRepository,
     DpmWaveSourceRef,
+    build_bulk_review_campaign_discovery_item,
 )
 from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinitionCandidate,
@@ -360,42 +362,6 @@ class DpmBulkReviewCampaignDefinitionSupersessionRequest(BaseModel):
 
 class DpmBulkReviewCampaignDefinitionPage(BaseModel):
     items: list[DpmBulkReviewCampaignDefinition]
-    limit: int
-    offset: int
-    count: int
-
-
-class DpmBulkReviewCampaignDiscoveryItem(BaseModel):
-    product_name: Literal["BulkReviewCampaignDiscovery"] = "BulkReviewCampaignDiscovery"
-    product_version: Literal["v1"] = "v1"
-    campaign_id: str
-    campaign_version: str
-    display_name: str
-    campaign_status: Literal["ACTIVE", "RETIRED", "SUPERSEDED"]
-    as_of_date: str
-    eligible_portfolio_types: list[str]
-    candidate_count: int
-    eligible_candidate_count: int
-    governance_status: Literal["APPROVED", "INCOMPLETE", "NOT_SUPPLIED"]
-    expiry_state: Literal["ACTIVE", "EXPIRED", "INVALID", "NOT_SUPPLIED"]
-    expires_on: str | None = None
-    access_purpose: str | None = None
-    source_ref_count: int
-    content_hash: str
-    superseded_by_campaign_id: str | None = None
-    superseded_by_campaign_version: str | None = None
-    superseded_by_content_hash: str | None = None
-    preview_reference: dict[str, str] = Field(
-        description=(
-            "Bounded reference clients can use to preview or create a BULK_REVIEW_CAMPAIGN wave "
-            "from the persisted definition. Manage still resolves membership only from the "
-            "source-backed candidate set in that definition."
-        )
-    )
-
-
-class DpmBulkReviewCampaignDiscoveryPage(BaseModel):
-    items: list[DpmBulkReviewCampaignDiscoveryItem]
     limit: int
     offset: int
     count: int
@@ -1925,7 +1891,7 @@ def discover_bulk_review_campaigns(
         offset=offset,
     )
     items = [
-        _campaign_discovery_item(definition=definition, active_on=active_on_date)
+        build_bulk_review_campaign_discovery_item(definition=definition, active_on=active_on_date)
         for definition in definitions
     ]
     if active_on_date is not None and not include_expired:
@@ -2019,87 +1985,6 @@ def _parse_optional_campaign_discovery_date(
                 "message": f"{field_name} must be an ISO date.",
             },
         ) from exc
-
-
-def _campaign_discovery_item(
-    *,
-    definition: DpmBulkReviewCampaignDefinition,
-    active_on: date | None,
-) -> DpmBulkReviewCampaignDiscoveryItem:
-    eligible_types = {
-        portfolio_type.strip()
-        for portfolio_type in definition.eligible_portfolio_types
-        if portfolio_type.strip()
-    }
-    governance = definition.governance
-    governance_status: Literal["APPROVED", "INCOMPLETE", "NOT_SUPPLIED"] = "NOT_SUPPLIED"
-    expiry_state: Literal["ACTIVE", "EXPIRED", "INVALID", "NOT_SUPPLIED"] = "NOT_SUPPLIED"
-    expires_on: str | None = None
-    access_purpose: str | None = None
-    source_ref_count = len(definition.source_refs)
-    if governance is not None:
-        approval_values = [
-            governance.approval_ref,
-            governance.approved_by,
-            governance.approved_at,
-        ]
-        governance_status = (
-            "APPROVED"
-            if all(approval_values)
-            else "INCOMPLETE"
-            if any(approval_values)
-            else "NOT_SUPPLIED"
-        )
-        expires_on = governance.expires_on
-        access_purpose = governance.access_purpose
-        source_ref_count += len(governance.source_refs)
-        expiry_state = _campaign_discovery_expiry_state(
-            expires_on=governance.expires_on,
-            active_on=active_on,
-        )
-    return DpmBulkReviewCampaignDiscoveryItem(
-        campaign_id=definition.campaign_id,
-        campaign_version=definition.campaign_version,
-        display_name=definition.display_name,
-        campaign_status=definition.status,
-        as_of_date=definition.as_of_date,
-        eligible_portfolio_types=definition.eligible_portfolio_types,
-        candidate_count=len(definition.candidates),
-        eligible_candidate_count=sum(
-            1 for candidate in definition.candidates if candidate.portfolio_type in eligible_types
-        ),
-        governance_status=governance_status,
-        expiry_state=expiry_state,
-        expires_on=expires_on,
-        access_purpose=access_purpose,
-        source_ref_count=source_ref_count,
-        content_hash=definition.content_hash,
-        superseded_by_campaign_id=definition.superseded_by_campaign_id,
-        superseded_by_campaign_version=definition.superseded_by_campaign_version,
-        superseded_by_content_hash=definition.superseded_by_content_hash,
-        preview_reference={
-            "trigger_type": "BULK_REVIEW_CAMPAIGN",
-            "campaign_definition_id": definition.campaign_id,
-            "campaign_definition_version": definition.campaign_version,
-            "as_of_date": definition.as_of_date,
-        },
-    )
-
-
-def _campaign_discovery_expiry_state(
-    *,
-    expires_on: str | None,
-    active_on: date | None,
-) -> Literal["ACTIVE", "EXPIRED", "INVALID", "NOT_SUPPLIED"]:
-    if not expires_on:
-        return "NOT_SUPPLIED"
-    try:
-        expiry_date = date.fromisoformat(expires_on)
-    except ValueError:
-        return "INVALID"
-    if active_on is None:
-        return "ACTIVE"
-    return "EXPIRED" if expiry_date < active_on else "ACTIVE"
 
 
 @router.post(

--- a/src/core/waves/__init__.py
+++ b/src/core/waves/__init__.py
@@ -18,6 +18,12 @@ from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinitionCandidate,
     DpmBulkReviewCampaignDefinitionGovernance,
 )
+from src.core.waves.campaign_discovery import (
+    DpmBulkReviewCampaignDiscoveryItem,
+    DpmBulkReviewCampaignDiscoveryPage,
+    build_bulk_review_campaign_discovery_item,
+    classify_bulk_review_campaign_expiry,
+)
 from src.core.waves.campaign_definition_events import (
     DpmBulkReviewCampaignDefinitionLifecycleEvent,
     DpmBulkReviewCampaignDefinitionLifecycleEventPage,
@@ -58,6 +64,8 @@ __all__ = [
     "DpmBulkReviewCampaignDefinitionCandidate",
     "DpmBulkReviewCampaignDefinitionConflictError",
     "DpmBulkReviewCampaignDefinitionGovernance",
+    "DpmBulkReviewCampaignDiscoveryItem",
+    "DpmBulkReviewCampaignDiscoveryPage",
     "DpmBulkReviewCampaignDefinitionLifecycleEvent",
     "DpmBulkReviewCampaignDefinitionLifecycleEventPage",
     "DpmBulkReviewCampaignDefinitionRepository",
@@ -82,8 +90,10 @@ __all__ = [
     "WaveState",
     "WaveTriggerType",
     "apply_wave_transition",
+    "build_bulk_review_campaign_discovery_item",
     "build_bulk_review_campaign_definition_lifecycle_events",
     "build_wave_report_input",
     "classify_wave_item_source_readiness",
+    "classify_bulk_review_campaign_expiry",
     "validate_wave_transition",
 ]

--- a/src/core/waves/campaign_discovery.py
+++ b/src/core/waves/campaign_discovery.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from src.core.waves.campaign_definitions import DpmBulkReviewCampaignDefinition
+
+
+class DpmBulkReviewCampaignDiscoveryItem(BaseModel):
+    """Bounded front-office read model for one persisted campaign definition."""
+
+    product_name: Literal["BulkReviewCampaignDiscovery"] = "BulkReviewCampaignDiscovery"
+    product_version: Literal["v1"] = "v1"
+    campaign_id: str
+    campaign_version: str
+    display_name: str
+    campaign_status: Literal["ACTIVE", "RETIRED", "SUPERSEDED"]
+    as_of_date: str
+    eligible_portfolio_types: list[str]
+    candidate_count: int
+    eligible_candidate_count: int
+    governance_status: Literal["APPROVED", "INCOMPLETE", "NOT_SUPPLIED"]
+    expiry_state: Literal["ACTIVE", "EXPIRED", "INVALID", "NOT_SUPPLIED"]
+    expires_on: str | None = None
+    access_purpose: str | None = None
+    source_ref_count: int
+    content_hash: str
+    superseded_by_campaign_id: str | None = None
+    superseded_by_campaign_version: str | None = None
+    superseded_by_content_hash: str | None = None
+    preview_reference: dict[str, str] = Field(
+        description=(
+            "Bounded reference clients can use to preview or create a BULK_REVIEW_CAMPAIGN wave "
+            "from the persisted definition. Manage still resolves membership only from the "
+            "source-backed candidate set in that definition."
+        )
+    )
+
+
+class DpmBulkReviewCampaignDiscoveryPage(BaseModel):
+    """Bounded page of persisted campaign-definition discovery records."""
+
+    items: list[DpmBulkReviewCampaignDiscoveryItem]
+    limit: int
+    offset: int
+    count: int
+
+
+def build_bulk_review_campaign_discovery_item(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+    active_on: date | None,
+) -> DpmBulkReviewCampaignDiscoveryItem:
+    eligible_types = {
+        portfolio_type.strip()
+        for portfolio_type in definition.eligible_portfolio_types
+        if portfolio_type.strip()
+    }
+    governance = definition.governance
+    governance_status: Literal["APPROVED", "INCOMPLETE", "NOT_SUPPLIED"] = "NOT_SUPPLIED"
+    expiry_state: Literal["ACTIVE", "EXPIRED", "INVALID", "NOT_SUPPLIED"] = "NOT_SUPPLIED"
+    expires_on: str | None = None
+    access_purpose: str | None = None
+    source_ref_count = len(definition.source_refs)
+    if governance is not None:
+        approval_values = [
+            governance.approval_ref,
+            governance.approved_by,
+            governance.approved_at,
+        ]
+        governance_status = (
+            "APPROVED"
+            if all(approval_values)
+            else "INCOMPLETE"
+            if any(approval_values)
+            else "NOT_SUPPLIED"
+        )
+        expires_on = governance.expires_on
+        access_purpose = governance.access_purpose
+        source_ref_count += len(governance.source_refs)
+        expiry_state = classify_bulk_review_campaign_expiry(
+            expires_on=governance.expires_on,
+            active_on=active_on,
+        )
+    return DpmBulkReviewCampaignDiscoveryItem(
+        campaign_id=definition.campaign_id,
+        campaign_version=definition.campaign_version,
+        display_name=definition.display_name,
+        campaign_status=definition.status,
+        as_of_date=definition.as_of_date,
+        eligible_portfolio_types=definition.eligible_portfolio_types,
+        candidate_count=len(definition.candidates),
+        eligible_candidate_count=sum(
+            1 for candidate in definition.candidates if candidate.portfolio_type in eligible_types
+        ),
+        governance_status=governance_status,
+        expiry_state=expiry_state,
+        expires_on=expires_on,
+        access_purpose=access_purpose,
+        source_ref_count=source_ref_count,
+        content_hash=definition.content_hash,
+        superseded_by_campaign_id=definition.superseded_by_campaign_id,
+        superseded_by_campaign_version=definition.superseded_by_campaign_version,
+        superseded_by_content_hash=definition.superseded_by_content_hash,
+        preview_reference={
+            "trigger_type": "BULK_REVIEW_CAMPAIGN",
+            "campaign_definition_id": definition.campaign_id,
+            "campaign_definition_version": definition.campaign_version,
+            "as_of_date": definition.as_of_date,
+        },
+    )
+
+
+def classify_bulk_review_campaign_expiry(
+    *,
+    expires_on: str | None,
+    active_on: date | None,
+) -> Literal["ACTIVE", "EXPIRED", "INVALID", "NOT_SUPPLIED"]:
+    if not expires_on:
+        return "NOT_SUPPLIED"
+    try:
+        expiry_date = date.fromisoformat(expires_on)
+    except ValueError:
+        return "INVALID"
+    if active_on is None:
+        return "ACTIVE"
+    return "EXPIRED" if expiry_date < active_on else "ACTIVE"

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import date
+
+from src.core.waves import DpmWaveSourceRef
+from src.core.waves.campaign_definitions import (
+    DpmBulkReviewCampaignDefinition,
+    DpmBulkReviewCampaignDefinitionCandidate,
+    DpmBulkReviewCampaignDefinitionGovernance,
+)
+from src.core.waves.campaign_discovery import (
+    build_bulk_review_campaign_discovery_item,
+    classify_bulk_review_campaign_expiry,
+)
+
+
+def _definition(
+    *,
+    expires_on: str | None = "2026-06-30",
+    approval_ref: str | None = "BRC-APPROVAL-2026-05",
+    approved_by: str | None = "cio_ops_committee",
+    approved_at: str | None = "2026-05-14T08:30:00+08:00",
+) -> DpmBulkReviewCampaignDefinition:
+    return DpmBulkReviewCampaignDefinition(
+        campaign_id="campaign-holdings-apple-tesla-20260510",
+        campaign_version="2026.05",
+        display_name="Apple and Tesla holdings review",
+        as_of_date="2026-05-10",
+        rationale="Review source-backed discretionary portfolios affected by the campaign.",
+        eligible_portfolio_types=["DISCRETIONARY"],
+        candidates=[
+            DpmBulkReviewCampaignDefinitionCandidate(
+                portfolio_id="PB_SG_GLOBAL_BAL_001",
+                mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+                portfolio_type="DISCRETIONARY",
+                source_refs=[
+                    DpmWaveSourceRef(
+                        source_system="lotus-core",
+                        source_type="HoldingsAsOf",
+                        source_id="holdings-asof-pb-sg-global-bal-001",
+                    )
+                ],
+            ),
+            DpmBulkReviewCampaignDefinitionCandidate(
+                portfolio_id="PB_SG_ADVISORY_001",
+                portfolio_type="ADVISORY",
+                source_refs=[
+                    DpmWaveSourceRef(
+                        source_system="lotus-core",
+                        source_type="PortfolioProfile",
+                        source_id="portfolio-profile-pb-sg-advisory-001",
+                    )
+                ],
+            ),
+        ],
+        governance=DpmBulkReviewCampaignDefinitionGovernance(
+            approval_ref=approval_ref,
+            approved_by=approved_by,
+            approved_at=approved_at,
+            expires_on=expires_on,
+            source_refs=[
+                DpmWaveSourceRef(
+                    source_system="lotus-manage",
+                    source_type="CAMPAIGN_APPROVAL",
+                    source_id="brc-approval-2026-05",
+                )
+            ],
+        ),
+        source_refs=[
+            DpmWaveSourceRef(
+                source_system="lotus-manage",
+                source_type="CAMPAIGN_SOURCE_FILE",
+                source_id="campaign-source-20260510",
+            )
+        ],
+        created_by="ops",
+        correlation_id="corr-campaign-definition-001",
+    )
+
+
+def test_campaign_discovery_item_projects_governance_and_candidate_posture() -> None:
+    item = build_bulk_review_campaign_discovery_item(
+        definition=_definition(),
+        active_on=date(2026, 5, 16),
+    )
+
+    assert item.product_name == "BulkReviewCampaignDiscovery"
+    assert item.campaign_status == "ACTIVE"
+    assert item.governance_status == "APPROVED"
+    assert item.expiry_state == "ACTIVE"
+    assert item.candidate_count == 2
+    assert item.eligible_candidate_count == 1
+    assert item.source_ref_count == 2
+    assert item.preview_reference == {
+        "trigger_type": "BULK_REVIEW_CAMPAIGN",
+        "campaign_definition_id": "campaign-holdings-apple-tesla-20260510",
+        "campaign_definition_version": "2026.05",
+        "as_of_date": "2026-05-10",
+    }
+
+
+def test_campaign_discovery_item_marks_incomplete_and_invalid_governance() -> None:
+    item = build_bulk_review_campaign_discovery_item(
+        definition=_definition(
+            expires_on="not-a-date",
+            approval_ref="BRC-APPROVAL-2026-05",
+            approved_by=None,
+            approved_at=None,
+        ),
+        active_on=date(2026, 5, 16),
+    )
+
+    assert item.governance_status == "INCOMPLETE"
+    assert item.expiry_state == "INVALID"
+
+
+def test_campaign_expiry_classifier_is_bounded_and_date_driven() -> None:
+    assert classify_bulk_review_campaign_expiry(expires_on=None, active_on=None) == "NOT_SUPPLIED"
+    assert classify_bulk_review_campaign_expiry(expires_on="bad-date", active_on=None) == "INVALID"
+    assert (
+        classify_bulk_review_campaign_expiry(
+            expires_on="2026-05-15",
+            active_on=date(2026, 5, 16),
+        )
+        == "EXPIRED"
+    )


### PR DESCRIPTION
## Summary
- Extract bulk-review campaign discovery read-model DTOs and projection logic from the wave router into `src/core/waves/campaign_discovery.py`.
- Keep the API route behavior and OpenAPI contract stable while reducing router-local business logic.
- Add focused core tests for governance posture, candidate counts, expiry classification, and preview-reference construction.

## Boundaries
- Refactor only; no new API behavior or product claim.
- No global campaign discovery, cohort calculation, maker-checker workflow, or OMS/execution claim.
- No wiki source change; post-check drift remains zero.

## Validation
- `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py tests/unit/dpm/api/test_waves_api.py -q` -> 107 passed
- `make lint` -> passed
- `make typecheck` -> passed
- `make openapi-gate` -> passed
- `make api-vocabulary-gate` -> passed, no drift
- `make no-alias-gate` -> passed
- `make test-unit` -> 1208 passed, 2 known deprecation warnings
- `make test-integration` -> 168 passed
- `make test-e2e` -> 28 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` -> passed
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> drift 0

## Stranded-truth reconciliation
- `git fetch origin --prune` -> completed
- `git branch -r --no-merged origin/main` -> no unmerged remote branches before PR
- `gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100` -> `[]` before PR