### PR TITLE
Extract campaign definition launch command

### DIFF
--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -36,6 +36,7 @@ from src.core.waves import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionConflictError,
     DpmBulkReviewCampaignDiscoveryPage,
+    DpmBulkReviewCampaignDefinitionLaunchBlocked,
     DpmBulkReviewCampaignDefinitionLaunchPackage,
     DpmBulkReviewCampaignDefinitionPreviewReadiness,
     DpmBulkReviewCampaignDefinitionRepository,
@@ -46,6 +47,7 @@ from src.core.waves import (
     build_bulk_review_campaign_discovery_item,
     build_bulk_review_campaign_definition_preview_readiness,
     build_bulk_review_campaign_definition_launch_package,
+    build_bulk_review_campaign_definition_launch_command,
     record_bulk_review_campaign_definition_launch,
 )
 from src.core.waves.campaign_definitions import (
@@ -2127,32 +2129,30 @@ def launch_bulk_review_campaign_definition(
                 "message": "Bulk-review campaign definition was not found.",
             },
         )
-    launch_package = build_bulk_review_campaign_definition_launch_package(
-        definition=definition,
-        requested_as_of_date=request.requested_as_of_date,
-        actor_id=request.actor_id,
-        correlation_id=request.correlation_id,
-    )
-    if (
-        launch_package.launch_state != "READY"
-        or not launch_package.readiness.preview_create_allowed
-    ):
+    try:
+        launch_command = build_bulk_review_campaign_definition_launch_command(
+            definition=definition,
+            requested_as_of_date=request.requested_as_of_date,
+            actor_id=request.actor_id,
+            correlation_id=request.correlation_id,
+        )
+    except DpmBulkReviewCampaignDefinitionLaunchBlocked as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={
                 "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_LAUNCH_BLOCKED",
                 "message": "Bulk-review campaign definition is not ready for durable launch.",
-                "reason_codes": launch_package.reason_codes,
-                "readiness": launch_package.readiness.model_dump(mode="json"),
+                "reason_codes": exc.reason_codes,
+                "readiness": exc.readiness.model_dump(mode="json"),
             },
