### PR TITLE
Extract wave date validation helper

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -477,3 +477,22 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   boundary has focused unit tests and route-level regression coverage.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-005: Source-cohort wave routes repeated as-of-date validation
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_date_validation.py`
+- Finding: source-cohort wave resolution paths repeated identical ISO `as_of_date` parsing and
+  `INVALID_AS_OF_DATE` domain-validation error construction. The repeated code was small, but it sat
+  in the same high-risk router area as source-owner cohort calls and campaign membership, making
+  future route-family splits easier to drift.
+- Action: extracted the shared wave `as_of_date` parser into
+  `src/api/routers/wave_date_validation.py` and reused it across PM-book, CIO model-change,
+  tactical house-view, risk-event, and bulk-review campaign resolution paths.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_date_validation.py`; full validation
+  is recorded in the PR evidence for this slice.
+- Follow-up: keep extracting cohesive source-cohort helper boundaries only when behavior-preserving
+  tests cover the shared domain error semantics.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_date_validation.py
+++ b/src/api/routers/wave_date_validation.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from datetime import date
+
+from src.api.services import wave_service
+
+
+def parse_wave_as_of_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise wave_service.DpmWaveValidationError(
+            "INVALID_AS_OF_DATE",
+            "as_of_date must be an ISO date.",
+        ) from exc

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -45,6 +45,7 @@ from src.api.routers.wave_http_errors import (
     wave_lookup_http_exception,
     wave_validation_http_exception,
 )
+from src.api.routers.wave_date_validation import parse_wave_as_of_date
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
 from src.api.services import wave_service
@@ -765,13 +766,7 @@ def _resolve_pm_book_portfolios(
             "PM_BOOK_REVIEW_PORTFOLIO_MANAGER_REQUIRED",
             "PM_BOOK_REVIEW requires portfolio_manager_id.",
         )
-    try:
-        as_of_date = date.fromisoformat(request.as_of_date)
-    except ValueError as exc:
-        raise wave_service.DpmWaveValidationError(
-            "INVALID_AS_OF_DATE",
-            "as_of_date must be an ISO date.",
-        ) from exc
+    as_of_date = parse_wave_as_of_date(request.as_of_date)
     portfolio_types = [value.strip().upper() for value in request.portfolio_types if value.strip()]
     if not portfolio_types:
         raise wave_service.DpmWaveValidationError(
@@ -861,13 +856,7 @@ def _resolve_cio_model_change_portfolios(
             "CIO_MODEL_CHANGE_MODEL_PORTFOLIO_REQUIRED",
             "CIO_MODEL_CHANGE requires model_portfolio_id.",
         )
-    try:
-        as_of_date = date.fromisoformat(request.as_of_date)
-    except ValueError as exc:
-        raise wave_service.DpmWaveValidationError(
-            "INVALID_AS_OF_DATE",
-            "as_of_date must be an ISO date.",
-        ) from exc
+    as_of_date = parse_wave_as_of_date(request.as_of_date)
     try:
         cohort = build_core_resolver_client().resolve_cio_model_change_affected_cohort(
             model_portfolio_id=model_portfolio_id,
@@ -972,13 +961,7 @@ def _resolve_tactical_house_view_portfolios(
                 "message": "DPM_ADVISE_BASE_URL is not configured.",
             },
         )
-    try:
-        as_of_date = date.fromisoformat(request.as_of_date)
-    except ValueError as exc:
-        raise wave_service.DpmWaveValidationError(
-            "INVALID_AS_OF_DATE",
-            "as_of_date must be an ISO date.",
-        ) from exc
+    as_of_date = parse_wave_as_of_date(request.as_of_date)
     eligible_portfolio_types = [
         value.strip().upper() for value in request.portfolio_types if value.strip()
     ]
@@ -1139,13 +1122,7 @@ def _resolve_risk_event_portfolios(
             "RISK_EVENT_CANDIDATE_PORTFOLIOS_REQUIRED",
             "RISK_EVENT requires candidate portfolios with source-supplied exposure weights.",
         )
-    try:
-        as_of_date = date.fromisoformat(request.as_of_date)
-    except ValueError as exc:
-        raise wave_service.DpmWaveValidationError(
-            "INVALID_AS_OF_DATE",
-            "as_of_date must be an ISO date.",
-        ) from exc
+    as_of_date = parse_wave_as_of_date(request.as_of_date)
     if risk_authority_client is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -1273,13 +1250,7 @@ def _resolve_bulk_review_campaign_portfolios(
             "BULK_REVIEW_CAMPAIGN_CANDIDATE_PORTFOLIOS_REQUIRED",
             "BULK_REVIEW_CAMPAIGN requires source-backed candidate portfolios.",
         )
-    try:
-        campaign_as_of_date = date.fromisoformat(request.as_of_date)
-    except ValueError as exc:
-        raise wave_service.DpmWaveValidationError(
-            "INVALID_AS_OF_DATE",
-            "as_of_date must be an ISO date.",
-        ) from exc
+    campaign_as_of_date = parse_wave_as_of_date(request.as_of_date)
     governance_diagnostics, governance_refs = _resolve_bulk_review_campaign_governance(
         request=request,
         campaign_as_of_date=campaign_as_of_date,

--- a/tests/unit/api/test_wave_date_validation.py
+++ b/tests/unit/api/test_wave_date_validation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.api.routers.wave_date_validation import parse_wave_as_of_date
+from src.api.services import wave_service
+
+
+def test_parse_wave_as_of_date_accepts_iso_date() -> None:
+    assert parse_wave_as_of_date("2026-05-10") == date(2026, 5, 10)
+
+
+def test_parse_wave_as_of_date_raises_wave_validation_error() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        parse_wave_as_of_date("2026/05/10")
+
+    assert exc_info.value.code == "INVALID_AS_OF_DATE"
+    assert exc_info.value.message == "as_of_date must be an ISO date."


### PR DESCRIPTION
## Summary
- Extract shared wave `as_of_date` parsing into `wave_date_validation.py`
- Reuse the helper across PM-book, CIO model-change, tactical house-view, risk-event, and bulk-review campaign resolution paths
- Add focused helper tests and update the codebase review ledger

## WTBD / Docs / Wiki
- Re-counted mainline WTBD ledger before branch: `59 total / 44 done / 9 partial / 6 open`
- WTBD count unchanged; this is an internal backend maintainability slice supporting the WTBD completion program
- No API shape, supported-feature, operator workflow, or wiki source change
- Wiki drift check: `0`

## Validation
- `python -m ruff check src\api\routers\waves.py src\api\routers\wave_date_validation.py tests\unit\api\test_wave_date_validation.py tests\unit\dpm\api\test_waves_api.py`
- `python -m pytest tests\unit\api\test_wave_date_validation.py tests\unit\dpm\api\test_waves_api.py -q` (`112 passed`)
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` (`1274 passed, 2 warnings`)
- `make test-integration` (`168 passed`)
- `make test-e2e` (`28 passed`)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (`DiffCount 0`)

## Stranded Truth
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged lotus-manage remote branches
- `gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100` -> no open PRs before this PR