### PR TITLE
Extract wave required text validation

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -596,3 +596,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   helpers can preserve route-specific validation semantics.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-011: Source-cohort routes repeated required identifier validation
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_required_text_validation.py`
+- Finding: PM-book, CIO model-change, and risk-event route helpers repeated the same trim and
+  required-value validation for source-cohort identifiers while embedding route-specific error
+  codes and messages in the router body. The behavior was correct, but the repeated pattern made
+  source-cohort normalization harder to review as route orchestration continued to shrink.
+- Action: extracted `normalize_required_text()` into
+  `src/api/routers/wave_required_text_validation.py` and reused it for `portfolio_manager_id`,
+  `model_portfolio_id`, and `risk_event_id` validation while preserving each route's existing
+  validation code and message.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_required_text_validation.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: continue extracting source-cohort request normalization only when route-specific
+  validation semantics remain explicit at the call site.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_required_text_validation.py
+++ b/src/api/routers/wave_required_text_validation.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from src.api.services import wave_service
+
+
+def normalize_required_text(
+    value: str | None,
+    *,
+    required_code: str,
+    required_message: str,
+) -> str:
+    normalized = (value or "").strip()
+    if not normalized:
+        raise wave_service.DpmWaveValidationError(required_code, required_message)
+    return normalized

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -49,6 +49,7 @@ from src.api.routers.wave_http_errors import (
 )
 from src.api.routers.wave_date_validation import parse_wave_as_of_date
 from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_types
+from src.api.routers.wave_required_text_validation import normalize_required_text
 from src.api.routers.wave_source_dependency_http import (
     source_authority_unavailable_http_exception,
     source_dependency_failed_http_exception,
@@ -786,12 +787,11 @@ def _resolve_pm_book_portfolios(
             "PM_BOOK_REVIEW_REJECTS_CALLER_PORTFOLIOS",
             "PM_BOOK_REVIEW resolves the affected portfolio set from lotus-core.",
         )
-    portfolio_manager_id = (request.portfolio_manager_id or "").strip()
-    if not portfolio_manager_id:
-        raise wave_service.DpmWaveValidationError(
-            "PM_BOOK_REVIEW_PORTFOLIO_MANAGER_REQUIRED",
-            "PM_BOOK_REVIEW requires portfolio_manager_id.",
-        )
+    portfolio_manager_id = normalize_required_text(
+        request.portfolio_manager_id,
+        required_code="PM_BOOK_REVIEW_PORTFOLIO_MANAGER_REQUIRED",
+        required_message="PM_BOOK_REVIEW requires portfolio_manager_id.",
+    )
     as_of_date = parse_wave_as_of_date(request.as_of_date)
     portfolio_types = normalize_required_portfolio_types(
         request.portfolio_types,
@@ -865,12 +865,11 @@ def _resolve_cio_model_change_portfolios(
             "CIO_MODEL_CHANGE_REJECTS_CALLER_PORTFOLIOS",
             "CIO_MODEL_CHANGE resolves the affected portfolio set from lotus-core.",
         )
-    model_portfolio_id = (request.model_portfolio_id or "").strip()
-    if not model_portfolio_id:
-        raise wave_service.DpmWaveValidationError(
-            "CIO_MODEL_CHANGE_MODEL_PORTFOLIO_REQUIRED",
-            "CIO_MODEL_CHANGE requires model_portfolio_id.",
-        )
+    model_portfolio_id = normalize_required_text(
+        request.model_portfolio_id,
+        required_code="CIO_MODEL_CHANGE_MODEL_PORTFOLIO_REQUIRED",
+        required_message="CIO_MODEL_CHANGE requires model_portfolio_id.",
+    )
     as_of_date = parse_wave_as_of_date(request.as_of_date)
     try:
         cohort = build_core_resolver_client().resolve_cio_model_change_affected_cohort(
@@ -1099,12 +1098,11 @@ def _resolve_risk_event_portfolios(
     correlation_id: str,
     risk_authority_client: LotusRiskAuthorityClient | None,
 ) -> list[dict[str, object]]:
-    risk_event_id = (request.risk_event_id or "").strip()
-    if not risk_event_id:
-        raise wave_service.DpmWaveValidationError(
-            "RISK_EVENT_ID_REQUIRED",
-            "RISK_EVENT requires risk_event_id.",
-        )
+    risk_event_id = normalize_required_text(
+        request.risk_event_id,
+        required_code="RISK_EVENT_ID_REQUIRED",
+        required_message="RISK_EVENT requires risk_event_id.",
+    )
     if not request.portfolios:
         raise wave_service.DpmWaveValidationError(
             "RISK_EVENT_CANDIDATE_PORTFOLIOS_REQUIRED",

--- a/tests/unit/api/test_wave_required_text_validation.py
+++ b/tests/unit/api/test_wave_required_text_validation.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from src.api.routers.wave_required_text_validation import normalize_required_text
+from src.api.services import wave_service
+
+
+def test_normalize_required_text_strips_supplied_value() -> None:
+    assert (
+        normalize_required_text(
+            " PM_SG_DPM_001 ",
+            required_code="VALUE_REQUIRED",
+            required_message="Value is required.",
+        )
+        == "PM_SG_DPM_001"
+    )
+
+
+def test_normalize_required_text_raises_for_none() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        normalize_required_text(
+            None,
+            required_code="VALUE_REQUIRED",
+            required_message="Value is required.",
+        )
+
+    assert exc_info.value.code == "VALUE_REQUIRED"
+    assert exc_info.value.message == "Value is required."
+
+
+def test_normalize_required_text_raises_for_blank_value() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        normalize_required_text(
+            "   ",
+            required_code="VALUE_REQUIRED",
+            required_message="Value is required.",
+        )
+
+    assert exc_info.value.code == "VALUE_REQUIRED"
+    assert exc_info.value.message == "Value is required."


### PR DESCRIPTION
## Summary
- Extract shared required text normalization for PM-book, CIO model-change, and risk-event wave source-cohort identifiers.
- Preserve route-specific validation codes and messages while reducing repeated router logic.
- Record backend review ledger entry BACKEND-REVIEW-20260519-011 with no wiki source change required.

## Validation
- python -m ruff check src\api\routers\waves.py src\api\routers\wave_required_text_validation.py tests\unit\api\test_wave_required_text_validation.py tests\unit\dpm\api\test_waves_api.py
- python -m pytest tests\unit\api\test_wave_required_text_validation.py tests\unit\dpm\api\test_waves_api.py -q (113 passed)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1296 passed, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Governance
- Stranded-truth reconciliation before PR: git fetch origin --prune; no unmerged lotus-manage remote branches; no open lotus-manage PRs.
- No API shape, supported-feature, or operator-facing wiki truth change.