### PR TITLE
Extract wave source reference builders

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -516,3 +516,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   broader campaign workflow surfaces.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-007: Source-cohort routes built lineage refs inline
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_source_refs.py`
+- Finding: source-cohort wave resolution paths built PM-book, CIO model-change, tactical
+  house-view, risk-event, and bulk-review campaign source-reference dictionaries inline in route
+  orchestration. The repeated lineage construction made it harder to review whether source-owner
+  product names, fallback identities, supportability state casing, and content hashes stayed
+  consistent across source families.
+- Action: extracted pure source-reference builders into
+  `src/api/routers/wave_source_refs.py` and reused them across the source-cohort route helpers
+  without changing API response shape. Focused tests now cover fallback identities, content-hash
+  preservation, supportability state propagation, and member-level refs that intentionally omit
+  `content_hash`.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_source_refs.py`; full validation is
+  recorded in the PR evidence for this slice.
+- Follow-up: continue separating source-cohort payload preparation and route orchestration in small
+  behavior-preserving slices only when focused tests pin the source-owner boundary.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_source_refs.py
+++ b/src/api/routers/wave_source_refs.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from datetime import date
+
+
+def source_ref_payload(
+    *,
+    source_system: str,
+    source_type: str,
+    source_id: str | None,
+    source_version: str | None,
+    supportability_state: str,
+    content_hash: str | None = None,
+    include_content_hash: bool = True,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "source_system": source_system,
+        "source_type": source_type,
+        "source_id": source_id,
+        "source_version": source_version,
+        "supportability_state": supportability_state,
+    }
+    if include_content_hash:
+        payload["content_hash"] = content_hash
+    return payload
+
+
+def pm_book_membership_ref(
+    *,
+    source_id: str | None,
+    product_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system="lotus-core",
+        source_type="PortfolioManagerBookMembership",
+        source_id=source_id,
+        source_version=product_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def pm_book_member_ref(
+    *,
+    source_record_id: str | None,
+    portfolio_id: str,
+    as_of_date: date,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system="lotus-core",
+        source_type="PORTFOLIO_MANAGER_BOOK_MEMBER",
+        source_id=source_record_id or portfolio_id,
+        source_version=as_of_date.isoformat(),
+        supportability_state="READY",
+        include_content_hash=False,
+    )
+
+
+def cio_model_change_cohort_ref(
+    *,
+    source_id: str | None,
+    product_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system="lotus-core",
+        source_type="CioModelChangeAffectedCohort",
+        source_id=source_id,
+        source_version=product_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def cio_model_change_event_ref(
+    *,
+    model_change_event_id: str,
+    model_portfolio_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system="lotus-core",
+        source_type="CIO_MODEL_CHANGE_EVENT",
+        source_id=model_change_event_id,
+        source_version=model_portfolio_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def cio_model_change_affected_mandate_ref(
+    *,
+    source_record_id: str | None,
+    mandate_id: str,
+    binding_version: object,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system="lotus-core",
+        source_type="CIO_MODEL_CHANGE_AFFECTED_MANDATE",
+        source_id=source_record_id or mandate_id,
+        source_version=str(binding_version),
+        supportability_state="READY",
+        include_content_hash=False,
+    )
+
+
+def tactical_house_view_cohort_ref(
+    *,
+    source_service: str,
+    product_name: str,
+    cohort_id: str,
+    product_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system=source_service,
+        source_type=product_name,
+        source_id=cohort_id,
+        source_version=product_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def tactical_house_view_ref(
+    *,
+    source_service: str,
+    tactical_view_id: str,
+    tactical_view_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system=source_service,
+        source_type="TACTICAL_HOUSE_VIEW",
+        source_id=tactical_view_id,
+        source_version=tactical_view_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def tactical_house_view_affected_portfolio_ref(
+    *,
+    source_service: str,
+    cohort_id: str,
+    portfolio_id: str,
+    product_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system=source_service,
+        source_type="TACTICAL_HOUSE_VIEW_AFFECTED_PORTFOLIO",
+        source_id=f"{cohort_id}:{portfolio_id}",
+        source_version=product_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def risk_event_cohort_ref(
+    *,
+    source_service: str,
+    product_name: str,
+    source_id: str,
+    product_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system=source_service,
+        source_type=product_name,
+        source_id=source_id,
+        source_version=product_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def risk_event_ref(
+    *,
+    source_service: str,
+    risk_event_id: str,
+    product_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system=source_service,
+        source_type="RISK_EVENT",
+        source_id=risk_event_id,
+        source_version=product_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def risk_event_affected_portfolio_ref(
+    *,
+    source_service: str,
+    source_ref: str,
+    product_version: str,
+    supportability_state: str,
+    content_hash: str | None,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system=source_service,
+        source_type="RISK_EVENT_AFFECTED_PORTFOLIO",
+        source_id=source_ref,
+        source_version=product_version,
+        supportability_state=supportability_state,
+        content_hash=content_hash,
+    )
+
+
+def bulk_review_campaign_membership_ref(
+    *,
+    trigger_id: str,
+    campaign_as_of_date: date,
+    membership_hash: str,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system="lotus-manage",
+        source_type="BulkReviewCampaignMembership",
+        source_id=f"campaign:{trigger_id}:{campaign_as_of_date.isoformat()}",
+        source_version="v1",
+        supportability_state="READY",
+        content_hash=membership_hash,
+    )
+
+
+def bulk_review_campaign_member_ref(
+    *,
+    trigger_id: str,
+    portfolio_id: str,
+    campaign_as_of_date: date,
+    membership_hash: str,
+) -> dict[str, object]:
+    return source_ref_payload(
+        source_system="lotus-manage",
+        source_type="BULK_REVIEW_CAMPAIGN_MEMBER",
+        source_id=f"{trigger_id}:{portfolio_id}",
+        source_version=campaign_as_of_date.isoformat(),
+        supportability_state="READY",
+        content_hash=membership_hash,
+    )

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -53,6 +53,21 @@ from src.api.routers.wave_source_dependency_http import (
     upstream_dependency_failed_http_exception,
     upstream_unavailable_http_exception,
 )
+from src.api.routers.wave_source_refs import (
+    bulk_review_campaign_member_ref,
+    bulk_review_campaign_membership_ref,
+    cio_model_change_affected_mandate_ref,
+    cio_model_change_cohort_ref,
+    cio_model_change_event_ref,
+    pm_book_member_ref,
+    pm_book_membership_ref,
+    risk_event_affected_portfolio_ref,
+    risk_event_cohort_ref,
+    risk_event_ref,
+    tactical_house_view_affected_portfolio_ref,
+    tactical_house_view_cohort_ref,
+    tactical_house_view_ref,
+)
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
 from src.api.services import wave_service
@@ -815,26 +830,22 @@ def _resolve_pm_book_portfolios(
         or membership.source_batch_fingerprint
         or f"pm_book:{membership.portfolio_manager_id}:{membership.as_of_date.isoformat()}"
     )
-    book_ref = {
-        "source_system": "lotus-core",
-        "source_type": "PortfolioManagerBookMembership",
-        "source_id": source_id,
-        "source_version": membership.product_version,
-        "supportability_state": membership.supportability.state,
-        "content_hash": membership.source_batch_fingerprint,
-    }
+    book_ref = pm_book_membership_ref(
+        source_id=source_id,
+        product_version=membership.product_version,
+        supportability_state=membership.supportability.state,
+        content_hash=membership.source_batch_fingerprint,
+    )
     return [
         {
             "portfolio_id": member.portfolio_id,
             "source_refs": [
                 book_ref,
-                {
-                    "source_system": "lotus-core",
-                    "source_type": "PORTFOLIO_MANAGER_BOOK_MEMBER",
-                    "source_id": member.source_record_id or member.portfolio_id,
-                    "source_version": membership.as_of_date.isoformat(),
-                    "supportability_state": "READY",
-                },
+                pm_book_member_ref(
+                    source_record_id=member.source_record_id,
+                    portfolio_id=member.portfolio_id,
+                    as_of_date=membership.as_of_date,
+                ),
             ],
         }
         for member in membership.members
@@ -890,22 +901,18 @@ def _resolve_cio_model_change_portfolios(
     source_id = (
         cohort.snapshot_id or cohort.source_batch_fingerprint or cohort.model_change_event_id
     )
-    cohort_ref = {
-        "source_system": "lotus-core",
-        "source_type": "CioModelChangeAffectedCohort",
-        "source_id": source_id,
-        "source_version": cohort.product_version,
-        "supportability_state": cohort.supportability.state,
-        "content_hash": cohort.source_batch_fingerprint,
-    }
-    event_ref = {
-        "source_system": "lotus-core",
-        "source_type": "CIO_MODEL_CHANGE_EVENT",
-        "source_id": cohort.model_change_event_id,
-        "source_version": cohort.model_portfolio_version,
-        "supportability_state": cohort.supportability.state,
-        "content_hash": cohort.source_batch_fingerprint,
-    }
+    cohort_ref = cio_model_change_cohort_ref(
+        source_id=source_id,
+        product_version=cohort.product_version,
+        supportability_state=cohort.supportability.state,
+        content_hash=cohort.source_batch_fingerprint,
+    )
+    event_ref = cio_model_change_event_ref(
+        model_change_event_id=cohort.model_change_event_id,
+        model_portfolio_version=cohort.model_portfolio_version,
+        supportability_state=cohort.supportability.state,
+        content_hash=cohort.source_batch_fingerprint,
+    )
     return [
         {
             "portfolio_id": mandate.portfolio_id,
@@ -913,13 +920,11 @@ def _resolve_cio_model_change_portfolios(
             "source_refs": [
                 cohort_ref,
                 event_ref,
-                {
-                    "source_system": "lotus-core",
-                    "source_type": "CIO_MODEL_CHANGE_AFFECTED_MANDATE",
-                    "source_id": mandate.source_record_id or mandate.mandate_id,
-                    "source_version": str(mandate.binding_version),
-                    "supportability_state": "READY",
-                },
+                cio_model_change_affected_mandate_ref(
+                    source_record_id=mandate.source_record_id,
+                    mandate_id=mandate.mandate_id,
+                    binding_version=mandate.binding_version,
+                ),
             ],
         }
         for mandate in cohort.affected_mandates
@@ -1040,22 +1045,21 @@ def _resolve_tactical_house_view_portfolios(
             message="Tactical house-view cohort returned no affected portfolios.",
         )
 
-    cohort_ref = {
-        "source_system": cohort.source_service,
-        "source_type": cohort.product_name,
-        "source_id": cohort.cohort_id,
-        "source_version": cohort.product_version,
-        "supportability_state": cohort.supportability_state,
-        "content_hash": cohort.content_hash,
-    }
-    house_view_ref = {
-        "source_system": cohort.source_service,
-        "source_type": "TACTICAL_HOUSE_VIEW",
-        "source_id": cohort.tactical_view_id,
-        "source_version": cohort.tactical_view_version,
-        "supportability_state": cohort.supportability_state,
-        "content_hash": cohort.content_hash,
-    }
+    cohort_ref = tactical_house_view_cohort_ref(
+        source_service=cohort.source_service,
+        product_name=cohort.product_name,
+        cohort_id=cohort.cohort_id,
+        product_version=cohort.product_version,
+        supportability_state=cohort.supportability_state,
+        content_hash=cohort.content_hash,
+    )
+    house_view_ref = tactical_house_view_ref(
+        source_service=cohort.source_service,
+        tactical_view_id=cohort.tactical_view_id,
+        tactical_view_version=cohort.tactical_view_version,
+        supportability_state=cohort.supportability_state,
+        content_hash=cohort.content_hash,
+    )
     return [
         {
             "portfolio_id": affected.portfolio_id,
@@ -1063,14 +1067,14 @@ def _resolve_tactical_house_view_portfolios(
             "source_refs": [
                 cohort_ref,
                 house_view_ref,
-                {
-                    "source_system": cohort.source_service,
-                    "source_type": "TACTICAL_HOUSE_VIEW_AFFECTED_PORTFOLIO",
-                    "source_id": f"{cohort.cohort_id}:{affected.portfolio_id}",
-                    "source_version": cohort.product_version,
-                    "supportability_state": cohort.supportability_state,
-                    "content_hash": cohort.content_hash,
-                },
+                tactical_house_view_affected_portfolio_ref(
+                    source_service=cohort.source_service,
+                    cohort_id=cohort.cohort_id,
+                    portfolio_id=affected.portfolio_id,
+                    product_version=cohort.product_version,
+                    supportability_state=cohort.supportability_state,
+                    content_hash=cohort.content_hash,
+                ),
                 *affected.source_refs,
             ],
             "diagnostics": {
@@ -1169,22 +1173,22 @@ def _resolve_risk_event_portfolios(
         )
 
     source_id = cohort.cohort_id or cohort.request_fingerprint or risk_event_id
-    cohort_ref = {
-        "source_system": cohort.source_service,
-        "source_type": cohort.product_name,
-        "source_id": source_id,
-        "source_version": cohort.product_version,
-        "supportability_state": cohort.calculation_supportability.upper(),
-        "content_hash": cohort.request_fingerprint,
-    }
-    event_ref = {
-        "source_system": cohort.source_service,
-        "source_type": "RISK_EVENT",
-        "source_id": cohort.risk_event_id,
-        "source_version": cohort.product_version,
-        "supportability_state": cohort.calculation_supportability.upper(),
-        "content_hash": cohort.request_fingerprint,
-    }
+    supportability_state = cohort.calculation_supportability.upper()
+    cohort_ref = risk_event_cohort_ref(
+        source_service=cohort.source_service,
+        product_name=cohort.product_name,
+        source_id=source_id,
+        product_version=cohort.product_version,
+        supportability_state=supportability_state,
+        content_hash=cohort.request_fingerprint,
+    )
+    event_ref = risk_event_ref(
+        source_service=cohort.source_service,
+        risk_event_id=cohort.risk_event_id,
+        product_version=cohort.product_version,
+        supportability_state=supportability_state,
+        content_hash=cohort.request_fingerprint,
+    )
     portfolios: list[dict[str, object]] = []
     for affected in cohort.affected_portfolios:
         matched_candidate = candidate_by_portfolio_id.get(affected.portfolio_id)
@@ -1196,14 +1200,13 @@ def _resolve_risk_event_portfolios(
                 "source_refs": [
                     cohort_ref,
                     event_ref,
-                    {
-                        "source_system": cohort.source_service,
-                        "source_type": "RISK_EVENT_AFFECTED_PORTFOLIO",
-                        "source_id": affected.source_ref,
-                        "source_version": cohort.product_version,
-                        "supportability_state": cohort.calculation_supportability.upper(),
-                        "content_hash": cohort.request_fingerprint,
-                    },
+                    risk_event_affected_portfolio_ref(
+                        source_service=cohort.source_service,
+                        source_ref=affected.source_ref,
+                        product_version=cohort.product_version,
+                        supportability_state=supportability_state,
+                        content_hash=cohort.request_fingerprint,
+                    ),
                     *[ref.model_dump(mode="json") for ref in candidate_refs],
                 ],
             }
@@ -1268,14 +1271,11 @@ def _resolve_bulk_review_campaign_portfolios(
         portfolio_types=sorted(eligible_portfolio_types),
         portfolios=[candidate.model_dump(mode="json") for candidate in included_candidates],
     )
-    membership_ref = {
-        "source_system": "lotus-manage",
-        "source_type": "BulkReviewCampaignMembership",
-        "source_id": f"campaign:{request.trigger_id}:{campaign_as_of_date.isoformat()}",
-        "source_version": "v1",
-        "supportability_state": "READY",
-        "content_hash": membership_hash,
-    }
+    membership_ref = bulk_review_campaign_membership_ref(
+        trigger_id=request.trigger_id,
+        campaign_as_of_date=campaign_as_of_date,
+        membership_hash=membership_hash,
+    )
     return [
         {
             "portfolio_id": candidate.portfolio_id,
@@ -1283,14 +1283,12 @@ def _resolve_bulk_review_campaign_portfolios(
             "source_refs": [
                 membership_ref,
                 *governance_refs,
-                {
-                    "source_system": "lotus-manage",
-                    "source_type": "BULK_REVIEW_CAMPAIGN_MEMBER",
-                    "source_id": f"{request.trigger_id}:{candidate.portfolio_id}",
-                    "source_version": campaign_as_of_date.isoformat(),
-                    "supportability_state": "READY",
-                    "content_hash": membership_hash,
-                },
+                bulk_review_campaign_member_ref(
+                    trigger_id=request.trigger_id,
+                    portfolio_id=candidate.portfolio_id,
+                    campaign_as_of_date=campaign_as_of_date,
+                    membership_hash=membership_hash,
+                ),
                 *[ref.model_dump(mode="json") for ref in candidate.source_refs],
             ],
             "diagnostics": {

--- a/tests/unit/api/test_wave_source_refs.py
+++ b/tests/unit/api/test_wave_source_refs.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import date
+
+from src.api.routers.wave_source_refs import (
+    bulk_review_campaign_member_ref,
+    bulk_review_campaign_membership_ref,
+    cio_model_change_affected_mandate_ref,
+    pm_book_member_ref,
+    pm_book_membership_ref,
+    risk_event_affected_portfolio_ref,
+    tactical_house_view_affected_portfolio_ref,
+)
+
+
+def test_pm_book_membership_ref_preserves_source_batch_lineage() -> None:
+    assert pm_book_membership_ref(
+        source_id="pm-book-snapshot-001",
+        product_version="v1",
+        supportability_state="READY",
+        content_hash="sha256:pm-book",
+    ) == {
+        "source_system": "lotus-core",
+        "source_type": "PortfolioManagerBookMembership",
+        "source_id": "pm-book-snapshot-001",
+        "source_version": "v1",
+        "supportability_state": "READY",
+        "content_hash": "sha256:pm-book",
+    }
+
+
+def test_pm_book_member_ref_falls_back_to_portfolio_id() -> None:
+    assert pm_book_member_ref(
+        source_record_id=None,
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        as_of_date=date(2026, 5, 18),
+    ) == {
+        "source_system": "lotus-core",
+        "source_type": "PORTFOLIO_MANAGER_BOOK_MEMBER",
+        "source_id": "PB_SG_GLOBAL_BAL_001",
+        "source_version": "2026-05-18",
+        "supportability_state": "READY",
+    }
+
+
+def test_cio_model_change_affected_mandate_ref_stringifies_binding_version() -> None:
+    assert cio_model_change_affected_mandate_ref(
+        source_record_id=None,
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        binding_version=7,
+    ) == {
+        "source_system": "lotus-core",
+        "source_type": "CIO_MODEL_CHANGE_AFFECTED_MANDATE",
+        "source_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+        "source_version": "7",
+        "supportability_state": "READY",
+    }
+
+
+def test_tactical_house_view_affected_portfolio_ref_uses_cohort_portfolio_identity() -> None:
+    assert tactical_house_view_affected_portfolio_ref(
+        source_service="lotus-advise",
+        cohort_id="thv-cohort-001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        product_version="v1",
+        supportability_state="READY",
+        content_hash="sha256:thv",
+    ) == {
+        "source_system": "lotus-advise",
+        "source_type": "TACTICAL_HOUSE_VIEW_AFFECTED_PORTFOLIO",
+        "source_id": "thv-cohort-001:PB_SG_GLOBAL_BAL_001",
+        "source_version": "v1",
+        "supportability_state": "READY",
+        "content_hash": "sha256:thv",
+    }
+
+
+def test_risk_event_affected_portfolio_ref_preserves_source_ref() -> None:
+    assert risk_event_affected_portfolio_ref(
+        source_service="lotus-risk",
+        source_ref="risk-event-source-row-001",
+        product_version="v1",
+        supportability_state="READY",
+        content_hash="sha256:risk-event",
+    ) == {
+        "source_system": "lotus-risk",
+        "source_type": "RISK_EVENT_AFFECTED_PORTFOLIO",
+        "source_id": "risk-event-source-row-001",
+        "source_version": "v1",
+        "supportability_state": "READY",
+        "content_hash": "sha256:risk-event",
+    }
+
+
+def test_bulk_review_campaign_refs_preserve_membership_and_member_lineage() -> None:
+    campaign_as_of_date = date(2026, 5, 18)
+
+    assert bulk_review_campaign_membership_ref(
+        trigger_id="campaign-q2-review",
+        campaign_as_of_date=campaign_as_of_date,
+        membership_hash="sha256:membership",
+    ) == {
+        "source_system": "lotus-manage",
+        "source_type": "BulkReviewCampaignMembership",
+        "source_id": "campaign:campaign-q2-review:2026-05-18",
+        "source_version": "v1",
+        "supportability_state": "READY",
+        "content_hash": "sha256:membership",
+    }
+    assert bulk_review_campaign_member_ref(
+        trigger_id="campaign-q2-review",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        campaign_as_of_date=campaign_as_of_date,
+        membership_hash="sha256:membership",
+    ) == {
+        "source_system": "lotus-manage",
+        "source_type": "BULK_REVIEW_CAMPAIGN_MEMBER",
+        "source_id": "campaign-q2-review:PB_SG_GLOBAL_BAL_001",
+        "source_version": "2026-05-18",
+        "supportability_state": "READY",
+        "content_hash": "sha256:membership",
+    }


### PR DESCRIPTION
## Summary
- Extract pure source-reference builders for PM-book, CIO model-change, tactical house-view, risk-event, and bulk-review campaign lineage refs.
- Reuse the builders from wave source-cohort route helpers while preserving existing payload shape, including member refs that omit content_hash.
- Add focused source-ref helper tests and record BACKEND-REVIEW-20260519-007 in the codebase review ledger.

## Validation
- python -m ruff check src\\api\\routers\\waves.py src\\api\\routers\\wave_source_refs.py tests\\unit\\api\\test_wave_source_refs.py tests\\unit\\dpm\\api\\test_waves_api.py
- python -m pytest tests\\unit\\api\\test_wave_source_refs.py tests\\unit\\dpm\\api\\test_waves_api.py -q (116 passed)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1286 passed, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Wiki
- No wiki source change required; this is an internal backend modularity refactor with no supported-feature or operator-contract change.