### PR TITLE
Extract wave source dependency HTTP errors

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -496,3 +496,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   tests cover the shared domain error semantics.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-006: Source-cohort routes repeated dependency HTTP mapping
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_source_dependency_http.py`
+- Finding: source-owner cohort resolution paths repeated `503` unavailable and `424` dependency
+  failure response construction for Core PM-book membership, Core CIO model-change cohorts,
+  Advise tactical house-view cohorts, and Risk risk-event cohorts. The behavior was correct, but
+  source-specific status-code rules were embedded in route orchestration.
+- Action: extracted reusable source-dependency HTTP exception builders into
+  `src/api/routers/wave_source_dependency_http.py` and reused them across the source-cohort routes
+  while preserving rejected-source `424`, unavailable-source `503`, not-ready, empty, and
+  reason-code payload behavior.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_source_dependency_http.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: continue separating source-cohort orchestration from router concerns before adding
+  broader campaign workflow surfaces.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_source_dependency_http.py
+++ b/src/api/routers/wave_source_dependency_http.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+
+def upstream_unavailable_http_exception(
+    exc: Exception,
+    *,
+    default_code: str,
+) -> HTTPException:
+    return source_unavailable_http_exception(code=str(exc) or default_code)
+
+
+def upstream_dependency_failed_http_exception(
+    exc: Exception,
+    *,
+    default_code: str,
+) -> HTTPException:
+    return source_dependency_failed_http_exception(code=str(exc) or default_code)
+
+
+def source_authority_unavailable_http_exception(
+    exc: Exception,
+    *,
+    default_code: str,
+    rejected_code: str,
+) -> HTTPException:
+    error_code = str(exc) or default_code
+    if error_code == rejected_code:
+        return source_dependency_failed_http_exception(code=error_code)
+    return source_unavailable_http_exception(code=error_code)
+
+
+def source_unavailable_http_exception(
+    *,
+    code: str,
+    message: str | None = None,
+) -> HTTPException:
+    return _source_dependency_http_exception(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        code=code,
+        message=message,
+    )
+
+
+def source_dependency_failed_http_exception(
+    *,
+    code: str,
+    message: str | None = None,
+    reason_codes: list[str] | None = None,
+) -> HTTPException:
+    return _source_dependency_http_exception(
+        status_code=status.HTTP_424_FAILED_DEPENDENCY,
+        code=code,
+        message=message,
+        reason_codes=reason_codes,
+    )
+
+
+def _source_dependency_http_exception(
+    *,
+    status_code: int,
+    code: str,
+    message: str | None = None,
+    reason_codes: list[str] | None = None,
+) -> HTTPException:
+    detail: dict[str, object] = {"code": code}
+    if message is not None:
+        detail["message"] = message
+    if reason_codes is not None:
+        detail["reason_codes"] = reason_codes
+    return HTTPException(status_code=status_code, detail=detail)

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -46,6 +46,13 @@ from src.api.routers.wave_http_errors import (
     wave_validation_http_exception,
 )
 from src.api.routers.wave_date_validation import parse_wave_as_of_date
+from src.api.routers.wave_source_dependency_http import (
+    source_authority_unavailable_http_exception,
+    source_dependency_failed_http_exception,
+    source_unavailable_http_exception,
+    upstream_dependency_failed_http_exception,
+    upstream_unavailable_http_exception,
+)
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
 from src.api.services import wave_service
@@ -784,30 +791,24 @@ def _resolve_pm_book_portfolios(
             correlation_id=correlation_id,
         )
     except DpmCoreResolverUnavailableError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={"code": str(exc) or "DPM_CORE_PM_BOOK_MEMBERSHIP_UNAVAILABLE"},
+        raise upstream_unavailable_http_exception(
+            exc,
+            default_code="DPM_CORE_PM_BOOK_MEMBERSHIP_UNAVAILABLE",
         ) from exc
     except DpmCoreResolverError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={"code": str(exc) or "DPM_CORE_PM_BOOK_MEMBERSHIP_INCOMPLETE"},
+        raise upstream_dependency_failed_http_exception(
+            exc,
+            default_code="DPM_CORE_PM_BOOK_MEMBERSHIP_INCOMPLETE",
         ) from exc
     if membership.supportability.state != "READY":
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": membership.supportability.reason,
-                "message": "PM-book membership is not source-ready.",
-            },
+        raise source_dependency_failed_http_exception(
+            code=membership.supportability.reason,
+            message="PM-book membership is not source-ready.",
         )
     if not membership.members:
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": "DPM_CORE_PM_BOOK_MEMBERSHIP_EMPTY",
-                "message": "PM-book membership returned no affected portfolios.",
-            },
+        raise source_dependency_failed_http_exception(
+            code="DPM_CORE_PM_BOOK_MEMBERSHIP_EMPTY",
+            message="PM-book membership returned no affected portfolios.",
         )
     source_id = (
         membership.snapshot_id
@@ -867,30 +868,24 @@ def _resolve_cio_model_change_portfolios(
             correlation_id=correlation_id,
         )
     except DpmCoreResolverUnavailableError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={"code": str(exc) or "DPM_CORE_CIO_MODEL_CHANGE_COHORT_UNAVAILABLE"},
+        raise upstream_unavailable_http_exception(
+            exc,
+            default_code="DPM_CORE_CIO_MODEL_CHANGE_COHORT_UNAVAILABLE",
         ) from exc
     except DpmCoreResolverError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={"code": str(exc) or "DPM_CORE_CIO_MODEL_CHANGE_COHORT_INCOMPLETE"},
+        raise upstream_dependency_failed_http_exception(
+            exc,
+            default_code="DPM_CORE_CIO_MODEL_CHANGE_COHORT_INCOMPLETE",
         ) from exc
     if cohort.supportability.state != "READY":
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": cohort.supportability.reason,
-                "message": "CIO model-change affected cohort is not source-ready.",
-            },
+        raise source_dependency_failed_http_exception(
+            code=cohort.supportability.reason,
+            message="CIO model-change affected cohort is not source-ready.",
         )
     if not cohort.affected_mandates:
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": "DPM_CORE_CIO_MODEL_CHANGE_COHORT_EMPTY",
-                "message": "CIO model-change affected cohort returned no portfolios.",
-            },
+        raise source_dependency_failed_http_exception(
+            code="DPM_CORE_CIO_MODEL_CHANGE_COHORT_EMPTY",
+            message="CIO model-change affected cohort returned no portfolios.",
         )
     source_id = (
         cohort.snapshot_id or cohort.source_batch_fingerprint or cohort.model_change_event_id
@@ -954,12 +949,9 @@ def _resolve_tactical_house_view_portfolios(
             "TACTICAL_HOUSE_VIEW requires tactical house-view source_refs.",
         )
     if advise_authority_client is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={
-                "code": "DPM_TACTICAL_HOUSE_VIEW_COHORT_UNAVAILABLE",
-                "message": "DPM_ADVISE_BASE_URL is not configured.",
-            },
+        raise source_unavailable_http_exception(
+            code="DPM_TACTICAL_HOUSE_VIEW_COHORT_UNAVAILABLE",
+            message="DPM_ADVISE_BASE_URL is not configured.",
         )
     as_of_date = parse_wave_as_of_date(request.as_of_date)
     eligible_portfolio_types = [
@@ -1028,32 +1020,24 @@ def _resolve_tactical_house_view_portfolios(
             correlation_id=correlation_id,
         )
     except LotusAdviseAuthorityUnavailableError as exc:
-        error_code = str(exc) or "DPM_TACTICAL_HOUSE_VIEW_COHORT_UNAVAILABLE"
-        status_code = (
-            status.HTTP_424_FAILED_DEPENDENCY
-            if error_code == "LOTUS_ADVISE_TACTICAL_HOUSE_VIEW_COHORT_REJECTED"
-            else status.HTTP_503_SERVICE_UNAVAILABLE
-        )
-        raise HTTPException(status_code=status_code, detail={"code": error_code}) from exc
+        raise source_authority_unavailable_http_exception(
+            exc,
+            default_code="DPM_TACTICAL_HOUSE_VIEW_COHORT_UNAVAILABLE",
+            rejected_code="LOTUS_ADVISE_TACTICAL_HOUSE_VIEW_COHORT_REJECTED",
+        ) from exc
 
     if cohort.supportability_state != "READY":
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": "DPM_TACTICAL_HOUSE_VIEW_COHORT_EMPTY"
-                if cohort.supportability_state == "EMPTY"
-                else "DPM_TACTICAL_HOUSE_VIEW_COHORT_INCOMPLETE",
-                "message": "Tactical house-view affected cohort is not source-ready.",
-                "reason_codes": list(cohort.supportability_reason_codes),
-            },
+        raise source_dependency_failed_http_exception(
+            code="DPM_TACTICAL_HOUSE_VIEW_COHORT_EMPTY"
+            if cohort.supportability_state == "EMPTY"
+            else "DPM_TACTICAL_HOUSE_VIEW_COHORT_INCOMPLETE",
+            message="Tactical house-view affected cohort is not source-ready.",
+            reason_codes=list(cohort.supportability_reason_codes),
         )
     if not cohort.affected_portfolios:
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": "DPM_TACTICAL_HOUSE_VIEW_COHORT_EMPTY",
-                "message": "Tactical house-view cohort returned no affected portfolios.",
-            },
+        raise source_dependency_failed_http_exception(
+            code="DPM_TACTICAL_HOUSE_VIEW_COHORT_EMPTY",
+            message="Tactical house-view cohort returned no affected portfolios.",
         )
 
     cohort_ref = {
@@ -1124,12 +1108,9 @@ def _resolve_risk_event_portfolios(
         )
     as_of_date = parse_wave_as_of_date(request.as_of_date)
     if risk_authority_client is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={
-                "code": "DPM_RISK_EVENT_COHORT_UNAVAILABLE",
-                "message": "DPM_RISK_BASE_URL is not configured.",
-            },
+        raise source_unavailable_http_exception(
+            code="DPM_RISK_EVENT_COHORT_UNAVAILABLE",
+            message="DPM_RISK_BASE_URL is not configured.",
         )
 
     candidate_by_portfolio_id: dict[str, DpmWavePortfolioInput] = {}
@@ -1169,33 +1150,22 @@ def _resolve_risk_event_portfolios(
             correlation_id=correlation_id,
         )
     except LotusRiskAuthorityUnavailableError as exc:
-        error_code = str(exc) or "DPM_RISK_EVENT_COHORT_UNAVAILABLE"
-        status_code = (
-            status.HTTP_424_FAILED_DEPENDENCY
-            if error_code == "LOTUS_RISK_EVENT_COHORT_REJECTED"
-            else status.HTTP_503_SERVICE_UNAVAILABLE
-        )
-        raise HTTPException(
-            status_code=status_code,
-            detail={"code": error_code},
+        raise source_authority_unavailable_http_exception(
+            exc,
+            default_code="DPM_RISK_EVENT_COHORT_UNAVAILABLE",
+            rejected_code="LOTUS_RISK_EVENT_COHORT_REJECTED",
         ) from exc
 
     if cohort.calculation_supportability != "ready":
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": "DPM_RISK_EVENT_COHORT_INCOMPLETE",
-                "message": "Risk-event affected cohort is not source-ready.",
-                "reason_codes": list(cohort.reason_codes),
-            },
+        raise source_dependency_failed_http_exception(
+            code="DPM_RISK_EVENT_COHORT_INCOMPLETE",
+            message="Risk-event affected cohort is not source-ready.",
+            reason_codes=list(cohort.reason_codes),
         )
     if not cohort.affected_portfolios:
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": "DPM_RISK_EVENT_COHORT_EMPTY",
-                "message": "Risk-event affected cohort returned no affected portfolios.",
-            },
+        raise source_dependency_failed_http_exception(
+            code="DPM_RISK_EVENT_COHORT_EMPTY",
+            message="Risk-event affected cohort returned no affected portfolios.",
         )
 
     source_id = cohort.cohort_id or cohort.request_fingerprint or risk_event_id

--- a/tests/unit/api/test_wave_source_dependency_http.py
+++ b/tests/unit/api/test_wave_source_dependency_http.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from fastapi import status
+
+from src.api.routers.wave_source_dependency_http import (
+    source_authority_unavailable_http_exception,
+    source_dependency_failed_http_exception,
+    source_unavailable_http_exception,
+    upstream_dependency_failed_http_exception,
+    upstream_unavailable_http_exception,
+)
+
+
+def test_upstream_unavailable_http_exception_uses_default_code_for_blank_exception() -> None:
+    http_exc = upstream_unavailable_http_exception(Exception(), default_code="SOURCE_UNAVAILABLE")
+
+    assert http_exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert http_exc.detail == {"code": "SOURCE_UNAVAILABLE"}
+
+
+def test_upstream_dependency_failed_http_exception_preserves_exception_code() -> None:
+    http_exc = upstream_dependency_failed_http_exception(
+        RuntimeError("SOURCE_INCOMPLETE"),
+        default_code="DEFAULT_INCOMPLETE",
+    )
+
+    assert http_exc.status_code == status.HTTP_424_FAILED_DEPENDENCY
+    assert http_exc.detail == {"code": "SOURCE_INCOMPLETE"}
+
+
+def test_source_authority_unavailable_http_exception_maps_rejection_to_dependency() -> None:
+    http_exc = source_authority_unavailable_http_exception(
+        RuntimeError("SOURCE_REJECTED"),
+        default_code="SOURCE_UNAVAILABLE",
+        rejected_code="SOURCE_REJECTED",
+    )
+
+    assert http_exc.status_code == status.HTTP_424_FAILED_DEPENDENCY
+    assert http_exc.detail == {"code": "SOURCE_REJECTED"}
+
+
+def test_source_authority_unavailable_http_exception_maps_other_errors_to_unavailable() -> None:
+    http_exc = source_authority_unavailable_http_exception(
+        RuntimeError("SOURCE_DOWN"),
+        default_code="SOURCE_UNAVAILABLE",
+        rejected_code="SOURCE_REJECTED",
+    )
+
+    assert http_exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert http_exc.detail == {"code": "SOURCE_DOWN"}
+
+
+def test_source_unavailable_http_exception_includes_message_when_supplied() -> None:
+    http_exc = source_unavailable_http_exception(
+        code="SOURCE_URL_MISSING",
+        message="Source base URL is not configured.",
+    )
+
+    assert http_exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert http_exc.detail == {
+        "code": "SOURCE_URL_MISSING",
+        "message": "Source base URL is not configured.",
+    }
+
+
+def test_source_dependency_failed_http_exception_includes_reason_codes() -> None:
+    http_exc = source_dependency_failed_http_exception(
+        code="SOURCE_NOT_READY",
+        message="Source cohort is not ready.",
+        reason_codes=["MISSING_SOURCE_REF"],
+    )
+
+    assert http_exc.status_code == status.HTTP_424_FAILED_DEPENDENCY
+    assert http_exc.detail == {
+        "code": "SOURCE_NOT_READY",
+        "message": "Source cohort is not ready.",
+        "reason_codes": ["MISSING_SOURCE_REF"],
+    }


### PR DESCRIPTION
## Summary
- Extract shared source-dependency HTTP exception builders into `wave_source_dependency_http.py`
- Reuse the helpers from Core PM-book, Core CIO model-change, Advise tactical house-view, and Risk risk-event source-cohort paths
- Preserve existing `503` unavailable, `424` rejected/dependency failed, not-ready, empty, and reason-code response behavior
- Add focused helper coverage and update the codebase review ledger

## WTBD / Docs / Wiki
- Re-counted mainline WTBD ledger before branch: `59 total / 44 done / 9 partial / 6 open`
- WTBD count unchanged; this is an internal backend maintainability slice supporting the WTBD completion program
- No API shape, supported-feature, operator workflow, or wiki source change
- Wiki drift check: `0`

## Validation
- `python -m ruff check src\api\routers\waves.py src\api\routers\wave_source_dependency_http.py tests\unit\api\test_wave_source_dependency_http.py tests\unit\dpm\api\test_waves_api.py`
- `python -m pytest tests\unit\api\test_wave_source_dependency_http.py tests\unit\dpm\api\test_waves_api.py -q` (`116 passed`)
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` (`1280 passed, 2 warnings`)
- `make test-integration` (`168 passed`)
- `make test-e2e` (`28 passed`)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (`DiffCount 0`)

## Stranded Truth
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged lotus-manage remote branches
- `gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100` -> no open PRs before this PR