### PR TITLE
Refactor tactical house-view candidate selection

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -695,3 +695,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   response projection object is introduced.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-016: Tactical house-view candidate payload assembly embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_tactical_candidate_selection.py`
+- Finding: tactical house-view source-backed candidate validation and payload assembly lived inside
+  the router resolver beside lotus-advise source-authority calls and response source-ref assembly.
+  The behavior was correct, but the candidate payload builder is pure Manage-side source-evidence
+  normalization and was harder to test directly while embedded in the route.
+- Action: extracted `build_tactical_house_view_candidate_payloads()` into
+  `src/api/routers/wave_tactical_candidate_selection.py` and reused it from the tactical
+  house-view resolver while preserving existing fail-closed validation codes, messages, source-ref
+  payload shape, exposure-weight string conversion, and reason-code semantics.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_tactical_candidate_selection.py`;
+  full validation is recorded in the PR evidence for this slice.
+- Follow-up: keep lotus-advise authority invocation and affected-portfolio response projection in
+  the route until a stable tactical house-view workflow projection object is introduced.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_tactical_candidate_selection.py
+++ b/src/api/routers/wave_tactical_candidate_selection.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Protocol
+
+from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_type
+from src.api.routers.wave_source_refs import source_refs_payload
+from src.api.services import wave_service
+from src.core.waves import DpmWaveSourceRef
+
+
+class TacticalHouseViewCandidate(Protocol):
+    @property
+    def portfolio_id(self) -> str: ...
+
+    @property
+    def mandate_id(self) -> str | None: ...
+
+    @property
+    def portfolio_type(self) -> str | None: ...
+
+    @property
+    def discretionary_mandate(self) -> bool | None: ...
+
+    @property
+    def current_exposure_weight(self) -> float | None: ...
+
+    @property
+    def alignment_signal(self) -> str: ...
+
+    @property
+    def source_refs(self) -> Sequence[DpmWaveSourceRef]: ...
+
+
+def build_tactical_house_view_candidate_payloads(
+    candidates: Iterable[TacticalHouseViewCandidate],
+) -> list[dict[str, object]]:
+    payloads: list[dict[str, object]] = []
+    for candidate in candidates:
+        portfolio_type = normalize_required_portfolio_type(
+            candidate.portfolio_type,
+            required_code="TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPE_REQUIRED",
+            required_message=(
+                "TACTICAL_HOUSE_VIEW candidate portfolios require source-owned portfolio_type."
+            ),
+        )
+        if candidate.discretionary_mandate is None:
+            raise wave_service.DpmWaveValidationError(
+                "TACTICAL_HOUSE_VIEW_DISCRETIONARY_MANDATE_REQUIRED",
+                "TACTICAL_HOUSE_VIEW candidate portfolios require source-owned discretionary_mandate.",
+            )
+        if not candidate.source_refs:
+            raise wave_service.DpmWaveValidationError(
+                "TACTICAL_HOUSE_VIEW_CANDIDATE_SOURCE_REFS_REQUIRED",
+                "TACTICAL_HOUSE_VIEW candidate portfolios require source_refs.",
+            )
+        payloads.append(
+            {
+                "portfolio_id": candidate.portfolio_id,
+                "mandate_id": candidate.mandate_id,
+                "portfolio_type": portfolio_type,
+                "discretionary_mandate": candidate.discretionary_mandate,
+                "current_exposure_weight": (
+                    str(candidate.current_exposure_weight)
+                    if candidate.current_exposure_weight is not None
+                    else None
+                ),
+                "alignment_signal": candidate.alignment_signal,
+                "source_refs": source_refs_payload(candidate.source_refs),
+                "reason_codes": ["TACTICAL_HOUSE_VIEW_CANDIDATE_SOURCE_BACKED"],
+            }
+        )
+    return payloads

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -57,7 +57,6 @@ from src.api.routers.wave_http_errors import (
 )
 from src.api.routers.wave_date_validation import parse_wave_as_of_date
 from src.api.routers.wave_portfolio_type_validation import (
-    normalize_required_portfolio_type,
     normalize_required_portfolio_types,
 )
 from src.api.routers.wave_required_text_validation import normalize_required_text
@@ -84,6 +83,9 @@ from src.api.routers.wave_source_refs import (
     tactical_house_view_affected_portfolio_ref,
     tactical_house_view_cohort_ref,
     tactical_house_view_ref,
+)
+from src.api.routers.wave_tactical_candidate_selection import (
+    build_tactical_house_view_candidate_payloads,
 )
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
@@ -979,41 +981,7 @@ def _resolve_tactical_house_view_portfolios(
         required_message="TACTICAL_HOUSE_VIEW requires at least one eligible portfolio type.",
     )
 
