### PR TITLE
Align Manage source consumer declarations

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -57,6 +57,16 @@ Current repository posture:
     `DpmSourceReadiness:v1` through `/integration/portfolios/{portfolio_id}/dpm-source-readiness`,
     and `TransactionCostCurve:v1` through
     `/integration/portfolios/{portfolio_id}/transaction-cost-curve`.
+    The repo-native domain-data-product consumer declaration now also records the broader current
+    source-consumer surface for mandate health, construction, proof-pack, wave, outcome-review,
+    PM-quality, and portfolio-memory paths, including projected cashflow, liquidity/income
+    reference evidence, external treasury/OMS fail-closed posture,
+    CIO model-change cohorts, PM-book membership, risk-event/tactical cohorts, transaction-cost
+    curves, and regime-scenario evaluation. This is declaration truth only; it does not make Manage
+    the source owner for market data, valuation, risk, performance, tax, financial planning,
+    scenario methodology, treasury, execution, OMS, fill, or settlement facts.
+    `BenchmarkAssignment:v1` remains a declaration watchlist item until upstream producer approval
+    explicitly includes `lotus-manage`.
 11. RFC-0037 through RFC-0043 define the strategic revamp into a DPM operating system.
     RFC-0038, RFC-0039, RFC-0040, the manage-owned explicit portfolio-list wave scope of
     RFC-0041, Gateway RFC-0098 wave composition, and the first-wave Workbench wave command center

--- a/contracts/domain-data-products/README.md
+++ b/contracts/domain-data-products/README.md
@@ -12,18 +12,30 @@ Current declarations:
 1. `lotus-manage-consumers.v1.json`
    Consumer declaration for governed `lotus-core` products used by management execution workflows.
    It includes the request-payload `PortfolioStateSnapshot:v1` dependency, stateful
+   `DpmModelPortfolioTarget:v1`, `DiscretionaryMandateBinding:v1`,
+   `InstrumentEligibilityProfile:v1`, `PortfolioTaxLotWindow:v1`,
+   `MarketDataCoverageWindow:v1`, and `DpmSourceReadiness:v1` dependencies used by stateful
+   source-backed execution, mandate
+   health, source readiness, and tax/market-data supportability,
    `ClientRestrictionProfile:v1` / `SustainabilityPreferenceProfile:v1` dependencies used by
-   ESG/restriction-aware construction and proof-pack source preservation, and the
+   ESG/restriction-aware construction and proof-pack source preservation, the
+   `PortfolioCashflowProjection:v1`, `ClientIncomeNeedsSchedule:v1`,
+   `LiquidityReserveRequirement:v1`, and `PlannedWithdrawalSchedule:v1` dependencies used for
+   bounded cash/liquidity reference evidence, and the
    `lotus-risk:RiskEventAffectedCohort:v1` API-read dependency used by source-owned
    risk-event rebalance waves, plus the `lotus-advise:TacticalHouseViewAffectedCohort:v1`
    API-read dependency used by Advise-owned tactical house-view rebalance waves. It also declares
+   `lotus-core:CioModelChangeAffectedCohort:v1` for source-owned CIO model-change wave
+   discovery, `lotus-core:TransactionCostCurve:v1` for source-owned observed cost evidence,
+   `lotus-risk:RegimeScenarioPackEvaluation:v1` for source-owned regime-stress evidence, and
    the `lotus-core:PortfolioManagerBookMembership:v1` API-read dependency used by PM-book
    rebalance-wave discovery and optional PM operating quality score-run scope materialization, and
    the stateful `lotus-core:ExternalCurrencyExposure:v1`, `ExternalHedgePolicy:v1`,
    `ExternalEligibleHedgeInstrument:v1`, `ExternalFXForwardCurve:v1`, and
    `ExternalHedgeExecutionReadiness:v1` dependencies used to preserve fail-closed external
    treasury exposure, policy, eligible-instrument, forward-curve, and readiness posture in
