### PR TITLE
Extract wave portfolio type validation

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -577,3 +577,22 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   pin lineage, supportability, and failure semantics without broad route coupling.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-010: Source-cohort routes repeated portfolio-type normalization
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_portfolio_type_validation.py`
+- Finding: PM-book, tactical house-view, and bulk-review campaign route helpers repeated
+  portfolio-type trimming, upper-casing, and required-list validation with route-specific error
+  codes. The duplication was small but sat in source-cohort orchestration, where future route
+  splits could drift on accepted portfolio-type casing or missing-input semantics.
+- Action: extracted `normalize_required_portfolio_types()` into
+  `src/api/routers/wave_portfolio_type_validation.py` and reused it across the source-cohort paths
+  while preserving each route's existing validation code and message.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_portfolio_type_validation.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: continue moving source-cohort request normalization into focused helpers only where the
+  helpers can preserve route-specific validation semantics.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_portfolio_type_validation.py
+++ b/src/api/routers/wave_portfolio_type_validation.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from src.api.services import wave_service
+
+
+def normalize_required_portfolio_types(
+    values: Iterable[str],
+    *,
+    required_code: str,
+    required_message: str,
+) -> list[str]:
+    portfolio_types = [value.strip().upper() for value in values if value.strip()]
+    if not portfolio_types:
+        raise wave_service.DpmWaveValidationError(required_code, required_message)
+    return portfolio_types

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -48,6 +48,7 @@ from src.api.routers.wave_http_errors import (
     wave_validation_http_exception,
 )
 from src.api.routers.wave_date_validation import parse_wave_as_of_date
+from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_types
 from src.api.routers.wave_source_dependency_http import (
     source_authority_unavailable_http_exception,
     source_dependency_failed_http_exception,
@@ -792,12 +793,11 @@ def _resolve_pm_book_portfolios(
             "PM_BOOK_REVIEW requires portfolio_manager_id.",
         )
     as_of_date = parse_wave_as_of_date(request.as_of_date)
-    portfolio_types = [value.strip().upper() for value in request.portfolio_types if value.strip()]
-    if not portfolio_types:
-        raise wave_service.DpmWaveValidationError(
-            "PM_BOOK_REVIEW_PORTFOLIO_TYPES_REQUIRED",
-            "PM_BOOK_REVIEW requires at least one portfolio type.",
-        )
+    portfolio_types = normalize_required_portfolio_types(
+        request.portfolio_types,
+        required_code="PM_BOOK_REVIEW_PORTFOLIO_TYPES_REQUIRED",
+        required_message="PM_BOOK_REVIEW requires at least one portfolio type.",
+    )
     try:
         membership = build_core_resolver_client().resolve_portfolio_manager_book_membership(
             portfolio_manager_id=portfolio_manager_id,
@@ -962,14 +962,11 @@ def _resolve_tactical_house_view_portfolios(
             message="DPM_ADVISE_BASE_URL is not configured.",
         )
     as_of_date = parse_wave_as_of_date(request.as_of_date)
-    eligible_portfolio_types = [
-        value.strip().upper() for value in request.portfolio_types if value.strip()
-    ]
-    if not eligible_portfolio_types:
-        raise wave_service.DpmWaveValidationError(
-            "TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPES_REQUIRED",
-            "TACTICAL_HOUSE_VIEW requires at least one eligible portfolio type.",
-        )
+    eligible_portfolio_types = normalize_required_portfolio_types(
+        request.portfolio_types,
+        required_code="TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPES_REQUIRED",
+        required_message="TACTICAL_HOUSE_VIEW requires at least one eligible portfolio type.",
+    )
 
     candidate_payloads: list[dict[str, object]] = []
     for candidate in request.portfolios:
@@ -1231,14 +1228,15 @@ def _resolve_bulk_review_campaign_portfolios(
         request=request,
         campaign_as_of_date=campaign_as_of_date,
     )
-    eligible_portfolio_types = {
-        value.strip().upper() for value in request.portfolio_types if value.strip()
-    }
-    if not eligible_portfolio_types:
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPES_REQUIRED",
-            "BULK_REVIEW_CAMPAIGN requires at least one eligible portfolio type.",
+    eligible_portfolio_types = set(
+        normalize_required_portfolio_types(
+            request.portfolio_types,
+            required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPES_REQUIRED",
+            required_message=(
+                "BULK_REVIEW_CAMPAIGN requires at least one eligible portfolio type."
+            ),
         )
+    )
 
     included_candidates: list[DpmWavePortfolioInput] = []
     excluded_count = 0

--- a/tests/unit/api/test_wave_portfolio_type_validation.py
+++ b/tests/unit/api/test_wave_portfolio_type_validation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_types
+from src.api.services import wave_service
+
+
+def test_normalize_required_portfolio_types_strips_and_uppercases_values() -> None:
+    assert normalize_required_portfolio_types(
+        [" discretionary ", "", "advisory"],
+        required_code="PORTFOLIO_TYPES_REQUIRED",
+        required_message="Portfolio types are required.",
+    ) == ["DISCRETIONARY", "ADVISORY"]
+
+
+def test_normalize_required_portfolio_types_raises_domain_validation_error() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        normalize_required_portfolio_types(
+            ["", "   "],
+            required_code="PORTFOLIO_TYPES_REQUIRED",
+            required_message="Portfolio types are required.",
+        )
+
+    assert exc_info.value.code == "PORTFOLIO_TYPES_REQUIRED"
+    assert exc_info.value.message == "Portfolio types are required."


### PR DESCRIPTION
## Summary
- Extract shared portfolio-type normalization and required-list validation for source-cohort wave routes.
- Reuse it across PM-book, tactical house-view, and bulk-review campaign paths while preserving route-specific validation codes/messages.
- Add focused helper tests and record BACKEND-REVIEW-20260519-010 in the codebase review ledger.

## Validation
- python -m ruff check src\\api\\routers\\waves.py src\\api\\routers\\wave_portfolio_type_validation.py tests\\unit\\api\\test_wave_portfolio_type_validation.py tests\\unit\\dpm\\api\\test_waves_api.py
- python -m pytest tests\\unit\\api\\test_wave_portfolio_type_validation.py tests\\unit\\dpm\\api\\test_waves_api.py -q (112 passed)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1293 passed, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Wiki
- No wiki source change required; this is an internal backend modularity refactor with no supported-feature or operator-contract change.