### PR TITLE
Reclassify RFC37 partial WTBDs

### DIFF
--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -55,11 +55,15 @@ retained only as evidence index and sequencing control.
 ## Mainline WTBD Control Snapshot
 
 Snapshot basis: the 2026-05-18 clean mainline after `lotus-manage` PR #286 (`6a4e199e31466dd9cf1a3b882072803c364a51e4`) reclassified the external OMS/execution boundary as partial
-and the wiki source was published at commit `3062697`. This update reclassifies RFC39-WTBD-008 as
-partial because external treasury contracts, active fail-closed source postures, and Manage
-consumption are merged while runtime external treasury ingestion remains pending. The current
-classification is 59 total WTBD items: 44 done on merged/published truth, 6 partial or in progress,
-and 9 remaining/open.
+and the wiki source was published at commit `3062697`. Later classification updates reclassified
+RFC39-WTBD-008 as partial because external treasury contracts, active fail-closed source postures,
+and Manage consumption are merged while runtime external treasury ingestion remains pending. This
+update also normalizes RFC37-WTBD-002, RFC37-WTBD-003, and RFC37-WTBD-007 as partial, matching the
+detail rows: bounded first-wave product paths, cross-app product surfaces, and portfolio-memory
+lineage exist, while the full copilot workspace, broader front-office realization, full portfolio
+memory, OMS execution/fill/settlement projection, PM scoring, and remaining source-owner depth
+remain future scope. The current classification is 59 total WTBD items: 44 done on
+merged/published truth, 9 partial or in progress, and 6 remaining/open.
 Earlier source slices include the RFC40-WTBD-009
 selected-alternative regime-scenario proof-pack preservation slice, the RFC-0043 owner-side AI
 workflow-pack truth reintegration slice, the RFC41-WTBD-003 manage risk-event consumer slice, the
@@ -97,8 +101,8 @@ methodology, performance benchmark analytics, or unsupported ESG approval.
 | --- | ---: | --- |
 | Total WTBD items | 59 | RFC-0036 through RFC-0042 follow-up items tracked in this ledger. |
 | Done on merged/published truth | 44 | Implementation-backed items merged to owning `main` branches, validated, and published where wiki truth changed. |