-   currency-overlay diagnostics.
+   currency-overlay diagnostics, plus `ExternalOrderExecutionAcknowledgement:v1` for fail-closed
+   external OMS acknowledgement boundary evidence.
 2. `lotus-manage-products.v1.json`
    Producer declaration for `lotus-manage:PortfolioActionRegister:v1`, surfaced through the
    implemented rebalance supportability, artifact, and workflow route families, and
@@ -64,6 +76,11 @@ Current watchlist:
 1. `lotus-manage` stateful source consumption must stay aligned with certified producer
    declarations. New source products should be added here only after source-owner approval,
    trust metadata, tests, and live proof exist.
-2. Market-data request payloads remain source-data-authority sensitive, but `MarketDataWindow` is not
-   currently approved for `lotus-manage` in the upstream producer declaration. Do not declare it here
-   until upstream approval and required trust metadata are explicit.
+2. Market-data request payloads remain source-data-authority sensitive, but raw `MarketDataWindow`
+   is not currently approved for `lotus-manage` in the upstream producer declaration. Manage
+   declares only the bounded `MarketDataCoverageWindow:v1` supportability product and must not
+   treat it as raw market-data or valuation-methodology ownership.
+3. `BenchmarkAssignment:v1` is referenced in mandate-health source lineage but is not currently
+   approved for `lotus-manage` in the upstream producer declaration. Keep it out of the
+   machine-readable consumer declaration until the source owner explicitly approves Manage
+   consumption.

--- a/contracts/domain-data-products/lotus-manage-consumers.v1.json
+++ b/contracts/domain-data-products/lotus-manage-consumers.v1.json
@@ -27,6 +27,156 @@
       "failure_posture": "fail_closed"
     },
     {
+      "product_name": "DpmModelPortfolioTarget",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Resolve model portfolio target weights, model version, target bands, and source lineage for stateful discretionary mandate execution without making lotus-manage the model-governance authority.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed"
+    },
+    {
+      "product_name": "DiscretionaryMandateBinding",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Resolve mandate, model, policy-pack, booking-center, jurisdiction, review cadence, and objective binding for stateful DPM workflows while preserving lotus-core as mandate administration authority.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed"
+    },
+    {
+      "product_name": "InstrumentEligibilityProfile",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Resolve buy/sell eligibility, shelf status, restriction reasons, settlement, liquidity-tier, issuer, asset-class, and country-of-risk source evidence for DPM universe and diagnostics without local eligibility ownership.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed"
+    },
+    {
+      "product_name": "PortfolioTaxLotWindow",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Preserve source-owned tax-lot window evidence for tax-aware construction diagnostics and source-readiness posture without tax advice, tax optimization, or tax-reporting certification claims.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "degrade_or_block"
+    },
+    {
+      "product_name": "MarketDataCoverageWindow",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Preserve source-owned price and FX coverage freshness posture for stateful DPM source readiness and mandate health without valuation methodology or FX attribution ownership.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "degrade_or_block"
+    },
+    {
+      "product_name": "DpmSourceReadiness",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "snapshot_id",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Resolve composed DPM source-readiness posture, missing source families, and data-quality mapping for stateful mandate workflows without locally reassembling source-owner readiness semantics.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed"
+    },
+    {
       "product_name": "ClientRestrictionProfile",
       "producer_repository": "lotus-core",
       "required_product_version": "v1",
@@ -80,6 +230,30 @@
       },
       "consumption_mode": "stateful_core_sourcing",
       "business_purpose": "Preserve source-backed sustainability preferences in construction alternatives and proof packs, including allocation review posture, without inferring unsupported ESG classifications.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "degrade_or_pending_review"
