### PR TITLE
Preserve drawdown analytics outcome measures

### DIFF
--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -4658,6 +4658,26 @@ Latest WTBD-006 risk drawdown analytics time-under-water methodology proof:
    liquidity ladders, execution methodology, and client tax/OMS claims remain future source-owner
    work.
 
+Latest WTBD-006 manage drawdown analytics consumer-preservation proof:
+
+1. `lotus-manage` now preserves source-emitted `DrawdownAnalyticsReport:v1` average drawdown,
+   ulcer index, and time-under-water values in RFC-0042 realized outcome snapshots through
+   `realized_drawdown_source_from_drawdown_response`,
+2. the adapter maps only `summary.average_drawdown`, `summary.ulcer_index`, and
+   `summary.time_under_water_days` values supplied by `lotus-risk`; it does not calculate cumulative wealth, running peaks, underwater paths,
+   squared drawdowns, observation counts,
+   episode lists, relative benchmark behavior, or any drawdown methodology locally,
+3. source references, request fingerprints, as-of date, supportability state, quality, and reason
+   codes remain source-owned and hash-backed so report, AI, portfolio-memory, Gateway, and
+   Workbench consumers can preserve the source-owner posture without reconstructing risk facts,
+4. focused Manage proof covers maximum drawdown, relative maximum drawdown, average drawdown,
+   ulcer index, time-under-water, degraded relative benchmark posture, and realized-snapshot
+   supportability through `tests/unit/core/test_risk_realized_outcome_sources.py`,
+5. this advances RFC42-WTBD-006 but does not close it: broader aggregate risk/performance
+   products, broader FX methodology beyond performance-owned Karnosky-Singer attribution totals,
+   predictive execution, OMS acknowledgement, client tax advice, after-tax optimization, and
+   financial-planning claims remain unsupported source-owner work.
+
 Latest WTBD-006 risk concentration position-HHI methodology proof:
 
 1. `lotus-risk` PR #133 was merged to `main` as

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -15,7 +15,13 @@ RiskOutcomeMeasure = Literal[
     "INFORMATION_RATIO",
     "VAR",
 ]
