### PR TITLE
Extract rebalance wave response contracts

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -394,3 +394,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   to RFC-0036 Slice 4.
 - Status: deliberately retained until Slice 4 review
 - Wiki decision: no wiki source change in Slice 2.
+
+## BACKEND-REVIEW-20260519-001: Wave router mixed response contracts with endpoint orchestration
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, rebalance-wave API response DTOs and response mapper
+- Finding: `src/api/routers/waves.py` had grown past 3,000 lines and combined endpoint routing,
+  request DTOs, response DTOs, source-cohort resolution, workflow orchestration, and HTTP error
+  mapping in one module. This made the wave surface harder to review and increased the risk that
+  reusable response contracts or supportability serialization would drift from endpoint behavior.
+- Action: extracted wave response DTOs and the shared response mapper into
+  `src/api/routers/wave_response_contracts.py`. The router now keeps endpoint wiring and request
+  parsing while response contract models and supportability response assembly live in a dedicated
+  module that can be reused by future wave route splits.
+- Status: hardened
+- Evidence: `python -m ruff check src\api\routers\waves.py src\api\routers\wave_response_contracts.py`
+  during implementation; full validation is recorded in the PR evidence for this slice.
+- Follow-up: continue splitting `waves.py` by bounded route families only after the response-contract
+  boundary stays green in OpenAPI and wave API tests.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature or operator-contract change.

