### PR TITLE
Extract wave campaign governance validation

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -655,3 +655,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   retain source-owner boundaries and route-specific failure semantics.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-014: Campaign governance validation embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_campaign_governance_validation.py`
+- Finding: bulk-review campaign governance approval completeness, expiry-date posture, and
+  actor-entitlement checks were embedded directly in `waves.py`. The behavior was correct, but the
+  validation rules are private-banking governance semantics and deserve focused tests separate from
+  route orchestration and source-ref assembly.
+- Action: extracted `campaign_approval_status()`, `campaign_expiry_state()`, and
+  `campaign_actor_entitlement_state()` into
+  `src/api/routers/wave_campaign_governance_validation.py`, then reused them from the bulk-review
+  campaign governance resolver while preserving existing validation codes and messages.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_campaign_governance_validation.py`;
+  full validation is recorded in the PR evidence for this slice.
+- Follow-up: keep source-ref and diagnostic assembly near the route request context unless a stable
+  campaign-governance domain object emerges.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_campaign_governance_validation.py
+++ b/src/api/routers/wave_campaign_governance_validation.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date
+
+from src.api.services import wave_service
+
+
+def campaign_approval_status(
+    *,
+    approval_ref: str | None,
+    approved_by: str | None,
+    approved_at: str | None,
+) -> str:
+    approval_fields = [approval_ref, approved_by, approved_at]
+    supplied_approval_fields = [value for value in approval_fields if value]
+    if supplied_approval_fields and len(supplied_approval_fields) != len(approval_fields):
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_APPROVAL_EVIDENCE_INCOMPLETE",
+            "Bulk-review campaign approval evidence requires approval_ref, approved_by, and approved_at.",
+        )
+    return "APPROVED" if len(supplied_approval_fields) == len(approval_fields) else "NOT_SUPPLIED"
+
+
+def campaign_expiry_state(
+    *,
+    expires_on: str | None,
+    campaign_as_of_date: date,
+) -> str:
+    if not expires_on:
+        return "NOT_SUPPLIED"
+    try:
+        expiry_date = date.fromisoformat(expires_on)
+    except ValueError as exc:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_EXPIRY_DATE_INVALID",
+            "campaign_governance.expires_on must be an ISO date.",
+        ) from exc
+    if expiry_date < campaign_as_of_date:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_EXPIRED",
+            "Bulk-review campaign governance is expired for the requested as_of_date.",
+        )
+    return "ACTIVE"
+
+
+def campaign_actor_entitlement_state(
+    *,
+    entitled_actor_ids: Iterable[str],
+    actor_id: str,
+) -> str:
+    entitled_actors = {actor.strip() for actor in entitled_actor_ids if actor.strip()}
+    if not entitled_actors:
+        return "NOT_SUPPLIED"
+    if actor_id not in entitled_actors:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_ACTOR_NOT_ENTITLED",
+            "actor_id is not entitled for this bulk-review campaign.",
+        )
+    return "AUTHORIZED"

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -43,6 +43,11 @@ from src.api.routers.wave_campaign_hashing import (
     campaign_governance_hash,
     campaign_membership_hash,
 )
