### PR TITLE
Extract outcome review router models

### DIFF
--- a/src/api/routers/outcome_review_models.py
+++ b/src/api/routers/outcome_review_models.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from pydantic import BaseModel, Field
+
+from src.api.services.outcome_review_service import DpmOutcomeDimensionConfig
+from src.core.outcomes import (
+    DpmExpectedOutcomeSnapshot,
+    DpmOutcomeClientCommunicationBoundaryEvidence,
+    DpmOutcomeEvent,
+    DpmOutcomeExternalExecutionBoundaryEvidence,
+    DpmOutcomeReviewComparison,
+    DpmOutcomeSupportability,
+    DpmOutcomeTolerance,
+    DpmPostTradeOutcomeReview,
+    DpmRealizedOutcomeSnapshot,
+    OutcomeComparisonDirection,
+    OutcomeDimension,
+)
+
+
+class DpmOutcomeDimensionConfigRequest(BaseModel):
+    dimension: OutcomeDimension = Field(
+        description="Outcome dimension to compare.",
+        examples=["DRIFT_REDUCTION"],
+    )
+    tolerance: DpmOutcomeTolerance = Field(description="Soft and hard tolerance for the dimension.")
+    materiality: Decimal = Field(
+        default=Decimal("0"),
+        ge=0,
+        description="Materiality threshold used in comparison output.",
+        examples=["0.0050"],
+    )
+    direction: OutcomeComparisonDirection = Field(
+        description="Comparison direction for the dimension.",
+        examples=["LOWER_IS_BETTER"],
+    )
+
+    def to_domain(self) -> DpmOutcomeDimensionConfig:
+        return DpmOutcomeDimensionConfig(
+            dimension=self.dimension,
+            tolerance=self.tolerance,
+            materiality=self.materiality,
+            direction=self.direction,
+        )
+
+
+class DpmOutcomeReviewPreviewRequest(BaseModel):
+    expected_snapshot: DpmExpectedOutcomeSnapshot = Field(
+        description="Expected snapshot assembled from pre-trade manage evidence.",
+    )
+    realized_snapshot: DpmRealizedOutcomeSnapshot = Field(
+        description="Realized snapshot assembled from source-owner evidence.",
+    )
+    dimension_configs: list[DpmOutcomeDimensionConfigRequest] = Field(
+        min_length=1,
+        description="Dimensions to compare and their tolerance policy.",
+    )
+
+
+class DpmOutcomeReviewPreviewResponse(BaseModel):
+    comparison: DpmOutcomeReviewComparison = Field(description="Deterministic comparison result.")
+
+
+class DpmOutcomeReviewCreateRequest(DpmOutcomeReviewPreviewRequest):
+    actor_id: str = Field(description="Actor creating the outcome review.", examples=["pm_001"])
+
+
+class DpmOutcomeReviewCreateResponse(BaseModel):
+    outcome_review: DpmPostTradeOutcomeReview = Field(description="Persisted immutable review.")
+
+
+class DpmOutcomeReviewLookupResponse(BaseModel):
+    outcome_review: DpmPostTradeOutcomeReview = Field(description="Persisted immutable review.")
+
+
+class DpmOutcomeReviewListResponse(BaseModel):
+    items: list[DpmPostTradeOutcomeReview] = Field(description="Bounded review search results.")
+    total: int = Field(description="Returned item count.", examples=[1])
+
+
+class DpmOutcomeReviewSupportabilityResponse(BaseModel):
+    outcome_review_id: str = Field(description="Outcome review identifier.", examples=["dor_001"])
+    supportability: DpmOutcomeSupportability = Field(description="Operator-safe supportability.")
+    state: str = Field(description="Outcome review state.", examples=["DEGRADED"])
+    reason_codes: list[str] = Field(description="Bounded supportability reason codes.")
+    source_ref_count: int = Field(
+        description="Count of source refs linked to the review.",
+        examples=[3],
+    )
+    source_owners: list[str] = Field(
+        description="Bounded source-owner systems represented in lineage.",
+        examples=[["lotus-manage", "lotus-risk", "lotus-performance"]],
+    )
+    dimension_state_counts: dict[str, int] = Field(
+        description="Count of compared dimensions by outcome state.",
+        examples=[{"READY": 2, "DEGRADED": 1, "BLOCKED": 1}],
+    )
+    blocked_dimension_count: int = Field(
+        description="Number of blocked dimensions.",
+        examples=[1],
+    )
+    degraded_dimension_count: int = Field(
+        description="Number of degraded dimensions.",
+        examples=[1],
+    )
+    unsupported_dimension_count: int = Field(
+        description="Number of not-supported dimensions.",
+        examples=[0],
+    )
+    freshness_state_counts: dict[str, int] = Field(
+        description="Count of source freshness states across compared dimensions.",
+        examples=[{"CURRENT": 2, "STALE": 1}],
+    )
+    remediation_routes: list[str] = Field(
+        description="Operator-safe remediation routes by source-owner family.",
+        examples=[["lotus-risk:refresh-post-trade-risk-source"]],
+    )
+    external_execution_boundary: DpmOutcomeExternalExecutionBoundaryEvidence = Field(
+        description=(
+            "Structured fail-closed no-OMS boundary evidence for outcome-review supportability "
+            "consumers."
+        )
+    )
+    client_communication_boundary: DpmOutcomeClientCommunicationBoundaryEvidence = Field(
+        description=(
+            "Structured fail-closed no-client-communication boundary evidence for outcome-review "
+            "supportability consumers."
+        )
+    )
+
+
+class DpmOutcomeReviewRefreshSourcesRequest(BaseModel):
+    actor_id: str = Field(description="Actor requesting source refresh.", examples=["pm_001"])
+    realized_snapshot: DpmRealizedOutcomeSnapshot = Field(
+        description=(
+            "New realized source-owner snapshot to compare against the immutable expected snapshot."
+        ),
+    )
+    dimension_configs: list[DpmOutcomeDimensionConfigRequest] = Field(
+        min_length=1,
+        description="Dimensions to re-evaluate and their tolerance policy.",
+    )
+
+
+class DpmOutcomeReviewRefreshSourcesResponse(BaseModel):
+    event: DpmOutcomeEvent = Field(description="Appended source-refresh event.")
+    comparison: DpmOutcomeReviewComparison = Field(
+        description=(
+            "Fresh expected-versus-realized comparison produced from the supplied source snapshot."
+        ),
+    )

