### PR TITLE
Extract wave campaign candidate selection

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -675,3 +675,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   campaign-governance domain object emerges.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-015: Bulk-review candidate selection embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_campaign_candidate_selection.py`
+- Finding: bulk-review campaign candidate filtering, excluded-candidate counting, portfolio-type
+  validation, and required source-ref validation were still embedded directly in `waves.py`. The
+  behavior was correct, but the loop is pure source-backed candidate selection logic and made the
+  route resolver harder to scan beside membership hashing, governance diagnostics, and source-ref
+  assembly.
+- Action: extracted `select_bulk_review_campaign_candidates()` into
+  `src/api/routers/wave_campaign_candidate_selection.py` and reused it from the campaign resolver
+  while preserving existing validation codes, messages, and excluded-candidate diagnostics.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_campaign_candidate_selection.py`;
+  full validation is recorded in the PR evidence for this slice.
+- Follow-up: keep membership source-ref assembly in the route until a stable campaign-membership
+  response projection object is introduced.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_campaign_candidate_selection.py
+++ b/src/api/routers/wave_campaign_candidate_selection.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Collection, Iterable, Sequence
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar
+
+from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_type
+from src.api.services import wave_service
+
+
+class BulkReviewCampaignCandidate(Protocol):
+    @property
+    def portfolio_type(self) -> str | None: ...
+
+    @property
+    def source_refs(self) -> Sequence[object]: ...
+
+
+T = TypeVar("T", bound=BulkReviewCampaignCandidate)
+
+
+@dataclass(frozen=True)
+class BulkReviewCampaignCandidateSelection(Generic[T]):
+    included_candidates: list[T]
+    excluded_count: int
+
+
+def select_bulk_review_campaign_candidates(
+    *,
+    candidates: Iterable[T],
+    eligible_portfolio_types: Collection[str],
+) -> BulkReviewCampaignCandidateSelection[T]:
+    included_candidates: list[T] = []
+    excluded_count = 0
+    for candidate in candidates:
+        portfolio_type = normalize_required_portfolio_type(
+            candidate.portfolio_type,
+            required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_REQUIRED",
+            required_message=(
+                "BULK_REVIEW_CAMPAIGN candidate portfolios require source-owned portfolio_type."
+            ),
+        )
+        if portfolio_type not in eligible_portfolio_types:
+            excluded_count += 1
+            continue
+        if not candidate.source_refs:
+            raise wave_service.DpmWaveValidationError(
+                "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_REQUIRED",
+                "BULK_REVIEW_CAMPAIGN candidate portfolios require source_refs.",
+            )
+        included_candidates.append(candidate)
+
+    return BulkReviewCampaignCandidateSelection(
+        included_candidates=included_candidates,
+        excluded_count=excluded_count,
+    )

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -43,6 +43,9 @@ from src.api.routers.wave_campaign_hashing import (
     campaign_governance_hash,
     campaign_membership_hash,
 )
+from src.api.routers.wave_campaign_candidate_selection import (
+    select_bulk_review_campaign_candidates,
+)
 from src.api.routers.wave_campaign_governance_validation import (
     campaign_actor_entitlement_state,
     campaign_approval_status,
@@ -1232,25 +1235,11 @@ def _resolve_bulk_review_campaign_portfolios(
         )
     )
 