--- a/src/api/routers/wave_response_contracts.py
+++ b/src/api/routers/wave_response_contracts.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from src.api.services import wave_service
+from src.core.waves import DpmRebalanceWave
+from src.core.waves.models import (
+    DpmRebalanceWaveItem,
+    DpmWaveAggregateMetrics,
+    DpmWaveExternalExecutionBoundaryEvidence,
+    DpmWaveHandoffRef,
+)
+
+
+class DpmWaveSupportabilityIssue(BaseModel):
+    support_ref: str = Field(
+        description="Opaque support reference that avoids portfolio or client identifiers.",
+        examples=["wave:dwv_001:item:1"],
+    )
+    item_state: str = Field(description="Wave item workflow state.", examples=["SOURCE_BLOCKED"])
+    severity: Literal["INFO", "WARNING", "CRITICAL"] = Field(
+        description="Operator severity for this issue.",
+        examples=["CRITICAL"],
+    )
+    source_owner: str = Field(
+        description="Owning product or route responsible for remediation.",
+        examples=["lotus-manage"],
+    )
+    reason_codes: list[str] = Field(
+        description="Bounded reason codes explaining supportability posture.",
+        examples=[["MANDATE_DIGITAL_TWIN_MISSING"]],
+    )
+    remediation_route: str = Field(
+        description="Product-safe remediation route or action.",
+        examples=["REPAIR_SOURCE_DATA"],
+    )
+
+
+class DpmWaveSupportabilityResponse(BaseModel):
+    wave_id: str = Field(description="Wave identifier.", examples=["dwv_001"])
+    wave_state: str = Field(description="Current wave state.", examples=["SOURCE_CHECKED"])
+    supportability_state: Literal["ready", "degraded", "blocked"] = Field(
+        description="Bounded supportability state for the wave.",
+        examples=["blocked"],
+    )
+    reason: str = Field(
+        description="Bounded supportability reason.",
+        examples=["wave_blocked_items"],
+    )
+    item_count: int = Field(description="Number of wave items inspected.", examples=[2])
+    issue_counts: dict[str, int] = Field(
+        description="Issue count by severity.",
+        examples=[{"critical": 1, "warning": 0, "info": 1}],
+    )
+    issues: list[DpmWaveSupportabilityIssue] = Field(
+        description=(
+            "Product-safe issues without portfolio ids, client ids, raw requests, raw responses, "
+            "secrets, or trace values."
+        )
+    )
+    operator_actions: list[str] = Field(
+        description="Deduplicated product-safe remediation actions.",
+        examples=[["REPAIR_SOURCE_DATA", "RUN_WAVE_SIMULATION"]],
+    )
+
+
+class DpmWaveResponse(BaseModel):
+    wave: DpmRebalanceWave = Field(description="Previewed or durable rebalance wave.")
+    durable: bool = Field(
+        description="Whether this response was durably persisted.", examples=[False]
+    )
+    supportability: DpmWaveSupportabilityResponse = Field(
+        description=(
+            "Product-safe wave supportability derived by lotus-manage from item states. "
+            "Gateway and Workbench must preserve this authority-owned posture instead of "
+            "reconstructing readiness."
+        )
+    )
+    idempotent_replay: bool = Field(
+        default=False,
+        description="True when create returned an already persisted wave for the idempotency key.",
+        examples=[False],
+    )
+
+
+class DpmWaveSearchItem(BaseModel):
+    wave_id: str = Field(description="Wave identifier.", examples=["dwv_001"])
+    wave_state: str = Field(description="Current wave state.", examples=["HANDOFF_READY"])
+    trigger_type: str = Field(
+        description="Bounded trigger type used to create the wave.",
+        examples=["EXPLICIT_PORTFOLIO_LIST"],
+    )
+    trigger_id: str = Field(description="Business trigger identifier.", examples=["manual-001"])
+    as_of_date: str = Field(description="Business as-of date.", examples=["2026-05-03"])
+    created_at: datetime = Field(
+        description="UTC timestamp when the wave was created.",
+        examples=["2026-05-03T09:30:00Z"],
+    )
+    created_by: str = Field(description="Actor that created the wave.", examples=["pm_001"])
+    item_count: int = Field(description="Number of wave items.", examples=[2])
+    aggregate_metrics: DpmWaveAggregateMetrics = Field(
+        description="Aggregate item counts reconciled from persisted wave state."
+    )
+    supportability_state: Literal["ready", "degraded", "blocked"] = Field(
+        description="Product-safe supportability posture for search and triage.",
+        examples=["ready"],
+    )
+    supportability_reason: str = Field(
+        description="Bounded reason for the supportability state.",
+        examples=["wave_supportability_ready"],
+    )
+    latest_event_type: str | None = Field(
+        default=None,
+        description="Latest persisted event type for operator context.",
+        examples=["STATE_TRANSITION"],
+    )
+    latest_event_reason_code: str | None = Field(
+        default=None,
+        description="Latest persisted event reason code for operator context.",
+        examples=["WAVE_HANDOFF_READY"],
+    )
+
+
+class DpmWaveSearchResponse(BaseModel):
+    items: list[DpmWaveSearchItem] = Field(
+        description="Bounded page of persisted waves matching the search filters."
+    )
+    limit: int = Field(description="Requested page size.", examples=[50])
+    offset: int = Field(description="Requested page offset.", examples=[0])
+    returned_count: int = Field(description="Number of waves returned.", examples=[1])
+
+
+class DpmWaveDetailResponse(BaseModel):
+    wave: DpmRebalanceWave = Field(description="Persisted wave detail.")
+    supportability: DpmWaveSupportabilityResponse = Field(
+        description="Latest product-safe supportability derived from persisted item states."
+    )
+    proof_pack_posture: "DpmWaveProofPackPostureResponse" = Field(
+        description="Wave proof-pack and internal operations handoff posture."
+    )
+
+
+class DpmWaveItemsResponse(BaseModel):
+    wave_id: str = Field(description="Wave identifier.", examples=["dwv_001"])
+    wave_state: str = Field(description="Current wave state.", examples=["HANDOFF_READY"])
+    items: list[DpmRebalanceWaveItem] = Field(
+        description=(
+            "Persisted item list with source readiness, selection, proof-pack, and handoff posture."
+        )
+    )
+    aggregate_metrics: DpmWaveAggregateMetrics = Field(
+        description="Aggregate item counts reconciled from persisted wave state."
+    )
+
+
+class DpmWaveProofPackRef(BaseModel):
+    wave_item_id: str = Field(description="Wave item identifier.", examples=["dwi_001"])
+    proof_pack_id: str | None = Field(
+        default=None,
+        description="Linked RFC-0040 proof-pack id when generated.",
+        examples=["dpp_001"],
+    )
+    item_state: str = Field(description="Current item state.", examples=["PROOF_PACK_READY"])
+    proof_pack_state: str | None = Field(
+        default=None,
+        description="Proof-pack posture captured in item diagnostics.",
+        examples=["READY"],
+    )
+    selected_alternative_id: str | None = Field(
+        default=None,
+        description="Selected RFC-0039 construction alternative id.",
+        examples=["alt_min_turnover"],
+    )
+
+
+class DpmWaveProofPackPostureResponse(BaseModel):
+    wave_id: str = Field(description="Wave identifier.", examples=["dwv_001"])
+    wave_state: str = Field(description="Current wave state.", examples=["HANDOFF_READY"])
+    item_count: int = Field(description="Total item count.", examples=[2])
+    linked_item_count: int = Field(description="Items with linked proof packs.", examples=[1])
+    ready_proof_pack_count: int = Field(
+        description="Linked proof packs that are not degraded.", examples=[1]
+    )
+    degraded_proof_pack_count: int = Field(
+        description="Items with degraded proof-pack posture.", examples=[0]
+    )
+    proof_pack_refs: list[DpmWaveProofPackRef] = Field(
+        description="Item-level proof-pack references and posture."
+    )
+    handoff_refs: list[DpmWaveHandoffRef] = Field(
+        description="Append-only internal operations handoff evidence refs."
+    )
+    external_execution_claimed: bool = Field(
+        description=(
+            "Always false for valid manage-owned handoff evidence. If persisted evidence ever "
+            "contains an external execution claim, downstream report input is blocked until an "
+            "external OMS/execution owner contract exists."
+        ),
+        examples=[False],
+    )
+    external_execution_boundary: DpmWaveExternalExecutionBoundaryEvidence = Field(
+        description=(
+            "Structured fail-closed no-OMS boundary evidence for downstream reports, audit, and "
+            "operator diagnosis."
+        )
+    )
+
+
+def wave_response(
+    *,
+    wave: DpmRebalanceWave,
+    durable: bool,
+    idempotent_replay: bool = False,
+) -> DpmWaveResponse:
+    return DpmWaveResponse(
+        wave=wave,
+        durable=durable,
+        supportability=DpmWaveSupportabilityResponse.model_validate(
+            wave_service.wave_supportability_payload(wave)
+        ),
+        idempotent_replay=idempotent_replay,
+    )

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from datetime import date, datetime
+from datetime import date
 from decimal import Decimal
 from typing import Annotated, Literal, cast
 