-    candidate_payloads: list[dict[str, object]] = []
-    for candidate in request.portfolios:
-        portfolio_type = normalize_required_portfolio_type(
-            candidate.portfolio_type,
-            required_code="TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPE_REQUIRED",
-            required_message=(
-                "TACTICAL_HOUSE_VIEW candidate portfolios require source-owned portfolio_type."
-            ),
-        )
-        if candidate.discretionary_mandate is None:
-            raise wave_service.DpmWaveValidationError(
-                "TACTICAL_HOUSE_VIEW_DISCRETIONARY_MANDATE_REQUIRED",
-                "TACTICAL_HOUSE_VIEW candidate portfolios require source-owned discretionary_mandate.",
-            )
-        if not candidate.source_refs:
-            raise wave_service.DpmWaveValidationError(
-                "TACTICAL_HOUSE_VIEW_CANDIDATE_SOURCE_REFS_REQUIRED",
-                "TACTICAL_HOUSE_VIEW candidate portfolios require source_refs.",
-            )
-        candidate_payloads.append(
-            {
-                "portfolio_id": candidate.portfolio_id,
-                "mandate_id": candidate.mandate_id,
-                "portfolio_type": portfolio_type,
-                "discretionary_mandate": candidate.discretionary_mandate,
-                "current_exposure_weight": (
-                    str(candidate.current_exposure_weight)
-                    if candidate.current_exposure_weight is not None
-                    else None
-                ),
-                "alignment_signal": candidate.alignment_signal,
-                "source_refs": source_refs_payload(candidate.source_refs),
-                "reason_codes": ["TACTICAL_HOUSE_VIEW_CANDIDATE_SOURCE_BACKED"],
-            }
-        )
+    candidate_payloads = build_tactical_house_view_candidate_payloads(request.portfolios)
 
     try:
         cohort = advise_authority_client.tactical_house_view_affected_cohort(

--- a/tests/unit/api/test_wave_tactical_candidate_selection.py
+++ b/tests/unit/api/test_wave_tactical_candidate_selection.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from src.api.routers.wave_tactical_candidate_selection import (
+    build_tactical_house_view_candidate_payloads,
+)
+from src.api.services import wave_service
+from src.core.waves import DpmWaveSourceRef
+
+
+@dataclass(frozen=True)
+class Candidate:
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001"
+    mandate_id: str | None = "MANDATE_PB_SG_GLOBAL_BAL_001"
+    portfolio_type: str | None = " discretionary "
+    discretionary_mandate: bool | None = True
+    current_exposure_weight: float | None = 0.18
+    alignment_signal: str = "UNDERWEIGHT"
+    source_refs: list[DpmWaveSourceRef] = field(
+        default_factory=lambda: [
+            DpmWaveSourceRef(
+                source_system="lotus-core",
+                source_type="TACTICAL_CANDIDATE_SET",
+                source_id="candidate-set-20260519",
+                source_version="2026-05-19",
+                supportability_state="READY",
+                content_hash="sha256:candidate-set",
+            )
+        ]
+    )
+
+
+def test_build_tactical_house_view_candidate_payloads_maps_source_backed_candidate() -> None:
+    payloads = build_tactical_house_view_candidate_payloads([Candidate()])
+
+    assert payloads == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "portfolio_type": "DISCRETIONARY",
+            "discretionary_mandate": True,
+            "current_exposure_weight": "0.18",
+            "alignment_signal": "UNDERWEIGHT",
+            "source_refs": [
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "TACTICAL_CANDIDATE_SET",
+                    "source_id": "candidate-set-20260519",
+                    "source_version": "2026-05-19",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:candidate-set",
+                }
+            ],
+            "reason_codes": ["TACTICAL_HOUSE_VIEW_CANDIDATE_SOURCE_BACKED"],
+        }
+    ]
+
+
+def test_build_tactical_house_view_candidate_payloads_preserves_missing_weight() -> None:
+    payloads = build_tactical_house_view_candidate_payloads(
+        [Candidate(current_exposure_weight=None)]
+    )
+
+    assert payloads[0]["current_exposure_weight"] is None
+
+
+@pytest.mark.parametrize(
+    ("candidate", "code", "message"),
+    [
+        (
+            Candidate(portfolio_type=" "),
+            "TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPE_REQUIRED",
+            "TACTICAL_HOUSE_VIEW candidate portfolios require source-owned portfolio_type.",
+        ),
+        (
+            Candidate(discretionary_mandate=None),
+            "TACTICAL_HOUSE_VIEW_DISCRETIONARY_MANDATE_REQUIRED",
+            "TACTICAL_HOUSE_VIEW candidate portfolios require source-owned discretionary_mandate.",
+        ),
+        (
+            Candidate(source_refs=[]),
+            "TACTICAL_HOUSE_VIEW_CANDIDATE_SOURCE_REFS_REQUIRED",
+            "TACTICAL_HOUSE_VIEW candidate portfolios require source_refs.",
+        ),
+    ],
+)
+def test_build_tactical_house_view_candidate_payloads_requires_source_evidence(
+    candidate: Candidate,
+    code: str,
+    message: str,
+) -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        build_tactical_house_view_candidate_payloads([candidate])
+
+    assert exc_info.value.code == code
+    assert exc_info.value.message == message


### PR DESCRIPTION
## Summary
- Extract tactical house-view candidate validation and payload assembly from `waves.py` into `wave_tactical_candidate_selection.py`.
- Preserve existing fail-closed validation codes/messages, source-ref payload shape, exposure-weight string conversion, and reason-code semantics.
- Add focused unit coverage and record `BACKEND-REVIEW-20260519-016` in the codebase review ledger.

## Validation
- `python -m ruff check src\api\routers\wave_tactical_candidate_selection.py tests\unit\api\test_wave_tactical_candidate_selection.py src\api\routers\waves.py`
- `python -m pytest tests\unit\api\test_wave_tactical_candidate_selection.py tests\unit\dpm\api\test_waves_api.py -q` (115 passed)
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` (1320 passed, 2 warnings)
- `make test-integration` (168 passed)
- `make test-e2e` (28 passed)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check` (CRLF warnings only)
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no unmerged `lotus-manage` remote branches before PR.
- Open PRs before this PR: none.
- Wiki decision: no wiki source change required; this is an internal modularity refactor with no supported-feature, API shape, or operator-contract change.
- WTBD movement: none claimed; this is backend maintainability hardening, not a WTBD closure slice.