### PR TITLE
Refactor risk-event wave projection

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -775,3 +775,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   until a stable CIO model-change workflow projection object is introduced.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-020: Risk-event cohort projection embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_risk_event_validation.py`
+- Finding: risk-event affected-cohort projection was still embedded in the route resolver after the
+  lotus-risk source-authority call. The behavior was correct, but it mixed source dependency error
+  handling with deterministic wave portfolio/source-ref materialization, making lineage fallback
+  behavior harder to test directly.
+- Action: added `build_risk_event_resolved_portfolios()` to
+  `src/api/routers/wave_risk_event_validation.py` and reused it from the risk-event resolver while
+  preserving cohort-id, request-fingerprint, requested-event fallback, event source-ref,
+  affected-portfolio source-ref, candidate source-ref, and supportability-state behavior.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_risk_event_validation.py`; full
+  validation is recorded in the PR evidence for this slice.
+- Follow-up: keep lotus-risk resolver invocation and source dependency error mapping in the route
+  until a stable risk-event workflow projection object is introduced.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_risk_event_validation.py
+++ b/src/api/routers/wave_risk_event_validation.py
@@ -4,7 +4,14 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Generic, Protocol, TypeVar
 
+from src.api.routers.wave_source_refs import (
+    risk_event_affected_portfolio_ref,
+    risk_event_cohort_ref,
+    risk_event_ref,
+    source_refs_payload,
+)
 from src.api.services import wave_service
+from src.core.waves import DpmWaveSourceRef
 
 
 class RiskEventCandidate(Protocol):
@@ -19,6 +26,46 @@ class RiskEventCandidate(Protocol):
 
     @property
     def exposure_weights(self) -> Mapping[str, float]: ...
+
+    @property
+    def source_refs(self) -> list[DpmWaveSourceRef]: ...
+
+
+class RiskEventAffectedPortfolio(Protocol):
+    @property
+    def portfolio_id(self) -> str: ...
+
+    @property
+    def mandate_id(self) -> str | None: ...
+
+    @property
+    def source_ref(self) -> str: ...
+
+
+class RiskEventAffectedCohort(Protocol):
+    @property
+    def cohort_id(self) -> str | None: ...
+
+    @property
+    def risk_event_id(self) -> str: ...
+
+    @property
+    def product_name(self) -> str: ...
+
+    @property
+    def product_version(self) -> str: ...
+
+    @property
+    def source_service(self) -> str: ...
+
+    @property
+    def request_fingerprint(self) -> str | None: ...
+
+    @property
+    def calculation_supportability(self) -> str: ...
+
+    @property
+    def affected_portfolios(self) -> tuple[RiskEventAffectedPortfolio, ...]: ...
 
 
 T = TypeVar("T", bound=RiskEventCandidate)
@@ -68,3 +115,51 @@ def build_risk_event_candidate_payloads(
         candidate_by_portfolio_id=candidate_by_portfolio_id,
         risk_portfolios=risk_portfolios,
     )
+
+
+def build_risk_event_resolved_portfolios(
+    *,
+    cohort: RiskEventAffectedCohort,
+    candidate_by_portfolio_id: Mapping[str, RiskEventCandidate],
+    fallback_risk_event_id: str,
+) -> list[dict[str, object]]:
+    source_id = cohort.cohort_id or cohort.request_fingerprint or fallback_risk_event_id
+    supportability_state = cohort.calculation_supportability.upper()
+    cohort_ref = risk_event_cohort_ref(
+        source_service=cohort.source_service,
+        product_name=cohort.product_name,
+        source_id=source_id,
+        product_version=cohort.product_version,
+        supportability_state=supportability_state,
+        content_hash=cohort.request_fingerprint,
+    )
+    event_ref = risk_event_ref(
+        source_service=cohort.source_service,
+        risk_event_id=cohort.risk_event_id,
+        product_version=cohort.product_version,
+        supportability_state=supportability_state,
+        content_hash=cohort.request_fingerprint,
+    )
+    portfolios: list[dict[str, object]] = []
+    for affected in cohort.affected_portfolios:
+        matched_candidate = candidate_by_portfolio_id.get(affected.portfolio_id)
+        candidate_refs = matched_candidate.source_refs if matched_candidate is not None else []
+        portfolios.append(
+            {
+                "portfolio_id": affected.portfolio_id,
+                "mandate_id": affected.mandate_id,
+                "source_refs": [
+                    cohort_ref,
+                    event_ref,
+                    risk_event_affected_portfolio_ref(
+                        source_service=cohort.source_service,
+                        source_ref=affected.source_ref,
+                        product_version=cohort.product_version,
+                        supportability_state=supportability_state,
+                        content_hash=cohort.request_fingerprint,
+                    ),
+                    *source_refs_payload(candidate_refs),
+                ],
+            }
+        )
+    return portfolios

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -64,7 +64,10 @@ from src.api.routers.wave_portfolio_type_validation import (
 )
 from src.api.routers.wave_pm_book_projection import build_pm_book_resolved_portfolios
 from src.api.routers.wave_required_text_validation import normalize_required_text
