### PR TITLE
Extract PM quality fairness service

### DIFF
--- a/src/api/routers/pm_operating_quality.py
+++ b/src/api/routers/pm_operating_quality.py
@@ -8,6 +8,12 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from pydantic import BaseModel, Field, model_validator
 
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
+from src.api.services.pm_operating_quality_service import (
+    DpmPmOperatingQualityServiceError,
+    DpmPmQualityFairnessAnalysisCommand,
+    DpmPmQualityFairnessSegmentCommand,
+    build_pm_quality_fairness_analysis_from_command,
+)
 from src.api.dependencies import (
     get_pm_quality_fairness_analysis_repository,
     get_outcome_review_repository,
@@ -22,7 +28,6 @@ from src.core.pm_quality import (
     DpmPmQualityFairnessAnalysisConflictError,
     DpmPmQualityFairnessAnalysisRepository,
     DpmPmQualityFairnessAnalysis,
-    DpmPmQualityFairnessSegmentInput,
     DpmPmQualityBookScopeEvidence,
     DpmPmQualityEvidenceItem,
     DpmPmQualityPolicyConflictError,
@@ -31,7 +36,6 @@ from src.core.pm_quality import (
     DpmPmQualityScoreRunRepository,
     DpmPmQualityValidationError,
     PmQualityFairnessSegmentType,
-    build_pm_operating_quality_fairness_analysis,
     build_pm_operating_quality_score_run,
 )
 from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
@@ -684,41 +688,39 @@ def _build_fairness_analysis(
     x_correlation_id: str | None,
     repository: DpmPmQualityScoreRunRepository,
 ) -> DpmPmQualityFairnessAnalysis:
-    segments = []
-    for segment_request in request.segments:
-        score_runs = []
-        for score_run_id in segment_request.score_run_ids:
-            score_run = repository.get_score_run(score_run_id=score_run_id)
-            if score_run is None:
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"PM_QUALITY_SCORE_RUN_NOT_FOUND:{score_run_id}",
-                )
-            score_runs.append(score_run)
-        segments.append(
-            DpmPmQualityFairnessSegmentInput(
-                segment_id=segment_request.segment_id,
-                segment_type=segment_request.segment_type,
-                display_name=segment_request.display_name,
-                score_runs=score_runs,
-                source_refs=segment_request.source_refs,
+    command = DpmPmQualityFairnessAnalysisCommand(
+        policy_id=request.policy_id,
+        policy_version=request.policy_version,
+        as_of_date=request.as_of_date,
+        segments=[
+            DpmPmQualityFairnessSegmentCommand(
+                segment_id=segment.segment_id,
+                segment_type=segment.segment_type,
+                display_name=segment.display_name,
+                score_run_ids=segment.score_run_ids,
+                source_refs=segment.source_refs,
             )
-        )
+            for segment in request.segments
+        ],
+        minimum_segment_score_run_count=request.minimum_segment_score_run_count,
+        maximum_average_score_spread=request.maximum_average_score_spread,
+        actor_id=request.actor_id,
+        correlation_id=x_correlation_id or request.actor_id,
+    )
     try:
-        return build_pm_operating_quality_fairness_analysis(
-            policy_id=request.policy_id,
-            policy_version=request.policy_version,
-            as_of_date=request.as_of_date,
-            segments=segments,
-            minimum_segment_score_run_count=request.minimum_segment_score_run_count,
-            maximum_average_score_spread=request.maximum_average_score_spread,
-            generated_by=request.actor_id,
-            correlation_id=x_correlation_id or request.actor_id,
+        return build_pm_quality_fairness_analysis_from_command(
+            command=command,
+            score_run_repository=repository,
         )
-    except DpmPmQualityValidationError as exc:
+    except DpmPmOperatingQualityServiceError as exc:
+        status_code = (
+            status.HTTP_404_NOT_FOUND
+            if exc.code.startswith("PM_QUALITY_SCORE_RUN_NOT_FOUND:")
+            else status.HTTP_422_UNPROCESSABLE_CONTENT
+        )
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
+            status_code=status_code,
+            detail=exc.code,
         ) from exc
 
 

--- a/src/api/services/pm_operating_quality_service.py
+++ b/src/api/services/pm_operating_quality_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from src.core.outcomes import DpmOutcomeSourceRef
+from src.core.pm_quality import (
+    DpmPmQualityFairnessAnalysis,
+    DpmPmQualityFairnessSegmentInput,
+    DpmPmQualityScoreRunRepository,
+    DpmPmQualityValidationError,
+    PmQualityFairnessSegmentType,
+    build_pm_operating_quality_fairness_analysis,
+)
+
+
+class DpmPmOperatingQualityServiceError(ValueError):
+    """API-service error with a stable PM operating-quality code."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class DpmPmQualityFairnessSegmentCommand:
+    segment_id: str
+    segment_type: PmQualityFairnessSegmentType
+    display_name: str
+    score_run_ids: list[str]
+    source_refs: list[DpmOutcomeSourceRef] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DpmPmQualityFairnessAnalysisCommand:
+    policy_id: str
+    policy_version: str
+    as_of_date: str
+    segments: list[DpmPmQualityFairnessSegmentCommand]
+    minimum_segment_score_run_count: int
+    maximum_average_score_spread: Decimal
+    actor_id: str
+    correlation_id: str
+
+
+def build_pm_quality_fairness_analysis_from_command(
+    *,
+    command: DpmPmQualityFairnessAnalysisCommand,
+    score_run_repository: DpmPmQualityScoreRunRepository,
+) -> DpmPmQualityFairnessAnalysis:
+    segment_inputs = []
+    for segment in command.segments:
+        score_runs = []
+        for score_run_id in segment.score_run_ids:
+            score_run = score_run_repository.get_score_run(score_run_id=score_run_id)
+            if score_run is None:
+                raise DpmPmOperatingQualityServiceError(
+                    f"PM_QUALITY_SCORE_RUN_NOT_FOUND:{score_run_id}"
+                )
+            score_runs.append(score_run)
+        segment_inputs.append(
+            DpmPmQualityFairnessSegmentInput(
+                segment_id=segment.segment_id,
+                segment_type=segment.segment_type,
+                display_name=segment.display_name,
+                score_runs=score_runs,
+                source_refs=segment.source_refs,
+            )
+        )
+    try:
+        return build_pm_operating_quality_fairness_analysis(
+            policy_id=command.policy_id,
+            policy_version=command.policy_version,
+            as_of_date=command.as_of_date,
+            segments=segment_inputs,
+            minimum_segment_score_run_count=command.minimum_segment_score_run_count,
+            maximum_average_score_spread=command.maximum_average_score_spread,
+            generated_by=command.actor_id,
+            correlation_id=command.correlation_id,
+        )
+    except DpmPmQualityValidationError as exc:
+        raise DpmPmOperatingQualityServiceError(str(exc)) from exc

--- a/tests/unit/api/test_pm_operating_quality_service.py
+++ b/tests/unit/api/test_pm_operating_quality_service.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from src.api.services.pm_operating_quality_service import (
+    DpmPmOperatingQualityServiceError,
+    DpmPmQualityFairnessAnalysisCommand,
+    DpmPmQualityFairnessSegmentCommand,
+    build_pm_quality_fairness_analysis_from_command,
+)
+from src.core.pm_quality import (
+    DpmPmOperatingQualityPolicy,
+    DpmPmQualityEvidenceItem,
+    DpmPmQualityGovernanceApproval,
+    DpmPmQualityWeight,
+    build_pm_operating_quality_score_run,
+)
+from src.infrastructure.pm_quality import InMemoryDpmPmQualityScoreRunRepository
+
+
+def _score_run(*, pm_id: str, score: Decimal, correlation_id: str):
+    policy = DpmPmOperatingQualityPolicy(
+        policy_id="pmq_sg_dpm",
+        policy_version="2026.05",
+        enabled=True,
+        as_of_date="2026-05-12",
+        access_purpose="SUPERVISORY_CONTROL_REVIEW",
+        weights=[
+            DpmPmQualityWeight(
+                indicator="SOURCE_QUALITY",
+                weight=Decimal("100"),
+                minimum_evidence_count=1,
+            )
+        ],
+        governance_approval=DpmPmQualityGovernanceApproval(
+            approval_ref="PMQ-APPROVAL-2026-05",
+            approved_by="pm_quality_committee",
+            approved_at="2026-05-10T09:00:00Z",
+            fairness_review_ref="FAIRNESS-PMQ-2026-05",
+            fairness_reviewed_by="model_risk_governance",
+            fairness_reviewed_at="2026-05-10T10:00:00Z",
+        ),
+    )
+    return build_pm_operating_quality_score_run(
+        pm_id=pm_id,
+        book_id="sg_dpm_book",
+        as_of_date="2026-05-12",
+        policy=policy,
+        evidence_items=[
+            DpmPmQualityEvidenceItem(
+                indicator="SOURCE_QUALITY",
+                evidence_state="READY",
+                score=score,
+                source_system="lotus-risk",
+                source_type="RiskMetricsReport",
+                source_id=f"risk-{pm_id}",
+            )
+        ],
+        outcome_reviews=[],
+        generated_by="ops",
+        correlation_id=correlation_id,
+    )
+
+
+def test_pm_quality_service_builds_fairness_analysis_from_persisted_score_runs() -> None:
+    repository = InMemoryDpmPmQualityScoreRunRepository()
+    balanced = _score_run(pm_id="pm_balanced", score=Decimal("91"), correlation_id="corr-1")
+    growth = _score_run(pm_id="pm_growth", score=Decimal("59"), correlation_id="corr-2")
+    repository.save_score_run(score_run=balanced)
+    repository.save_score_run(score_run=growth)
+
+    analysis = build_pm_quality_fairness_analysis_from_command(
+        command=DpmPmQualityFairnessAnalysisCommand(
+            policy_id="pmq_sg_dpm",
+            policy_version="2026.05",
+            as_of_date="2026-05-12",
+            segments=[
+                DpmPmQualityFairnessSegmentCommand(
+                    segment_id="balanced",
+                    segment_type="MANDATE_TYPE",
+                    display_name="Balanced mandates",
+                    score_run_ids=[balanced.score_run_id],
+                ),
+                DpmPmQualityFairnessSegmentCommand(
+                    segment_id="growth",
+                    segment_type="MANDATE_TYPE",
+                    display_name="Growth mandates",
+                    score_run_ids=[growth.score_run_id],
+                ),
+            ],
+            minimum_segment_score_run_count=1,
+            maximum_average_score_spread=Decimal("15"),
+            actor_id="ops",
+            correlation_id="corr-fairness",
+        ),
+        score_run_repository=repository,
+    )
+
+    assert analysis.policy_id == "pmq_sg_dpm"
+    assert analysis.state == "PENDING_REVIEW"
+    assert analysis.observed_average_score_spread == Decimal("32.00")
+    assert analysis.correlation_id == "corr-fairness"
+
+
+def test_pm_quality_service_reports_missing_score_run_with_stable_code() -> None:
+    repository = InMemoryDpmPmQualityScoreRunRepository()
+
+    with pytest.raises(
+        DpmPmOperatingQualityServiceError,
+        match="PM_QUALITY_SCORE_RUN_NOT_FOUND:missing",
+    ):
+        build_pm_quality_fairness_analysis_from_command(
+            command=DpmPmQualityFairnessAnalysisCommand(
+                policy_id="pmq_sg_dpm",
+                policy_version="2026.05",
+                as_of_date="2026-05-12",
+                segments=[
+                    DpmPmQualityFairnessSegmentCommand(
+                        segment_id="balanced",
+                        segment_type="MANDATE_TYPE",
+                        display_name="Balanced mandates",
+                        score_run_ids=["missing"],
+                    ),
+                    DpmPmQualityFairnessSegmentCommand(
+                        segment_id="growth",
+                        segment_type="MANDATE_TYPE",
+                        display_name="Growth mandates",
+                        score_run_ids=["also-missing"],
+                    ),
+                ],
+                minimum_segment_score_run_count=1,
+                maximum_average_score_spread=Decimal("15"),
+                actor_id="ops",
+                correlation_id="corr-fairness",
+            ),
+            score_run_repository=repository,
+        )


### PR DESCRIPTION
## Summary
- Extract PM operating quality fairness-analysis orchestration from the router into `src/api/services/pm_operating_quality_service.py`.
- Keep router responsibility to request mapping, dependency injection, and HTTP error translation.
- Add focused service tests for persisted score-run lookup, fairness-analysis construction, and stable missing-score-run errors.

## Boundaries
- Refactor only; no new API behavior or product claim.
- No PM ranking, protected-class inference, HR/compensation/conduct decision, AI scoring, execution, or source-owner methodology claim.
- No docs/wiki source change; wiki drift remains zero.

## Validation
- `python -m pytest tests/unit/api/test_pm_operating_quality_service.py tests/unit/api/test_pm_operating_quality_api.py -q` -> 22 passed
- `make lint` -> passed
- `make typecheck` -> passed
- `make openapi-gate` -> passed
- `make api-vocabulary-gate` -> passed, no drift
- `make no-alias-gate` -> passed
- `make test-unit` -> 1210 passed, 2 known deprecation warnings
- `make test-integration` -> 168 passed
- `make test-e2e` -> 28 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` -> passed
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> drift 0

## Stranded-truth reconciliation
- `git fetch origin --prune` -> completed
- `git branch -r --no-merged origin/main` -> no unmerged remote branches before PR
- `gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100` -> `[]` before PR