### PR TITLE
Refactor risk-event candidate payloads

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -715,3 +715,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   the route until a stable tactical house-view workflow projection object is introduced.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-017: Risk-event candidate payload assembly embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_risk_event_validation.py`
+- Finding: risk-event candidate exposure normalization and lotus-risk request payload assembly
+  were still embedded in the router resolver. The logic was correct, but it mixed pure
+  source-candidate preparation with source-authority invocation and affected-portfolio projection,
+  making the risk-event cohort boundary harder to test directly.
+- Action: added `build_risk_event_candidate_payloads()` and
+  `RiskEventCandidatePayloads` to `src/api/routers/wave_risk_event_validation.py`, then reused the
+  helper from the risk-event resolver while preserving exposure-bucket normalization, validation
+  codes, duplicate portfolio-id mapping behavior, and request payload shape.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_risk_event_validation.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: keep lotus-risk authority invocation and affected-portfolio response source-ref
+  projection in the route until a stable risk-event workflow projection object is introduced.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_risk_event_validation.py
+++ b/src/api/routers/wave_risk_event_validation.py
@@ -1,8 +1,33 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Generic, Protocol, TypeVar
 
 from src.api.services import wave_service
+
+
+class RiskEventCandidate(Protocol):
+    @property
+    def portfolio_id(self) -> str: ...
+
+    @property
+    def mandate_id(self) -> str | None: ...
+
+    @property
+    def portfolio_manager_id(self) -> str | None: ...
+
+    @property
+    def exposure_weights(self) -> Mapping[str, float]: ...
+
+
+T = TypeVar("T", bound=RiskEventCandidate)
+
+
+@dataclass(frozen=True)
+class RiskEventCandidatePayloads(Generic[T]):
+    candidate_by_portfolio_id: dict[str, T]
+    risk_portfolios: list[dict[str, object]]
 
 
 def normalize_risk_event_exposure_weights(values: Mapping[str, float]) -> dict[str, float]:
@@ -20,3 +45,26 @@ def normalize_risk_event_exposure_weights(values: Mapping[str, float]) -> dict[s
             "RISK_EVENT exposure_weights must be non-negative.",
         )
     return exposure_weights
+
+
+def build_risk_event_candidate_payloads(
+    candidates: list[T],
+) -> RiskEventCandidatePayloads[T]:
+    candidate_by_portfolio_id: dict[str, T] = {}
+    risk_portfolios: list[dict[str, object]] = []
+    for candidate in candidates:
+        exposure_weights = normalize_risk_event_exposure_weights(candidate.exposure_weights)
+        candidate_by_portfolio_id[candidate.portfolio_id] = candidate
+        risk_portfolios.append(
+            {
+                "portfolio_id": candidate.portfolio_id,
+                "mandate_id": candidate.mandate_id,
+                "portfolio_manager_id": candidate.portfolio_manager_id,
+                "exposure_weights": exposure_weights,
+            }
+        )
+
+    return RiskEventCandidatePayloads(
+        candidate_by_portfolio_id=candidate_by_portfolio_id,
+        risk_portfolios=risk_portfolios,
+    )

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -60,7 +60,7 @@ from src.api.routers.wave_portfolio_type_validation import (
     normalize_required_portfolio_types,
 )
 from src.api.routers.wave_required_text_validation import normalize_required_text
-from src.api.routers.wave_risk_event_validation import normalize_risk_event_exposure_weights
+from src.api.routers.wave_risk_event_validation import build_risk_event_candidate_payloads
 from src.api.routers.wave_source_dependency_http import (
     source_authority_unavailable_http_exception,
     source_dependency_failed_http_exception,
@@ -1096,25 +1096,13 @@ def _resolve_risk_event_portfolios(
             message="DPM_RISK_BASE_URL is not configured.",
         )
 
-    candidate_by_portfolio_id: dict[str, DpmWavePortfolioInput] = {}
-    risk_portfolios: list[dict[str, object]] = []
-    for candidate in request.portfolios:
-        exposure_weights = normalize_risk_event_exposure_weights(candidate.exposure_weights)
-        candidate_by_portfolio_id[candidate.portfolio_id] = candidate
-        risk_portfolios.append(
-            {
-                "portfolio_id": candidate.portfolio_id,
-                "mandate_id": candidate.mandate_id,
-                "portfolio_manager_id": candidate.portfolio_manager_id,
-                "exposure_weights": exposure_weights,
-            }
-        )
+    candidate_payloads = build_risk_event_candidate_payloads(request.portfolios)
 
     try:
         cohort = risk_authority_client.risk_event_affected_cohort(
             risk_event_id=risk_event_id,
             as_of_date=as_of_date,
-            portfolios=risk_portfolios,
+            portfolios=candidate_payloads.risk_portfolios,
             minimum_impact_score=Decimal(str(request.minimum_impact_score)),
             correlation_id=correlation_id,
         )
@@ -1156,7 +1144,7 @@ def _resolve_risk_event_portfolios(
     )
     portfolios: list[dict[str, object]] = []
     for affected in cohort.affected_portfolios:
-        matched_candidate = candidate_by_portfolio_id.get(affected.portfolio_id)
+        matched_candidate = candidate_payloads.candidate_by_portfolio_id.get(affected.portfolio_id)
         candidate_refs = matched_candidate.source_refs if matched_candidate is not None else []
         portfolios.append(
             {

--- a/tests/unit/api/test_wave_risk_event_validation.py
+++ b/tests/unit/api/test_wave_risk_event_validation.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
 import pytest
 
-from src.api.routers.wave_risk_event_validation import normalize_risk_event_exposure_weights
+from src.api.routers.wave_risk_event_validation import (
+    build_risk_event_candidate_payloads,
+    normalize_risk_event_exposure_weights,
+)
 from src.api.services import wave_service
+
+
+@dataclass(frozen=True)
+class Candidate:
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001"
+    mandate_id: str | None = "MANDATE_PB_SG_GLOBAL_BAL_001"
+    portfolio_manager_id: str | None = "PM_SG_DPM_001"
+    exposure_weights: dict[str, float] = field(
+        default_factory=lambda: {" equity ": 0.55, " fixed_income": 0.35, "": 0.10}
+    )
 
 
 def test_normalize_risk_event_exposure_weights_strips_and_uppercases_buckets() -> None:
@@ -32,3 +47,42 @@ def test_normalize_risk_event_exposure_weights_raises_for_negative_weight() -> N
 
     assert exc_info.value.code == "RISK_EVENT_EXPOSURE_WEIGHTS_INVALID"
     assert exc_info.value.message == "RISK_EVENT exposure_weights must be non-negative."
+
+
+def test_build_risk_event_candidate_payloads_maps_candidates_for_source_authority() -> None:
+    candidate = Candidate()
+
+    payloads = build_risk_event_candidate_payloads([candidate])
+
+    assert payloads.candidate_by_portfolio_id == {"PB_SG_GLOBAL_BAL_001": candidate}
+    assert payloads.risk_portfolios == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "portfolio_manager_id": "PM_SG_DPM_001",
+            "exposure_weights": {"EQUITY": 0.55, "FIXED_INCOME": 0.35},
+        }
+    ]
+
+
+def test_build_risk_event_candidate_payloads_uses_last_candidate_by_portfolio_id() -> None:
+    first = Candidate(mandate_id="MANDATE_OLD", exposure_weights={"EQUITY": 0.40})
+    second = Candidate(mandate_id="MANDATE_NEW", exposure_weights={"EQUITY": 0.60})
+
+    payloads = build_risk_event_candidate_payloads([first, second])
+
+    assert payloads.candidate_by_portfolio_id["PB_SG_GLOBAL_BAL_001"] == second
+    assert payloads.risk_portfolios == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_id": "MANDATE_OLD",
+            "portfolio_manager_id": "PM_SG_DPM_001",
+            "exposure_weights": {"EQUITY": 0.40},
+        },
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_id": "MANDATE_NEW",
+            "portfolio_manager_id": "PM_SG_DPM_001",
+            "exposure_weights": {"EQUITY": 0.60},
+        },
+    ]


### PR DESCRIPTION
## Summary
- Extract risk-event candidate exposure normalization and lotus-risk request payload assembly from `waves.py` into `wave_risk_event_validation.py`.
- Preserve existing exposure-bucket normalization, fail-closed validation codes/messages, duplicate portfolio-id mapping behavior, and request payload shape.
- Add focused unit coverage and record `BACKEND-REVIEW-20260519-017` in the codebase review ledger.

## Validation
- `python -m ruff check src\api\routers\wave_risk_event_validation.py tests\unit\api\test_wave_risk_event_validation.py src\api\routers\waves.py`
- `python -m pytest tests\unit\api\test_wave_risk_event_validation.py tests\unit\dpm\api\test_waves_api.py -q` (115 passed)
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` (1322 passed, 2 warnings)
- `make test-integration` (168 passed)
- `make test-e2e` (28 passed)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check` (CRLF warnings only)
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no unmerged `lotus-manage` remote branches before PR.
- Open PRs before this PR: none.
- Wiki decision: no wiki source change required; this is an internal modularity refactor with no supported-feature, API shape, or operator-contract change.
- WTBD movement: none claimed; this is backend maintainability hardening, not a WTBD closure slice.