-from src.api.routers.wave_risk_event_validation import build_risk_event_candidate_payloads
+from src.api.routers.wave_risk_event_validation import (
+    build_risk_event_candidate_payloads,
+    build_risk_event_resolved_portfolios,
+)
 from src.api.routers.wave_source_dependency_http import (
     source_authority_unavailable_http_exception,
     source_dependency_failed_http_exception,
@@ -75,9 +78,6 @@ from src.api.routers.wave_source_dependency_http import (
 from src.api.routers.wave_source_refs import (
     bulk_review_campaign_member_ref,
     bulk_review_campaign_membership_ref,
-    risk_event_affected_portfolio_ref,
-    risk_event_cohort_ref,
-    risk_event_ref,
     source_refs_payload,
     tactical_house_view_affected_portfolio_ref,
     tactical_house_view_cohort_ref,
@@ -1070,46 +1070,11 @@ def _resolve_risk_event_portfolios(
             message="Risk-event affected cohort returned no affected portfolios.",
         )
 
-    source_id = cohort.cohort_id or cohort.request_fingerprint or risk_event_id
-    supportability_state = cohort.calculation_supportability.upper()
-    cohort_ref = risk_event_cohort_ref(
-        source_service=cohort.source_service,
-        product_name=cohort.product_name,
-        source_id=source_id,
-        product_version=cohort.product_version,
-        supportability_state=supportability_state,
-        content_hash=cohort.request_fingerprint,
+    return build_risk_event_resolved_portfolios(
+        cohort=cohort,
+        candidate_by_portfolio_id=candidate_payloads.candidate_by_portfolio_id,
+        fallback_risk_event_id=risk_event_id,
     )
-    event_ref = risk_event_ref(
-        source_service=cohort.source_service,
-        risk_event_id=cohort.risk_event_id,
-        product_version=cohort.product_version,
-        supportability_state=supportability_state,
-        content_hash=cohort.request_fingerprint,
-    )
-    portfolios: list[dict[str, object]] = []
-    for affected in cohort.affected_portfolios:
-        matched_candidate = candidate_payloads.candidate_by_portfolio_id.get(affected.portfolio_id)
-        candidate_refs = matched_candidate.source_refs if matched_candidate is not None else []
-        portfolios.append(
-            {
-                "portfolio_id": affected.portfolio_id,
-                "mandate_id": affected.mandate_id,
-                "source_refs": [
-                    cohort_ref,
-                    event_ref,
-                    risk_event_affected_portfolio_ref(
-                        source_service=cohort.source_service,
-                        source_ref=affected.source_ref,
-                        product_version=cohort.product_version,
-                        supportability_state=supportability_state,
-                        content_hash=cohort.request_fingerprint,
-                    ),
-                    *source_refs_payload(candidate_refs),
-                ],
-            }
-        )
-    return portfolios
 
 
 def _resolve_bulk_review_campaign_portfolios(

--- a/tests/unit/api/test_wave_risk_event_validation.py
+++ b/tests/unit/api/test_wave_risk_event_validation.py
@@ -6,9 +6,11 @@ import pytest
 
 from src.api.routers.wave_risk_event_validation import (
     build_risk_event_candidate_payloads,
+    build_risk_event_resolved_portfolios,
     normalize_risk_event_exposure_weights,
 )
 from src.api.services import wave_service
+from src.core.waves import DpmWaveSourceRef
 
 
 @dataclass(frozen=True)
@@ -19,6 +21,37 @@ class Candidate:
     exposure_weights: dict[str, float] = field(
         default_factory=lambda: {" equity ": 0.55, " fixed_income": 0.35, "": 0.10}
     )
+    source_refs: list[DpmWaveSourceRef] = field(
+        default_factory=lambda: [
+            DpmWaveSourceRef(
+                source_system="lotus-core",
+                source_type="RISK_EVENT_CANDIDATE_SET",
+                source_id="candidate-set-20260519",
+                source_version="2026-05-19",
+                supportability_state="READY",
+                content_hash="sha256:candidate-set",
+            )
+        ]
+    )
+
+
+@dataclass(frozen=True)
+class AffectedPortfolio:
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001"
+    mandate_id: str | None = "MANDATE_PB_SG_GLOBAL_BAL_001"
+    source_ref: str = "risk-event-row-001"
+
+
+@dataclass(frozen=True)
+class Cohort:
+    cohort_id: str | None = "risk-event-cohort-20260519"
+    risk_event_id: str = "RISK_EVT_20260519"
+    product_name: str = "RiskEventAffectedCohort"
+    product_version: str = "RiskEventAffectedCohort:v1"
+    source_service: str = "lotus-risk"
+    request_fingerprint: str | None = "sha256:risk-event-cohort"
+    calculation_supportability: str = "ready"
+    affected_portfolios: tuple[AffectedPortfolio, ...] = (AffectedPortfolio(),)
 
 
 def test_normalize_risk_event_exposure_weights_strips_and_uppercases_buckets() -> None:
@@ -86,3 +119,76 @@ def test_build_risk_event_candidate_payloads_uses_last_candidate_by_portfolio_id
             "exposure_weights": {"EQUITY": 0.60},
         },
     ]
+
+
+def test_build_risk_event_resolved_portfolios_preserves_cohort_event_and_candidate_lineage() -> (
+    None
+):
+    portfolios = build_risk_event_resolved_portfolios(
+        cohort=Cohort(),
+        candidate_by_portfolio_id={"PB_SG_GLOBAL_BAL_001": Candidate()},
+        fallback_risk_event_id="RISK_EVT_FALLBACK",
+    )
+
+    assert portfolios == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "source_refs": [
+                {
+                    "source_system": "lotus-risk",
+                    "source_type": "RiskEventAffectedCohort",
+                    "source_id": "risk-event-cohort-20260519",
+                    "source_version": "RiskEventAffectedCohort:v1",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:risk-event-cohort",
+                },
+                {
+                    "source_system": "lotus-risk",
+                    "source_type": "RISK_EVENT",
+                    "source_id": "RISK_EVT_20260519",
+                    "source_version": "RiskEventAffectedCohort:v1",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:risk-event-cohort",
+                },
+                {
+                    "source_system": "lotus-risk",
+                    "source_type": "RISK_EVENT_AFFECTED_PORTFOLIO",
+                    "source_id": "risk-event-row-001",
+                    "source_version": "RiskEventAffectedCohort:v1",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:risk-event-cohort",
+                },
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "RISK_EVENT_CANDIDATE_SET",
+                    "source_id": "candidate-set-20260519",
+                    "source_version": "2026-05-19",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:candidate-set",
+                },
+            ],
+        }
+    ]
+
+
+def test_build_risk_event_resolved_portfolios_falls_back_to_request_fingerprint() -> None:
+    portfolios = build_risk_event_resolved_portfolios(
+        cohort=Cohort(cohort_id=None),
+        candidate_by_portfolio_id={},
+        fallback_risk_event_id="RISK_EVT_FALLBACK",
+    )
+
+    assert portfolios[0]["source_refs"][0]["source_id"] == "sha256:risk-event-cohort"
+
+
+def test_build_risk_event_resolved_portfolios_falls_back_to_requested_event_id() -> None:
+    portfolios = build_risk_event_resolved_portfolios(
+        cohort=Cohort(cohort_id=None, request_fingerprint=None),
+        candidate_by_portfolio_id={},
+        fallback_risk_event_id="RISK_EVT_FALLBACK",
+    )
+
+    assert portfolios[0]["source_refs"][0]["source_id"] == "RISK_EVT_FALLBACK"
+    assert portfolios[0]["source_refs"][0]["content_hash"] is None
+    assert portfolios[0]["source_refs"][1]["content_hash"] is None


### PR DESCRIPTION
## Summary
- Extract pure risk-event affected-cohort projection into wave_risk_event_validation.
- Keep lotus-risk authority invocation and error mapping in the waves router.
- Add focused lineage fallback tests and record BACKEND-REVIEW-20260519-020.

## Validation
- python -m ruff check src\\api\\routers\\wave_risk_event_validation.py src\\api\\routers\\waves.py tests\\unit\\api\\test_wave_risk_event_validation.py
- python -m pytest tests\\unit\\api\\test_wave_risk_event_validation.py tests\\unit\\dpm\\api\\test_waves_api.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- git diff --check
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage

## Governance
- Stranded truth: no unmerged lotus-manage remote branches after fetch/prune.
- Open PR baseline before this PR: none.
- Wiki decision: no wiki source change required; internal modularity refactor only.
- WTBD count: unchanged; no product-scope closure claim.