### PR TITLE
Refactor tactical wave projection

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -795,3 +795,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   until a stable risk-event workflow projection object is introduced.
 - Wiki decision: no wiki source change required; this is an internal modularity refactor with no
   supported-feature, API shape, or operator-contract change.
+
+## BACKEND-REVIEW-20260519-021: Tactical house-view cohort projection embedded in router
+
+- Date: 2026-05-19
+- Scope: `src/api/routers/waves.py`, `src/api/routers/wave_tactical_candidate_selection.py`
+- Finding: tactical house-view affected-cohort projection was still embedded in the route resolver
+  after the lotus-advise source-authority call. The behavior was correct, but it mixed source
+  dependency error handling with deterministic wave portfolio/source-ref and diagnostics
+  materialization, making the tactical house-view lineage contract harder to test directly.
+- Action: added `build_tactical_house_view_resolved_portfolios()` to
+  `src/api/routers/wave_tactical_candidate_selection.py` and reused it from the tactical
+  house-view resolver while preserving cohort, house-view, affected-portfolio, source-owned
+  candidate lineage, supportability, and diagnostics behavior.
+- Status: hardened
+- Evidence: focused helper tests in `tests/unit/api/test_wave_tactical_candidate_selection.py`;
+  full validation is recorded in the PR evidence for this slice.
+- Follow-up: keep lotus-advise resolver invocation and source dependency error mapping in the route
+  until a stable tactical house-view workflow projection object is introduced.
+- Wiki decision: no wiki source change required; this is an internal modularity refactor with no
+  supported-feature, API shape, or operator-contract change.

--- a/src/api/routers/wave_tactical_candidate_selection.py
+++ b/src/api/routers/wave_tactical_candidate_selection.py
@@ -4,7 +4,12 @@ from collections.abc import Iterable, Sequence
 from typing import Protocol
 
 from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_type
-from src.api.routers.wave_source_refs import source_refs_payload
+from src.api.routers.wave_source_refs import (
+    source_refs_payload,
+    tactical_house_view_affected_portfolio_ref,
+    tactical_house_view_cohort_ref,
+    tactical_house_view_ref,
+)
 from src.api.services import wave_service
 from src.core.waves import DpmWaveSourceRef
 
@@ -30,6 +35,58 @@ class TacticalHouseViewCandidate(Protocol):
 
     @property
     def source_refs(self) -> Sequence[DpmWaveSourceRef]: ...
+
+
+class TacticalHouseViewAffectedPortfolio(Protocol):
+    @property
+    def portfolio_id(self) -> str: ...
+
+    @property
+    def mandate_id(self) -> str | None: ...
+
+    @property
+    def inclusion_reason_codes(self) -> tuple[str, ...]: ...
+
+    @property
+    def source_refs(self) -> Sequence[dict[str, object]]: ...
+
+
+class TacticalHouseViewAffectedCohort(Protocol):
+    @property
+    def cohort_id(self) -> str: ...
+
+    @property
+    def tactical_view_id(self) -> str: ...
+
+    @property
+    def tactical_view_version(self) -> str: ...
+
+    @property
+    def theme_id(self) -> str: ...
+
+    @property
+    def target_action(self) -> str: ...
+
+    @property
+    def product_name(self) -> str: ...
+
+    @property
+    def product_version(self) -> str: ...
+
+    @property
+    def source_service(self) -> str: ...
+
+    @property
+    def content_hash(self) -> str | None: ...
+
+    @property
+    def supportability_state(self) -> str: ...
+
+    @property
+    def supportability_reason_codes(self) -> tuple[str, ...]: ...
+
+    @property
+    def affected_portfolios(self) -> tuple[TacticalHouseViewAffectedPortfolio, ...]: ...
 
 
 def build_tactical_house_view_candidate_payloads(
@@ -71,3 +128,54 @@ def build_tactical_house_view_candidate_payloads(
             }
         )
     return payloads
