### PR TITLE
Extract wave risk event exposure validation

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -636,3 +636,22 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   preserve private-banking semantics and fail-closed route-specific error codes.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-013: Risk-event exposure-weight validation embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_risk_event_validation.py`
+- Finding: risk-event source-cohort resolution normalized source-supplied exposure bucket names and
+  enforced missing/negative exposure-weight validation inline inside `waves.py`. The behavior was
+  correct, but it kept risk-event candidate validation coupled to route orchestration and made the
+  source-owned exposure contract harder to test directly.
+- Action: extracted `normalize_risk_event_exposure_weights()` into
+  `src/api/routers/wave_risk_event_validation.py` and reused it from the risk-event resolver while
+  preserving the existing fail-closed validation codes and messages.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_risk_event_validation.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: continue moving pure request-normalization logic out of `waves.py` when the helper can
+  retain source-owner boundaries and route-specific failure semantics.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_risk_event_validation.py
+++ b/src/api/routers/wave_risk_event_validation.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from src.api.services import wave_service
+
+
+def normalize_risk_event_exposure_weights(values: Mapping[str, float]) -> dict[str, float]:
+    exposure_weights = {
+        bucket.strip().upper(): weight for bucket, weight in values.items() if bucket.strip()
+    }
+    if not exposure_weights:
+        raise wave_service.DpmWaveValidationError(
+            "RISK_EVENT_EXPOSURE_WEIGHTS_REQUIRED",
+            "RISK_EVENT candidate portfolios require source-supplied exposure_weights.",
+        )
+    if any(weight < 0 for weight in exposure_weights.values()):
+        raise wave_service.DpmWaveValidationError(
+            "RISK_EVENT_EXPOSURE_WEIGHTS_INVALID",
+            "RISK_EVENT exposure_weights must be non-negative.",
+        )
+    return exposure_weights

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -53,6 +53,7 @@ from src.api.routers.wave_portfolio_type_validation import (
     normalize_required_portfolio_types,
 )
 from src.api.routers.wave_required_text_validation import normalize_required_text
+from src.api.routers.wave_risk_event_validation import normalize_risk_event_exposure_weights
 from src.api.routers.wave_source_dependency_http import (
     source_authority_unavailable_http_exception,
     source_dependency_failed_http_exception,
@@ -1122,21 +1123,7 @@ def _resolve_risk_event_portfolios(
     candidate_by_portfolio_id: dict[str, DpmWavePortfolioInput] = {}
     risk_portfolios: list[dict[str, object]] = []
     for candidate in request.portfolios:
-        exposure_weights = {
-            bucket.strip().upper(): weight
-            for bucket, weight in candidate.exposure_weights.items()
-            if bucket.strip()
-        }
-        if not exposure_weights:
-            raise wave_service.DpmWaveValidationError(
-                "RISK_EVENT_EXPOSURE_WEIGHTS_REQUIRED",
-                "RISK_EVENT candidate portfolios require source-supplied exposure_weights.",
-            )
-        if any(weight < 0 for weight in exposure_weights.values()):
-            raise wave_service.DpmWaveValidationError(
-                "RISK_EVENT_EXPOSURE_WEIGHTS_INVALID",
-                "RISK_EVENT exposure_weights must be non-negative.",
-            )
+        exposure_weights = normalize_risk_event_exposure_weights(candidate.exposure_weights)
         candidate_by_portfolio_id[candidate.portfolio_id] = candidate
         risk_portfolios.append(
             {

--- a/tests/unit/api/test_wave_risk_event_validation.py
+++ b/tests/unit/api/test_wave_risk_event_validation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from src.api.routers.wave_risk_event_validation import normalize_risk_event_exposure_weights
+from src.api.services import wave_service
+
+
+def test_normalize_risk_event_exposure_weights_strips_and_uppercases_buckets() -> None:
+    assert normalize_risk_event_exposure_weights(
+        {" equity ": 0.55, "": 0.25, " fixed_income": 0.35}
+    ) == {
+        "EQUITY": 0.55,
+        "FIXED_INCOME": 0.35,
+    }
+
+
+def test_normalize_risk_event_exposure_weights_raises_when_empty() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        normalize_risk_event_exposure_weights({" ": 0.25})
+
+    assert exc_info.value.code == "RISK_EVENT_EXPOSURE_WEIGHTS_REQUIRED"
+    assert (
+        exc_info.value.message
+        == "RISK_EVENT candidate portfolios require source-supplied exposure_weights."
+    )
+
+
+def test_normalize_risk_event_exposure_weights_raises_for_negative_weight() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        normalize_risk_event_exposure_weights({"EQUITY": -0.1})
+
+    assert exc_info.value.code == "RISK_EVENT_EXPOSURE_WEIGHTS_INVALID"
+    assert exc_info.value.message == "RISK_EVENT exposure_weights must be non-negative."


### PR DESCRIPTION
## Summary
- Extract risk-event exposure-weight normalization and fail-closed validation from `waves.py` into `wave_risk_event_validation.py`.
- Preserve existing source-owned exposure bucket normalization and validation codes/messages for missing and negative weights.
- Record backend review ledger entry BACKEND-REVIEW-20260519-013 with no wiki source change required.

## Validation
- python -m ruff check src\api\routers\waves.py src\api\routers\wave_risk_event_validation.py tests\unit\api\test_wave_risk_event_validation.py tests\unit\dpm\api\test_waves_api.py
- python -m pytest tests\unit\api\test_wave_risk_event_validation.py tests\unit\dpm\api\test_waves_api.py -q (113 passed)
- git diff --check (CRLF warnings only)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1301 passed, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Governance
- Stranded-truth reconciliation before PR: git fetch origin --prune; no unmerged lotus-manage remote branches; no open lotus-manage PRs.
- No API shape, supported-feature, or operator-facing wiki truth change.