+    },
+    {
+      "product_name": "PortfolioCashflowProjection",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Preserve source-owned projected net-cashflow pressure in mandate-health lineage and liquidity-aware construction diagnostics without cashflow forecasting, funding recommendation, or financial-planning advice claims.",
       "validation_lanes": [
         "feature",
         "pr-merge"
@@ -279,6 +453,30 @@
       "failure_posture": "fail_closed"
     },
     {
+      "product_name": "ExternalOrderExecutionAcknowledgement",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Preserve fail-closed external OMS acknowledgement posture in construction diagnostics, outcome-review evidence, report input, AI evidence input, and portfolio-memory boundary events without claiming execution, fills, settlement, or OMS ingestion.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed"
+    },
+    {
       "product_name": "RiskEventAffectedCohort",
       "producer_repository": "lotus-risk",
       "required_product_version": "v1",
@@ -295,6 +493,28 @@
       },
       "consumption_mode": "api_read",
       "business_purpose": "Resolve source-owned risk-event affected portfolio cohorts for discretionary rebalance wave preview and creation while preserving lotus-risk lineage, supportability, request fingerprint, and reason codes without recalculating risk-event impact in lotus-manage.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed"
+    },
+    {
+      "product_name": "CioModelChangeAffectedCohort",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "source_batch_fingerprint",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Resolve source-owned CIO model-change affected-mandate cohorts for rebalance wave preview and creation without caller-supplied portfolio fabrication or local cohort discovery.",
       "validation_lanes": [
         "feature",
         "pr-merge"
@@ -345,6 +565,53 @@
         "pr-merge"
       ],
       "failure_posture": "fail_closed"
+    },
+    {
+      "product_name": "TransactionCostCurve",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "data_quality_status",
+        "latest_evidence_timestamp",
+        "source_batch_fingerprint",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "stateful_core_sourcing",
+      "business_purpose": "Preserve source-owned observed transaction-cost curve evidence for cost-aware construction comparison and proof-pack turnover/cost supportability without predictive execution, market-impact, venue-routing, or OMS claims.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "degrade"
+    },
+    {
+      "product_name": "RegimeScenarioPackEvaluation",
+      "producer_repository": "lotus-risk",
+      "required_product_version": "v1",
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services"
+      ],
+      "migration_posture": {
+        "status": "current"
+      },
+      "consumption_mode": "api_read",
+      "business_purpose": "Resolve source-owned regime scenario-pack evaluation for regime-stress-aware construction and proof-pack scenario evidence without local scenario methodology, contribution, CIO approval, effective-period, or applicability calculation.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "degrade_or_pending_review"
     }
   ]
 }

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -518,6 +518,32 @@ Expected implementation wave:
 
 Implement product by product as new stateful source dependencies are introduced.
 
