### PR TITLE
Extract wave candidate portfolio type validation

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -616,3 +616,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   validation semantics remain explicit at the call site.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-012: Candidate portfolio-type normalization drift risk
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_portfolio_type_validation.py`
+- Finding: tactical house-view and bulk-review campaign route helpers still repeated single
+  candidate portfolio-type trimming, upper-casing, and required-value validation even after the
+  eligible portfolio-type list normalizer was centralized. The duplicated single-value path could
+  drift from list normalization and route-specific error handling as source-cohort routes continue
+  to be decomposed.
+- Action: added `normalize_required_portfolio_type()` next to the existing required-list helper
+  and reused it for tactical house-view and bulk-review campaign candidate validation while keeping
+  each route's validation code and message explicit.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_portfolio_type_validation.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: continue consolidating source-cohort candidate validation where shared helpers can
+  preserve private-banking semantics and fail-closed route-specific error codes.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_portfolio_type_validation.py
+++ b/src/api/routers/wave_portfolio_type_validation.py
@@ -5,6 +5,18 @@ from collections.abc import Iterable
 from src.api.services import wave_service
 
 
+def normalize_required_portfolio_type(
+    value: str | None,
+    *,
+    required_code: str,
+    required_message: str,
+) -> str:
+    portfolio_type = (value or "").strip().upper()
+    if not portfolio_type:
+        raise wave_service.DpmWaveValidationError(required_code, required_message)
+    return portfolio_type
+
+
 def normalize_required_portfolio_types(
     values: Iterable[str],
     *,

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -48,7 +48,10 @@ from src.api.routers.wave_http_errors import (
     wave_validation_http_exception,
 )
 from src.api.routers.wave_date_validation import parse_wave_as_of_date
-from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_types
+from src.api.routers.wave_portfolio_type_validation import (
+    normalize_required_portfolio_type,
+    normalize_required_portfolio_types,
+)
 from src.api.routers.wave_required_text_validation import normalize_required_text
 from src.api.routers.wave_source_dependency_http import (
     source_authority_unavailable_http_exception,
@@ -969,12 +972,13 @@ def _resolve_tactical_house_view_portfolios(
 
     candidate_payloads: list[dict[str, object]] = []
     for candidate in request.portfolios:
-        portfolio_type = (candidate.portfolio_type or "").strip().upper()
-        if not portfolio_type:
-            raise wave_service.DpmWaveValidationError(
-                "TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPE_REQUIRED",
-                "TACTICAL_HOUSE_VIEW candidate portfolios require source-owned portfolio_type.",
-            )
+        portfolio_type = normalize_required_portfolio_type(
+            candidate.portfolio_type,
+            required_code="TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPE_REQUIRED",
+            required_message=(
+                "TACTICAL_HOUSE_VIEW candidate portfolios require source-owned portfolio_type."
+            ),
+        )
         if candidate.discretionary_mandate is None:
             raise wave_service.DpmWaveValidationError(
                 "TACTICAL_HOUSE_VIEW_DISCRETIONARY_MANDATE_REQUIRED",
@@ -1239,12 +1243,13 @@ def _resolve_bulk_review_campaign_portfolios(
     included_candidates: list[DpmWavePortfolioInput] = []
     excluded_count = 0
     for candidate in request.portfolios:
-        portfolio_type = (candidate.portfolio_type or "").strip().upper()
-        if not portfolio_type:
-            raise wave_service.DpmWaveValidationError(
-                "BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_REQUIRED",
-                "BULK_REVIEW_CAMPAIGN candidate portfolios require source-owned portfolio_type.",
-            )
+        portfolio_type = normalize_required_portfolio_type(
+            candidate.portfolio_type,
+            required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_REQUIRED",
+            required_message=(
+                "BULK_REVIEW_CAMPAIGN candidate portfolios require source-owned portfolio_type."
+            ),
+        )
         if portfolio_type not in eligible_portfolio_types:
             excluded_count += 1
             continue

--- a/tests/unit/api/test_wave_portfolio_type_validation.py
+++ b/tests/unit/api/test_wave_portfolio_type_validation.py
@@ -2,8 +2,34 @@ from __future__ import annotations
 
 import pytest
 
-from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_types
+from src.api.routers.wave_portfolio_type_validation import (
+    normalize_required_portfolio_type,
+    normalize_required_portfolio_types,
+)
 from src.api.services import wave_service
+
+
+def test_normalize_required_portfolio_type_strips_and_uppercases_value() -> None:
+    assert (
+        normalize_required_portfolio_type(
+            " discretionary ",
+            required_code="PORTFOLIO_TYPE_REQUIRED",
+            required_message="Portfolio type is required.",
+        )
+        == "DISCRETIONARY"
+    )
+
+
+def test_normalize_required_portfolio_type_raises_domain_validation_error() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        normalize_required_portfolio_type(
+            "   ",
+            required_code="PORTFOLIO_TYPE_REQUIRED",
+            required_message="Portfolio type is required.",
+        )
+
+    assert exc_info.value.code == "PORTFOLIO_TYPE_REQUIRED"
+    assert exc_info.value.message == "Portfolio type is required."
 
 
 def test_normalize_required_portfolio_types_strips_and_uppercases_values() -> None:


### PR DESCRIPTION
## Summary
- Add a single-value `normalize_required_portfolio_type()` helper beside the existing source-cohort portfolio-type list normalizer.
- Reuse it for tactical house-view and bulk-review campaign candidate portfolio validation while preserving route-specific error codes/messages.
- Record backend review ledger entry BACKEND-REVIEW-20260519-012 with no wiki source change required.

## Validation
- python -m ruff check src\api\routers\waves.py src\api\routers\wave_portfolio_type_validation.py tests\unit\api\test_wave_portfolio_type_validation.py tests\unit\dpm\api\test_waves_api.py
- python -m pytest tests\unit\api\test_wave_portfolio_type_validation.py tests\unit\dpm\api\test_waves_api.py -q (114 passed)
- git diff --check (CRLF warnings only)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1298 passed, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Governance
- Stranded-truth reconciliation before PR: git fetch origin --prune; no unmerged lotus-manage remote branches; no open lotus-manage PRs.
- No API shape, supported-feature, or operator-facing wiki truth change.