### PR TITLE
Extract wave campaign hashing helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -557,3 +557,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   request DTO ownership boundary is split cleanly enough to avoid router-helper cycles.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-009: Campaign membership hashing lived in router orchestration
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_campaign_hashing.py`
+- Finding: deterministic hash construction for `BulkReviewCampaignMembership:v1` and
+  `BulkReviewCampaignGovernance:v1` lived inside the wave router. The code was pure and correct,
+  but keeping canonical payload construction beside route orchestration made campaign lineage
+  behavior harder to test directly and forced the router to own low-level JSON/hash mechanics.
+- Action: extracted campaign governance and membership hash builders into
+  `src/api/routers/wave_campaign_hashing.py` and reused them from the bulk-review campaign
+  resolution helpers. Focused tests now pin stable canonical hashing, actor sensitivity, and
+  membership-change sensitivity.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_campaign_hashing.py`; full validation
+  is recorded in the PR evidence for this slice.
+- Follow-up: continue moving pure campaign membership helpers out of `waves.py` only when tests can
+  pin lineage, supportability, and failure semantics without broad route coupling.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_campaign_hashing.py
+++ b/src/api/routers/wave_campaign_hashing.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+
+
+def campaign_governance_hash(
+    *,
+    trigger_id: str,
+    actor_id: str,
+    governance: dict[str, object],
+) -> str:
+    payload: dict[str, object] = {
+        "product_name": "BulkReviewCampaignGovernance",
+        "product_version": "v1",
+        "trigger_id": trigger_id,
+        "actor_id": actor_id,
+        "governance": governance,
+    }
+    return _canonical_sha256(payload)
+
+
+def campaign_membership_hash(
+    *,
+    trigger_id: str,
+    as_of_date: date,
+    portfolio_types: list[str],
+    portfolios: list[dict[str, object]],
+) -> str:
+    payload: dict[str, object] = {
+        "product_name": "BulkReviewCampaignMembership",
+        "product_version": "v1",
+        "trigger_id": trigger_id,
+        "as_of_date": as_of_date.isoformat(),
+        "portfolio_types": portfolio_types,
+        "portfolios": portfolios,
+    }
+    return _canonical_sha256(payload)
+
+
+def _canonical_sha256(payload: dict[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
 from datetime import date
 from decimal import Decimal
@@ -40,6 +38,10 @@ from src.api.routers.wave_campaign_definition_http import (
     campaign_definition_value_http_exception,
     get_campaign_definition_or_404,
     invalid_campaign_discovery_date_http_exception,
+)
+from src.api.routers.wave_campaign_hashing import (
+    campaign_governance_hash,
+    campaign_membership_hash,
 )
 from src.api.routers.wave_http_errors import (
     wave_lookup_http_exception,
@@ -1266,7 +1268,7 @@ def _resolve_bulk_review_campaign_portfolios(
             },
         )
 
-    membership_hash = _campaign_membership_hash(
+    membership_hash = campaign_membership_hash(
         trigger_id=request.trigger_id,
         as_of_date=campaign_as_of_date,
         portfolio_types=sorted(eligible_portfolio_types),
@@ -1361,7 +1363,7 @@ def _resolve_bulk_review_campaign_governance(
                 "actor_id is not entitled for this bulk-review campaign.",
             )
 
-    governance_hash = _campaign_governance_hash(
+    governance_hash = campaign_governance_hash(
         trigger_id=request.trigger_id,
         actor_id=request.actor_id,
         governance=governance.model_dump(mode="json"),
@@ -1392,42 +1394,6 @@ def _resolve_bulk_review_campaign_governance(
         },
         governance_refs,
     )
-
-
-def _campaign_governance_hash(
-    *,
-    trigger_id: str,
-    actor_id: str,
-    governance: dict[str, object],
-) -> str:
-    payload = {
-        "product_name": "BulkReviewCampaignGovernance",
-        "product_version": "v1",
-        "trigger_id": trigger_id,
-        "actor_id": actor_id,
-        "governance": governance,
-    }
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
-    return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
-
-
-def _campaign_membership_hash(
-    *,
-    trigger_id: str,
-    as_of_date: date,
-    portfolio_types: list[str],
-    portfolios: list[dict[str, object]],
-) -> str:
-    payload = {
-        "product_name": "BulkReviewCampaignMembership",
-        "product_version": "v1",
-        "trigger_id": trigger_id,
-        "as_of_date": as_of_date.isoformat(),
-        "portfolio_types": portfolio_types,
-        "portfolios": portfolios,
-    }
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
-    return f"sha256:{hashlib.sha256(canonical.encode()).hexdigest()}"
 
 
 @router.put(

--- a/tests/unit/api/test_wave_campaign_hashing.py
+++ b/tests/unit/api/test_wave_campaign_hashing.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import date
+
+from src.api.routers.wave_campaign_hashing import (
+    campaign_governance_hash,
+    campaign_membership_hash,
+)
+
+
+def test_campaign_governance_hash_is_stable_for_reordered_governance_fields() -> None:
+    first = campaign_governance_hash(
+        trigger_id="campaign-q2-review",
+        actor_id="pm_001",
+        governance={
+            "approved_by": "cio_001",
+            "approval_ref": "approval-001",
+            "approved_at": "2026-05-18T09:00:00Z",
+        },
+    )
+    second = campaign_governance_hash(
+        trigger_id="campaign-q2-review",
+        actor_id="pm_001",
+        governance={
+            "approved_at": "2026-05-18T09:00:00Z",
+            "approval_ref": "approval-001",
+            "approved_by": "cio_001",
+        },
+    )
+
+    assert first == second
+    assert first.startswith("sha256:")
+
+
+def test_campaign_governance_hash_changes_when_actor_changes() -> None:
+    governance = {
+        "approval_ref": "approval-001",
+        "approved_by": "cio_001",
+        "approved_at": "2026-05-18T09:00:00Z",
+    }
+
+    assert campaign_governance_hash(
+        trigger_id="campaign-q2-review",
+        actor_id="pm_001",
+        governance=governance,
+    ) != campaign_governance_hash(
+        trigger_id="campaign-q2-review",
+        actor_id="pm_002",
+        governance=governance,
+    )
+
+
+def test_campaign_membership_hash_is_stable_for_same_payload() -> None:
+    portfolios = [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "portfolio_type": "DISCRETIONARY",
+        }
+    ]
+
+    assert campaign_membership_hash(
+        trigger_id="campaign-q2-review",
+        as_of_date=date(2026, 5, 18),
+        portfolio_types=["DISCRETIONARY"],
+        portfolios=portfolios,
+    ) == campaign_membership_hash(
+        trigger_id="campaign-q2-review",
+        as_of_date=date(2026, 5, 18),
+        portfolio_types=["DISCRETIONARY"],
+        portfolios=portfolios,
+    )
+
+
+def test_campaign_membership_hash_changes_when_membership_changes() -> None:
+    base_portfolios = [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "portfolio_type": "DISCRETIONARY",
+        }
+    ]
+    expanded_portfolios = [
+        *base_portfolios,
+        {
+            "portfolio_id": "PB_SG_INCOME_002",
+            "portfolio_type": "DISCRETIONARY",
+        },
+    ]
+
+    assert campaign_membership_hash(
+        trigger_id="campaign-q2-review",
+        as_of_date=date(2026, 5, 18),
+        portfolio_types=["DISCRETIONARY"],
+        portfolios=base_portfolios,
+    ) != campaign_membership_hash(
+        trigger_id="campaign-q2-review",
+        as_of_date=date(2026, 5, 18),
+        portfolio_types=["DISCRETIONARY"],
+        portfolios=expanded_portfolios,
+    )


### PR DESCRIPTION
## Summary
- Extract deterministic BulkReviewCampaignGovernance and BulkReviewCampaignMembership hash builders from the wave router into wave_campaign_hashing.py.
- Remove router-owned hashlib/json mechanics while preserving existing membership and governance content-hash behavior.
- Add focused hash tests and record BACKEND-REVIEW-20260519-009 in the codebase review ledger.

## Validation
- python -m ruff check src\\api\\routers\\waves.py src\\api\\routers\\wave_campaign_hashing.py tests\\unit\\api\\test_wave_campaign_hashing.py tests\\unit\\dpm\\api\\test_waves_api.py
- python -m pytest tests\\unit\\api\\test_wave_campaign_hashing.py tests\\unit\\dpm\\api\\test_waves_api.py -q (114 passed)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1291 passed, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Wiki
- No wiki source change required; this is an internal backend modularity refactor with no supported-feature or operator-contract change.