### PR TITLE
Refactor PM-book wave projection

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -735,3 +735,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   projection in the route until a stable risk-event workflow projection object is introduced.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-018: PM-book membership projection embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_pm_book_projection.py`
+- Finding: PM-book source membership projection was embedded in the route resolver after the
+  lotus-core call. The projection was correct, but it mixed source-authority failure handling with
+  deterministic wave portfolio/source-ref materialization, making PM-book lineage fallback behavior
+  harder to test directly.
+- Action: extracted `build_pm_book_resolved_portfolios()` into
+  `src/api/routers/wave_pm_book_projection.py` and reused it from the PM-book resolver while
+  preserving snapshot-id, batch-fingerprint, deterministic book-id, and member source-record
+  fallback behavior.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_pm_book_projection.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: keep lotus-core resolver invocation and source dependency error mapping in the route
+  until a stable PM-book workflow projection object is introduced.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_pm_book_projection.py
+++ b/src/api/routers/wave_pm_book_projection.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date
+from typing import Protocol
+
+from src.api.routers.wave_source_refs import pm_book_member_ref, pm_book_membership_ref
+
+
+class PmBookSupportability(Protocol):
+    @property
+    def state(self) -> str: ...
+
+
+class PmBookMember(Protocol):
+    @property
+    def portfolio_id(self) -> str: ...
+
+    @property
+    def source_record_id(self) -> str | None: ...
+
+
+class PmBookMembership(Protocol):
+    @property
+    def snapshot_id(self) -> str | None: ...
+
+    @property
+    def source_batch_fingerprint(self) -> str | None: ...
+
+    @property
+    def portfolio_manager_id(self) -> str: ...
+
+    @property
+    def as_of_date(self) -> date: ...
+
+    @property
+    def product_version(self) -> str: ...
+
+    @property
+    def supportability(self) -> PmBookSupportability: ...
+
+    @property
+    def members(self) -> Sequence[PmBookMember]: ...
+
+
+def build_pm_book_resolved_portfolios(
+    membership: PmBookMembership,
+) -> list[dict[str, object]]:
+    source_id = (
+        membership.snapshot_id
+        or membership.source_batch_fingerprint
+        or f"pm_book:{membership.portfolio_manager_id}:{membership.as_of_date.isoformat()}"
+    )
+    book_ref = pm_book_membership_ref(
+        source_id=source_id,
+        product_version=membership.product_version,
+        supportability_state=membership.supportability.state,
+        content_hash=membership.source_batch_fingerprint,
+    )
+    return [
+        {
+            "portfolio_id": member.portfolio_id,
+            "source_refs": [
+                book_ref,
+                pm_book_member_ref(
+                    source_record_id=member.source_record_id,
+                    portfolio_id=member.portfolio_id,
+                    as_of_date=membership.as_of_date,
+                ),
+            ],
+        }
+        for member in membership.members
+    ]

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -59,6 +59,7 @@ from src.api.routers.wave_date_validation import parse_wave_as_of_date
 from src.api.routers.wave_portfolio_type_validation import (
     normalize_required_portfolio_types,
 )
+from src.api.routers.wave_pm_book_projection import build_pm_book_resolved_portfolios
 from src.api.routers.wave_required_text_validation import normalize_required_text
 from src.api.routers.wave_risk_event_validation import build_risk_event_candidate_payloads
 from src.api.routers.wave_source_dependency_http import (
@@ -74,8 +75,6 @@ from src.api.routers.wave_source_refs import (
     cio_model_change_affected_mandate_ref,
     cio_model_change_cohort_ref,
     cio_model_change_event_ref,
-    pm_book_member_ref,
-    pm_book_membership_ref,
     risk_event_affected_portfolio_ref,
     risk_event_cohort_ref,
     risk_event_ref,
@@ -842,31 +841,7 @@ def _resolve_pm_book_portfolios(
             code="DPM_CORE_PM_BOOK_MEMBERSHIP_EMPTY",
             message="PM-book membership returned no affected portfolios.",
         )
-    source_id = (
-        membership.snapshot_id
-        or membership.source_batch_fingerprint
-        or f"pm_book:{membership.portfolio_manager_id}:{membership.as_of_date.isoformat()}"
-    )
-    book_ref = pm_book_membership_ref(
-        source_id=source_id,
-        product_version=membership.product_version,
-        supportability_state=membership.supportability.state,
-        content_hash=membership.source_batch_fingerprint,
-    )
-    return [
-        {
-            "portfolio_id": member.portfolio_id,
-            "source_refs": [
-                book_ref,
-                pm_book_member_ref(
-                    source_record_id=member.source_record_id,
-                    portfolio_id=member.portfolio_id,
-                    as_of_date=membership.as_of_date,
-                ),
-            ],
-        }
-        for member in membership.members
-    ]
+    return build_pm_book_resolved_portfolios(membership)
 
 
 def _resolve_cio_model_change_portfolios(

--- a/tests/unit/api/test_wave_pm_book_projection.py
+++ b/tests/unit/api/test_wave_pm_book_projection.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from src.api.routers.wave_pm_book_projection import build_pm_book_resolved_portfolios
+
+
+@dataclass(frozen=True)
+class Supportability:
+    state: str = "READY"
+
+
+@dataclass(frozen=True)
+class Member:
+    portfolio_id: str
+    source_record_id: str | None
+
+
+@dataclass(frozen=True)
+class Membership:
+    snapshot_id: str | None = "pm-book-snapshot-20260519"
+    source_batch_fingerprint: str | None = "sha256:pm-book"
+    portfolio_manager_id: str = "PM_SG_DPM_001"
+    as_of_date: date = date(2026, 5, 19)
+    product_version: str = "PortfolioManagerBookMembership:v1"
+    supportability: Supportability = Supportability()
+    members: list[Member] | None = None
+
+    def __post_init__(self) -> None:
+        if self.members is None:
+            object.__setattr__(
+                self,
+                "members",
+                [Member("PB_SG_GLOBAL_BAL_001", "pm-book-member-001")],
+            )
+
+
+def test_build_pm_book_resolved_portfolios_preserves_snapshot_lineage() -> None:
+    assert build_pm_book_resolved_portfolios(Membership()) == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "source_refs": [
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "PortfolioManagerBookMembership",
+                    "source_id": "pm-book-snapshot-20260519",
+                    "source_version": "PortfolioManagerBookMembership:v1",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:pm-book",
+                },
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "PORTFOLIO_MANAGER_BOOK_MEMBER",
+                    "source_id": "pm-book-member-001",
+                    "source_version": "2026-05-19",
+                    "supportability_state": "READY",
+                },
+            ],
+        }
+    ]
+
+
+def test_build_pm_book_resolved_portfolios_falls_back_to_batch_fingerprint() -> None:
+    portfolios = build_pm_book_resolved_portfolios(Membership(snapshot_id=None))
+
+    assert portfolios[0]["source_refs"][0]["source_id"] == "sha256:pm-book"
+
+
+def test_build_pm_book_resolved_portfolios_falls_back_to_deterministic_book_id() -> None:
+    portfolios = build_pm_book_resolved_portfolios(
+        Membership(snapshot_id=None, source_batch_fingerprint=None)
+    )
+
+    assert portfolios[0]["source_refs"][0]["source_id"] == "pm_book:PM_SG_DPM_001:2026-05-19"
+    assert portfolios[0]["source_refs"][0]["content_hash"] is None
+
+
+def test_build_pm_book_resolved_portfolios_falls_back_member_ref_to_portfolio_id() -> None:
+    portfolios = build_pm_book_resolved_portfolios(
+        Membership(members=[Member("PB_SG_GLOBAL_BAL_002", None)])
+    )
+
+    assert portfolios[0]["source_refs"][1]["source_id"] == "PB_SG_GLOBAL_BAL_002"


### PR DESCRIPTION
## Summary
- Extract PM-book membership-to-wave portfolio projection from `waves.py` into `wave_pm_book_projection.py`.
- Preserve snapshot-id, source-batch-fingerprint, deterministic PM-book id, and member source-record fallback lineage behavior.
- Add focused unit coverage and record `BACKEND-REVIEW-20260519-018` in the codebase review ledger.

## Validation
- `python -m ruff check src\api\routers\wave_pm_book_projection.py tests\unit\api\test_wave_pm_book_projection.py src\api\routers\waves.py`
- `python -m pytest tests\unit\api\test_wave_pm_book_projection.py tests\unit\dpm\api\test_waves_api.py -q` (114 passed)
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` (1326 passed, 2 warnings)
- `make test-integration` (168 passed)
- `make test-e2e` (28 passed)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check` (CRLF warnings only)
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no unmerged `lotus-manage` remote branches before PR.
- Open PRs before this PR: none.
- Wiki decision: no wiki source change required; this is an internal modularity refactor with no supported-feature, API shape, or operator-contract change.
- WTBD movement: none claimed; this is backend maintainability hardening, not a WTBD closure slice.