--- a/src/api/routers/outcome_reviews.py
+++ b/src/api/routers/outcome_reviews.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import logging
-from decimal import Decimal
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
-from pydantic import BaseModel, Field
 
 from src.api.dependencies import (
     get_mandate_repository,
@@ -13,9 +11,19 @@ from src.api.dependencies import (
     get_proof_pack_repository,
     get_wave_repository,
 )
+from src.api.routers.outcome_review_models import (
+    DpmOutcomeReviewCreateRequest,
+    DpmOutcomeReviewCreateResponse,
+    DpmOutcomeReviewListResponse,
+    DpmOutcomeReviewLookupResponse,
+    DpmOutcomeReviewPreviewRequest,
+    DpmOutcomeReviewPreviewResponse,
+    DpmOutcomeReviewRefreshSourcesRequest,
+    DpmOutcomeReviewRefreshSourcesResponse,
+    DpmOutcomeReviewSupportabilityResponse,
+)
 from src.api.observability import record_outcome_review_supportability
 from src.api.services.outcome_review_service import (
-    DpmOutcomeDimensionConfig,
     DpmOutcomeReviewNotFoundError,
     DpmOutcomeReviewValidationError,
     create_outcome_review,
@@ -25,19 +33,9 @@ from src.api.services.outcome_review_service import (
     refresh_outcome_review_sources,
 )
 from src.core.outcomes import (
-    DpmExpectedOutcomeSnapshot,
     DpmOutcomeAiEvidenceInput,
-    DpmOutcomeClientCommunicationBoundaryEvidence,
-    DpmOutcomeEvent,
-    DpmOutcomeExternalExecutionBoundaryEvidence,
-    DpmOutcomeReviewComparison,
     DpmOutcomeReportInput,
-    DpmOutcomeSupportability,
-    DpmOutcomeTolerance,
     DpmPostTradeOutcomeReview,
-    DpmRealizedOutcomeSnapshot,
-    OutcomeComparisonDirection,
-    OutcomeDimension,
     OutcomeReviewState,
     build_outcome_client_communication_boundary,
     build_outcome_external_execution_boundary,
@@ -51,135 +49,6 @@ logger = logging.getLogger("lotus-manage.outcome_reviews")
 OUTCOME_CREATE_SURFACE = "rebalance/outcome-reviews/create"
 OUTCOME_REFRESH_SURFACE = "rebalance/outcome-reviews/refresh-sources"
 OUTCOME_SUPPORTABILITY_SURFACE = "rebalance/outcome-reviews/supportability"
-
-
-class DpmOutcomeDimensionConfigRequest(BaseModel):
-    dimension: OutcomeDimension = Field(
-        description="Outcome dimension to compare.",
-        examples=["DRIFT_REDUCTION"],
-    )
-    tolerance: DpmOutcomeTolerance = Field(description="Soft and hard tolerance for the dimension.")
-    materiality: Decimal = Field(
-        default=Decimal("0"),
-        ge=0,
-        description="Materiality threshold used in comparison output.",
-        examples=["0.0050"],
-    )
-    direction: OutcomeComparisonDirection = Field(
-        description="Comparison direction for the dimension.",
-        examples=["LOWER_IS_BETTER"],
-    )
-
-    def to_domain(self) -> DpmOutcomeDimensionConfig:
-        return DpmOutcomeDimensionConfig(
-            dimension=self.dimension,
-            tolerance=self.tolerance,
-            materiality=self.materiality,
-            direction=self.direction,
-        )
-
-
-class DpmOutcomeReviewPreviewRequest(BaseModel):
-    expected_snapshot: DpmExpectedOutcomeSnapshot = Field(
-        description="Expected snapshot assembled from pre-trade manage evidence.",
-    )
-    realized_snapshot: DpmRealizedOutcomeSnapshot = Field(
-        description="Realized snapshot assembled from source-owner evidence.",
-    )
-    dimension_configs: list[DpmOutcomeDimensionConfigRequest] = Field(
-        min_length=1,
-        description="Dimensions to compare and their tolerance policy.",
-    )
-
-
-class DpmOutcomeReviewPreviewResponse(BaseModel):
-    comparison: DpmOutcomeReviewComparison = Field(description="Deterministic comparison result.")
-
-
-class DpmOutcomeReviewCreateRequest(DpmOutcomeReviewPreviewRequest):
-    actor_id: str = Field(description="Actor creating the outcome review.", examples=["pm_001"])
-
-
-class DpmOutcomeReviewCreateResponse(BaseModel):
-    outcome_review: DpmPostTradeOutcomeReview = Field(description="Persisted immutable review.")
-
-
-class DpmOutcomeReviewLookupResponse(BaseModel):
-    outcome_review: DpmPostTradeOutcomeReview = Field(description="Persisted immutable review.")
-
-
-class DpmOutcomeReviewListResponse(BaseModel):
-    items: list[DpmPostTradeOutcomeReview] = Field(description="Bounded review search results.")
-    total: int = Field(description="Returned item count.", examples=[1])
-
-
-class DpmOutcomeReviewSupportabilityResponse(BaseModel):
-    outcome_review_id: str = Field(description="Outcome review identifier.", examples=["dor_001"])
-    supportability: DpmOutcomeSupportability = Field(description="Operator-safe supportability.")
-    state: str = Field(description="Outcome review state.", examples=["DEGRADED"])
-    reason_codes: list[str] = Field(description="Bounded supportability reason codes.")
-    source_ref_count: int = Field(
-        description="Count of source refs linked to the review.",
-        examples=[3],
-    )
-    source_owners: list[str] = Field(
-        description="Bounded source-owner systems represented in lineage.",
-        examples=[["lotus-manage", "lotus-risk", "lotus-performance"]],
-    )
-    dimension_state_counts: dict[str, int] = Field(
-        description="Count of compared dimensions by outcome state.",
-        examples=[{"READY": 2, "DEGRADED": 1, "BLOCKED": 1}],
-    )
-    blocked_dimension_count: int = Field(
-        description="Number of blocked dimensions.",
-        examples=[1],
-    )
-    degraded_dimension_count: int = Field(
-        description="Number of degraded dimensions.",
-        examples=[1],
-    )
-    unsupported_dimension_count: int = Field(
-        description="Number of not-supported dimensions.",
-        examples=[0],
-    )
-    freshness_state_counts: dict[str, int] = Field(
-        description="Count of source freshness states across compared dimensions.",
-        examples=[{"CURRENT": 2, "STALE": 1}],
-    )
-    remediation_routes: list[str] = Field(
-        description="Operator-safe remediation routes by source-owner family.",
-        examples=[["lotus-risk:refresh-post-trade-risk-source"]],
-    )
-    external_execution_boundary: DpmOutcomeExternalExecutionBoundaryEvidence = Field(
-        description=(
-            "Structured fail-closed no-OMS boundary evidence for outcome-review supportability "
-            "consumers."
-        )
-    )
-    client_communication_boundary: DpmOutcomeClientCommunicationBoundaryEvidence = Field(
-        description=(
-            "Structured fail-closed no-client-communication boundary evidence for outcome-review "
-            "supportability consumers."
-        )
-    )
-
-
-class DpmOutcomeReviewRefreshSourcesRequest(BaseModel):
-    actor_id: str = Field(description="Actor requesting source refresh.", examples=["pm_001"])
-    realized_snapshot: DpmRealizedOutcomeSnapshot = Field(
-        description="New realized source-owner snapshot to compare against the immutable expected snapshot.",
-    )
-    dimension_configs: list[DpmOutcomeDimensionConfigRequest] = Field(
-        min_length=1,
-        description="Dimensions to re-evaluate and their tolerance policy.",
-    )
-
-
-class DpmOutcomeReviewRefreshSourcesResponse(BaseModel):
-    event: DpmOutcomeEvent = Field(description="Appended source-refresh event.")
-    comparison: DpmOutcomeReviewComparison = Field(
-        description="Fresh expected-versus-realized comparison produced from the supplied source snapshot.",
-    )
 
 
 router = APIRouter(


### PR DESCRIPTION
## Summary
- move outcome-review request/response DTOs into a dedicated router model module
- keep outcome-review endpoint behavior and OpenAPI semantics unchanged
- reduce router responsibility to endpoint orchestration and supportability assembly

## Validation
- python -m ruff format src\\api\\routers\\outcome_reviews.py src\\api\\routers\\outcome_review_models.py
- python -m ruff check src\\api\\routers\\outcome_reviews.py src\\api\\routers\\outcome_review_models.py
- python -m pytest tests\\unit\\api\\test_outcome_reviews_api.py tests\\unit\\dpm\\outcomes\\test_expected_snapshot_assembly.py tests\\unit\\core\\test_outcome_comparison.py tests\\unit\\core\\test_outcome_handoffs.py -q
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make lint
- make typecheck
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- powershell -NoProfile -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage