### PR TITLE
Preserve outcome AI evidence source lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,8 @@ evidence with review-required guardrails. RFC-0042 is
 authority:
 source-backed outcome-review preview/create/retrieve/search, immutable persistence and events,
 source-refresh eventing, report-input and AI-evidence handoff contracts, supportability telemetry,
-and live canonical manage proof under `output/rfc0042-outcome-proof/20260505-024352`; Slice 12
+deduplicated AI-evidence source lineage across review, snapshot, dimension-result, and metric-level
+refs, and live canonical manage proof under `output/rfc0042-outcome-proof/20260505-024352`; Slice 12
 hardening proof under `output/rfc0042-outcome-proof/20260505-025613` adds idempotency conflict and
 state-filter validation evidence. Full post-trade outcome product support remains downstream until
 Gateway/Workbench implementation where surfaced is complete and canonically proven. RFC-0043 is
@@ -545,7 +546,9 @@ Operationally important truths:
     `DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY` evidence. Manage may support internal PM, CIO,
     compliance, operations, report, and AI review workflows, but it does not contact clients,
     generate client-ready messages, collect client approval, confirm delivery, or certify client
-    communication audit truth.
+    communication audit truth. AI-evidence handoff source refs are bounded to persisted
+    outcome-review lineage and deduplicated review, snapshot, dimension-result, and metric-level
+    evidence refs.
 
 ## Documentation Map
 

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -4133,7 +4133,8 @@ RFC-0042 is `DONE - MANAGE BACKEND COMPLETE; FIRST-WAVE PRODUCT REALIZATION COMP
 ENRICHMENT REMAINS`. `lotus-manage` owns the implementation-backed outcome-review authority:
 source-backed preview/create/retrieve/search, immutable persistence and append-only events,
 source-refresh eventing, supportability diagnostics, deterministic report-input and AI-evidence
-input handoff contracts, certified OpenAPI, and live manage proof under
+input handoff contracts with deduplicated review, snapshot, dimension-result, and metric-level
+source refs, certified OpenAPI, and live manage proof under
 `output/rfc0042-outcome-proof/20260505-024352/` plus hardening proof under
 `output/rfc0042-outcome-proof/20260505-025613/`. Gateway, Workbench, report/render/archive, and
 AI first-wave realization is now implemented and merged in the owning repositories. Remaining

--- a/src/core/outcomes/handoffs.py
+++ b/src/core/outcomes/handoffs.py
@@ -315,7 +315,23 @@ def _find_forbidden_field_names(value: Any) -> set[str]:
 
 def _dedupe_source_refs(review: DpmPostTradeOutcomeReview) -> list[DpmOutcomeSourceRef]:
     refs_by_key: dict[tuple[str, str, str], DpmOutcomeSourceRef] = {}
-    for ref in review.source_lineage:
+    refs = [
+        *review.source_lineage,
+        *review.expected_snapshot.source_lineage,
+        *review.realized_snapshot.source_lineage,
+        *(ref for result in review.dimension_results for ref in result.source_refs),
+        *(
+            ref
+            for metric in review.expected_snapshot.expected_values.values()
+            for ref in metric.source_refs
+        ),
+        *(
+            ref
+            for metric in review.realized_snapshot.realized_values.values()
+            for ref in metric.source_refs
+        ),
+    ]
+    for ref in refs:
         refs_by_key[(ref.source_system, ref.source_type, ref.source_id)] = ref
     return list(refs_by_key.values())
 

--- a/tests/unit/api/test_outcome_reviews_api.py
+++ b/tests/unit/api/test_outcome_reviews_api.py
@@ -155,6 +155,11 @@ def test_outcome_review_api_preview_create_lookup_supportability_and_events() ->
             assert ai_input["client_communication_boundary"]["boundary_id"] == (
                 "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY"
             )
+            assert {ref["source_id"] for ref in ai_input["source_refs"]} >= {
+                "expected",
+                "realized",
+                "metric",
+            }
             assert "place_orders" in ai_input["forbidden_actions"]
             assert "score_portfolio_manager" in ai_input["forbidden_actions"]
 

--- a/tests/unit/core/test_outcome_handoffs.py
+++ b/tests/unit/core/test_outcome_handoffs.py
@@ -88,9 +88,15 @@ def test_outcome_report_input_carries_portfolio_memory_without_changing_hash() -
 def test_outcome_ai_evidence_input_is_bounded_and_forbids_actions() -> None:
     ai_input = build_ai_evidence_input(_review())
 
+    source_ids = {ref.source_id for ref in ai_input.source_refs}
+
     assert ai_input.evidence_ref.source_type == OUTCOME_AI_EVIDENCE_REF_TYPE
     assert ai_input.evidence_ref.content_hash == ai_input.content_hash
     assert ai_input.content_hash.startswith("sha256:")
+    assert source_ids >= {"expected", "realized", "metric"}
+    assert len(ai_input.source_refs) == len(
+        {(ref.source_system, ref.source_type, ref.source_id) for ref in ai_input.source_refs}
+    )
     assert "place_orders" in ai_input.forbidden_actions
     assert "approve_rebalance" in ai_input.forbidden_actions
     assert "score_portfolio_manager" in ai_input.forbidden_actions

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -1913,7 +1913,9 @@ Functional behavior:
   `DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY` evidence, and a canonical handoff hash without
   rendering reports, archive records, client messages, delivery records, or OMS execution claims.
 - AI evidence input returns bounded source-backed facts, permitted use, forbidden actions, source
-  refs, structured `DPM_OUTCOME_EXTERNAL_EXECUTION_BOUNDARY` and
+  refs deduplicated across persisted review lineage, expected/realized snapshots,
+  dimension-results, and metric-level evidence, structured
+  `DPM_OUTCOME_EXTERNAL_EXECUTION_BOUNDARY` and
   `DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY` evidence, and a canonical handoff hash without
   generating prompts, memos, recommendations, approvals, client communications, or execution
   instructions.


### PR DESCRIPTION
## Summary
- preserve deduplicated outcome AI-evidence source refs across review lineage, expected/realized snapshots, dimension results, and metric-level evidence
- assert API and core handoff outputs include expected, realized, and metric lineage without duplicate source ref identities
- update README, RFC WTBD ledger, and Endpoint Certification wiki source for the clarified handoff contract

## Validation
- python -m ruff check src\\core\\outcomes\\handoffs.py tests\\unit\\core\\test_outcome_handoffs.py tests\\unit\\api\\test_outcome_reviews_api.py
- python -m pytest tests\\unit\\core\\test_outcome_handoffs.py tests\\unit\\api\\test_outcome_reviews_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- powershell -NoProfile -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected drift: Endpoint-Certification.md until post-merge publish)