### PR TITLE
Guard WTBD ledger control counts

### DIFF
--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -54,18 +54,21 @@ retained only as evidence index and sequencing control.
 
 ## Mainline WTBD Control Snapshot
 
-Snapshot basis: the 2026-05-10 mainline after the RFC40-WTBD-009 selected-alternative
-regime-scenario proof-pack preservation slice, the RFC-0043 owner-side AI workflow-pack truth
-reintegration slice, the RFC41-WTBD-003 manage risk-event consumer slice, the RFC38-WTBD-006
-source-backed mandate-health consumption slice, the RFC38-WTBD-008 command-center product closure,
-the RFC38-WTBD-005 mandate objective/benchmark/review source-consumption slice, and the
-RFC39-WTBD-010 construction lifecycle
-audit. RFC37-WTBD-005 now has the supported proof-pack, rebalance-wave, and outcome-review report,
-render, archive, Gateway/Workbench posture, and AI-evidence handoff truth moved into RFC-0037 as a
-completed parent-roadmap closure result. RFC36-WTBD-006 is now closed as a no-migration-required
-conditional item after the cross-repo audit found no active consumer dependency that justifies
-restoring retired manage proposal routes; the only stale durable truth found was the platform API
-vocabulary mirror, which `lotus-platform` PR #316 refreshed and validated. RFC41-WTBD-003 now has
+Snapshot basis: the 2026-05-18 clean mainline after `lotus-manage` PR #273 (`58e8662114f2c0a66b2f3aaff60eda9001a855f8`) closed the bounded RFC42-WTBD-008 PM operating
+quality downstream realization and the wiki source was published at commit `4fc0dd7`. The current
+classification remains 59 total WTBD items: 44 done on merged/published truth, 4 partial or in
+progress, and 11 remaining/open. Earlier source slices include the RFC40-WTBD-009
+selected-alternative regime-scenario proof-pack preservation slice, the RFC-0043 owner-side AI
+workflow-pack truth reintegration slice, the RFC41-WTBD-003 manage risk-event consumer slice, the
+RFC38-WTBD-006 source-backed mandate-health consumption slice, the RFC38-WTBD-008 command-center
+product closure, the RFC38-WTBD-005 mandate objective/benchmark/review source-consumption slice,
+and the RFC39-WTBD-010 construction lifecycle audit. RFC37-WTBD-005 now has the supported
+proof-pack, rebalance-wave, and outcome-review report, render, archive, Gateway/Workbench posture,
+and AI-evidence handoff truth moved into RFC-0037 as a completed parent-roadmap closure result.
+RFC36-WTBD-006 is now closed as a no-migration-required conditional item after the cross-repo audit
+found no active consumer dependency that justifies restoring retired manage proposal routes; the
+only stale durable truth found was the platform API vocabulary mirror, which `lotus-platform`
+PR #316 refreshed and validated. RFC41-WTBD-003 now has
 `lotus-risk:RiskEventAffectedCohort:v1` source ownership, the platform mesh mirror, and the
 `lotus-manage` `RISK_EVENT` wave preview/create consumer implemented, validated, merged to
 `main`, and wiki-published. RFC38-WTBD-006 now has `lotus-manage` first-wave mandate-health

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -1,9 +1,31 @@
+import re
 from pathlib import Path
 
 from src.api.main import app
 
 
 ROOT = Path(__file__).resolve().parents[2]