+
+
+def build_tactical_house_view_resolved_portfolios(
+    cohort: TacticalHouseViewAffectedCohort,
+) -> list[dict[str, object]]:
+    cohort_ref = tactical_house_view_cohort_ref(
+        source_service=cohort.source_service,
+        product_name=cohort.product_name,
+        cohort_id=cohort.cohort_id,
+        product_version=cohort.product_version,
+        supportability_state=cohort.supportability_state,
+        content_hash=cohort.content_hash,
+    )
+    house_view_ref = tactical_house_view_ref(
+        source_service=cohort.source_service,
+        tactical_view_id=cohort.tactical_view_id,
+        tactical_view_version=cohort.tactical_view_version,
+        supportability_state=cohort.supportability_state,
+        content_hash=cohort.content_hash,
+    )
+    return [
+        {
+            "portfolio_id": affected.portfolio_id,
+            "mandate_id": affected.mandate_id,
+            "source_refs": [
+                cohort_ref,
+                house_view_ref,
+                tactical_house_view_affected_portfolio_ref(
+                    source_service=cohort.source_service,
+                    cohort_id=cohort.cohort_id,
+                    portfolio_id=affected.portfolio_id,
+                    product_version=cohort.product_version,
+                    supportability_state=cohort.supportability_state,
+                    content_hash=cohort.content_hash,
+                ),
+                *affected.source_refs,
+            ],
+            "diagnostics": {
+                "source_owner": cohort.source_service,
+                "source_product": f"{cohort.product_name}:{cohort.product_version}",
+                "tactical_view_id": cohort.tactical_view_id,
+                "tactical_view_version": cohort.tactical_view_version,
+                "theme_id": cohort.theme_id,
+                "target_action": cohort.target_action,
+                "cohort_supportability_state": cohort.supportability_state,
+                "cohort_reason_codes": list(cohort.supportability_reason_codes),
+                "inclusion_reason_codes": list(affected.inclusion_reason_codes),
+            },
+        }
+        for affected in cohort.affected_portfolios
+    ]

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -79,12 +79,10 @@ from src.api.routers.wave_source_refs import (
     bulk_review_campaign_member_ref,
     bulk_review_campaign_membership_ref,
     source_refs_payload,
-    tactical_house_view_affected_portfolio_ref,
-    tactical_house_view_cohort_ref,
-    tactical_house_view_ref,
 )
 from src.api.routers.wave_tactical_candidate_selection import (
     build_tactical_house_view_candidate_payloads,
+    build_tactical_house_view_resolved_portfolios,
 )
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
@@ -970,52 +968,7 @@ def _resolve_tactical_house_view_portfolios(
             message="Tactical house-view cohort returned no affected portfolios.",
         )
 
-    cohort_ref = tactical_house_view_cohort_ref(
-        source_service=cohort.source_service,
-        product_name=cohort.product_name,
-        cohort_id=cohort.cohort_id,
-        product_version=cohort.product_version,
-        supportability_state=cohort.supportability_state,
-        content_hash=cohort.content_hash,
-    )
-    house_view_ref = tactical_house_view_ref(
-        source_service=cohort.source_service,
-        tactical_view_id=cohort.tactical_view_id,
-        tactical_view_version=cohort.tactical_view_version,
-        supportability_state=cohort.supportability_state,
-        content_hash=cohort.content_hash,
-    )
-    return [
-        {
-            "portfolio_id": affected.portfolio_id,
-            "mandate_id": affected.mandate_id,
-            "source_refs": [
-                cohort_ref,
-                house_view_ref,
-                tactical_house_view_affected_portfolio_ref(
-                    source_service=cohort.source_service,
-                    cohort_id=cohort.cohort_id,
-                    portfolio_id=affected.portfolio_id,
-                    product_version=cohort.product_version,
-                    supportability_state=cohort.supportability_state,
-                    content_hash=cohort.content_hash,
-                ),
-                *affected.source_refs,
-            ],
-            "diagnostics": {
-                "source_owner": cohort.source_service,
-                "source_product": f"{cohort.product_name}:{cohort.product_version}",
-                "tactical_view_id": cohort.tactical_view_id,
-                "tactical_view_version": cohort.tactical_view_version,
-                "theme_id": cohort.theme_id,
-                "target_action": cohort.target_action,
-                "cohort_supportability_state": cohort.supportability_state,
-                "cohort_reason_codes": list(cohort.supportability_reason_codes),
-                "inclusion_reason_codes": list(affected.inclusion_reason_codes),
-            },
-        }
-        for affected in cohort.affected_portfolios
-    ]
+    return build_tactical_house_view_resolved_portfolios(cohort)
 
 
 def _resolve_risk_event_portfolios(

--- a/tests/unit/api/test_wave_tactical_candidate_selection.py
+++ b/tests/unit/api/test_wave_tactical_candidate_selection.py
@@ -6,6 +6,7 @@ import pytest
 
 from src.api.routers.wave_tactical_candidate_selection import (
     build_tactical_house_view_candidate_payloads,
+    build_tactical_house_view_resolved_portfolios,
 )
 from src.api.services import wave_service
 from src.core.waves import DpmWaveSourceRef
@@ -31,6 +32,39 @@ class Candidate:
             )
         ]
     )