-        )
+        ) from exc
     wave_request = DpmWavePreviewRequest.model_validate(
-        launch_package.create_request.model_dump(mode="json")
+        launch_command.create_request.model_dump(mode="json")
     )
     try:
         portfolios = _portfolio_inputs_for_request(
             request=wave_request,
-            correlation_id=launch_package.correlation_id,
+            correlation_id=launch_command.correlation_id,
             advise_authority_client=None,
             risk_authority_client=None,
             campaign_definition_repository=campaign_definition_repository,
@@ -2163,9 +2163,9 @@ def launch_bulk_review_campaign_definition(
             rationale=wave_request.rationale,
             as_of_date=wave_request.as_of_date,
             actor_id=wave_request.actor_id,
-            correlation_id=launch_package.correlation_id,
+            correlation_id=launch_command.correlation_id,
             portfolios=portfolios,
-            idempotency_key=launch_package.create_headers["Idempotency-Key"],
+            idempotency_key=launch_command.idempotency_key,
             mandate_repository=mandate_repository,
             wave_repository=wave_repository,
         )
@@ -2174,8 +2174,8 @@ def launch_bulk_review_campaign_definition(
             wave_id=wave.wave_id,
             launched_by=wave_request.actor_id,
             requested_as_of_date=wave_request.as_of_date,
-            correlation_id=launch_package.correlation_id,
-            idempotency_key=launch_package.create_headers["Idempotency-Key"],
+            correlation_id=launch_command.correlation_id,
+            idempotency_key=launch_command.idempotency_key,
         )
         if launched_definition.content_hash != definition.content_hash:
             campaign_definition_repository.record_definition_launch(definition=launched_definition)

--- a/src/core/waves/__init__.py
+++ b/src/core/waves/__init__.py
@@ -38,6 +38,11 @@ from src.core.waves.campaign_definition_launch_package import (
 from src.core.waves.campaign_definition_launch_history import (
     record_bulk_review_campaign_definition_launch,
 )
+from src.core.waves.campaign_definition_launch_execution import (
+    DpmBulkReviewCampaignDefinitionLaunchBlocked,
+    DpmBulkReviewCampaignDefinitionLaunchCommand,
+    build_bulk_review_campaign_definition_launch_command,
+)
 from src.core.waves.campaign_definition_readiness import (
     DpmBulkReviewCampaignDefinitionPreviewReadiness,
     build_bulk_review_campaign_definition_preview_readiness,
@@ -82,6 +87,8 @@ __all__ = [
     "DpmBulkReviewCampaignDiscoveryPage",
     "DpmBulkReviewCampaignDefinitionLifecycleEvent",
     "DpmBulkReviewCampaignDefinitionLifecycleEventPage",
+    "DpmBulkReviewCampaignDefinitionLaunchBlocked",
+    "DpmBulkReviewCampaignDefinitionLaunchCommand",
     "DpmBulkReviewCampaignDefinitionLaunchPackage",
     "DpmBulkReviewCampaignDefinitionPreviewReadiness",
     "DpmBulkReviewCampaignDefinitionWaveRequestDraft",
@@ -109,6 +116,7 @@ __all__ = [
     "apply_wave_transition",
     "build_bulk_review_campaign_discovery_item",
     "build_bulk_review_campaign_definition_lifecycle_events",
+    "build_bulk_review_campaign_definition_launch_command",
     "record_bulk_review_campaign_definition_launch",
     "build_bulk_review_campaign_definition_launch_package",
     "build_bulk_review_campaign_definition_preview_readiness",

--- a/src/core/waves/campaign_definition_launch_execution.py
+++ b/src/core/waves/campaign_definition_launch_execution.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from src.core.waves.campaign_definition_launch_package import (
+    DpmBulkReviewCampaignDefinitionLaunchPackage,
+    DpmBulkReviewCampaignDefinitionWaveRequestDraft,
+    build_bulk_review_campaign_definition_launch_package,
+)
+from src.core.waves.campaign_definition_readiness import (
+    DpmBulkReviewCampaignDefinitionPreviewReadiness,
+)
+from src.core.waves.campaign_definitions import DpmBulkReviewCampaignDefinition
+
+
+class DpmBulkReviewCampaignDefinitionLaunchBlocked(ValueError):
+    def __init__(
+        self,
+        *,
+        reason_codes: list[str],
+        readiness: DpmBulkReviewCampaignDefinitionPreviewReadiness,
+    ) -> None:
+        super().__init__("BULK_REVIEW_CAMPAIGN_DEFINITION_LAUNCH_BLOCKED")
+        self.reason_codes = reason_codes
+        self.readiness = readiness
+
+
+class DpmBulkReviewCampaignDefinitionLaunchCommand(BaseModel):
+    """Ready-only durable launch command derived from a persisted campaign definition."""
+
+    launch_package: DpmBulkReviewCampaignDefinitionLaunchPackage = Field(
+        description="Readiness package and idempotency/correlation headers used for launch."
+    )
+    create_request: DpmBulkReviewCampaignDefinitionWaveRequestDraft = Field(
+        description="Bounded durable-wave create request draft."
+    )
+    idempotency_key: str = Field(description="Deterministic durable launch idempotency key.")
+    correlation_id: str = Field(description="Correlation id carried into the durable wave.")
+
+
+def build_bulk_review_campaign_definition_launch_command(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+    requested_as_of_date: str,
+    actor_id: str,
+    correlation_id: str | None,
+) -> DpmBulkReviewCampaignDefinitionLaunchCommand:
+    launch_package = build_bulk_review_campaign_definition_launch_package(
+        definition=definition,
+        requested_as_of_date=requested_as_of_date,
+        actor_id=actor_id,
+        correlation_id=correlation_id,
+    )
+    if (
+        launch_package.launch_state != "READY"
+        or not launch_package.readiness.preview_create_allowed
+    ):
+        raise DpmBulkReviewCampaignDefinitionLaunchBlocked(
+            reason_codes=launch_package.reason_codes,
+            readiness=launch_package.readiness,
+        )
+    return DpmBulkReviewCampaignDefinitionLaunchCommand(
+        launch_package=launch_package,
+        create_request=launch_package.create_request,
+        idempotency_key=launch_package.create_headers["Idempotency-Key"],
+        correlation_id=launch_package.correlation_id,
+    )

--- a/tests/unit/dpm/waves/test_campaign_definition_repository.py
+++ b/tests/unit/dpm/waves/test_campaign_definition_repository.py
@@ -13,6 +13,10 @@ from src.core.waves.campaign_definition_lifecycle import (
 from src.core.waves.campaign_definition_launch_history import (
     record_bulk_review_campaign_definition_launch,
 )
+from src.core.waves.campaign_definition_launch_execution import (
+    DpmBulkReviewCampaignDefinitionLaunchBlocked,
+    build_bulk_review_campaign_definition_launch_command,
+)
 from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionCandidate,
@@ -264,6 +268,46 @@ def test_campaign_definition_launch_history_is_append_only_and_idempotent() -> N
         )
         is None
     )
+
+
+def test_campaign_definition_launch_command_is_ready_only() -> None:
+    definition = _definition()
+
+    command = build_bulk_review_campaign_definition_launch_command(
+        definition=definition,
+        requested_as_of_date="2026-05-10",
+        actor_id="ops",
+        correlation_id="corr-campaign-definition-launch-001",
+    )
+
+    assert command.create_request.trigger_type == "BULK_REVIEW_CAMPAIGN"
+    assert command.create_request.campaign_definition_id == definition.campaign_id
+    assert command.correlation_id == "corr-campaign-definition-launch-001"
+    assert command.idempotency_key.startswith(
+        "campaign-launch:campaign-holdings-apple-tesla-20260510:2026.05:"
+    )
+    assert command.launch_package.launch_state == "READY"
+
+    expired = DpmBulkReviewCampaignDefinition.model_validate(
+        {
+            **definition.model_dump(mode="python"),
+            "governance": {
+                **definition.governance.model_dump(mode="python"),
+                "expires_on": "2026-05-09",
+            },
+            "content_hash": "",
+        }
+    )
+    with pytest.raises(DpmBulkReviewCampaignDefinitionLaunchBlocked) as blocked:
+        build_bulk_review_campaign_definition_launch_command(
+            definition=expired,
+            requested_as_of_date="2026-05-10",
+            actor_id="ops",
+            correlation_id=None,
+        )
+
+    assert "BULK_REVIEW_CAMPAIGN_EXPIRED" in blocked.value.reason_codes
+    assert blocked.value.readiness.preview_create_allowed is False
 
 
 def test_campaign_definition_retirement_validation_and_in_memory_lifecycle() -> None:


### PR DESCRIPTION
## Summary
- Extract ready-only bulk-review campaign-definition launch command construction into the waves core domain layer.
- Keep the waves router focused on HTTP translation, portfolio sourcing, durable wave creation, and launch-history persistence.
- Add focused unit coverage for ready launch command construction and fail-closed blocked launch behavior.

## Validation
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Governance
- API shape unchanged; OpenAPI and vocabulary gates passed with no drift.
- Wiki/source documentation unchanged; no wiki publication required for this refactor slice.
- No Gateway or Workbench changes required.