-| Partial / in progress | 6 | Items with meaningful implementation-backed progress but known source-owner or downstream gaps. |
-| Remaining / open | 9 | Items still deferred, proposed, conditional, unsupported, or awaiting ownership. |
+| Partial / in progress | 9 | Items with meaningful implementation-backed progress but known source-owner or downstream gaps. |
+| Remaining / open | 6 | Items still deferred, proposed, conditional, unsupported, or awaiting ownership. |
 
 Recently closed in this snapshot:
 

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -8,6 +8,9 @@ ROOT = Path(__file__).resolve().parents[2]
 
 WTBD_PARTIAL_IDS = {
     "RFC37-WTBD-001",
+    "RFC37-WTBD-002",
+    "RFC37-WTBD-003",
+    "RFC37-WTBD-007",
     "RFC39-WTBD-008",
     "RFC40-WTBD-009",
     "RFC41-WTBD-003",
@@ -18,10 +21,7 @@ WTBD_PARTIAL_IDS = {
 WTBD_OPEN_IDS = {
     "RFC36-WTBD-004",
     "RFC36-WTBD-005",
-    "RFC37-WTBD-002",
-    "RFC37-WTBD-003",
     "RFC37-WTBD-004",
-    "RFC37-WTBD-007",
     "RFC38-WTBD-007",
     "RFC39-WTBD-005",
     "RFC41-WTBD-010",
@@ -330,8 +330,8 @@ def test_wtbd_control_snapshot_counts_match_detailed_ledger() -> None:
 
     assert len(rows) == 59
     assert len(done_ids) == 44
-    assert len(WTBD_PARTIAL_IDS) == 6
-    assert len(WTBD_OPEN_IDS) == 9
+    assert len(WTBD_PARTIAL_IDS) == 9
+    assert len(WTBD_OPEN_IDS) == 6
     assert WTBD_PARTIAL_IDS <= all_ids
     assert WTBD_OPEN_IDS <= all_ids
 
@@ -340,8 +340,8 @@ def test_wtbd_control_snapshot_counts_match_detailed_ledger() -> None:
         assert f"| {wtbd_id} |" in ledger
 
     supported_features = (ROOT / "wiki" / "Supported-Features.md").read_text(encoding="utf-8")
-    assert "59 WTBD items: 44 done on merged/published truth, 6 partial" in supported_features
-    assert "9 remaining or open" in supported_features
+    assert "59 WTBD items: 44 done on merged/published truth, 9 partial" in supported_features
+    assert "6 remaining or open" in supported_features
 
 
 def test_indexed_rfc_and_adr_files_exist() -> None:
@@ -1464,8 +1464,8 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     )
     assert "| Total WTBD items | 59 |" in work_to_be_done
     assert "| Done on merged/published truth | 44 |" in work_to_be_done
-    assert "| Partial / in progress | 6 |" in work_to_be_done
-    assert "| Remaining / open | 9 |" in work_to_be_done
+    assert "| Partial / in progress | 9 |" in work_to_be_done
+    assert "| Remaining / open | 6 |" in work_to_be_done
     assert "RFC36-WTBD-006 is now closed as a no-migration-required" in work_to_be_done
     assert "`lotus-platform` PR #316" in work_to_be_done
     assert "RFC38-WTBD-004 - PM-Book Discovery" in work_to_be_done
@@ -2080,7 +2080,7 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "## WTBD Product-Readiness Roadmap" in supported_features
     assert "flowchart LR" in supported_features
     assert "developers, business users, operations, sales/pre-sales" in supported_features
-    assert "59 WTBD items: 44 done on merged/published truth, 6 partial" in (supported_features)
+    assert "59 WTBD items: 44 done on merged/published truth, 9 partial" in (supported_features)
     assert "`lotus-platform` PR #310 and wiki publication commit `884bec3`" in (supported_features)
     assert "Canonical DPM demo story" in supported_features
     assert (

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -313,8 +313,8 @@ Audience use:
 ## WTBD Product-Readiness Roadmap
 
 `docs/rfcs/RFC-worktobedone.md` is the governed WTBD ledger. As of the 2026-05-18 clean mainline
-snapshot after `lotus-manage` PR #286 and the RFC39-WTBD-008 external treasury reclassification,
-it tracks 59 WTBD items: 44 done on merged/published truth, 6 partial or in progress, and 9 remaining or open. The next execution wave should focus on product
+snapshot after `lotus-manage` PR #286, the RFC39-WTBD-008 external treasury reclassification, and
+the RFC37 partial-classification normalization, it tracks 59 WTBD items: 44 done on merged/published truth, 9 partial or in progress, and 6 remaining or open. The next execution wave should focus on product
 surfaces that materially improve bank-buyable demo and operating value without inventing
 unsupported source truth.
 


### PR DESCRIPTION
## Summary
- Reclassifies `RFC37-WTBD-002`, `RFC37-WTBD-003`, and `RFC37-WTBD-007` from open to partial in the WTBD control snapshot.
- Aligns aggregate counts with the existing detailed row truth: 59 total, 44 done, 9 partial, 6 remaining/open.
- Updates Supported Features wiki source and documentation regression tests.

## Support Boundary
This PR does not promote any RFC37 item to done and does not add a new runtime support claim. The full copilot workspace, broader front-office product realization, full portfolio memory, OMS execution/fill/settlement projection, PM scoring, and remaining source-owner depth remain future scope.

## Validation
- `python -m ruff format tests\\unit\\test_documentation_current_state.py`
- `python -m pytest tests\\unit\\test_documentation_current_state.py -q` -> 22 passed
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make test-unit` -> 1260 passed, 2 warnings
- `make test-integration` -> 168 passed
- `make test-e2e` -> 28 passed
- `python ..\\lotus-platform\\automation\\validate_engineering_context_system.py`
- `python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py`
- `..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> expected pre-merge drift: `Supported-Features.md`

## Stranded Truth
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> none
- `gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100` -> none before PR creation