### PR TITLE
Extract wave source analytics aggregation

### DIFF
--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -6,7 +6,7 @@ import uuid
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Literal, cast
+from typing import cast
 
 from src.api.request_models import RebalanceRequest
 from src.api.services import construction_service, proof_pack_service
@@ -31,7 +31,6 @@ from src.core.waves import (
     DpmWaveReportInputBoundaryError,
     DpmWaveReportInput,
     DpmWaveSourceRef,
-    DpmWaveSourceAnalyticsSummary,
     DpmWaveVersionConflictError,
     DpmWaveTrigger,
     WaveTriggerType,
@@ -39,6 +38,10 @@ from src.core.waves import (
     WaveState,
     apply_wave_transition,
     build_wave_report_input,
+)
+from src.core.waves.source_analytics import (
+    aggregate_wave_source_analytics,
+    build_source_analytics_from_alternative_set,
 )
 from src.api.services.portfolio_memory_context_service import (
     build_report_portfolio_memory_context,
@@ -1004,7 +1007,7 @@ def _simulate_item(
                 "construction_state": alternative_set.status.value,
                 "alternative_count": len(alternative_set.alternatives),
                 "proposed_changes": _proposed_changes_from_alternative_set(alternative_set),
-                "source_analytics": _source_analytics_from_alternative_set(alternative_set),
+                "source_analytics": build_source_analytics_from_alternative_set(alternative_set),
             },
         },
         deep=True,
@@ -1454,27 +1457,8 @@ def _aggregate(items: list[DpmRebalanceWaveItem]) -> DpmWaveAggregateMetrics:
         + state_counts.get("SIMULATION_BLOCKED", 0),
         review_required_item_count=state_counts.get("REVIEW_REQUIRED", 0),
         source_degraded_item_count=state_counts.get("SOURCE_DEGRADED", 0),
-        source_analytics=_aggregate_source_analytics(items),
+        source_analytics=aggregate_wave_source_analytics(items),
     )