-DrawdownOutcomeMeasure = Literal["max_drawdown", "relative_max_drawdown"]
+DrawdownOutcomeMeasure = Literal[
+    "max_drawdown",
+    "relative_max_drawdown",
+    "average_drawdown",
+    "ulcer_index",
+    "time_under_water_days",
+]
 ConcentrationOutcomeMeasure = Literal[
     "hhi_current",
     "hhi_proposed",
@@ -157,7 +163,7 @@ def realized_drawdown_source_from_drawdown_response(
         source_type="DRAWDOWN_RESPONSE",
         source_id=f"{request_fingerprint}:{period}:{measure}",
         value=value if source_state != "NOT_SUPPORTED" else None,
-        unit="ratio",
+        unit=_drawdown_unit(measure),
         source_state=source_state,
         quality=quality,
         observed_at=None,
@@ -431,13 +437,34 @@ def _drawdown_value(
     result: dict[str, Any],
     measure: DrawdownOutcomeMeasure,
 ) -> tuple[Decimal | None, str]:
+    summary = _read_mapping(result.get("summary"))
     if measure == "max_drawdown":
-        summary = _read_mapping(result.get("summary"))
         return (
             _decimal_value(summary.get("max_drawdown"))
             if summary.get("max_drawdown") is not None
             else None,
             "RISK_DRAWDOWN_ABSOLUTE",
+        )
+    if measure == "average_drawdown":
+        return (
+            _decimal_value(summary.get("average_drawdown"))
+            if summary.get("average_drawdown") is not None
+            else None,
+            "RISK_DRAWDOWN_AVERAGE",
+        )
+    if measure == "ulcer_index":
+        return (
+            _decimal_value(summary.get("ulcer_index"))
+            if summary.get("ulcer_index") is not None
+            else None,
+            "RISK_DRAWDOWN_ULCER_INDEX",
+        )
+    if measure == "time_under_water_days":
+        return (
+            _decimal_value(summary.get("time_under_water_days"))
+            if summary.get("time_under_water_days") is not None
+            else None,
+            "RISK_DRAWDOWN_TIME_UNDER_WATER",
         )
 
     relative_context = _read_mapping(result.get("relative_to_benchmark_context"))
@@ -721,6 +748,12 @@ def _metric_unit(metric: RiskOutcomeMeasure) -> str:
         return "percentage_point"
     if metric in {"SHARPE", "SORTINO", "BETA", "INFORMATION_RATIO"}:
         return "ratio"
+    return "ratio"
+
+
+def _drawdown_unit(measure: DrawdownOutcomeMeasure) -> str:
+    if measure == "time_under_water_days":
+        return "days"
     return "ratio"
 
 

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -742,6 +742,46 @@ def test_drawdown_response_adapter_wraps_source_owned_relative_max_drawdown() ->
     assert "RISK_DRAWDOWN_RELATIVE_APPLIED" in source.reason_codes
 
 
+def test_drawdown_response_adapter_wraps_source_owned_average_drawdown() -> None:
+    source = realized_drawdown_source_from_drawdown_response(
+        _drawdown_response(),
+        measure="average_drawdown",
+    )
+
+    assert source.source_type == "DRAWDOWN_RESPONSE"
+    assert source.source_id == "sha256:drawdown-request:YTD:average_drawdown"
+    assert str(source.value) == "-0.041208"
+    assert source.unit == "ratio"
+    assert "RISK_DRAWDOWN_MEASURE_AVERAGE_DRAWDOWN" in source.reason_codes
+    assert "RISK_DRAWDOWN_AVERAGE" in source.reason_codes
+
+
+def test_drawdown_response_adapter_wraps_source_owned_ulcer_index() -> None:
+    source = realized_drawdown_source_from_drawdown_response(
+        _drawdown_response(),
+        measure="ulcer_index",
+    )
+
+    assert source.source_id == "sha256:drawdown-request:YTD:ulcer_index"
+    assert str(source.value) == "0.053901"
+    assert source.unit == "ratio"
+    assert "RISK_DRAWDOWN_MEASURE_ULCER_INDEX" in source.reason_codes
+    assert "RISK_DRAWDOWN_ULCER_INDEX" in source.reason_codes
+
+
+def test_drawdown_response_adapter_wraps_source_owned_time_under_water() -> None:
+    source = realized_drawdown_source_from_drawdown_response(
+        _drawdown_response(),
+        measure="time_under_water_days",
+    )
+
+    assert source.source_id == "sha256:drawdown-request:YTD:time_under_water_days"
+    assert str(source.value) == "27"
+    assert source.unit == "days"
+    assert "RISK_DRAWDOWN_MEASURE_TIME_UNDER_WATER_DAYS" in source.reason_codes
+    assert "RISK_DRAWDOWN_TIME_UNDER_WATER" in source.reason_codes
+
+
 def test_risk_metrics_report_adapter_supports_explicit_metric() -> None:
     source = realized_risk_source_from_risk_metrics_report(
         _risk_metrics_report(),

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -1669,6 +1669,15 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "strictly-underwater observation counting" in work_to_be_done
     assert "explicit non-duration posture for calendar/business-day settings" in work_to_be_done
     assert "source-owner proof passed locally with `348` unit tests" in work_to_be_done
+    assert "Latest WTBD-006 manage drawdown analytics consumer-preservation proof" in (
+        work_to_be_done
+    )
+    assert "realized_drawdown_source_from_drawdown_response" in work_to_be_done
+    assert "`summary.average_drawdown`, `summary.ulcer_index`, and" in work_to_be_done
+    assert "it does not calculate cumulative wealth, running peaks, underwater paths" in (
+        work_to_be_done
+    )
+    assert "tests/unit/core/test_risk_realized_outcome_sources.py" in work_to_be_done
     assert "Latest WTBD-006 risk concentration position-HHI methodology proof" in work_to_be_done
     assert "`lotus-risk` PR #133" in work_to_be_done
     assert "`dea20b5a6f99403a9b8e974ac9da823c691c5465`" in work_to_be_done
@@ -2072,6 +2081,13 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "`lotus-risk` PR\n#139 / wiki `421ae79`" in supported_features
     assert "degrade response-level\ncalculation supportability" in supported_features
     assert "empty\nactive-risk alignment" in supported_features
+    assert "Current Manage drawdown analytics consumer proof additionally preserves" in (
+        supported_features
+    )
+    assert "`summary.average_drawdown`, `summary.ulcer_index`, and" in supported_features
+    assert "it does not reconstruct cumulative wealth, running peaks, underwater paths" in (
+        supported_features
+    )
     assert "`lotus-risk` PR #138 (`8ae3e4a`, wiki `616a10c`)" in supported_features
     assert "stateful\n`ACTIVE_RISK + ISSUER` historical attribution" in supported_features
     assert "performs no local benchmark issuer exposure, covariance, tracking-error" in (

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -336,6 +336,13 @@ Gateway, Workbench, reporting, and AI consumers must preserve missing grouping d
 active-risk alignment, and unsupported attribution combinations as degraded source truth rather
 than promoting them as ready analytics or recalculating risk attribution locally.
 
+Current Manage drawdown analytics consumer proof additionally preserves source-emitted
+`DrawdownAnalyticsReport:v1` `summary.average_drawdown`, `summary.ulcer_index`, and
+`summary.time_under_water_days` values in RFC-0042 realized outcome snapshots. Manage records those
+values with source refs, request fingerprints, as-of date, supportability, quality, and reason codes
+only; it does not reconstruct cumulative wealth, running peaks, underwater paths, squared
+drawdowns, observation counts, or any drawdown methodology locally.
+
 Current external execution boundary proof additionally includes Core-owned
 `ExternalOrderExecutionAcknowledgement:v1` and Manage construction-authority consumption of that
 posture. The posture is fail-closed `UNAVAILABLE`: Manage preserves acknowledgement counts, empty


### PR DESCRIPTION
## Summary
- preserve source-emitted DrawdownAnalyticsReport:v1 average drawdown, ulcer index, and time-under-water values in realized outcome snapshots
- add source-owned reason codes and day/ration unit handling without local drawdown methodology calculation
- update WTBD and wiki source truth for RFC42-WTBD-006 consumer-preservation progress

## Validation
- python -m pytest tests\\unit\\core\\test_risk_realized_outcome_sources.py tests\\unit\\test_documentation_current_state.py -q
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected pre-merge drift: Supported-Features.md)

No OpenAPI/API vocabulary gate was required locally because this slice did not touch API schema or OpenAPI files.