@@ -22,6 +22,16 @@ from src.api.dependencies import (
     get_wave_repository,
 )
 from src.api.request_models import RebalanceRequest
+from src.api.routers.wave_response_contracts import (
+    DpmWaveDetailResponse,
+    DpmWaveItemsResponse,
+    DpmWaveProofPackPostureResponse,
+    DpmWaveResponse,
+    DpmWaveSearchItem,
+    DpmWaveSearchResponse,
+    DpmWaveSupportabilityResponse,
+    wave_response,
+)
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
 from src.api.services import wave_service
@@ -41,7 +51,6 @@ from src.core.waves import (
     DpmBulkReviewCampaignDefinitionLaunchPackage,
     DpmBulkReviewCampaignDefinitionPreviewReadiness,
     DpmBulkReviewCampaignDefinitionRepository,
-    DpmRebalanceWave,
     DpmWaveReportInput,
     DpmWaveRepository,
     DpmWaveSourceRef,
@@ -73,12 +82,6 @@ from src.infrastructure.risk_authority import (
 from src.infrastructure.advise_authority import (
     LotusAdviseAuthorityClient,
     LotusAdviseAuthorityUnavailableError,
-)
-from src.core.waves.models import (
-    DpmWaveExternalExecutionBoundaryEvidence,
-    DpmRebalanceWaveItem,
-    DpmWaveAggregateMetrics,
-    DpmWaveHandoffRef,
 )
 
 
@@ -518,72 +521,6 @@ class DpmWavePreviewRequest(BaseModel):
     )
 
 
-class DpmWaveResponse(BaseModel):
-    wave: DpmRebalanceWave = Field(description="Previewed or durable rebalance wave.")
-    durable: bool = Field(
-        description="Whether this response was durably persisted.", examples=[False]
-    )
-    supportability: "DpmWaveSupportabilityResponse" = Field(
-        description=(
-            "Product-safe wave supportability derived by lotus-manage from item states. "
-            "Gateway and Workbench must preserve this authority-owned posture instead of "
-            "reconstructing readiness."
-        )
-    )
-    idempotent_replay: bool = Field(
-        default=False,
-        description="True when create returned an already persisted wave for the idempotency key.",
-        examples=[False],
-    )
-
-
-class DpmWaveSearchItem(BaseModel):
-    wave_id: str = Field(description="Wave identifier.", examples=["dwv_001"])
-    wave_state: str = Field(description="Current wave state.", examples=["HANDOFF_READY"])
-    trigger_type: str = Field(
-        description="Bounded trigger type used to create the wave.",
-        examples=["EXPLICIT_PORTFOLIO_LIST"],
-    )
-    trigger_id: str = Field(description="Business trigger identifier.", examples=["manual-001"])
-    as_of_date: str = Field(description="Business as-of date.", examples=["2026-05-03"])
-    created_at: datetime = Field(
-        description="UTC timestamp when the wave was created.",
-        examples=["2026-05-03T09:30:00Z"],
-    )
-    created_by: str = Field(description="Actor that created the wave.", examples=["pm_001"])
-    item_count: int = Field(description="Number of wave items.", examples=[2])
-    aggregate_metrics: DpmWaveAggregateMetrics = Field(
-        description="Aggregate item counts reconciled from persisted wave state."
-    )
-    supportability_state: Literal["ready", "degraded", "blocked"] = Field(
-        description="Product-safe supportability posture for search and triage.",
-        examples=["ready"],
-    )
-    supportability_reason: str = Field(
-        description="Bounded reason for the supportability state.",
-        examples=["wave_supportability_ready"],
-    )
-    latest_event_type: str | None = Field(
-        default=None,
-        description="Latest persisted event type for operator context.",
-        examples=["STATE_TRANSITION"],
-    )
-    latest_event_reason_code: str | None = Field(
-        default=None,
-        description="Latest persisted event reason code for operator context.",
-        examples=["WAVE_HANDOFF_READY"],
-    )
-
-
-class DpmWaveSearchResponse(BaseModel):
-    items: list[DpmWaveSearchItem] = Field(
-        description="Bounded page of persisted waves matching the search filters."
-    )
-    limit: int = Field(description="Requested page size.", examples=[50])
-    offset: int = Field(description="Requested page offset.", examples=[0])
-    returned_count: int = Field(description="Number of waves returned.", examples=[1])
-
-
 class DpmWaveSourceCheckRequest(BaseModel):
     actor_id: str = Field(
         description="Human or service actor requesting the source-check.",
@@ -679,150 +616,8 @@ class DpmWaveWorkflowCommandRequest(BaseModel):
     )
 
 
-class DpmWaveSupportabilityIssue(BaseModel):
-    support_ref: str = Field(
-        description="Opaque support reference that avoids portfolio or client identifiers.",
-        examples=["wave:dwv_001:item:1"],
-    )
-    item_state: str = Field(description="Wave item workflow state.", examples=["SOURCE_BLOCKED"])
-    severity: Literal["INFO", "WARNING", "CRITICAL"] = Field(
-        description="Operator severity for this issue.",
-        examples=["CRITICAL"],
-    )
-    source_owner: str = Field(
-        description="Owning product or route responsible for remediation.",
-        examples=["lotus-manage"],
-    )
-    reason_codes: list[str] = Field(
-        description="Bounded reason codes explaining supportability posture.",
-        examples=[["MANDATE_DIGITAL_TWIN_MISSING"]],
-    )
-    remediation_route: str = Field(
-        description="Product-safe remediation route or action.",
-        examples=["REPAIR_SOURCE_DATA"],
-    )
-
-
-class DpmWaveSupportabilityResponse(BaseModel):
-    wave_id: str = Field(description="Wave identifier.", examples=["dwv_001"])
-    wave_state: str = Field(description="Current wave state.", examples=["SOURCE_CHECKED"])
-    supportability_state: Literal["ready", "degraded", "blocked"] = Field(
-        description="Bounded supportability state for the wave.",
-        examples=["blocked"],
-    )
-    reason: str = Field(
-        description="Bounded supportability reason.",
-        examples=["wave_blocked_items"],
-    )
-    item_count: int = Field(description="Number of wave items inspected.", examples=[2])
-    issue_counts: dict[str, int] = Field(
-        description="Issue count by severity.",
-        examples=[{"critical": 1, "warning": 0, "info": 1}],
-    )
-    issues: list[DpmWaveSupportabilityIssue] = Field(
-        description=(
-            "Product-safe issues without portfolio ids, client ids, raw requests, raw responses, "
-            "secrets, or trace values."
-        )
-    )
-    operator_actions: list[str] = Field(
-        description="Deduplicated product-safe remediation actions.",
-        examples=[["REPAIR_SOURCE_DATA", "RUN_WAVE_SIMULATION"]],
-    )
-
-
-class DpmWaveDetailResponse(BaseModel):
-    wave: DpmRebalanceWave = Field(description="Persisted wave detail.")
-    supportability: DpmWaveSupportabilityResponse = Field(
-        description="Latest product-safe supportability derived from persisted item states."
-    )
-    proof_pack_posture: "DpmWaveProofPackPostureResponse" = Field(
-        description="Wave proof-pack and internal operations handoff posture."
-    )
-
-
-class DpmWaveItemsResponse(BaseModel):
-    wave_id: str = Field(description="Wave identifier.", examples=["dwv_001"])
-    wave_state: str = Field(description="Current wave state.", examples=["HANDOFF_READY"])
-    items: list[DpmRebalanceWaveItem] = Field(
-        description="Persisted item list with source readiness, selection, proof-pack, and handoff posture."
-    )
-    aggregate_metrics: DpmWaveAggregateMetrics = Field(
-        description="Aggregate item counts reconciled from persisted wave state."
-    )
-
-
-class DpmWaveProofPackRef(BaseModel):
-    wave_item_id: str = Field(description="Wave item identifier.", examples=["dwi_001"])
-    proof_pack_id: str | None = Field(
-        default=None,
-        description="Linked RFC-0040 proof-pack id when generated.",
-        examples=["dpp_001"],
-    )
-    item_state: str = Field(description="Current item state.", examples=["PROOF_PACK_READY"])
-    proof_pack_state: str | None = Field(
-        default=None,
-        description="Proof-pack posture captured in item diagnostics.",
-        examples=["READY"],
-    )
-    selected_alternative_id: str | None = Field(
-        default=None,
-        description="Selected RFC-0039 construction alternative id.",
-        examples=["alt_min_turnover"],
-    )
-
-
-class DpmWaveProofPackPostureResponse(BaseModel):
-    wave_id: str = Field(description="Wave identifier.", examples=["dwv_001"])
-    wave_state: str = Field(description="Current wave state.", examples=["HANDOFF_READY"])
-    item_count: int = Field(description="Total item count.", examples=[2])
-    linked_item_count: int = Field(description="Items with linked proof packs.", examples=[1])
-    ready_proof_pack_count: int = Field(
-        description="Linked proof packs that are not degraded.", examples=[1]
-    )
-    degraded_proof_pack_count: int = Field(
-        description="Items with degraded proof-pack posture.", examples=[0]
-    )
-    proof_pack_refs: list[DpmWaveProofPackRef] = Field(
-        description="Item-level proof-pack references and posture."
-    )
-    handoff_refs: list[DpmWaveHandoffRef] = Field(
-        description="Append-only internal operations handoff evidence refs."
-    )
-    external_execution_claimed: bool = Field(
-        description=(
-            "Always false for valid manage-owned handoff evidence. If persisted evidence ever "
-            "contains an external execution claim, downstream report input is blocked until an "
-            "external OMS/execution owner contract exists."
-        ),
-        examples=[False],
-    )
-    external_execution_boundary: DpmWaveExternalExecutionBoundaryEvidence = Field(
-        description=(
-            "Structured fail-closed no-OMS boundary evidence for downstream reports, audit, and "
-            "operator diagnosis."
-        )
-    )
-
-
 router = APIRouter(prefix="/rebalance/waves", tags=["lotus-manage Rebalance Waves"])
 logger = logging.getLogger(__name__)
-
-
-def _wave_response(
-    *,
-    wave: DpmRebalanceWave,
-    durable: bool,
-    idempotent_replay: bool = False,
-) -> DpmWaveResponse:
-    return DpmWaveResponse(
-        wave=wave,
-        durable=durable,
-        supportability=DpmWaveSupportabilityResponse.model_validate(
-            wave_service.wave_supportability_payload(wave)
-        ),
-        idempotent_replay=idempotent_replay,
-    )
 
 
 def _portfolio_inputs_for_request(
@@ -2242,7 +2037,7 @@ def launch_bulk_review_campaign_definition(
                 "message": "Bulk-review campaign definition launch audit could not be recorded.",
             },
         ) from exc
-    return _wave_response(wave=wave, durable=True, idempotent_replay=replay)
+    return wave_response(wave=wave, durable=True, idempotent_replay=replay)
 
 
 def _parse_optional_campaign_discovery_date(
@@ -2345,7 +2140,7 @@ def preview_wave(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={"code": exc.code, "message": exc.message},
         ) from exc
-    return _wave_response(wave=wave, durable=False)
+    return wave_response(wave=wave, durable=False)
 
 
 @router.post(
@@ -2453,7 +2248,7 @@ def create_wave(
             status_code=status_code,
             detail={"code": exc.code, "message": exc.message},
         ) from exc
-    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.get(
@@ -2717,7 +2512,7 @@ def source_check_wave(
             status_code=status_code,
             detail={"code": exc.code, "message": exc.message},
         ) from exc
-    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -2783,7 +2578,7 @@ def simulate_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -2844,7 +2639,7 @@ def select_wave_item_alternative(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return _wave_response(wave=wave, durable=True)
+    return wave_response(wave=wave, durable=True)
 
 
 @router.post(
@@ -2893,7 +2688,7 @@ def approve_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -2942,7 +2737,7 @@ def stage_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -2990,7 +2785,7 @@ def handoff_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.post(
@@ -3041,7 +2836,7 @@ def cancel_wave(
         ) from exc
     except wave_service.DpmWaveValidationError as exc:
         raise _wave_validation_http_exception(exc) from exc
-    return _wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
 @router.get(


### PR DESCRIPTION
## Summary
- Extract rebalance-wave response DTOs and the shared response mapper from src/api/routers/waves.py into src/api/routers/wave_response_contracts.py.
- Keep endpoint wiring, request parsing, and source-cohort orchestration in the router while isolating reusable response contracts and supportability response assembly.
- Record the modularity finding and follow-up in docs/architecture/CODEBASE-REVIEW-LEDGER.md.

## WTBD / product posture
- No supported-feature or WTBD count change in this slice.
- This is a backend maintainability hardening step for the RFC-0041 wave surface; public route behavior and OpenAPI vocabulary are unchanged.
- Wiki source did not change; drift check is 0.

## Validation
- python -m ruff check src\\api\\routers\\waves.py src\\api\\routers\\wave_response_contracts.py
- python -m pytest tests\\unit\\dpm\\api\\test_waves_api.py tests\\unit\\dpm\\contracts\\test_contract_openapi_supportability_docs.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage

## Stranded truth
- git fetch origin --prune
- git branch -r --no-merged origin/main: no unmerged lotus-manage remote branches
- gh pr list --state open: none before this PR