-
-
-def _source_analytics_from_alternative_set(
-    alternative_set: ConstructionAlternativeSet,
-) -> dict[str, dict[str, object]]:
-    summaries: dict[str, dict[str, object]] = {}
-    for family in ("risk", "performance"):
-        candidates: list[dict[str, object]] = []
-        for alternative in alternative_set.alternatives:
-            candidate = _source_analytics_from_alternative(
-                alternative_set=alternative_set,
-                alternative_diagnostics=alternative.diagnostics,
-                family=family,
-            )
-            if candidate is not None:
-                candidates.append(candidate)
-        if candidates:
-            summaries[family] = _merge_item_source_analytics(candidates)
-    return summaries
 
 
 def _proposed_changes_from_alternative_set(
@@ -1485,217 +1469,6 @@ def _proposed_changes_from_alternative_set(
         if isinstance(changes, list) and changes:
             return [change for change in changes if isinstance(change, dict)]
     return []
-
-
-def _source_analytics_from_alternative(
-    *,
-    alternative_set: ConstructionAlternativeSet,
-    alternative_diagnostics: dict[str, object],
-    family: str,
-) -> dict[str, object] | None:
-    authority_context = _mapping(alternative_diagnostics.get("authority_context"))
-    source_context = _mapping(authority_context.get(f"{family}_context"))
-    if not source_context:
-        return None
-    enrichment_summary = _mapping(alternative_diagnostics.get("enrichment_summary"))
-    status_key = f"{family}_status"
-    supportability_state = str(
-        source_context.get("supportability_status")
-        or enrichment_summary.get(status_key)
-        or "DEGRADED"
-    ).upper()
-    source_system = str(source_context.get("source_system") or f"lotus-{family}")
-    source_ref = _analytics_source_ref(
-        source_context=source_context,
-        source_system=source_system,
-        family=family,
-        fallback_id=alternative_set.alternative_set_id,
-    )
-    return {
-        "supportability_state": supportability_state,
-        "source_systems": [source_system],
-        "source_refs": [source_ref.model_dump(mode="json")],
-        "reason_codes": _string_list(source_context.get("reason_codes"))
-        or _string_list(enrichment_summary.get("reason_codes")),
-        "source_measures": _source_measures(source_context=source_context, family=family),
-    }
-
-
-def _merge_item_source_analytics(
-    candidates: list[dict[str, object]],
-) -> dict[str, object]:
-    states = [str(candidate.get("supportability_state", "DEGRADED")) for candidate in candidates]
-    refs = [
-        ref
-        for candidate in candidates
-        for ref in cast(list[dict[str, object]], candidate.get("source_refs", []))
-    ]
-    measures: dict[str, list[str]] = {}
-    for candidate in candidates:
-        for measure, values in _mapping(candidate.get("source_measures")).items():
-            measure_values = measures.setdefault(str(measure), [])
-            measure_values.extend(str(value) for value in cast(list[object], values))
-    return {
-        "supportability_state": _worst_source_state(states),
-        "source_systems": sorted(
-            {
-                str(source_system)
-                for candidate in candidates
-                for source_system in cast(list[object], candidate.get("source_systems", []))
-            }
-        ),
-        "source_refs": _dedupe_source_ref_dicts(refs),
-        "reason_codes": sorted(
-            {
-                str(reason_code)
-                for candidate in candidates
-                for reason_code in cast(list[object], candidate.get("reason_codes", []))
-            }
-        ),
-        "source_measures": {
-            measure: sorted(set(values)) for measure, values in sorted(measures.items())
-        },
-    }
-
-
-def _aggregate_source_analytics(
-    items: list[DpmRebalanceWaveItem],
-) -> list[DpmWaveSourceAnalyticsSummary]:
-    summaries: list[DpmWaveSourceAnalyticsSummary] = []
-    for family in ("risk", "performance"):
-        item_summaries = [
-            _mapping(_mapping(item.diagnostics.get("source_analytics")).get(family))
-            for item in items
-        ]
-        item_summaries = [summary for summary in item_summaries if summary]
-        if not item_summaries:
-            continue
-        state_counts = Counter(
-            str(summary.get("supportability_state", "DEGRADED")).upper()
-            for summary in item_summaries
-        )
-        refs = [
-            ref
-            for summary in item_summaries
-            for ref in cast(list[dict[str, object]], summary.get("source_refs", []))
-        ]
-        measures: dict[str, list[str]] = {}
-        for summary in item_summaries:
-            for measure, values in _mapping(summary.get("source_measures")).items():
-                measure_values = measures.setdefault(str(measure), [])
-                measure_values.extend(str(value) for value in cast(list[object], values))
-        summaries.append(
-            DpmWaveSourceAnalyticsSummary(
-                source_family=cast(Literal["RISK", "PERFORMANCE"], family.upper()),
-                supportability_state=_worst_source_state(list(state_counts)),
-                item_count=len(item_summaries),
-                ready_item_count=state_counts.get("READY", 0),
-                degraded_item_count=state_counts.get("DEGRADED", 0),
-                blocked_item_count=state_counts.get("BLOCKED", 0),
-                pending_review_item_count=state_counts.get("PENDING_REVIEW", 0),
-                source_systems=sorted(
-                    {
-                        str(source_system)
-                        for summary in item_summaries
-                        for source_system in cast(list[object], summary.get("source_systems", []))
-                    }
-                ),
-                source_refs=[
-                    DpmWaveSourceRef.model_validate(ref) for ref in _dedupe_source_ref_dicts(refs)
-                ],
-                reason_codes=sorted(
-                    {
-                        str(reason_code)
-                        for summary in item_summaries
-                        for reason_code in cast(list[object], summary.get("reason_codes", []))
-                    }
-                ),
-                source_measures={
-                    measure: sorted(set(values)) for measure, values in sorted(measures.items())
-                },
-            )
-        )
-    return summaries
-
-
-def _analytics_source_ref(
-    *,
-    source_context: dict[str, object],
-    source_system: str,
-    family: str,
-    fallback_id: str,
-) -> DpmWaveSourceRef:
-    source_type = str(
-        source_context.get("source_product_name")
-        or ("RISK_AUTHORITY_CONTEXT" if family == "risk" else "PERFORMANCE_AUTHORITY_CONTEXT")
-    )
-    source_version = source_context.get("source_product_version")
-    return DpmWaveSourceRef(
-        source_system=source_system,
-        source_type=source_type,
-        source_id=str(source_context.get("source_id") or fallback_id),
-        source_version=str(source_version) if source_version is not None else None,
-        supportability_state=str(source_context.get("supportability_status") or "DEGRADED"),
-        content_hash=(
-            str(source_context.get("content_hash")) if source_context.get("content_hash") else None
-        ),
-    )
-
-
-def _source_measures(
-    *,
-    source_context: dict[str, object],
-    family: str,
-) -> dict[str, list[str]]:
-    measure_names = (
-        (
-            "tracking_error",
-            "concentration_breaches",
-            "concentration_hhi_delta",
-            "top_position_weight_proposed",
-            "issuer_coverage_status",
-        )
-        if family == "risk"
-        else ("benchmark_id", "active_return", "underperformance_flag")
-    )
-    return {
-        measure: [str(source_context[measure])]
-        for measure in measure_names
-        if source_context.get(measure) is not None
-    }
-
-
-def _mapping(value: object) -> dict[str, object]:
-    return cast(dict[str, object], value) if isinstance(value, dict) else {}
-
-
-def _string_list(value: object) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [str(item) for item in value]
-
-
-def _dedupe_source_ref_dicts(refs: list[dict[str, object]]) -> list[dict[str, object]]:
-    deduped: dict[tuple[str, str, str, str | None], dict[str, object]] = {}
-    for ref in refs:
-        validated = DpmWaveSourceRef.model_validate(ref)
-        deduped[
-            (
-                validated.source_system,
-                validated.source_type,
-                validated.source_id,
-                validated.source_version,
-            )
-        ] = validated.model_dump(mode="json")
-    return list(deduped.values())
-
-
-def _worst_source_state(states: list[str]) -> str:
-    order = {"BLOCKED": 0, "DEGRADED": 1, "PENDING_REVIEW": 2, "READY": 3}
-    normalized = [state.upper() for state in states if state]
-    if not normalized:
-        return "DEGRADED"
-    return min(normalized, key=lambda state: order.get(state, 1))
 
 
 def _trigger_source_refs(portfolios: list[dict[str, object]]) -> list[DpmWaveSourceRef]:

--- a/src/core/waves/source_analytics.py
+++ b/src/core/waves/source_analytics.py
@@ -1,0 +1,243 @@
+"""Source-owned analytics aggregation for rebalance waves."""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Literal, cast
+
+from src.core.construction.models import ConstructionAlternativeSet
+from src.core.waves.models import (
+    DpmRebalanceWaveItem,
+    DpmWaveSourceAnalyticsSummary,
+    DpmWaveSourceRef,
+)
+
+
+def build_source_analytics_from_alternative_set(
+    alternative_set: ConstructionAlternativeSet,
+) -> dict[str, dict[str, object]]:
+    summaries: dict[str, dict[str, object]] = {}
+    for family in ("risk", "performance"):
+        candidates: list[dict[str, object]] = []
+        for alternative in alternative_set.alternatives:
+            candidate = _source_analytics_from_alternative(
+                alternative_set=alternative_set,
+                alternative_diagnostics=alternative.diagnostics,
+                family=family,
+            )
+            if candidate is not None:
+                candidates.append(candidate)
+        if candidates:
+            summaries[family] = _merge_item_source_analytics(candidates)
+    return summaries
+
+
+def aggregate_wave_source_analytics(
+    items: list[DpmRebalanceWaveItem],
+) -> list[DpmWaveSourceAnalyticsSummary]:
+    summaries: list[DpmWaveSourceAnalyticsSummary] = []
+    for family in ("risk", "performance"):
+        item_summaries = [
+            _mapping(_mapping(item.diagnostics.get("source_analytics")).get(family))
+            for item in items
+        ]
+        item_summaries = [summary for summary in item_summaries if summary]
+        if not item_summaries:
+            continue
+        state_counts = Counter(
+            str(summary.get("supportability_state", "DEGRADED")).upper()
+            for summary in item_summaries
+        )
+        refs = [
+            ref
+            for summary in item_summaries
+            for ref in cast(list[dict[str, object]], summary.get("source_refs", []))
+        ]
+        measures: dict[str, list[str]] = {}
+        for summary in item_summaries:
+            for measure, values in _mapping(summary.get("source_measures")).items():
+                measure_values = measures.setdefault(str(measure), [])
+                measure_values.extend(str(value) for value in cast(list[object], values))
+        summaries.append(
+            DpmWaveSourceAnalyticsSummary(
+                source_family=cast(Literal["RISK", "PERFORMANCE"], family.upper()),
+                supportability_state=_worst_source_state(list(state_counts)),
+                item_count=len(item_summaries),
+                ready_item_count=state_counts.get("READY", 0),
+                degraded_item_count=state_counts.get("DEGRADED", 0),
+                blocked_item_count=state_counts.get("BLOCKED", 0),
+                pending_review_item_count=state_counts.get("PENDING_REVIEW", 0),
+                source_systems=sorted(
+                    {
+                        str(source_system)
+                        for summary in item_summaries
+                        for source_system in cast(list[object], summary.get("source_systems", []))
+                    }
+                ),
+                source_refs=[
+                    DpmWaveSourceRef.model_validate(ref) for ref in _dedupe_source_ref_dicts(refs)
+                ],
+                reason_codes=sorted(
+                    {
+                        str(reason_code)
+                        for summary in item_summaries
+                        for reason_code in cast(list[object], summary.get("reason_codes", []))
+                    }
+                ),
+                source_measures={
+                    measure: sorted(set(values)) for measure, values in sorted(measures.items())
+                },
+            )
+        )
+    return summaries
+
+
+def _source_analytics_from_alternative(
+    *,
+    alternative_set: ConstructionAlternativeSet,
+    alternative_diagnostics: dict[str, object],
+    family: str,
+) -> dict[str, object] | None:
+    authority_context = _mapping(alternative_diagnostics.get("authority_context"))
+    source_context = _mapping(authority_context.get(f"{family}_context"))
+    if not source_context:
+        return None
+    enrichment_summary = _mapping(alternative_diagnostics.get("enrichment_summary"))
+    status_key = f"{family}_status"
+    supportability_state = str(
+        source_context.get("supportability_status")
+        or enrichment_summary.get(status_key)
+        or "DEGRADED"
+    ).upper()
+    source_system = str(source_context.get("source_system") or f"lotus-{family}")
+    source_ref = _analytics_source_ref(
+        source_context=source_context,
+        source_system=source_system,
+        family=family,
+        fallback_id=alternative_set.alternative_set_id,
+    )
+    return {
+        "supportability_state": supportability_state,
+        "source_systems": [source_system],
+        "source_refs": [source_ref.model_dump(mode="json")],
+        "reason_codes": _string_list(source_context.get("reason_codes"))
+        or _string_list(enrichment_summary.get("reason_codes")),
+        "source_measures": _source_measures(source_context=source_context, family=family),
+    }
+
+
+def _merge_item_source_analytics(
+    candidates: list[dict[str, object]],
+) -> dict[str, object]:
+    states = [str(candidate.get("supportability_state", "DEGRADED")) for candidate in candidates]
+    refs = [
+        ref
+        for candidate in candidates
+        for ref in cast(list[dict[str, object]], candidate.get("source_refs", []))
+    ]
+    measures: dict[str, list[str]] = {}
+    for candidate in candidates:
+        for measure, values in _mapping(candidate.get("source_measures")).items():
+            measure_values = measures.setdefault(str(measure), [])
+            measure_values.extend(str(value) for value in cast(list[object], values))
+    return {
+        "supportability_state": _worst_source_state(states),
+        "source_systems": sorted(
+            {
+                str(source_system)
+                for candidate in candidates
+                for source_system in cast(list[object], candidate.get("source_systems", []))
+            }
+        ),
+        "source_refs": _dedupe_source_ref_dicts(refs),
+        "reason_codes": sorted(
+            {
+                str(reason_code)
+                for candidate in candidates
+                for reason_code in cast(list[object], candidate.get("reason_codes", []))
+            }
+        ),
+        "source_measures": {
+            measure: sorted(set(values)) for measure, values in sorted(measures.items())
+        },
+    }
+
+
+def _analytics_source_ref(
+    *,
+    source_context: dict[str, object],
+    source_system: str,
+    family: str,
+    fallback_id: str,
+) -> DpmWaveSourceRef:
+    source_type = str(
+        source_context.get("source_product_name")
+        or ("RISK_AUTHORITY_CONTEXT" if family == "risk" else "PERFORMANCE_AUTHORITY_CONTEXT")
+    )
+    source_version = source_context.get("source_product_version")
+    return DpmWaveSourceRef(
+        source_system=source_system,
+        source_type=source_type,
+        source_id=str(source_context.get("source_id") or fallback_id),
+        source_version=str(source_version) if source_version is not None else None,
+        supportability_state=str(source_context.get("supportability_status") or "DEGRADED"),
+        content_hash=(
+            str(source_context.get("content_hash")) if source_context.get("content_hash") else None
+        ),
+    )
+
+
+def _source_measures(
+    *,
+    source_context: dict[str, object],
+    family: str,
+) -> dict[str, list[str]]:
+    measure_names = (
+        (
+            "tracking_error",
+            "concentration_breaches",
+            "concentration_hhi_delta",
+            "top_position_weight_proposed",
+            "issuer_coverage_status",
+        )
+        if family == "risk"
+        else ("benchmark_id", "active_return", "underperformance_flag")
+    )
+    return {
+        measure: [str(source_context[measure])]
+        for measure in measure_names
+        if source_context.get(measure) is not None
+    }
+
+
+def _mapping(value: object) -> dict[str, object]:
+    return cast(dict[str, object], value) if isinstance(value, dict) else {}
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _dedupe_source_ref_dicts(refs: list[dict[str, object]]) -> list[dict[str, object]]:
+    deduped: dict[tuple[str, str, str, str | None], dict[str, object]] = {}
+    for ref in refs:
+        validated = DpmWaveSourceRef.model_validate(ref)
+        deduped[
+            (
+                validated.source_system,
+                validated.source_type,
+                validated.source_id,
+                validated.source_version,
+            )
+        ] = validated.model_dump(mode="json")
+    return list(deduped.values())
+
+
+def _worst_source_state(states: list[str]) -> str:
+    order = {"BLOCKED": 0, "DEGRADED": 1, "PENDING_REVIEW": 2, "READY": 3}
+    normalized = [state.upper() for state in states if state]
+    if not normalized:
+        return "DEGRADED"
+    return min(normalized, key=lambda state: order.get(state, 1))

--- a/tests/unit/dpm/waves/test_source_analytics.py
+++ b/tests/unit/dpm/waves/test_source_analytics.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from src.core.construction.models import (
+    ConstructionAlternative,
+    ConstructionAlternativeSet,
+    ConstructionComparisonMetrics,
+)
+from src.core.construction.vocabulary import ConstructionMethod, ConstructionMethodStatus
+from src.core.waves import DpmRebalanceWaveItem, DpmWaveSourceRef
+from src.core.waves.source_analytics import (
+    aggregate_wave_source_analytics,
+    build_source_analytics_from_alternative_set,
+)
+
+
+def test_build_source_analytics_from_alternative_set_preserves_source_owned_evidence() -> None:
+    alternative_set = ConstructionAlternativeSet(
+        alternative_set_id="cas_source_analytics_001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        as_of="2026-05-19",
+        status=ConstructionMethodStatus.DEGRADED,
+        alternatives=[
+            _alternative(
+                "alt_1",
+                {
+                    "authority_context": {
+                        "risk_context": {
+                            "supportability_status": "READY",
+                            "source_system": "lotus-risk",
+                            "source_product_name": "ConcentrationRiskReport",
+                            "source_product_version": "v1",
+                            "source_id": "risk-concentration-001",
+                            "content_hash": "sha256:risk-001",
+                            "tracking_error": Decimal("0.042"),
+                            "concentration_hhi_delta": Decimal("125.5"),
+                            "reason_codes": ["LOTUS_RISK_CONCENTRATION_READY"],
+                        },
+                        "performance_context": {
+                            "supportability_status": "DEGRADED",
+                            "source_system": "lotus-performance",
+                            "source_product_name": "PerformanceBenchmarkContext",
+                            "source_product_version": "v1",
+                            "source_id": "perf-benchmark-001",
+                            "benchmark_id": "BMK_GLOBAL_BAL",
+                            "active_return": Decimal("-0.018"),
+                            "reason_codes": ["PERFORMANCE_BENCHMARK_PARTIAL"],
+                        },
+                    }
+                },
+            )
+        ],
+    )
+
+    analytics = build_source_analytics_from_alternative_set(alternative_set)
+
+    assert analytics["risk"]["supportability_state"] == "READY"
+    assert analytics["risk"]["source_refs"][0]["source_type"] == "ConcentrationRiskReport"
+    assert analytics["risk"]["source_measures"] == {
+        "concentration_hhi_delta": ["125.5"],
+        "tracking_error": ["0.042"],
+    }
+    assert analytics["performance"]["supportability_state"] == "DEGRADED"
+    assert analytics["performance"]["source_measures"] == {
+        "active_return": ["-0.018"],
+        "benchmark_id": ["BMK_GLOBAL_BAL"],
+    }
+
+
+def test_aggregate_wave_source_analytics_deduplicates_refs_and_counts_posture() -> None:
+    source_analytics = {
+        "risk": {
+            "supportability_state": "READY",
+            "source_systems": ["lotus-risk"],
+            "source_refs": [
+                {
+                    "source_system": "lotus-risk",
+                    "source_type": "ConcentrationRiskReport",
+                    "source_id": "risk-concentration-001",
+                    "source_version": "v1",
+                    "supportability_state": "READY",
+                }
+            ],
+            "reason_codes": ["LOTUS_RISK_CONCENTRATION_READY"],
+            "source_measures": {"tracking_error": ["0.042"]},
+        }
+    }
+    items = [
+        _wave_item("dwi_001", source_analytics),
+        _wave_item("dwi_002", source_analytics),
+        _wave_item(
+            "dwi_003",
+            {
+                "risk": {
+                    **source_analytics["risk"],
+                    "supportability_state": "DEGRADED",
+                    "reason_codes": ["LOTUS_RISK_CONCENTRATION_PARTIAL"],
+                }
+            },
+        ),
+    ]
+
+    summary = aggregate_wave_source_analytics(items)[0]
+
+    assert summary.source_family == "RISK"
+    assert summary.supportability_state == "DEGRADED"
+    assert summary.item_count == 3
+    assert summary.ready_item_count == 2
+    assert summary.degraded_item_count == 1
+    assert summary.source_refs == [
+        DpmWaveSourceRef(
+            source_system="lotus-risk",
+            source_type="ConcentrationRiskReport",
+            source_id="risk-concentration-001",
+            source_version="v1",
+            supportability_state="READY",
+        )
+    ]
+    assert summary.reason_codes == [
+        "LOTUS_RISK_CONCENTRATION_PARTIAL",
+        "LOTUS_RISK_CONCENTRATION_READY",
+    ]
+
+
+def _alternative(
+    alternative_id: str,
+    diagnostics: dict[str, object],
+) -> ConstructionAlternative:
+    return ConstructionAlternative(
+        alternative_id=alternative_id,
+        method=ConstructionMethod.RISK_AWARE,
+        method_status=ConstructionMethodStatus.DEGRADED,
+        summary="Source-aware construction alternative.",
+        objective_trace=[],
+        constraint_trace=[],
+        comparison_metrics=ConstructionComparisonMetrics(
+            drift_before=Decimal("0.10"),
+            drift_after=Decimal("0.05"),
+            drift_reduction=Decimal("0.05"),
+            turnover_weight=Decimal("0.02"),
+            trade_count=1,
+        ),
+        diagnostics=diagnostics,
+    )
+
+
+def _wave_item(
+    wave_item_id: str,
+    source_analytics: dict[str, object],
+) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id=wave_item_id,
+        portfolio_id=f"PF_{wave_item_id}",
+        state="SIMULATED",
+        diagnostics={"source_analytics": source_analytics},
+    )


### PR DESCRIPTION
## Summary
- move rebalance-wave risk/performance source analytics aggregation out of wave_service into src/core/waves/source_analytics.py
- keep wave_service focused on orchestration while preserving source-owned supportability, source refs, reason codes, and measure aggregation behavior
- add focused unit coverage for source analytics construction, supportability counting, and source-ref deduplication

## Validation
- python -m pytest tests\\unit\\dpm\\waves\\test_source_analytics.py tests\\unit\\dpm\\api\\test_waves_api.py -q
- python -m ruff check src\\api\\services\\wave_service.py src\\core\\waves\\source_analytics.py tests\\unit\\dpm\\waves\\test_source_analytics.py
- python -m mypy src\\api\\services\\wave_service.py src\\core\\waves\\source_analytics.py
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- make openapi-gate
- make api-vocabulary-gate
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- git diff --check

## Contract / Docs
- No public API schema change; OpenAPI and API vocabulary gates passed with no drift.
- No wiki source change required.