### PR TITLE
Record risk attribution supportability WTBD proof

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -368,6 +368,12 @@ Current repository posture:
     dimension recompute the date/currency panel from summed weights and weight-averaged local/FX
     returns before applying Karnosky-Singer formulas. Manage consumes that as source-owner
     methodology truth only and still does not reconstruct FX attribution from visible rows.
+    The related `lotus-risk` PR #139 (`40ac7a5`, wiki `421ae79`) tightens
+    `HistoricalRiskAttributionReport:v1` supportability so any attribution set with source-owned
+    quality flags degrades response-level `metadata.calculation_supportability`. Manage preserves
+    that source-owned degraded posture for outcome-review evidence and does not promote missing
+    grouping data, empty active-risk alignment, or unsupported attribution combinations as ready
+    risk methodology.
     It also includes the merged and wiki-published `lotus-core`
     `PortfolioCashflowProjection:v1` methodology slice from PR #344
     (`3a29c3ea92fce92d39fbc91f325bd04cb1157d20`, wiki `231bd75`), which pins booked-only

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -121,6 +121,13 @@ from summed weights and weight-averaged local/FX returns before applying Karnosk
 This advances RFC42-WTBD-006 source-owner FX methodology depth without adding any Manage-local FX
 attribution calculation, tax, execution, OMS, or Workbench product claim.
 
+2026-05-16 source-owner historical-attribution supportability update: `lotus-risk` PR #139
+(`40ac7a5`, wiki `421ae79`) tightens `HistoricalRiskAttributionReport:v1` so any source-owned
+attribution-set quality flag degrades response-level `metadata.calculation_supportability`.
+Manage consumes this as source-owner supportability truth only: missing grouping data, empty
+active-risk alignment, and unsupported attribution combinations remain degraded risk evidence, not
+ready values for local promotion or recalculation.
+
 | Priority | WTBD | Why this is next | Promotion bar |
 | ---: | --- | --- | --- |
 | 1 | RFC42-WTBD-006 - Source-owner realized methodology depth | Promotes aggregate risk, performance, tax, FX, cash, liquidity, and execution methodology from selected adapters into auditable source-owned products. Current source-owner slices tighten `lotus-risk` non-rolling volatility, non-rolling drawdown, non-rolling Sharpe, non-rolling Sortino, non-rolling VaR, non-rolling beta, non-rolling tracking-error, non-rolling information-ratio, rolling volatility, rolling Sharpe, rolling beta, rolling maximum drawdown, rolling tracking-error, rolling information-ratio, drawdown analytics maximum-drawdown, average-drawdown, ulcer-index, and time-under-water methodology/wiki truth, and concentration position-HHI, top-position weight, top-N cumulative weight, issuer-HHI, and top-issuer weight methodology/wiki truth, `lotus-core` holdings-as-of, market-data coverage, DPM source-readiness, transaction-ledger window, cashflow-projection, liquidity-ladder, tax-lot window, client-tax profile/rule, portfolio realized-tax summary, and observed transaction-cost curve methodology/wiki truth, and `lotus-performance` MWR, contribution, and attribution methodology/wiki truth so stateful source resolution is auditable and downstream consumers cannot reconstruct `RiskMetricsReport:v1` volatility, drawdown, Sharpe, Sortino, VaR, beta, tracking error, or information ratio, rolling active-risk, rolling excess-return risk-adjusted performance, rolling benchmark sensitivity, rolling window maximum drawdown, drawdown analytics maximum drawdown, average drawdown, ulcer index, or time under water, concentration position HHI, concentration top-position weight, concentration top-N cumulative weight, concentration issuer HHI, concentration top issuer weight, rolling portfolio volatility, holdings snapshot selection, position weighting, cash-balance restatement, market price/FX freshness classification, DPM readiness family precedence, transaction row windowing/restatement, operational cash movement, cash-flow schedules, liquidity buckets, lot/cost-basis selection, explicit realized-tax aggregation, observed booked-fee cost curves, position contribution, active return, Brinson effects, or currency attribution locally. | Owning services provide methodology docs, contracts, degraded-state tests, live proof, and product-surface preservation without manage-local recalculation. |
@@ -4869,6 +4876,28 @@ Latest WTBD-006 risk-attribution tightening proof:
    applicable, stateful active-risk support metadata, quality-flag posture, period-error posture,
    period end date, as-of date, and source units, and performs no covariance, contribution,
    residual, grouping, top-contributor, or support-matrix calculation locally.
