### PR TITLE
Extract wave HTTP error mapping

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -436,3 +436,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   focused API tests and OpenAPI gates.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-003: Wave workflow routes repeated HTTP error mapping
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_http_errors.py`
+- Finding: durable wave read and workflow routes repeated identical `DpmWaveLookupError` and
+  `DpmWaveValidationError` HTTP response mapping. Some routes had route-specific conflict
+  semantics (`WAVE_CREATE_CONFLICT` versus optimistic `DPM_WAVE_VERSION_CONFLICT`), so the repeated
+  code was easy to keep mostly correct but harder to audit as the router grew.
+- Action: extracted reusable wave lookup and validation HTTP exception builders into
+  `src/api/routers/wave_http_errors.py`, including explicit route-level conflict-code selection.
+  The endpoint methods now preserve their existing status-code behavior while keeping HTTP mapping
+  outside the route orchestration body.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_http_errors.py`; focused wave API
+  regression `python -m pytest tests\unit\api\test_wave_http_errors.py tests\unit\dpm\api\test_waves_api.py -q`.
+- Follow-up: continue moving bounded route-family plumbing out of `waves.py` only when the helper
+  has direct tests and the route family stays green under OpenAPI and wave API regression tests.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_http_errors.py
+++ b/src/api/routers/wave_http_errors.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from src.api.services import wave_service
+
+
+def wave_lookup_http_exception(exc: wave_service.DpmWaveLookupError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={"code": exc.code, "message": exc.message},
+    )
+
+
+def wave_validation_http_exception(
+    exc: wave_service.DpmWaveValidationError,
+    *,
+    conflict_codes: tuple[str, ...] = ("DPM_WAVE_VERSION_CONFLICT",),
+) -> HTTPException:
+    status_code = (
+        status.HTTP_409_CONFLICT
+        if exc.code in conflict_codes
+        else status.HTTP_422_UNPROCESSABLE_CONTENT
+    )
+    return HTTPException(
+        status_code=status_code,
+        detail={"code": exc.code, "message": exc.message},
+    )

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -33,6 +33,10 @@ from src.api.routers.wave_response_contracts import (
     wave_response,
 )
 from src.api.routers.wave_campaign_definition_http import get_campaign_definition_or_404
+from src.api.routers.wave_http_errors import (
+    wave_lookup_http_exception,
+    wave_validation_http_exception,
+)
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
 from src.api.services import wave_service