+2026-05-20 current-state consumer declaration hardening:
+
+`lotus-manage` now declares the full current implementation-backed source-consumer surface used by
+stateful DPM execution, mandate health, source readiness, proof packs, waves, outcome evidence, PM
+operating quality, and portfolio memory. The repo-native consumer declaration now includes
+`DpmModelPortfolioTarget:v1`, `DiscretionaryMandateBinding:v1`,
+`InstrumentEligibilityProfile:v1`, `PortfolioTaxLotWindow:v1`, `MarketDataCoverageWindow:v1`,
+`DpmSourceReadiness:v1`, `PortfolioCashflowProjection:v1`,
+`ClientIncomeNeedsSchedule:v1`, `LiquidityReserveRequirement:v1`,
+`PlannedWithdrawalSchedule:v1`, `ClientRestrictionProfile:v1`,
+`SustainabilityPreferenceProfile:v1`, `ExternalCurrencyExposure:v1`,
+`ExternalHedgePolicy:v1`, `ExternalFXForwardCurve:v1`,
+`ExternalEligibleHedgeInstrument:v1`, `ExternalHedgeExecutionReadiness:v1`,
+`ExternalOrderExecutionAcknowledgement:v1`, `CioModelChangeAffectedCohort:v1`,
+`PortfolioManagerBookMembership:v1`, `TransactionCostCurve:v1`,
+`RiskEventAffectedCohort:v1`, `TacticalHouseViewAffectedCohort:v1`, and
+`RegimeScenarioPackEvaluation:v1`.
+
+This is a governance hardening slice for current truth, not a new runtime feature. It advances
+RFC36-WTBD-004 by making repo-native mesh declarations match the implemented source-consumer
+surface and by preserving explicit fail-closed/degraded/pending-review posture per dependency. It
+does not promote `BenchmarkAssignment:v1` until the upstream source owner approves Manage as a
+consumer, and it does not promote raw market-data ownership, valuation methodology, risk
+methodology, performance methodology, tax advice, financial-planning advice, scenario methodology,
+execution, OMS acknowledgement ingestion, fills, settlement, or treasury action.
+
 Promotion proof:
 
 1. producer and consumer declarations validate,

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -47,8 +47,15 @@ def test_manage_consumer_declaration_tracks_current_core_inputs() -> None:
     assert payload["consumer_repository"] == "lotus-manage"
     assert set(by_name) == {
         "PortfolioStateSnapshot",
+        "DpmModelPortfolioTarget",
+        "DiscretionaryMandateBinding",
+        "InstrumentEligibilityProfile",
+        "PortfolioTaxLotWindow",
+        "MarketDataCoverageWindow",
+        "DpmSourceReadiness",
         "ClientRestrictionProfile",
         "SustainabilityPreferenceProfile",
+        "PortfolioCashflowProjection",
         "ClientIncomeNeedsSchedule",
         "LiquidityReserveRequirement",
         "PlannedWithdrawalSchedule",
@@ -57,14 +64,36 @@ def test_manage_consumer_declaration_tracks_current_core_inputs() -> None:
         "ExternalFXForwardCurve",
         "ExternalEligibleHedgeInstrument",
         "ExternalHedgeExecutionReadiness",
+        "ExternalOrderExecutionAcknowledgement",
         "RiskEventAffectedCohort",
+        "CioModelChangeAffectedCohort",
         "TacticalHouseViewAffectedCohort",
         "PortfolioManagerBookMembership",
+        "TransactionCostCurve",
+        "RegimeScenarioPackEvaluation",
     }
     assert (
         by_name["PortfolioStateSnapshot"]["consumption_mode"] == "caller_supplied_contract_payload"
     )
     assert by_name["PortfolioStateSnapshot"]["failure_posture"] == "fail_closed"