+
+Latest WTBD-006 risk historical-attribution supportability proof:
+
+1. `lotus-risk` PR #139 was merged to `main` as `40ac7a5` and the repo-local wiki was published
+   to `lotus-risk.wiki` commit `421ae79`,
+2. `HistoricalRiskAttributionReport:v1` now degrades response-level
+   `metadata.calculation_supportability` whenever any attribution set emits source-owned quality
+   flags, including missing grouping data, empty active-risk alignment, and unsupported
+   attribution combinations,
+3. `docs/methodologies/metrics/attribution-volatility.md`,
+   `docs/methodologies/metrics/attribution-tracking-error.md`,
+   `docs/standards/risk-analytics-contract.md`, repo context, and wiki source record the
+   downstream preservation rule,
+4. source-owner proof passed locally with `make ci`, including Ruff, mypy, OpenAPI quality, API
+   vocabulary, domain-product validation, migration smoke, test-pyramid gate, dependency audit
+   with zero known vulnerabilities, `360` unit tests, `80` integration tests, `24` e2e tests,
+   `98%` coverage, and Docker build,
+5. GitHub PR Merge Gate passed workflow lint, lint/typecheck/security, unit, integration, e2e,
+   test-pyramid, coverage, and Docker build gates,
+6. Manage consumes this as source-owner supportability truth only and performs no covariance,
+   contribution, residual, grouping, supportability, or active-risk methodology calculation
+   locally.
 
 Latest WTBD-006 core-transaction-ledger tightening proof:
 

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -1872,6 +1872,12 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "`16261c9`" in work_to_be_done
     assert "`41bdaa3`" in work_to_be_done
     assert "weight-averaged local/FX returns" in work_to_be_done
+    assert "source-owner historical-attribution supportability update" in work_to_be_done
+    assert "`lotus-risk` PR #139" in work_to_be_done
+    assert "`40ac7a5`" in work_to_be_done
+    assert "`421ae79`" in work_to_be_done
+    assert "attribution-set quality flag degrades response-level" in work_to_be_done
+    assert "missing grouping data, empty active-risk alignment" in work_to_be_done
     assert "downstream no-reconstruction posture" in work_to_be_done
     assert "`aggregate_metrics.source_analytics`" in work_to_be_done
     assert "does not calculate risk or performance methodology locally" in work_to_be_done
@@ -1929,6 +1935,9 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "`lotus-performance` PR #165 (`191a405`, wiki `46a9124`)" in supported_features
     assert "`lotus-performance` PR\n#167 / wiki `41bdaa3`" in supported_features
     assert "weight-averaged local/FX returns before Karnosky-Singer effects" in (supported_features)
+    assert "`lotus-risk` PR\n#139 / wiki `421ae79`" in supported_features
+    assert "degrade response-level\ncalculation supportability" in supported_features
+    assert "empty\nactive-risk alignment" in supported_features
     assert "`lotus-risk` PR #138 (`8ae3e4a`, wiki `616a10c`)" in supported_features
     assert "stateful\n`ACTIVE_RISK + ISSUER` historical attribution" in supported_features
     assert "performs no local benchmark issuer exposure, covariance, tracking-error" in (

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -70,6 +70,11 @@ and weight-averaged local/FX returns before applying Karnosky-Singer formulas. T
 methodology truth consumed by Manage; it does not add Manage-local FX attribution, tax,
 execution/OMS, or Workbench product claims.
 
+2026-05-16 source-owner historical-attribution supportability update: `lotus-risk` PR #139
+(`40ac7a5`, wiki `421ae79`) tightens `HistoricalRiskAttributionReport:v1` so attribution-set
+quality flags degrade response-level calculation supportability. Manage consumes that degraded
+posture as risk source truth and does not promote flagged attribution to ready evidence locally.
+
 ## Business Value Themes
 
 1. scale PM capacity through exception-based monitoring and wave orchestration,

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -329,6 +329,13 @@ weight-averaged local/FX returns before Karnosky-Singer effects are applied. Man
 Workbench, reporting, and AI consumers must preserve this source-owned total rather than
 reconstructing FX attribution from visible rows.
 
+Current risk historical-attribution supportability proof additionally includes `lotus-risk` PR
+#139 / wiki `421ae79`, which makes `HistoricalRiskAttributionReport:v1` degrade response-level
+calculation supportability when any attribution set emits source-owned quality flags. Manage,
+Gateway, Workbench, reporting, and AI consumers must preserve missing grouping data, empty
+active-risk alignment, and unsupported attribution combinations as degraded source truth rather
+than promoting them as ready analytics or recalculating risk attribution locally.
+
 Current risk concentration source-owner proof additionally includes `ConcentrationRiskReport:v1`
 top-position weight methodology truth through `lotus-risk` PR #134 / wiki `dd25844`. Downstream
 services must preserve the decimal `0..1` top-position weight, proposed-state fallback,


### PR DESCRIPTION
## Summary
- record merged lotus-risk PR #139 / wiki 421ae79 as RFC42-WTBD-006 source-owner historical-attribution supportability proof
- document that Manage preserves degraded HistoricalRiskAttributionReport:v1 quality-flag posture without local covariance, contribution, residual, supportability, or active-risk calculation
- update repo context, WTBD ledger, roadmap, supported-features, and documentation guards

## Validation
- python -m pytest tests/unit/test_documentation_current_state.py -q
- make lint
- make typecheck
- make no-alias-gate
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected pre-merge drift: Roadmap.md, Supported-Features.md)