### PR TITLE
Centralize wave source reference serialization

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -538,3 +538,22 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   behavior-preserving slices only when focused tests pin the source-owner boundary.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-008: Source-cohort routes repeated source-ref serialization
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_source_refs.py`
+- Finding: source-cohort route helpers repeated `DpmWaveSourceRef` JSON serialization in tactical
+  house-view, risk-event, bulk-review campaign, and campaign-governance payload assembly. The
+  duplication was mechanically simple but easy to drift from the source-reference helper boundary
+  added for lineage dictionary construction.
+- Action: added `source_refs_payload()` to `src/api/routers/wave_source_refs.py` and reused it for
+  source-ref list serialization across source-cohort payload assembly. Focused tests pin JSON-mode
+  serialization and preserve the existing route-level regression coverage.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_source_refs.py`; full validation is
+  recorded in the PR evidence for this slice.
+- Follow-up: source-cohort payload preparation can continue moving out of `waves.py` once the
+  request DTO ownership boundary is split cleanly enough to avoid router-helper cycles.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_source_refs.py
+++ b/src/api/routers/wave_source_refs.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import date
+
+from src.core.waves import DpmWaveSourceRef
+
+
+def source_refs_payload(refs: Iterable[DpmWaveSourceRef]) -> list[dict[str, object]]:
+    return [ref.model_dump(mode="json") for ref in refs]
 
 
 def source_ref_payload(

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -64,6 +64,7 @@ from src.api.routers.wave_source_refs import (
     risk_event_affected_portfolio_ref,
     risk_event_cohort_ref,
     risk_event_ref,
+    source_refs_payload,
     tactical_house_view_affected_portfolio_ref,
     tactical_house_view_cohort_ref,
     tactical_house_view_ref,
@@ -998,7 +999,7 @@ def _resolve_tactical_house_view_portfolios(
                     else None
                 ),
                 "alignment_signal": candidate.alignment_signal,
-                "source_refs": [ref.model_dump(mode="json") for ref in candidate.source_refs],
+                "source_refs": source_refs_payload(candidate.source_refs),
                 "reason_codes": ["TACTICAL_HOUSE_VIEW_CANDIDATE_SOURCE_BACKED"],
             }
         )
@@ -1012,7 +1013,7 @@ def _resolve_tactical_house_view_portfolios(
                 "as_of_date": as_of_date.isoformat(),
                 "target_action": tactical_view.target_action,
                 "rationale": tactical_view.rationale,
-                "source_refs": [ref.model_dump(mode="json") for ref in tactical_view.source_refs],
+                "source_refs": source_refs_payload(tactical_view.source_refs),
                 "reason_codes": ["TACTICAL_HOUSE_VIEW_BANK_AUTHORED"],
             },
             candidate_portfolios=candidate_payloads,
@@ -1207,7 +1208,7 @@ def _resolve_risk_event_portfolios(
                         supportability_state=supportability_state,
                         content_hash=cohort.request_fingerprint,
                     ),
-                    *[ref.model_dump(mode="json") for ref in candidate_refs],
+                    *source_refs_payload(candidate_refs),
                 ],
             }
         )
@@ -1289,7 +1290,7 @@ def _resolve_bulk_review_campaign_portfolios(
                     campaign_as_of_date=campaign_as_of_date,
                     membership_hash=membership_hash,
                 ),
-                *[ref.model_dump(mode="json") for ref in candidate.source_refs],
+                *source_refs_payload(candidate.source_refs),
             ],
             "diagnostics": {
                 "source_owner": "lotus-manage",
@@ -1365,7 +1366,7 @@ def _resolve_bulk_review_campaign_governance(
         actor_id=request.actor_id,
         governance=governance.model_dump(mode="json"),
     )
-    governance_refs = [
+    governance_refs: list[dict[str, object]] = [
         {
             "source_system": "lotus-manage",
             "source_type": "BulkReviewCampaignGovernance",
@@ -1374,7 +1375,7 @@ def _resolve_bulk_review_campaign_governance(
             "supportability_state": "READY",
             "content_hash": governance_hash,
         },
-        *[ref.model_dump(mode="json") for ref in governance.source_refs],
+        *source_refs_payload(governance.source_refs),
     ]
     return (
         {

--- a/tests/unit/api/test_wave_source_refs.py
+++ b/tests/unit/api/test_wave_source_refs.py
@@ -9,8 +9,34 @@ from src.api.routers.wave_source_refs import (
     pm_book_member_ref,
     pm_book_membership_ref,
     risk_event_affected_portfolio_ref,
+    source_refs_payload,
     tactical_house_view_affected_portfolio_ref,
 )
+from src.core.waves import DpmWaveSourceRef
+
+
+def test_source_refs_payload_serializes_refs_with_json_mode() -> None:
+    refs = [
+        DpmWaveSourceRef(
+            source_system="lotus-core",
+            source_type="PortfolioManagerBookMembership",
+            source_id="pm-book-snapshot-001",
+            source_version="v1",
+            supportability_state="READY",
+            content_hash="sha256:pm-book",
+        )
+    ]
+
+    assert source_refs_payload(refs) == [
+        {
+            "source_system": "lotus-core",
+            "source_type": "PortfolioManagerBookMembership",
+            "source_id": "pm-book-snapshot-001",
+            "source_version": "v1",
+            "supportability_state": "READY",
+            "content_hash": "sha256:pm-book",
+        }
+    ]
 
 
 def test_pm_book_membership_ref_preserves_source_batch_lineage() -> None:


### PR DESCRIPTION
## Summary
- Add source_refs_payload() to centralize DpmWaveSourceRef JSON-mode serialization.
- Reuse it across tactical house-view, risk-event, bulk-review campaign, and campaign-governance source-cohort payload assembly.
- Add focused helper coverage and record BACKEND-REVIEW-20260519-008 in the codebase review ledger.

## Validation
- python -m ruff check src\\api\\routers\\waves.py src\\api\\routers\\wave_source_refs.py tests\\unit\\api\\test_wave_source_refs.py tests\\unit\\dpm\\api\\test_waves_api.py
- python -m pytest tests\\unit\\api\\test_wave_source_refs.py tests\\unit\\dpm\\api\\test_waves_api.py -q (117 passed)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1287 passed, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Wiki
- No wiki source change required; this is an internal backend modularity refactor with no supported-feature or operator-contract change.