### PR TITLE
Extract wave campaign-definition HTTP lookup

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -414,3 +414,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   boundary stays green in OpenAPI and wave API tests.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature or operator-contract change.
+
+## BACKEND-REVIEW-20260519-002: Campaign-definition routes repeated HTTP lookup handling
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`,
+  `src/api/routers/wave_campaign_definition_http.py`
+- Finding: the campaign-definition read, lifecycle projection, launch-history, readiness,
+  launch-package, and durable-launch routes repeated the same repository lookup and `404`
+  response construction. The duplication kept router behavior correct but made the already-large
+  wave router harder to audit and increased the risk of divergent error payloads across bounded
+  campaign-definition endpoints.
+- Action: extracted the API-level campaign-definition lookup and shared not-found response into
+  `src/api/routers/wave_campaign_definition_http.py`, then reused it across campaign-definition
+  read and launch routes. The domain-level preview/create validation path remains in `waves.py`
+  because it deliberately raises `DpmWaveValidationError` instead of an HTTP exception.
+- Status: hardened
+- Evidence: `python -m ruff check src\api\routers\waves.py src\api\routers\wave_campaign_definition_http.py tests\unit\dpm\api\test_waves_api.py`;
+  `python -m pytest tests\unit\dpm\api\test_waves_api.py -q` (`110 passed`).
+- Follow-up: continue route-family extraction only after each bounded helper remains covered by
+  focused API tests and OpenAPI gates.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_campaign_definition_http.py
+++ b/src/api/routers/wave_campaign_definition_http.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from src.core.waves import (
+    DpmBulkReviewCampaignDefinition,
+    DpmBulkReviewCampaignDefinitionRepository,
+)
+
+
+_CAMPAIGN_DEFINITION_NOT_FOUND_DETAIL = {
+    "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
+    "message": "Bulk-review campaign definition was not found.",
+}
+
+
+def get_campaign_definition_or_404(
+    *,
+    repository: DpmBulkReviewCampaignDefinitionRepository,
+    campaign_id: str,
+    campaign_version: str,
+) -> DpmBulkReviewCampaignDefinition:
+    definition = repository.get_definition(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+    )
+    if definition is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=_CAMPAIGN_DEFINITION_NOT_FOUND_DETAIL,
+        )
+    return definition

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -32,6 +32,7 @@ from src.api.routers.wave_response_contracts import (
     DpmWaveSupportabilityResponse,
     wave_response,
 )
+from src.api.routers.wave_campaign_definition_http import get_campaign_definition_or_404
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
 from src.api.services import wave_service
@@ -1747,18 +1748,11 @@ def get_bulk_review_campaign_definition(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinition:
-    definition = repository.get_definition(
+    definition = get_campaign_definition_or_404(
+        repository=repository,
         campaign_id=campaign_id,
         campaign_version=campaign_version,
     )
-    if definition is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-                "message": "Bulk-review campaign definition was not found.",
-            },
-        )
     return definition
 
 
@@ -1782,18 +1776,11 @@ def list_bulk_review_campaign_definition_lifecycle_events(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinitionLifecycleEventPage:
-    definition = repository.get_definition(
+    definition = get_campaign_definition_or_404(
+        repository=repository,
         campaign_id=campaign_id,
         campaign_version=campaign_version,
     )
-    if definition is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-                "message": "Bulk-review campaign definition was not found.",
-            },
-        )
     return build_bulk_review_campaign_definition_lifecycle_events(definition=definition)
 
 
@@ -1819,18 +1806,11 @@ def list_bulk_review_campaign_definition_launch_history(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinitionLaunchHistoryPage:
-    definition = repository.get_definition(
+    definition = get_campaign_definition_or_404(
+        repository=repository,
         campaign_id=campaign_id,
         campaign_version=campaign_version,
     )
-    if definition is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-                "message": "Bulk-review campaign definition was not found.",
-            },
-        )
     return build_bulk_review_campaign_definition_launch_history_page(
         definition=definition,
         limit=limit,
@@ -1867,18 +1847,11 @@ def get_bulk_review_campaign_definition_preview_readiness(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinitionPreviewReadiness:
-    definition = repository.get_definition(
+    definition = get_campaign_definition_or_404(
+        repository=repository,
         campaign_id=campaign_id,
         campaign_version=campaign_version,
     )
-    if definition is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-                "message": "Bulk-review campaign definition was not found.",
-            },
-        )
     return build_bulk_review_campaign_definition_preview_readiness(
         definition=definition,
         requested_as_of_date=requested_as_of_date,
@@ -1919,18 +1892,11 @@ def get_bulk_review_campaign_definition_launch_package(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinitionLaunchPackage:
-    definition = repository.get_definition(
+    definition = get_campaign_definition_or_404(
+        repository=repository,
         campaign_id=campaign_id,
         campaign_version=campaign_version,
     )
-    if definition is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-                "message": "Bulk-review campaign definition was not found.",
-            },
-        )
     return build_bulk_review_campaign_definition_launch_package(
         definition=definition,
         requested_as_of_date=requested_as_of_date,
@@ -1962,18 +1928,11 @@ def launch_bulk_review_campaign_definition(
         get_campaign_definition_repository
     ),
 ) -> DpmWaveResponse:
-    definition = campaign_definition_repository.get_definition(
+    definition = get_campaign_definition_or_404(
+        repository=campaign_definition_repository,
         campaign_id=campaign_id,
         campaign_version=campaign_version,
     )
-    if definition is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-                "message": "Bulk-review campaign definition was not found.",
-            },
-        )
     try:
         launch_command = build_bulk_review_campaign_definition_launch_command(
             definition=definition,


### PR DESCRIPTION
## Summary
- Extracts repeated bulk-review campaign-definition API lookup and 404 handling from `src/api/routers/waves.py` into `src/api/routers/wave_campaign_definition_http.py`.
- Reuses the helper across campaign-definition read, lifecycle-events, launch-history, preview-readiness, launch-package, and durable-launch routes.
- Updates the codebase review ledger with the modularity finding, action, evidence, and no-wiki-change decision.

## Boundary
- No API shape, OpenAPI path, supported-feature, WTBD classification, or operator-contract change.
- The preview/create validation path intentionally remains in `waves.py` because it raises `DpmWaveValidationError`, not an HTTP exception.
- No Gateway or Workbench work is included.

## Validation
- `python -m ruff check src\\api\\routers\\waves.py src\\api\\routers\\wave_campaign_definition_http.py tests\\unit\\dpm\\api\\test_waves_api.py`
- `python -m pytest tests\\unit\\dpm\\api\\test_waves_api.py -q` -> 110 passed
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` -> 1260 passed, 2 warnings
- `make test-integration` -> 168 passed
- `make test-e2e` -> 28 passed
- `python ..\\lotus-platform\\automation\\validate_engineering_context_system.py`
- `python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py`
- `..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> drift 0

## Stranded Truth
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> none before this PR
- `gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100` -> none before this PR