-    included_candidates: list[DpmWavePortfolioInput] = []
-    excluded_count = 0
-    for candidate in request.portfolios:
-        portfolio_type = normalize_required_portfolio_type(
-            candidate.portfolio_type,
-            required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_REQUIRED",
-            required_message=(
-                "BULK_REVIEW_CAMPAIGN candidate portfolios require source-owned portfolio_type."
-            ),
-        )
-        if portfolio_type not in eligible_portfolio_types:
-            excluded_count += 1
-            continue
-        if not candidate.source_refs:
-            raise wave_service.DpmWaveValidationError(
-                "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_REQUIRED",
-                "BULK_REVIEW_CAMPAIGN candidate portfolios require source_refs.",
-            )
-        included_candidates.append(candidate)
+    selection = select_bulk_review_campaign_candidates(
+        candidates=request.portfolios,
+        eligible_portfolio_types=eligible_portfolio_types,
+    )
+    included_candidates = selection.included_candidates
 
     if not included_candidates:
         raise HTTPException(
@@ -1296,7 +1285,7 @@ def _resolve_bulk_review_campaign_portfolios(
                 if candidate.portfolio_type
                 else None,
                 "eligible_portfolio_types": sorted(eligible_portfolio_types),
-                "excluded_candidate_count": excluded_count,
+                "excluded_candidate_count": selection.excluded_count,
                 "membership_supportability_state": "READY",
                 **governance_diagnostics,
             },

--- a/tests/unit/api/test_wave_campaign_candidate_selection.py
+++ b/tests/unit/api/test_wave_campaign_candidate_selection.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from src.api.routers.wave_campaign_candidate_selection import (
+    select_bulk_review_campaign_candidates,
+)
+from src.api.services import wave_service
+
+
+@dataclass(frozen=True)
+class Candidate:
+    portfolio_id: str
+    portfolio_type: str | None
+    source_refs: list[object] = field(default_factory=list)
+
+
+def test_select_bulk_review_campaign_candidates_includes_eligible_candidates() -> None:
+    candidate = Candidate(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        portfolio_type=" discretionary ",
+        source_refs=[{"source_id": "candidate-source"}],
+    )
+
+    selection = select_bulk_review_campaign_candidates(
+        candidates=[candidate],
+        eligible_portfolio_types={"DISCRETIONARY"},
+    )
+
+    assert selection.included_candidates == [candidate]
+    assert selection.excluded_count == 0
+
+
+def test_select_bulk_review_campaign_candidates_counts_ineligible_candidates() -> None:
+    eligible = Candidate(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        portfolio_type="DISCRETIONARY",
+        source_refs=[{"source_id": "candidate-source"}],
+    )
+    ineligible = Candidate(
+        portfolio_id="PB_SG_ADVISORY_001",
+        portfolio_type="ADVISORY",
+        source_refs=[{"source_id": "candidate-source"}],
+    )
+
+    selection = select_bulk_review_campaign_candidates(
+        candidates=[eligible, ineligible],
+        eligible_portfolio_types={"DISCRETIONARY"},
+    )
+
+    assert selection.included_candidates == [eligible]
+    assert selection.excluded_count == 1
+
+
+def test_select_bulk_review_campaign_candidates_requires_portfolio_type() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        select_bulk_review_campaign_candidates(
+            candidates=[
+                Candidate(
+                    portfolio_id="PB_SG_GLOBAL_BAL_001",
+                    portfolio_type=" ",
+                    source_refs=[{"source_id": "candidate-source"}],
+                )
+            ],
+            eligible_portfolio_types={"DISCRETIONARY"},
+        )
+
+    assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_REQUIRED"
+    assert (
+        exc_info.value.message
+        == "BULK_REVIEW_CAMPAIGN candidate portfolios require source-owned portfolio_type."
+    )
+
+
+def test_select_bulk_review_campaign_candidates_requires_source_refs() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        select_bulk_review_campaign_candidates(
+            candidates=[
+                Candidate(
+                    portfolio_id="PB_SG_GLOBAL_BAL_001",
+                    portfolio_type="DISCRETIONARY",
+                    source_refs=[],
+                )
+            ],
+            eligible_portfolio_types={"DISCRETIONARY"},
+        )
+
+    assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_REQUIRED"
+    assert (
+        exc_info.value.message == "BULK_REVIEW_CAMPAIGN candidate portfolios require source_refs."
+    )


### PR DESCRIPTION
## Summary
- Extract bulk-review campaign candidate filtering and source-ref validation from `waves.py` into `wave_campaign_candidate_selection.py`.
- Preserve existing validation codes/messages and excluded-candidate diagnostics.
- Record backend review ledger entry BACKEND-REVIEW-20260519-015 with no wiki source change required.

## Validation
- python -m ruff check src\api\routers\waves.py src\api\routers\wave_campaign_candidate_selection.py tests\unit\api\test_wave_campaign_candidate_selection.py tests\unit\dpm\api\test_waves_api.py
- python -m pytest tests\unit\api\test_wave_campaign_candidate_selection.py tests\unit\dpm\api\test_waves_api.py -q (114 passed)
- python -m pytest tests\unit\api\test_wave_campaign_candidate_selection.py -q (4 passed)
- git diff --check (CRLF warnings only)
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit (1315 passed, 2 warnings)
- make test-integration (168 passed)
- make test-e2e (28 passed)
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Governance
- Stranded-truth reconciliation before PR: git fetch origin --prune; no unmerged lotus-manage remote branches; no open lotus-manage PRs.
- No API shape, supported-feature, or operator-facing wiki truth change.