+from src.api.routers.wave_campaign_governance_validation import (
+    campaign_actor_entitlement_state,
+    campaign_approval_status,
+    campaign_expiry_state,
+)
 from src.api.routers.wave_http_errors import (
     wave_lookup_http_exception,
     wave_validation_http_exception,
@@ -1317,39 +1322,19 @@ def _resolve_bulk_review_campaign_governance(
             [],
         )
 
-    approval_fields = [governance.approval_ref, governance.approved_by, governance.approved_at]
-    supplied_approval_fields = [value for value in approval_fields if value]
-    if supplied_approval_fields and len(supplied_approval_fields) != len(approval_fields):
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_APPROVAL_EVIDENCE_INCOMPLETE",
-            "Bulk-review campaign approval evidence requires approval_ref, approved_by, and approved_at.",
-        )
-
-    expiry_state = "NOT_SUPPLIED"
-    if governance.expires_on:
-        try:
-            expires_on = date.fromisoformat(governance.expires_on)
-        except ValueError as exc:
-            raise wave_service.DpmWaveValidationError(
-                "BULK_REVIEW_CAMPAIGN_EXPIRY_DATE_INVALID",
-                "campaign_governance.expires_on must be an ISO date.",
-            ) from exc
-        if expires_on < campaign_as_of_date:
-            raise wave_service.DpmWaveValidationError(
-                "BULK_REVIEW_CAMPAIGN_EXPIRED",
-                "Bulk-review campaign governance is expired for the requested as_of_date.",
-            )
-        expiry_state = "ACTIVE"
-
-    entitled_actor_ids = {actor.strip() for actor in governance.entitled_actor_ids if actor.strip()}
-    actor_entitlement_state = "NOT_SUPPLIED"
-    if entitled_actor_ids:
-        actor_entitlement_state = "AUTHORIZED"
-        if request.actor_id not in entitled_actor_ids:
-            raise wave_service.DpmWaveValidationError(
-                "BULK_REVIEW_CAMPAIGN_ACTOR_NOT_ENTITLED",
-                "actor_id is not entitled for this bulk-review campaign.",
-            )
+    approval_status = campaign_approval_status(
+        approval_ref=governance.approval_ref,
+        approved_by=governance.approved_by,
+        approved_at=governance.approved_at,
+    )
+    expiry_state = campaign_expiry_state(
+        expires_on=governance.expires_on,
+        campaign_as_of_date=campaign_as_of_date,
+    )
+    actor_entitlement_state = campaign_actor_entitlement_state(
+        entitled_actor_ids=governance.entitled_actor_ids,
+        actor_id=request.actor_id,
+    )
 
     governance_hash = campaign_governance_hash(
         trigger_id=request.trigger_id,
@@ -1369,9 +1354,7 @@ def _resolve_bulk_review_campaign_governance(
     ]
     return (
         {
-            "campaign_governance_status": "APPROVED"
-            if len(supplied_approval_fields) == len(approval_fields)
-            else "NOT_SUPPLIED",
+            "campaign_governance_status": approval_status,
             "campaign_approval_ref": governance.approval_ref,
             "campaign_approved_by": governance.approved_by,
             "campaign_approved_at": governance.approved_at,

--- a/tests/unit/api/test_wave_campaign_governance_validation.py
+++ b/tests/unit/api/test_wave_campaign_governance_validation.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.api.routers.wave_campaign_governance_validation import (
+    campaign_actor_entitlement_state,
+    campaign_approval_status,
+    campaign_expiry_state,
+)
+from src.api.services import wave_service
+
+
+def test_campaign_approval_status_returns_approved_when_all_evidence_supplied() -> None:
+    assert (
+        campaign_approval_status(
+            approval_ref="APPROVAL-001",
+            approved_by="CIO_SG",
+            approved_at="2026-05-19T00:00:00Z",
+        )
+        == "APPROVED"
+    )
+
+
+def test_campaign_approval_status_returns_not_supplied_when_empty() -> None:
+    assert (
+        campaign_approval_status(approval_ref=None, approved_by=None, approved_at=None)
+        == "NOT_SUPPLIED"
+    )
+
+
+def test_campaign_approval_status_raises_for_partial_evidence() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        campaign_approval_status(
+            approval_ref="APPROVAL-001",
+            approved_by=None,
+            approved_at="2026-05-19T00:00:00Z",
+        )
+
+    assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_APPROVAL_EVIDENCE_INCOMPLETE"
+    assert (
+        exc_info.value.message
+        == "Bulk-review campaign approval evidence requires approval_ref, approved_by, and approved_at."
+    )
+
+
+def test_campaign_expiry_state_returns_not_supplied_without_expiry() -> None:
+    assert (
+        campaign_expiry_state(expires_on=None, campaign_as_of_date=date(2026, 5, 19))
+        == "NOT_SUPPLIED"
+    )
+
+
+def test_campaign_expiry_state_returns_active_for_current_expiry() -> None:
+    assert (
+        campaign_expiry_state(expires_on="2026-05-19", campaign_as_of_date=date(2026, 5, 19))
+        == "ACTIVE"
+    )
+
+
+def test_campaign_expiry_state_raises_for_invalid_date() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        campaign_expiry_state(expires_on="19-05-2026", campaign_as_of_date=date(2026, 5, 19))
+
+    assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_EXPIRY_DATE_INVALID"
+    assert exc_info.value.message == "campaign_governance.expires_on must be an ISO date."
+
+
+def test_campaign_expiry_state_raises_for_expired_governance() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        campaign_expiry_state(expires_on="2026-05-18", campaign_as_of_date=date(2026, 5, 19))
+
+    assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_EXPIRED"
+    assert (
+        exc_info.value.message
+        == "Bulk-review campaign governance is expired for the requested as_of_date."
+    )
+
+
+def test_campaign_actor_entitlement_state_returns_not_supplied_without_entitlements() -> None:
+    assert (
+        campaign_actor_entitlement_state(entitled_actor_ids=["", "   "], actor_id="PM_SG_DPM_001")
+        == "NOT_SUPPLIED"
+    )
+
+
+def test_campaign_actor_entitlement_state_returns_authorized_for_matching_actor() -> None:
+    assert (
+        campaign_actor_entitlement_state(
+            entitled_actor_ids=[" PM_SG_DPM_001 "],
+            actor_id="PM_SG_DPM_001",
+        )
+        == "AUTHORIZED"
+    )
+
+
+def test_campaign_actor_entitlement_state_raises_for_unentitled_actor() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        campaign_actor_entitlement_state(
+            entitled_actor_ids=["PM_SG_DPM_002"],
+            actor_id="PM_SG_DPM_001",
+        )
+
+    assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_ACTOR_NOT_ENTITLED"
+    assert exc_info.value.message == "actor_id is not entitled for this bulk-review campaign."


### PR DESCRIPTION
## Summary
- Extract bulk-review campaign approval, expiry, and actor-entitlement validation from `waves.py` into `wave_campaign_governance_validation.py`.
- Preserve existing fail-closed validation codes/messages while keeping source-ref and diagnostic assembly in the route context.
- Record backend review ledger entry BACKEND-REVIEW-20260519-014 with no wiki source change required.

## Validation
- python -m ruff check src\api\routers\waves.py src\api\routers\wave_campaign_governance_validation.py tests\unit\api\test_wave_campaign_governance_validation.py tests\unit\dpm\api\test_waves_api.py
- python -m pytest tests\unit\api\test_wave_campaign_governance_validation.py tests\unit\dpm\api\test_waves_api.py -q (120 passed)
- git diff --check (CRLF warnings only)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1298 passed, 13 skipped, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Governance
- Stranded-truth reconciliation before PR: git fetch origin --prune; no unmerged lotus-manage remote branches; no open lotus-manage PRs.
- No API shape, supported-feature, or operator-facing wiki truth change.