### PR TITLE
Refactor CIO model-change wave projection

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -755,3 +755,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   until a stable PM-book workflow projection object is introduced.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-019: CIO model-change cohort projection embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_cio_model_change_projection.py`
+- Finding: CIO model-change affected-cohort projection was embedded in the route resolver after
+  the lotus-core call. The projection was correct, but it mixed upstream source dependency handling
+  with deterministic wave portfolio/source-ref materialization, making lineage fallback behavior
+  harder to test directly.
+- Action: extracted `build_cio_model_change_resolved_portfolios()` into
+  `src/api/routers/wave_cio_model_change_projection.py` and reused it from the CIO model-change
+  resolver while preserving snapshot-id, batch-fingerprint, model-change-event id, event source-ref,
+  and affected-mandate source-record fallback behavior.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_cio_model_change_projection.py`;
+  full validation is recorded in the PR evidence for this slice.
+- Follow-up: keep lotus-core resolver invocation and source dependency error mapping in the route
+  until a stable CIO model-change workflow projection object is introduced.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_cio_model_change_projection.py
+++ b/src/api/routers/wave_cio_model_change_projection.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol
+
+from src.api.routers.wave_source_refs import (
+    cio_model_change_affected_mandate_ref,
+    cio_model_change_cohort_ref,
+    cio_model_change_event_ref,
+)
+
+
+class CioModelChangeSupportability(Protocol):
+    @property
+    def state(self) -> str: ...
+
+
+class CioModelChangeAffectedMandate(Protocol):
+    @property
+    def portfolio_id(self) -> str: ...
+
+    @property
+    def mandate_id(self) -> str: ...
+
+    @property
+    def source_record_id(self) -> str | None: ...
+
+    @property
+    def binding_version(self) -> object: ...
+
+
+class CioModelChangeAffectedCohort(Protocol):
+    @property
+    def snapshot_id(self) -> str | None: ...
+
+    @property
+    def source_batch_fingerprint(self) -> str | None: ...
+
+    @property
+    def model_change_event_id(self) -> str: ...
+
+    @property
+    def product_version(self) -> str: ...
+
+    @property
+    def supportability(self) -> CioModelChangeSupportability: ...
+
+    @property
+    def model_portfolio_version(self) -> str: ...
+
+    @property
+    def affected_mandates(self) -> Sequence[CioModelChangeAffectedMandate]: ...
+
+
+def build_cio_model_change_resolved_portfolios(
+    cohort: CioModelChangeAffectedCohort,
+) -> list[dict[str, object]]:
+    source_id = (
+        cohort.snapshot_id or cohort.source_batch_fingerprint or cohort.model_change_event_id
+    )
+    cohort_ref = cio_model_change_cohort_ref(
+        source_id=source_id,
+        product_version=cohort.product_version,
+        supportability_state=cohort.supportability.state,
+        content_hash=cohort.source_batch_fingerprint,
+    )
+    event_ref = cio_model_change_event_ref(
+        model_change_event_id=cohort.model_change_event_id,
+        model_portfolio_version=cohort.model_portfolio_version,
+        supportability_state=cohort.supportability.state,
+        content_hash=cohort.source_batch_fingerprint,
+    )
+    return [
+        {
+            "portfolio_id": mandate.portfolio_id,
+            "mandate_id": mandate.mandate_id,
+            "source_refs": [
+                cohort_ref,
+                event_ref,
+                cio_model_change_affected_mandate_ref(
+                    source_record_id=mandate.source_record_id,
+                    mandate_id=mandate.mandate_id,
+                    binding_version=mandate.binding_version,
+                ),
+            ],
+        }
+        for mandate in cohort.affected_mandates
+    ]

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -51,6 +51,9 @@ from src.api.routers.wave_campaign_governance_validation import (
     campaign_approval_status,
     campaign_expiry_state,
 )