+
+
+@dataclass(frozen=True)
+class AffectedPortfolio:
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001"
+    mandate_id: str | None = "MANDATE_PB_SG_GLOBAL_BAL_001"
+    inclusion_reason_codes: tuple[str, ...] = ("TACTICAL_UNDERWEIGHT",)
+    source_refs: tuple[dict[str, object], ...] = (
+        {
+            "source_system": "lotus-core",
+            "source_type": "HoldingsAsOf",
+            "source_id": "holdings-as-of-20260519",
+            "source_version": "2026-05-19",
+            "supportability_state": "READY",
+            "content_hash": "sha256:holdings",
+        },
+    )
+
+
+@dataclass(frozen=True)
+class Cohort:
+    cohort_id: str = "tactical-cohort-20260519"
+    tactical_view_id: str = "THV_20260519"
+    tactical_view_version: str = "v3"
+    theme_id: str = "QUALITY_ROTATION"
+    target_action: str = "REBALANCE"
+    product_name: str = "TacticalHouseViewAffectedCohort"
+    product_version: str = "v1"
+    source_service: str = "lotus-advise"
+    content_hash: str | None = "sha256:tactical-cohort"
+    supportability_state: str = "READY"
+    supportability_reason_codes: tuple[str, ...] = ("TACTICAL_HOUSE_VIEW_READY",)
+    affected_portfolios: tuple[AffectedPortfolio, ...] = (AffectedPortfolio(),)
 
 
 def test_build_tactical_house_view_candidate_payloads_maps_source_backed_candidate() -> None:
@@ -97,3 +131,67 @@ def test_build_tactical_house_view_candidate_payloads_requires_source_evidence(
 
     assert exc_info.value.code == code
     assert exc_info.value.message == message
+
+
+def test_build_tactical_house_view_resolved_portfolios_preserves_lineage_and_diagnostics() -> None:
+    portfolios = build_tactical_house_view_resolved_portfolios(Cohort())
+
+    assert portfolios == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "source_refs": [
+                {
+                    "source_system": "lotus-advise",
+                    "source_type": "TacticalHouseViewAffectedCohort",
+                    "source_id": "tactical-cohort-20260519",
+                    "source_version": "v1",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:tactical-cohort",
+                },
+                {
+                    "source_system": "lotus-advise",
+                    "source_type": "TACTICAL_HOUSE_VIEW",
+                    "source_id": "THV_20260519",
+                    "source_version": "v3",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:tactical-cohort",
+                },
+                {
+                    "source_system": "lotus-advise",
+                    "source_type": "TACTICAL_HOUSE_VIEW_AFFECTED_PORTFOLIO",
+                    "source_id": "tactical-cohort-20260519:PB_SG_GLOBAL_BAL_001",
+                    "source_version": "v1",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:tactical-cohort",
+                },
+                {
+                    "source_system": "lotus-core",
+                    "source_type": "HoldingsAsOf",
+                    "source_id": "holdings-as-of-20260519",
+                    "source_version": "2026-05-19",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:holdings",
+                },
+            ],
+            "diagnostics": {
+                "source_owner": "lotus-advise",
+                "source_product": "TacticalHouseViewAffectedCohort:v1",
+                "tactical_view_id": "THV_20260519",
+                "tactical_view_version": "v3",
+                "theme_id": "QUALITY_ROTATION",
+                "target_action": "REBALANCE",
+                "cohort_supportability_state": "READY",
+                "cohort_reason_codes": ["TACTICAL_HOUSE_VIEW_READY"],
+                "inclusion_reason_codes": ["TACTICAL_UNDERWEIGHT"],
+            },
+        }
+    ]
+
+
+def test_build_tactical_house_view_resolved_portfolios_preserves_missing_content_hash() -> None:
+    portfolios = build_tactical_house_view_resolved_portfolios(Cohort(content_hash=None))
+
+    assert portfolios[0]["source_refs"][0]["content_hash"] is None
+    assert portfolios[0]["source_refs"][1]["content_hash"] is None
+    assert portfolios[0]["source_refs"][2]["content_hash"] is None


### PR DESCRIPTION
## Summary
- Extract pure tactical house-view affected-cohort projection into wave_tactical_candidate_selection.
- Keep lotus-advise authority invocation and source dependency error mapping in the waves router.
- Add focused lineage/diagnostics tests and record BACKEND-REVIEW-20260519-021.

## Validation
- python -m ruff check src\\api\\routers\\wave_tactical_candidate_selection.py src\\api\\routers\\waves.py tests\\unit\\api\\test_wave_tactical_candidate_selection.py
- python -m pytest tests\\unit\\api\\test_wave_tactical_candidate_selection.py tests\\unit\\dpm\\api\\test_waves_api.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- git diff --check
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage

## Governance
- Stranded truth: no unmerged lotus-manage remote branches after fetch/prune.
- Open PR baseline before this PR: none.
- Wiki decision: no wiki source change required; internal modularity refactor only.
- WTBD count: unchanged; no product-scope closure claim.