+    assert by_name["DpmModelPortfolioTarget"]["producer_repository"] == "lotus-core"
+    assert by_name["DpmModelPortfolioTarget"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["DpmModelPortfolioTarget"]["failure_posture"] == "fail_closed"
+    assert by_name["DiscretionaryMandateBinding"]["producer_repository"] == "lotus-core"
+    assert by_name["DiscretionaryMandateBinding"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["DiscretionaryMandateBinding"]["failure_posture"] == "fail_closed"
+    assert by_name["InstrumentEligibilityProfile"]["producer_repository"] == "lotus-core"
+    assert by_name["InstrumentEligibilityProfile"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["InstrumentEligibilityProfile"]["failure_posture"] == "fail_closed"
+    assert by_name["PortfolioTaxLotWindow"]["producer_repository"] == "lotus-core"
+    assert by_name["PortfolioTaxLotWindow"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["PortfolioTaxLotWindow"]["failure_posture"] == "degrade_or_block"
+    assert by_name["MarketDataCoverageWindow"]["producer_repository"] == "lotus-core"
+    assert by_name["MarketDataCoverageWindow"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["MarketDataCoverageWindow"]["failure_posture"] == "degrade_or_block"
+    assert by_name["DpmSourceReadiness"]["producer_repository"] == "lotus-core"
+    assert by_name["DpmSourceReadiness"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["DpmSourceReadiness"]["failure_posture"] == "fail_closed"
     assert by_name["ClientRestrictionProfile"]["consumption_mode"] == "stateful_core_sourcing"
     assert by_name["ClientRestrictionProfile"]["failure_posture"] == "degrade_or_block"
     assert (
@@ -73,6 +102,9 @@ def test_manage_consumer_declaration_tracks_current_core_inputs() -> None:
     assert (
         by_name["SustainabilityPreferenceProfile"]["failure_posture"] == "degrade_or_pending_review"
     )
+    assert by_name["PortfolioCashflowProjection"]["producer_repository"] == "lotus-core"
+    assert by_name["PortfolioCashflowProjection"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["PortfolioCashflowProjection"]["failure_posture"] == "degrade_or_pending_review"
     assert by_name["ClientIncomeNeedsSchedule"]["consumption_mode"] == "stateful_core_sourcing"
     assert by_name["ClientIncomeNeedsSchedule"]["failure_posture"] == "degrade"
     assert by_name["LiquidityReserveRequirement"]["consumption_mode"] == "stateful_core_sourcing"
@@ -98,15 +130,30 @@ def test_manage_consumer_declaration_tracks_current_core_inputs() -> None:
         by_name["ExternalHedgeExecutionReadiness"]["consumption_mode"] == "stateful_core_sourcing"
     )
     assert by_name["ExternalHedgeExecutionReadiness"]["failure_posture"] == "fail_closed"
+    assert by_name["ExternalOrderExecutionAcknowledgement"]["producer_repository"] == "lotus-core"
+    assert (
+        by_name["ExternalOrderExecutionAcknowledgement"]["consumption_mode"]
+        == "stateful_core_sourcing"
+    )
+    assert by_name["ExternalOrderExecutionAcknowledgement"]["failure_posture"] == "fail_closed"
     assert by_name["RiskEventAffectedCohort"]["producer_repository"] == "lotus-risk"
     assert by_name["RiskEventAffectedCohort"]["consumption_mode"] == "api_read"
     assert by_name["RiskEventAffectedCohort"]["failure_posture"] == "fail_closed"
+    assert by_name["CioModelChangeAffectedCohort"]["producer_repository"] == "lotus-core"
+    assert by_name["CioModelChangeAffectedCohort"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["CioModelChangeAffectedCohort"]["failure_posture"] == "fail_closed"
     assert by_name["TacticalHouseViewAffectedCohort"]["producer_repository"] == "lotus-advise"
     assert by_name["TacticalHouseViewAffectedCohort"]["consumption_mode"] == "api_read"
     assert by_name["TacticalHouseViewAffectedCohort"]["failure_posture"] == "fail_closed"
     assert by_name["PortfolioManagerBookMembership"]["producer_repository"] == "lotus-core"
     assert by_name["PortfolioManagerBookMembership"]["consumption_mode"] == "api_read"
     assert by_name["PortfolioManagerBookMembership"]["failure_posture"] == "fail_closed"
+    assert by_name["TransactionCostCurve"]["producer_repository"] == "lotus-core"
+    assert by_name["TransactionCostCurve"]["consumption_mode"] == "stateful_core_sourcing"
+    assert by_name["TransactionCostCurve"]["failure_posture"] == "degrade"
+    assert by_name["RegimeScenarioPackEvaluation"]["producer_repository"] == "lotus-risk"
+    assert by_name["RegimeScenarioPackEvaluation"]["consumption_mode"] == "api_read"
+    assert by_name["RegimeScenarioPackEvaluation"]["failure_posture"] == "degrade_or_pending_review"
 
     request_models = REQUEST_MODELS_PATH.read_text(encoding="utf-8")
     assert "portfolio_snapshot: PortfolioSnapshot" in request_models
@@ -123,8 +170,15 @@ def test_manage_declaration_limits_live_source_data_api_reads_to_approved_profil
     upstream_family_map = UPSTREAM_FAMILY_MAP_PATH.read_text(encoding="utf-8")
 
     assert live_dependencies == {
+        "DpmModelPortfolioTarget",
+        "DiscretionaryMandateBinding",
+        "InstrumentEligibilityProfile",
+        "PortfolioTaxLotWindow",
+        "MarketDataCoverageWindow",
+        "DpmSourceReadiness",
         "ClientRestrictionProfile",
         "SustainabilityPreferenceProfile",
+        "PortfolioCashflowProjection",
         "ClientIncomeNeedsSchedule",
         "LiquidityReserveRequirement",
         "PlannedWithdrawalSchedule",
@@ -133,6 +187,9 @@ def test_manage_declaration_limits_live_source_data_api_reads_to_approved_profil
         "ExternalFXForwardCurve",
         "ExternalEligibleHedgeInstrument",
         "ExternalHedgeExecutionReadiness",
+        "ExternalOrderExecutionAcknowledgement",
+        "CioModelChangeAffectedCohort",
+        "TransactionCostCurve",
     }
     assert "modeled, feature-gated outbound resolver seam" in upstream_family_map
     assert (

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -320,15 +320,16 @@ Audience use:
 ## WTBD Product-Readiness Roadmap
 
 `docs/rfcs/RFC-worktobedone.md` is the governed WTBD ledger. As of the 2026-05-20 clean mainline
-snapshot after `lotus-manage` PR #317, the RFC39-WTBD-008 external treasury reclassification, the
+snapshot after `lotus-manage` PR #318, the RFC39-WTBD-008 external treasury reclassification, the
 RFC37 partial-classification normalization, and the source-owned performance MWR FX-evidence
 advance from `lotus-performance` PR #168, it tracks 59 WTBD items: 45 done on merged/published
 truth, 8 partial or in progress, and 6 remaining or open. The count does not move for PR #168
 because it advances an existing RFC42-WTBD-006 partial row rather than closing stateful per-input
-FX evidence, broader FX methodology, predictive execution, or OMS acknowledgement gaps. The next
-execution wave should focus on product
-surfaces that materially improve bank-buyable demo and operating value without inventing
-unsupported source truth.
+FX evidence, broader FX methodology, predictive execution, or OMS acknowledgement gaps. Current
+Manage source-consumer declaration hardening also does not move the count because it advances an
+existing partial row rather than closing a full WTBD promotion gate. The next execution wave should
+focus on product surfaces that materially improve bank-buyable demo and operating value without
+inventing unsupported source truth.
 
 | Priority | WTBD | Business value | Required proof before support claim |
 | ---: | --- | --- | --- |
@@ -350,6 +351,17 @@ single-reporting-currency without per-input FX metadata. Manage, Gateway, Workbe
 and AI consumers must preserve this source-owned evidence posture rather than converting MWR FX,
 sourcing rates, recalculating mixed-currency capital timing, or promoting missing stateful FX
 metadata as ready evidence.
+
+Current Manage source-consumer governance proof additionally keeps
+`contracts/domain-data-products/lotus-manage-consumers.v1.json` aligned to the current
+implementation-backed stateful source surface across model targets, mandate binding, benchmark
+watchlist posture, eligibility, tax lots, market-data coverage, DPM source readiness, projected cashflow,
+client liquidity references, restrictions, sustainability preferences, external treasury and OMS
+fail-closed postures, CIO model-change cohorts, PM-book membership, transaction-cost curves,
+risk-event and tactical cohorts, and regime-scenario evaluation. This is mesh declaration truth
+only; it is not raw market-data ownership, valuation methodology, risk/performance methodology,
+tax advice, financial-planning advice, scenario methodology, treasury instruction, execution,
+OMS acknowledgement ingestion, fill, or settlement support.
 
 Current risk historical-attribution supportability proof additionally includes `lotus-risk` PR
 #139 / wiki `421ae79`, which makes `HistoricalRiskAttributionReport:v1` degrade response-level


### PR DESCRIPTION
## Summary
- align lotus-manage consumer declaration to current approved implementation-backed source products
- document BenchmarkAssignment as a watchlist item until upstream producer approval includes lotus-manage
- update WTBD, repository context, wiki source, and contract tests for declaration truth

## Validation
- make domain-product-validate
- python -m pytest tests\unit\test_domain_data_product_contracts.py tests\unit\test_documentation_current_state.py -q
- make lint
- make typecheck
- make mesh-contract-validate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected pre-merge drift: Supported-Features.md)