+from src.api.routers.wave_cio_model_change_projection import (
+    build_cio_model_change_resolved_portfolios,
+)
 from src.api.routers.wave_http_errors import (
     wave_lookup_http_exception,
     wave_validation_http_exception,
@@ -72,9 +75,6 @@ from src.api.routers.wave_source_dependency_http import (
 from src.api.routers.wave_source_refs import (
     bulk_review_campaign_member_ref,
     bulk_review_campaign_membership_ref,
-    cio_model_change_affected_mandate_ref,
-    cio_model_change_cohort_ref,
-    cio_model_change_event_ref,
     risk_event_affected_portfolio_ref,
     risk_event_cohort_ref,
     risk_event_ref,
@@ -889,37 +889,7 @@ def _resolve_cio_model_change_portfolios(
             code="DPM_CORE_CIO_MODEL_CHANGE_COHORT_EMPTY",
             message="CIO model-change affected cohort returned no portfolios.",
         )
-    source_id = (
-        cohort.snapshot_id or cohort.source_batch_fingerprint or cohort.model_change_event_id
-    )
-    cohort_ref = cio_model_change_cohort_ref(
-        source_id=source_id,
-        product_version=cohort.product_version,
-        supportability_state=cohort.supportability.state,
-        content_hash=cohort.source_batch_fingerprint,
-    )
-    event_ref = cio_model_change_event_ref(
-        model_change_event_id=cohort.model_change_event_id,
-        model_portfolio_version=cohort.model_portfolio_version,
-        supportability_state=cohort.supportability.state,
-        content_hash=cohort.source_batch_fingerprint,
-    )
-    return [
-        {
-            "portfolio_id": mandate.portfolio_id,
-            "mandate_id": mandate.mandate_id,
-            "source_refs": [
-                cohort_ref,
-                event_ref,
-                cio_model_change_affected_mandate_ref(
-                    source_record_id=mandate.source_record_id,
-                    mandate_id=mandate.mandate_id,
-                    binding_version=mandate.binding_version,
-                ),
-            ],
-        }
-        for mandate in cohort.affected_mandates
-    ]
+    return build_cio_model_change_resolved_portfolios(cohort)
 
 
 def _resolve_tactical_house_view_portfolios(

--- a/tests/unit/api/test_wave_cio_model_change_projection.py
+++ b/tests/unit/api/test_wave_cio_model_change_projection.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.api.routers.wave_cio_model_change_projection import (
+    build_cio_model_change_resolved_portfolios,
+)
+
+
+@dataclass(frozen=True)
+class Supportability:
+    state: str = "READY"
+
+
+@dataclass(frozen=True)
+class Mandate:
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001"
+    mandate_id: str = "MANDATE_PB_SG_GLOBAL_BAL_001"
+    source_record_id: str | None = "mandate-binding-001"
+    binding_version: object = 3
+
+
+@dataclass(frozen=True)
+class Cohort:
+    snapshot_id: str | None = "cio-model-change-snapshot-20260519"
+    source_batch_fingerprint: str | None = "sha256:cio-model-change"
+    model_change_event_id: str = "cio_model_change:MODEL_PB_SG_GLOBAL_BAL_DPM:2026.05"
+    product_version: str = "v1"
+    supportability: Supportability = Supportability()
+    model_portfolio_version: str = "2026.05"
+    affected_mandates: list[Mandate] | None = None
+
+    def __post_init__(self) -> None:
+        if self.affected_mandates is None:
+            object.__setattr__(self, "affected_mandates", [Mandate()])
+
+
+def test_build_cio_model_change_resolved_portfolios_preserves_snapshot_lineage() -> None:
+    assert build_cio_model_change_resolved_portfolios(Cohort()) == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "source_refs": [
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "CioModelChangeAffectedCohort",
+                    "source_id": "cio-model-change-snapshot-20260519",
+                    "source_version": "v1",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:cio-model-change",
+                },
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "CIO_MODEL_CHANGE_EVENT",
+                    "source_id": "cio_model_change:MODEL_PB_SG_GLOBAL_BAL_DPM:2026.05",
+                    "source_version": "2026.05",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:cio-model-change",
+                },
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "CIO_MODEL_CHANGE_AFFECTED_MANDATE",
+                    "source_id": "mandate-binding-001",
+                    "source_version": "3",
+                    "supportability_state": "READY",
+                },
+            ],
+        }
+    ]
+
+
+def test_build_cio_model_change_resolved_portfolios_falls_back_to_batch_fingerprint() -> None:
+    portfolios = build_cio_model_change_resolved_portfolios(Cohort(snapshot_id=None))
+
+    assert portfolios[0]["source_refs"][0]["source_id"] == "sha256:cio-model-change"
+
+
+def test_build_cio_model_change_resolved_portfolios_falls_back_to_event_id() -> None:
+    portfolios = build_cio_model_change_resolved_portfolios(
+        Cohort(snapshot_id=None, source_batch_fingerprint=None)
+    )
+
+    assert (
+        portfolios[0]["source_refs"][0]["source_id"]
+        == "cio_model_change:MODEL_PB_SG_GLOBAL_BAL_DPM:2026.05"
+    )
+    assert portfolios[0]["source_refs"][0]["content_hash"] is None
+    assert portfolios[0]["source_refs"][1]["content_hash"] is None
+
+
+def test_build_cio_model_change_resolved_portfolios_falls_back_mandate_ref_to_mandate_id() -> None:
+    portfolios = build_cio_model_change_resolved_portfolios(
+        Cohort(affected_mandates=[Mandate(source_record_id=None, binding_version="4")])
+    )
+
+    assert portfolios[0]["source_refs"][2]["source_id"] == "MANDATE_PB_SG_GLOBAL_BAL_001"
+    assert portfolios[0]["source_refs"][2]["source_version"] == "4"


### PR DESCRIPTION
## Summary
- Extract CIO model-change affected-cohort projection from `waves.py` into `wave_cio_model_change_projection.py`.
- Preserve snapshot-id, source-batch-fingerprint, model-change-event id, event source-ref, and affected-mandate source-record fallback lineage behavior.
- Add focused unit coverage and record `BACKEND-REVIEW-20260519-019` in the codebase review ledger.

## Validation
- `python -m ruff check src\api\routers\wave_cio_model_change_projection.py tests\unit\api\test_wave_cio_model_change_projection.py src\api\routers\waves.py`
- `python -m pytest tests\unit\api\test_wave_cio_model_change_projection.py tests\unit\dpm\api\test_waves_api.py -q` (114 passed)
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` (1317 passed, 13 skipped, 2 warnings)
- `make test-integration` (168 passed)
- `make test-e2e` (28 passed)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check` (CRLF warnings only)
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no unmerged `lotus-manage` remote branches before PR.
- Open PRs before this PR: none.
- Wiki decision: no wiki source change required; this is an internal modularity refactor with no supported-feature, API shape, or operator-contract change.
- WTBD movement: none claimed; this is backend maintainability hardening, not a WTBD closure slice.