### PR TITLE
Extract campaign-definition HTTP errors

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -456,3 +456,24 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   has direct tests and the route family stays green under OpenAPI and wave API regression tests.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-004: Campaign-definition routes repeated lifecycle error mapping
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_campaign_definition_http.py`
+- Finding: campaign-definition create, retire, supersede, discovery, and launch routes repeated
+  HTTP exception construction for conflict, lifecycle, validation, not-found, launch-blocked, and
+  invalid-date cases. The route bodies remained behaviorally correct, but the repeated mappings made
+  status-code posture harder to review and increased the chance of future drift across the same
+  bounded API family.
+- Action: moved campaign-definition HTTP exception builders into
+  `src/api/routers/wave_campaign_definition_http.py`, including the explicit supersession lifecycle
+  status mapping and launch-readiness payload preservation. The router now delegates error
+  translation while keeping endpoint orchestration and request parsing local.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_campaign_definition_http.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: continue shrinking `waves.py` by cohesive route families only after each extracted
+  boundary has focused unit tests and route-level regression coverage.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_campaign_definition_http.py
+++ b/src/api/routers/wave_campaign_definition_http.py
@@ -4,7 +4,12 @@ from fastapi import HTTPException, status
 
 from src.core.waves import (
     DpmBulkReviewCampaignDefinition,
+    DpmBulkReviewCampaignDefinitionConflictError,
+    DpmBulkReviewCampaignDefinitionLaunchBlocked,
     DpmBulkReviewCampaignDefinitionRepository,
+)
+from src.core.waves.campaign_definition_lifecycle import (
+    DpmBulkReviewCampaignDefinitionLifecycleError,
 )
 
 
@@ -30,3 +35,69 @@ def get_campaign_definition_or_404(
             detail=_CAMPAIGN_DEFINITION_NOT_FOUND_DETAIL,
         )
     return definition
+
+
+def campaign_definition_not_found_http_exception() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=_CAMPAIGN_DEFINITION_NOT_FOUND_DETAIL,
+    )
+
+
+def campaign_definition_conflict_http_exception(
+    exc: DpmBulkReviewCampaignDefinitionConflictError,
+    *,
+    message: str | None = None,
+) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={"code": str(exc), "message": message or str(exc)},
+    )
+
+
+def campaign_definition_value_http_exception(exc: ValueError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail={"code": str(exc), "message": str(exc)},
+    )
+
+
+def campaign_definition_lifecycle_http_exception(
+    exc: DpmBulkReviewCampaignDefinitionLifecycleError,
+) -> HTTPException:
+    return HTTPException(
+        status_code=_campaign_definition_lifecycle_status_code(exc.code),
+        detail={"code": exc.code, "message": exc.message},
+    )
+
+
+def campaign_definition_launch_blocked_http_exception(
+    exc: DpmBulkReviewCampaignDefinitionLaunchBlocked,
+) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail={
+            "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_LAUNCH_BLOCKED",
+            "message": "Bulk-review campaign definition is not ready for durable launch.",
+            "reason_codes": exc.reason_codes,
+            "readiness": exc.readiness.model_dump(mode="json"),
+        },
+    )
+
+
+def invalid_campaign_discovery_date_http_exception(field_name: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail={
+            "code": "BULK_REVIEW_CAMPAIGN_DISCOVERY_DATE_INVALID",
+            "message": f"{field_name} must be an ISO date.",
+        },
+    )
+
+
+def _campaign_definition_lifecycle_status_code(code: str) -> int:
+    if code == "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_NOT_FOUND":
+        return status.HTTP_404_NOT_FOUND
+    if code == "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_VERSION_INVALID":
+        return status.HTTP_422_UNPROCESSABLE_CONTENT
+    return status.HTTP_409_CONFLICT

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -32,7 +32,15 @@ from src.api.routers.wave_response_contracts import (
     DpmWaveSupportabilityResponse,
     wave_response,
 )
-from src.api.routers.wave_campaign_definition_http import get_campaign_definition_or_404
+from src.api.routers.wave_campaign_definition_http import (
+    campaign_definition_conflict_http_exception,
+    campaign_definition_launch_blocked_http_exception,
+    campaign_definition_lifecycle_http_exception,
+    campaign_definition_not_found_http_exception,
+    campaign_definition_value_http_exception,
+    get_campaign_definition_or_404,
+    invalid_campaign_discovery_date_http_exception,
+)
 from src.api.routers.wave_http_errors import (
     wave_lookup_http_exception,
     wave_validation_http_exception,
@@ -1519,15 +1527,9 @@ def put_bulk_review_campaign_definition(
         )
         repository.save_definition(definition=definition)
     except DpmBulkReviewCampaignDefinitionConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={"code": str(exc), "message": str(exc)},
-        ) from exc
+        raise campaign_definition_conflict_http_exception(exc) from exc
     except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={"code": str(exc), "message": str(exc)},
-        ) from exc
+        raise campaign_definition_value_http_exception(exc) from exc
     return definition
 
 
@@ -1593,28 +1595,13 @@ def retire_bulk_review_campaign_definition(
             correlation_id=request.correlation_id,
         )
     except DpmBulkReviewCampaignDefinitionConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={"code": str(exc), "message": str(exc)},
-        ) from exc
+        raise campaign_definition_conflict_http_exception(exc) from exc
     except DpmBulkReviewCampaignDefinitionLifecycleError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise campaign_definition_lifecycle_http_exception(exc) from exc
     except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={"code": str(exc), "message": str(exc)},
-        ) from exc
+        raise campaign_definition_value_http_exception(exc) from exc
     if retired is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-                "message": "Bulk-review campaign definition was not found.",
-            },
-        )
+        raise campaign_definition_not_found_http_exception()
     return retired
 
 
@@ -1650,35 +1637,13 @@ def supersede_bulk_review_campaign_definition(
             correlation_id=request.correlation_id,
         )
     except DpmBulkReviewCampaignDefinitionConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={"code": str(exc), "message": str(exc)},
-        ) from exc
+        raise campaign_definition_conflict_http_exception(exc) from exc
     except DpmBulkReviewCampaignDefinitionLifecycleError as exc:
-        status_code = (
-            status.HTTP_404_NOT_FOUND
-            if exc.code == "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_NOT_FOUND"
-            else status.HTTP_422_UNPROCESSABLE_CONTENT
-            if exc.code == "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_VERSION_INVALID"
-            else status.HTTP_409_CONFLICT
-        )
-        raise HTTPException(
-            status_code=status_code,
-            detail={"code": exc.code, "message": exc.message},
-        ) from exc
+        raise campaign_definition_lifecycle_http_exception(exc) from exc
     except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={"code": str(exc), "message": str(exc)},
-        ) from exc
+        raise campaign_definition_value_http_exception(exc) from exc
     if superseded is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-                "message": "Bulk-review campaign definition was not found.",
-            },
-        )
+        raise campaign_definition_not_found_http_exception()
     return superseded
 
 
@@ -1945,15 +1910,7 @@ def launch_bulk_review_campaign_definition(
             correlation_id=request.correlation_id,
         )
     except DpmBulkReviewCampaignDefinitionLaunchBlocked as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_LAUNCH_BLOCKED",
-                "message": "Bulk-review campaign definition is not ready for durable launch.",
-                "reason_codes": exc.reason_codes,
-                "readiness": exc.readiness.model_dump(mode="json"),
-            },
-        ) from exc
+        raise campaign_definition_launch_blocked_http_exception(exc) from exc
     wave_request = DpmWavePreviewRequest.model_validate(
         launch_command.create_request.model_dump(mode="json")
     )
@@ -1990,12 +1947,9 @@ def launch_bulk_review_campaign_definition(
     except wave_service.DpmWaveValidationError as exc:
         raise wave_validation_http_exception(exc, conflict_codes=()) from exc
     except DpmBulkReviewCampaignDefinitionConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "code": str(exc),
-                "message": "Bulk-review campaign definition launch audit could not be recorded.",
-            },
+        raise campaign_definition_conflict_http_exception(
+            exc,
+            message="Bulk-review campaign definition launch audit could not be recorded.",
         ) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replay)
 
@@ -2010,13 +1964,7 @@ def _parse_optional_campaign_discovery_date(
     try:
         return date.fromisoformat(value)
     except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_DISCOVERY_DATE_INVALID",
-                "message": f"{field_name} must be an ISO date.",
-            },
-        ) from exc
+        raise invalid_campaign_discovery_date_http_exception(field_name) from exc
 
 
 @router.post(

--- a/tests/unit/api/test_wave_campaign_definition_http.py
+++ b/tests/unit/api/test_wave_campaign_definition_http.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from fastapi import status
+
+from src.api.routers.wave_campaign_definition_http import (
+    campaign_definition_conflict_http_exception,
+    campaign_definition_launch_blocked_http_exception,
+    campaign_definition_lifecycle_http_exception,
+    campaign_definition_not_found_http_exception,
+    campaign_definition_value_http_exception,
+    invalid_campaign_discovery_date_http_exception,
+)
+from src.core.waves.campaign_definition_launch_execution import (
+    DpmBulkReviewCampaignDefinitionLaunchBlocked,
+)
+from src.core.waves.campaign_definition_lifecycle import (
+    DpmBulkReviewCampaignDefinitionLifecycleError,
+)
+from src.core.waves.campaign_definition_readiness import (
+    DpmBulkReviewCampaignDefinitionPreviewReadiness,
+)
+from src.core.waves.campaign_repository import DpmBulkReviewCampaignDefinitionConflictError
+
+
+def test_campaign_definition_not_found_http_exception_maps_payload() -> None:
+    http_exc = campaign_definition_not_found_http_exception()
+
+    assert http_exc.status_code == status.HTTP_404_NOT_FOUND
+    assert http_exc.detail == {
+        "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
+        "message": "Bulk-review campaign definition was not found.",
+    }
+
+
+def test_campaign_definition_conflict_http_exception_uses_domain_code() -> None:
+    http_exc = campaign_definition_conflict_http_exception(
+        DpmBulkReviewCampaignDefinitionConflictError("BULK_REVIEW_CAMPAIGN_DUPLICATE")
+    )
+
+    assert http_exc.status_code == status.HTTP_409_CONFLICT
+    assert http_exc.detail == {
+        "code": "BULK_REVIEW_CAMPAIGN_DUPLICATE",
+        "message": "BULK_REVIEW_CAMPAIGN_DUPLICATE",
+    }
+
+
+def test_campaign_definition_conflict_http_exception_accepts_operator_message() -> None:
+    http_exc = campaign_definition_conflict_http_exception(
+        DpmBulkReviewCampaignDefinitionConflictError(
+            "BULK_REVIEW_CAMPAIGN_DEFINITION_LAUNCH_CONFLICT"
+        ),
+        message="Bulk-review campaign definition launch audit could not be recorded.",
+    )
+
+    assert http_exc.status_code == status.HTTP_409_CONFLICT
+    assert http_exc.detail == {
+        "code": "BULK_REVIEW_CAMPAIGN_DEFINITION_LAUNCH_CONFLICT",
+        "message": "Bulk-review campaign definition launch audit could not be recorded.",
+    }
+
+
+def test_campaign_definition_value_http_exception_maps_validation_failure() -> None:
+    http_exc = campaign_definition_value_http_exception(ValueError("CAMPAIGN_VERSION_REQUIRED"))
+
+    assert http_exc.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert http_exc.detail == {
+        "code": "CAMPAIGN_VERSION_REQUIRED",
+        "message": "CAMPAIGN_VERSION_REQUIRED",
+    }
+
+
+def test_campaign_definition_lifecycle_http_exception_maps_replacement_not_found() -> None:
+    http_exc = campaign_definition_lifecycle_http_exception(
+        DpmBulkReviewCampaignDefinitionLifecycleError(
+            "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_NOT_FOUND",
+            "Replacement bulk-review campaign definition was not found.",
+        )
+    )
+
+    assert http_exc.status_code == status.HTTP_404_NOT_FOUND
+    assert http_exc.detail == {
+        "code": "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_NOT_FOUND",
+        "message": "Replacement bulk-review campaign definition was not found.",
+    }
+
+
+def test_campaign_definition_lifecycle_http_exception_maps_invalid_replacement_version() -> None:
+    http_exc = campaign_definition_lifecycle_http_exception(
+        DpmBulkReviewCampaignDefinitionLifecycleError(
+            "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_VERSION_INVALID",
+            "superseded_by_campaign_version must identify a different version.",
+        )
+    )
+
+    assert http_exc.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+def test_campaign_definition_lifecycle_http_exception_maps_default_conflict() -> None:
+    http_exc = campaign_definition_lifecycle_http_exception(
+        DpmBulkReviewCampaignDefinitionLifecycleError(
+            "BULK_REVIEW_CAMPAIGN_DEFINITION_LIFECYCLE_CONFLICT",
+            "Only active campaign definitions can be superseded.",
+        )
+    )
+
+    assert http_exc.status_code == status.HTTP_409_CONFLICT
+
+
+def test_campaign_definition_launch_blocked_http_exception_preserves_readiness() -> None:
+    readiness = DpmBulkReviewCampaignDefinitionPreviewReadiness(
+        campaign_id="campaign-holdings-apple-tesla-20260510",
+        campaign_version="2026.05",
+        campaign_status="ACTIVE",
+        definition_as_of_date="2026-05-10",
+        requested_as_of_date="2026-05-11",
+        preview_create_allowed=False,
+        supportability_state="BLOCKED",
+        reason_codes=["BULK_REVIEW_CAMPAIGN_EXPIRED"],
+        candidate_count=1,
+        eligible_candidate_count=1,
+        excluded_candidate_count=0,
+        eligible_portfolio_types=["DISCRETIONARY"],
+        governance_status="APPROVED",
+        expiry_state="EXPIRED",
+        actor_entitlement_state="NOT_SUPPLIED",
+        lifecycle_event_count=1,
+        source_ref_count=2,
+        content_hash="sha256:readiness",
+    )
+    http_exc = campaign_definition_launch_blocked_http_exception(
+        DpmBulkReviewCampaignDefinitionLaunchBlocked(
+            reason_codes=["BULK_REVIEW_CAMPAIGN_EXPIRED"],
+            readiness=readiness,
+        )
+    )
+
+    assert http_exc.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert http_exc.detail["code"] == "BULK_REVIEW_CAMPAIGN_DEFINITION_LAUNCH_BLOCKED"
+    assert http_exc.detail["reason_codes"] == ["BULK_REVIEW_CAMPAIGN_EXPIRED"]
+    assert http_exc.detail["readiness"]["preview_create_allowed"] is False
+
+
+def test_invalid_campaign_discovery_date_http_exception_maps_field_name() -> None:
+    http_exc = invalid_campaign_discovery_date_http_exception("active_on")
+
+    assert http_exc.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert http_exc.detail == {
+        "code": "BULK_REVIEW_CAMPAIGN_DISCOVERY_DATE_INVALID",
+        "message": "active_on must be an ISO date.",
+    }


### PR DESCRIPTION
## Summary
- Extract campaign-definition HTTP exception builders into `wave_campaign_definition_http.py`
- Reuse the shared mappings from campaign-definition create, retire, supersede, discovery, and launch routes
- Add focused helper coverage and update the codebase review ledger

## WTBD / Docs / Wiki
- WTBD count unchanged; this is an internal backend modularity slice supporting the completion program
- No API shape, supported-feature, operator workflow, or wiki source change
- Wiki drift check: `0`

## Validation
- `python -m ruff check src\api\routers\waves.py src\api\routers\wave_campaign_definition_http.py tests\unit\api\test_wave_campaign_definition_http.py tests\unit\dpm\api\test_waves_api.py`
- `python -m pytest tests\unit\api\test_wave_campaign_definition_http.py tests\unit\dpm\api\test_waves_api.py -q` (`119 passed`)
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` (`1272 passed, 2 warnings`)
- `make test-integration` (`168 passed`)
- `make test-e2e` (`28 passed`)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (`DiffCount 0`)

## Stranded Truth
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged lotus-manage remote branches
- `gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100` -> no open PRs before this PR