+
+WTBD_PARTIAL_IDS = {
+    "RFC37-WTBD-001",
+    "RFC40-WTBD-009",
+    "RFC41-WTBD-003",
+    "RFC42-WTBD-006",
+}
+
+WTBD_OPEN_IDS = {
+    "RFC36-WTBD-004",
+    "RFC36-WTBD-005",
+    "RFC37-WTBD-002",
+    "RFC37-WTBD-003",
+    "RFC37-WTBD-004",
+    "RFC37-WTBD-007",
+    "RFC38-WTBD-007",
+    "RFC39-WTBD-005",
+    "RFC39-WTBD-008",
+    "RFC41-WTBD-010",
+    "RFC42-WTBD-007",
+}
 
 CURRENT_DOC_PATHS = [
     ROOT / "Makefile",
@@ -39,6 +61,18 @@ def _iter_current_docs() -> list[Path]:
             continue
         docs.extend(child for child in path.rglob("*.md") if "api-vocabulary" not in child.parts)
     return sorted(set(docs))
+
+
+def _detailed_wtbd_rows() -> list[list[str]]:
+    ledger = ROOT / "docs" / "rfcs" / "RFC-worktobedone.md"
+    rows: list[list[str]] = []
+    for line in ledger.read_text(encoding="utf-8").splitlines():
+        if not re.match(r"^\| RFC\d+-WTBD-\d+ ", line):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if len(cells) == 5:
+            rows.append(cells)
+    return rows
 
 
 def test_current_docs_do_not_advertise_removed_advisory_runtime_surface() -> None:
@@ -287,6 +321,27 @@ def test_wiki_sidebar_links_resolve_to_authored_pages() -> None:
             missing.append(target)
 
     assert missing == []
+
+
+def test_wtbd_control_snapshot_counts_match_detailed_ledger() -> None:
+    rows = _detailed_wtbd_rows()
+    all_ids = {row[0] for row in rows}
+    done_ids = all_ids - WTBD_PARTIAL_IDS - WTBD_OPEN_IDS
+
+    assert len(rows) == 59
+    assert len(done_ids) == 44
+    assert len(WTBD_PARTIAL_IDS) == 4
+    assert len(WTBD_OPEN_IDS) == 11
+    assert WTBD_PARTIAL_IDS <= all_ids
+    assert WTBD_OPEN_IDS <= all_ids
+
+    ledger = (ROOT / "docs" / "rfcs" / "RFC-worktobedone.md").read_text(encoding="utf-8")
+    for wtbd_id in WTBD_PARTIAL_IDS:
+        assert f"| {wtbd_id} |" in ledger
+
+    supported_features = (ROOT / "wiki" / "Supported-Features.md").read_text(encoding="utf-8")
+    assert "59 WTBD items: 44 done on merged/published truth, 4 partial" in supported_features
+    assert "11 remaining or open" in supported_features
 
 
 def test_indexed_rfc_and_adr_files_exist() -> None:
@@ -1361,6 +1416,10 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     )
     assert "RFC Work To Be Done Ledger" in work_to_be_done
     assert "## Mainline WTBD Control Snapshot" in work_to_be_done
+    assert "Snapshot basis: the 2026-05-18 clean mainline" in work_to_be_done
+    assert "`lotus-manage` PR #273 (`58e8662114f2c0a66b2f3aaff60eda9001a855f8`)" in (
+        work_to_be_done
+    )
     assert "| Total WTBD items | 59 |" in work_to_be_done
     assert "| Done on merged/published truth | 44 |" in work_to_be_done
     assert "| Partial / in progress | 4 |" in work_to_be_done

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -312,10 +312,10 @@ Audience use:
 
 ## WTBD Product-Readiness Roadmap
 
-`docs/rfcs/RFC-worktobedone.md` is the governed WTBD ledger. As of the current mainline snapshot it
-tracks 59 WTBD items: 44 done on merged/published truth, 4 partial or in progress, and 11 remaining
-or open. The next execution wave should focus on product surfaces that materially improve
-bank-buyable demo and operating value without inventing unsupported source truth.
+`docs/rfcs/RFC-worktobedone.md` is the governed WTBD ledger. As of the 2026-05-18 clean mainline
+snapshot after `lotus-manage` PR #273, it tracks 59 WTBD items: 44 done on merged/published truth, 4 partial or in progress, and 11 remaining or open. The next execution wave should focus on product
+surfaces that materially improve bank-buyable demo and operating value without inventing
+unsupported source truth.
 
 | Priority | WTBD | Business value | Required proof before support claim |
 | ---: | --- | --- | --- |


### PR DESCRIPTION
## Summary
- refresh the WTBD control snapshot to the 2026-05-18 clean mainline after PR #273
- update supported-features wiki source with the same current snapshot basis
- add a docs regression test that parses the detailed WTBD ledger and pins 59 total, 44 done, 4 partial, and 11 open items with explicit partial/open IDs

## Validation
- python -m pytest tests\\unit\\test_documentation_current_state.py -q
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected drift: Supported-Features.md, because this PR changes repo-authored wiki source before publication)

## Governance
- Stranded truth: git fetch origin --prune and git branch -r --no-merged origin/main returned no lotus-manage unmerged remote branches before implementation and before PR creation.
- API/schema: not touched; OpenAPI and API vocabulary gates are not applicable.
- Wiki: source changed; publish after merge and verify drift returns to 0.