### PR TITLE
Harden campaign workflow automation hashes

### DIFF
--- a/src/core/waves/campaign_workflow_automation.py
+++ b/src/core/waves/campaign_workflow_automation.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import hashlib
-import json
 from datetime import date
 from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from src.core.common.canonical import hash_canonical_payload, strip_keys
 from src.core.waves.campaign_assignment_plan import (
     DpmBulkReviewCampaignAssignmentPlanItem,
     build_bulk_review_campaign_assignment_plan_item,
@@ -82,7 +82,7 @@ def _workflow_capability_posture_payload() -> dict[str, object]:
         "operating_boundaries": list(WORKFLOW_AUTOMATION_OPERATING_BOUNDARIES),
         "content_hash": "",
     }
-    payload["content_hash"] = _hash_payload(payload)
+    payload["content_hash"] = _content_hash(payload)
     return payload
 
 
@@ -302,7 +302,7 @@ def build_bulk_review_campaign_workflow_automation_item(
         "operating_boundaries": list(WORKFLOW_AUTOMATION_OPERATING_BOUNDARIES),
         "content_hash": "",
     }
-    payload["content_hash"] = _hash_payload(payload)
+    payload["content_hash"] = _content_hash(payload)
     return DpmBulkReviewCampaignWorkflowAutomationItem.model_validate(payload)
 
 
@@ -352,7 +352,7 @@ def build_bulk_review_campaign_workflow_automation_page(
         "capability_posture": _workflow_capability_posture().model_dump(mode="json"),
         "content_hash": "",
     }
-    payload["content_hash"] = _hash_payload(payload)
+    payload["content_hash"] = _content_hash(payload)
     return DpmBulkReviewCampaignWorkflowAutomationPage.model_validate(payload)
 
 
@@ -440,6 +440,5 @@ def _workflow_capability_posture() -> DpmBulkReviewCampaignWorkflowCapabilityPos
     )
 
 
-def _hash_payload(payload: dict[str, object]) -> str:
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
-    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+def _content_hash(payload: dict[str, object]) -> str:
+    return hash_canonical_payload(strip_keys(payload, exclude={"content_hash"}))

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 import pytest
 
 from src.core.waves import DpmWaveSourceRef
+from src.core.common.canonical import hash_canonical_payload, strip_keys
 from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionCandidate,
@@ -803,6 +804,15 @@ def test_campaign_workflow_automation_classifies_candidates_active_tasks_and_blo
     )
     assert "NO_EXTERNAL_WORKFLOW_ORCHESTRATION" in candidate.capability_posture.operating_boundaries
     assert candidate.capability_posture.content_hash.startswith("sha256:")
+    assert candidate.capability_posture.content_hash == hash_canonical_payload(
+        strip_keys(
+            candidate.capability_posture.model_dump(mode="json"),
+            exclude={"content_hash"},
+        )
+    )
+    assert candidate.content_hash == hash_canonical_payload(
+        strip_keys(candidate.model_dump(mode="json"), exclude={"content_hash"})
+    )
 
     assert active.automation_status == "MANUAL_REVIEW_REQUIRED"
     assert active.automation_action == "MONITOR_ACTIVE_TASK"
@@ -842,6 +852,9 @@ def test_campaign_workflow_automation_classifies_candidates_active_tasks_and_blo
     )
     assert "external_workflow_escalation" in page.capability_posture.blocked_capabilities
     assert page.capability_posture.content_hash == candidate.capability_posture.content_hash
+    assert page.content_hash == hash_canonical_payload(
+        strip_keys(page.model_dump(mode="json"), exclude={"content_hash"})
+    )
 
     empty_page = build_bulk_review_campaign_workflow_automation_page(
         definitions=[],


### PR DESCRIPTION
## Summary
- replace campaign workflow automation content hashing with the shared canonical hash helper
- strip content_hash before hashing capability, item, and page payloads
- pin canonical lineage hash behavior in campaign workflow automation tests

## Validation
- python -m ruff check src/core/waves/campaign_workflow_automation.py tests/unit/dpm/waves/test_campaign_discovery.py
- python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py tests/unit/dpm/api/test_waves_api.py::test_bulk_review_campaign_workflow_automation_summarizes_manage_task_readiness -q
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- make test-unit
- make test-integration
- make test-e2e
- python ../lotus-platform/automation/validate_engineering_context_system.py
- python ../lotus-platform/automation/validate_lotus_skill_alignment.py

No Gateway, Workbench, or Advise changes. No wiki/source-doc truth changed.