@@ -1984,10 +1988,7 @@ def launch_bulk_review_campaign_definition(
         if launched_definition.content_hash != definition.content_hash:
             campaign_definition_repository.record_definition_launch(definition=launched_definition)
     except wave_service.DpmWaveValidationError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_validation_http_exception(exc, conflict_codes=()) from exc
     except DpmBulkReviewCampaignDefinitionConflictError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -2095,10 +2096,7 @@ def preview_wave(
             mandate_repository=mandate_repository,
         )
     except wave_service.DpmWaveValidationError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_validation_http_exception(exc, conflict_codes=()) from exc
     return wave_response(wave=wave, durable=False)
 
 
@@ -2198,15 +2196,7 @@ def create_wave(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveValidationError as exc:
-        status_code = (
-            status.HTTP_409_CONFLICT
-            if exc.code == "WAVE_CREATE_CONFLICT"
-            else status.HTTP_422_UNPROCESSABLE_CONTENT
-        )
-        raise HTTPException(
-            status_code=status_code,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_validation_http_exception(exc, conflict_codes=("WAVE_CREATE_CONFLICT",)) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
@@ -2337,10 +2327,7 @@ def get_wave_detail(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     return DpmWaveDetailResponse.model_validate(payload)
 
 
@@ -2369,10 +2356,7 @@ def get_wave_items(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     return DpmWaveItemsResponse.model_validate(payload)
 
 
@@ -2457,20 +2441,9 @@ def source_check_wave(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     except wave_service.DpmWaveValidationError as exc:
-        status_code = (
-            status.HTTP_409_CONFLICT
-            if exc.code == "DPM_WAVE_VERSION_CONFLICT"
-            else status.HTTP_422_UNPROCESSABLE_CONTENT
-        )
-        raise HTTPException(
-            status_code=status_code,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_validation_http_exception(exc) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
@@ -2531,12 +2504,9 @@ def simulate_wave(
             risk_authority_client=risk_authority_client,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     except wave_service.DpmWaveValidationError as exc:
-        raise _wave_validation_http_exception(exc) from exc
+        raise wave_validation_http_exception(exc) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
@@ -2592,12 +2562,9 @@ def select_wave_item_alternative(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     except wave_service.DpmWaveValidationError as exc:
-        raise _wave_validation_http_exception(exc) from exc
+        raise wave_validation_http_exception(exc) from exc
     return wave_response(wave=wave, durable=True)
 
 
@@ -2641,12 +2608,9 @@ def approve_wave(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     except wave_service.DpmWaveValidationError as exc:
-        raise _wave_validation_http_exception(exc) from exc
+        raise wave_validation_http_exception(exc) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
@@ -2690,12 +2654,9 @@ def stage_wave(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     except wave_service.DpmWaveValidationError as exc:
-        raise _wave_validation_http_exception(exc) from exc
+        raise wave_validation_http_exception(exc) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
@@ -2738,12 +2699,9 @@ def handoff_wave(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     except wave_service.DpmWaveValidationError as exc:
-        raise _wave_validation_http_exception(exc) from exc
+        raise wave_validation_http_exception(exc) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
@@ -2789,12 +2747,9 @@ def cancel_wave(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     except wave_service.DpmWaveValidationError as exc:
-        raise _wave_validation_http_exception(exc) from exc
+        raise wave_validation_http_exception(exc) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
 
 
@@ -2823,10 +2778,7 @@ def get_wave_proof_pack_posture(
             wave_repository=wave_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     return DpmWaveProofPackPostureResponse.model_validate(payload)
 
 
@@ -2869,12 +2821,9 @@ def get_wave_report_input(
             mandate_repository=mandate_repository,
         )
     except wave_service.DpmWaveLookupError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     except wave_service.DpmWaveValidationError as exc:
-        raise _wave_validation_http_exception(exc) from exc
+        raise wave_validation_http_exception(exc) from exc
 
 
 @router.get(
@@ -2908,10 +2857,7 @@ def get_wave_supportability(
             supportability_state="not_found",
             reason="wave_not_found",
         )
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise wave_lookup_http_exception(exc) from exc
     supportability_state = str(payload["supportability_state"])
     reason = str(payload["reason"])
     record_wave_supportability(
@@ -2931,15 +2877,3 @@ def get_wave_supportability(
         },
     )
     return DpmWaveSupportabilityResponse.model_validate(payload)
-
-
-def _wave_validation_http_exception(exc: wave_service.DpmWaveValidationError) -> HTTPException:
-    status_code = (
-        status.HTTP_409_CONFLICT
-        if exc.code == "DPM_WAVE_VERSION_CONFLICT"
-        else status.HTTP_422_UNPROCESSABLE_CONTENT
-    )
-    return HTTPException(
-        status_code=status_code,
-        detail={"code": exc.code, "message": exc.message},
-    )

--- a/tests/unit/api/test_wave_http_errors.py
+++ b/tests/unit/api/test_wave_http_errors.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from fastapi import status
+
+from src.api.routers.wave_http_errors import (
+    wave_lookup_http_exception,
+    wave_validation_http_exception,
+)
+from src.api.services import wave_service
+
+
+def test_wave_lookup_http_exception_maps_not_found_payload() -> None:
+    exc = wave_service.DpmWaveLookupError("DPM_WAVE_NOT_FOUND", "Wave was not found.")
+
+    http_exc = wave_lookup_http_exception(exc)
+
+    assert http_exc.status_code == status.HTTP_404_NOT_FOUND
+    assert http_exc.detail == {
+        "code": "DPM_WAVE_NOT_FOUND",
+        "message": "Wave was not found.",
+    }
+
+
+def test_wave_validation_http_exception_maps_default_version_conflict() -> None:
+    exc = wave_service.DpmWaveValidationError(
+        "DPM_WAVE_VERSION_CONFLICT",
+        "Wave changed while updating.",
+    )
+
+    http_exc = wave_validation_http_exception(exc)
+
+    assert http_exc.status_code == status.HTTP_409_CONFLICT
+    assert http_exc.detail == {
+        "code": "DPM_WAVE_VERSION_CONFLICT",
+        "message": "Wave changed while updating.",
+    }
+
+
+def test_wave_validation_http_exception_uses_route_specific_conflict_codes() -> None:
+    exc = wave_service.DpmWaveValidationError(
+        "WAVE_CREATE_CONFLICT",
+        "Idempotency conflict.",
+    )
+
+    create_http_exc = wave_validation_http_exception(
+        exc,
+        conflict_codes=("WAVE_CREATE_CONFLICT",),
+    )
+    preview_http_exc = wave_validation_http_exception(exc, conflict_codes=())
+
+    assert create_http_exc.status_code == status.HTTP_409_CONFLICT
+    assert preview_http_exc.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT


### PR DESCRIPTION
## Summary
- Extracts repeated wave lookup and validation HTTP exception mapping from `src/api/routers/waves.py` into `src/api/routers/wave_http_errors.py`.
- Preserves route-specific conflict semantics by making conflict-code selection explicit (`WAVE_CREATE_CONFLICT` for create, default optimistic version conflict for workflow commands, no conflict mapping for preview/launch).
- Adds direct helper regression tests and records the modularity finding in the codebase review ledger.

## Boundary
- No API path, response shape, OpenAPI contract, WTBD classification, supported-feature, or operator-contract change.
- No Gateway or Workbench work is included.
- No wiki source change required; pre-merge drift check is zero.

## Validation
- `python -m ruff check src\\api\\routers\\waves.py src\\api\\routers\\wave_http_errors.py tests\\unit\\api\\test_wave_http_errors.py tests\\unit\\dpm\\api\\test_waves_api.py`
- `python -m pytest tests\\unit\\api\\test_wave_http_errors.py tests\\unit\\dpm\\api\\test_waves_api.py -q` -> 113 passed
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` -> 1250 passed, 13 skipped, 2 warnings
- `make test-integration` -> 168 passed
- `make test-e2e` -> 28 passed
- `python ..\\lotus-platform\\automation\\validate_engineering_context_system.py`
- `python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py`
- `..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> drift 0

## Stranded Truth
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> none before this PR
- `gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100` -> none before this PR