### PR TITLE
Extract campaign source resolution

### DIFF
--- a/src/api/routers/wave_campaign_source_resolution.py
+++ b/src/api/routers/wave_campaign_source_resolution.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import HTTPException, status
+
+from src.api.routers.wave_campaign_candidate_selection import (
+    select_bulk_review_campaign_candidates,
+)
+from src.api.routers.wave_campaign_governance_validation import (
+    campaign_actor_entitlement_state,
+    campaign_approval_status,
+    campaign_expiry_state,
+)
+from src.api.routers.wave_campaign_hashing import (
+    campaign_governance_hash,
+    campaign_membership_hash,
+)
+from src.api.routers.wave_campaign_models import DpmBulkReviewCampaignGovernanceInput
+from src.api.routers.wave_date_validation import parse_wave_as_of_date
+from src.api.routers.wave_portfolio_type_validation import (
+    normalize_required_portfolio_types,
+)
+from src.api.routers.wave_request_models import DpmWavePortfolioInput, DpmWavePreviewRequest
+from src.api.routers.wave_source_refs import (
+    bulk_review_campaign_member_ref,
+    bulk_review_campaign_membership_ref,
+    source_refs_payload,
+)
+from src.api.services import wave_service
+from src.core.waves import (
+    DpmBulkReviewCampaignDefinitionRepository,
+    DpmWaveSourceRef,
+)
+
+
+def request_with_campaign_definition(
+    *,
+    request: DpmWavePreviewRequest,
+    repository: DpmBulkReviewCampaignDefinitionRepository,
+) -> DpmWavePreviewRequest:
+    if request.campaign_definition_id is None and request.campaign_definition_version is None:
+        return request
+    if not request.campaign_definition_id or not request.campaign_definition_version:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_DEFINITION_REF_INCOMPLETE",
+            "campaign_definition_id and campaign_definition_version must be supplied together.",
+        )
+    if request.portfolios:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_DEFINITION_REJECTS_CALLER_PORTFOLIOS",
+            "Persisted campaign definitions supply the candidate portfolio set.",
+        )
+    definition = repository.get_definition(
+        campaign_id=request.campaign_definition_id,
+        campaign_version=request.campaign_definition_version,
+    )
+    if definition is None:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
+            "Persisted bulk-review campaign definition was not found.",
+        )
+    if definition.status == "RETIRED":
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_DEFINITION_RETIRED",
+            "Retired bulk-review campaign definitions cannot be used for new wave preview/create.",
+        )
+    if definition.status == "SUPERSEDED":
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_DEFINITION_SUPERSEDED",
+            "Superseded bulk-review campaign definitions cannot be used for new wave preview/create.",
+        )
+    if definition.as_of_date != request.as_of_date:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_DEFINITION_AS_OF_DATE_MISMATCH",
+            "campaign definition as_of_date must match the wave request as_of_date.",
+        )
+    definition_ref = DpmWaveSourceRef(
+        source_system="lotus-manage",
+        source_type="BulkReviewCampaignDefinition",
+        source_id=f"campaign-definition:{definition.campaign_id}:{definition.campaign_version}",
+        source_version=definition.product_version,
+        supportability_state="READY",
+        content_hash=definition.content_hash,
+    )
+    portfolios = [
+        DpmWavePortfolioInput(
+            portfolio_id=candidate.portfolio_id,
+            mandate_id=candidate.mandate_id,
+            portfolio_manager_id=candidate.portfolio_manager_id,
+            portfolio_type=candidate.portfolio_type,
+            source_refs=[definition_ref, *candidate.source_refs],
+        )
+        for candidate in definition.candidates
+    ]
+    governance = (
+        DpmBulkReviewCampaignGovernanceInput.model_validate(
+            definition.governance.model_dump(mode="json")
+        )
+        if definition.governance is not None
+        else request.campaign_governance
+    )
+    return request.model_copy(
+        update={
+            "trigger_id": definition.campaign_id,
+            "rationale": definition.rationale,
+            "portfolios": portfolios,
+            "portfolio_types": definition.eligible_portfolio_types,
+            "campaign_governance": governance,
+        },
+        deep=True,
+    )
+
+
+def resolve_bulk_review_campaign_portfolios(
+    *,
+    request: DpmWavePreviewRequest,
+) -> list[dict[str, object]]:
+    if not request.portfolios:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_CANDIDATE_PORTFOLIOS_REQUIRED",
+            "BULK_REVIEW_CAMPAIGN requires source-backed candidate portfolios.",
+        )
+    campaign_as_of_date = parse_wave_as_of_date(request.as_of_date)
+    governance_diagnostics, governance_refs = resolve_bulk_review_campaign_governance(
+        request=request,
+        campaign_as_of_date=campaign_as_of_date,
+    )
+    eligible_portfolio_types = set(
+        normalize_required_portfolio_types(
+            request.portfolio_types,
+            required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPES_REQUIRED",
+            required_message=(
+                "BULK_REVIEW_CAMPAIGN requires at least one eligible portfolio type."
+            ),
+        )
+    )
+
+    selection = select_bulk_review_campaign_candidates(
+        candidates=request.portfolios,
+        eligible_portfolio_types=eligible_portfolio_types,
+    )
+    included_candidates = selection.included_candidates
+
+    if not included_candidates:
+        raise HTTPException(
+            status_code=status.HTTP_424_FAILED_DEPENDENCY,
+            detail={
+                "code": "BULK_REVIEW_CAMPAIGN_MEMBERSHIP_EMPTY",
+                "message": "Bulk-review campaign membership returned no eligible DPM portfolios.",
+            },
+        )
+
+    membership_hash = campaign_membership_hash(
+        trigger_id=request.trigger_id,
+        as_of_date=campaign_as_of_date,
+        portfolio_types=sorted(eligible_portfolio_types),
+        portfolios=[candidate.model_dump(mode="json") for candidate in included_candidates],
+    )
+    membership_ref = bulk_review_campaign_membership_ref(
+        trigger_id=request.trigger_id,
+        campaign_as_of_date=campaign_as_of_date,
+        membership_hash=membership_hash,
+    )
+    return [
+        {
+            "portfolio_id": candidate.portfolio_id,
+            "mandate_id": candidate.mandate_id,
+            "source_refs": [
+                membership_ref,
+                *governance_refs,
+                bulk_review_campaign_member_ref(
+                    trigger_id=request.trigger_id,
+                    portfolio_id=candidate.portfolio_id,
+                    campaign_as_of_date=campaign_as_of_date,
+                    membership_hash=membership_hash,
+                ),
+                *source_refs_payload(candidate.source_refs),
+            ],
+            "diagnostics": {
+                "source_owner": "lotus-manage",
+                "source_product": "BulkReviewCampaignMembership:v1",
+                "campaign_id": request.trigger_id,
+                "campaign_as_of_date": campaign_as_of_date.isoformat(),
+                "portfolio_type": candidate.portfolio_type.strip().upper()
+                if candidate.portfolio_type
+                else None,
+                "eligible_portfolio_types": sorted(eligible_portfolio_types),
+                "excluded_candidate_count": selection.excluded_count,
+                "membership_supportability_state": "READY",
+                **governance_diagnostics,
+            },
+        }
+        for candidate in included_candidates
+    ]
+
+
+def resolve_bulk_review_campaign_governance(
+    *,
+    request: DpmWavePreviewRequest,
+    campaign_as_of_date: date,
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    governance = request.campaign_governance
+    if governance is None:
+        return (
+            {
+                "campaign_governance_status": "NOT_SUPPLIED",
+                "campaign_access_purpose": None,
+                "campaign_expiry_state": "NOT_SUPPLIED",
+                "campaign_actor_entitlement_state": "NOT_SUPPLIED",
+            },
+            [],
+        )
+
+    approval_status = campaign_approval_status(
+        approval_ref=governance.approval_ref,
+        approved_by=governance.approved_by,
+        approved_at=governance.approved_at,
+    )
+    expiry_state = campaign_expiry_state(
+        expires_on=governance.expires_on,
+        campaign_as_of_date=campaign_as_of_date,
+    )
+    actor_entitlement_state = campaign_actor_entitlement_state(
+        entitled_actor_ids=governance.entitled_actor_ids,
+        actor_id=request.actor_id,
+    )
+
+    governance_hash = campaign_governance_hash(
+        trigger_id=request.trigger_id,
+        actor_id=request.actor_id,
+        governance=governance.model_dump(mode="json"),
+    )
+    governance_refs: list[dict[str, object]] = [
+        {
+            "source_system": "lotus-manage",
+            "source_type": "BulkReviewCampaignGovernance",
+            "source_id": f"campaign-governance:{request.trigger_id}",
+            "source_version": governance.approved_at or campaign_as_of_date.isoformat(),
+            "supportability_state": "READY",
+            "content_hash": governance_hash,
+        },
+        *source_refs_payload(governance.source_refs),
+    ]
+    return (
+        {
+            "campaign_governance_status": approval_status,
+            "campaign_approval_ref": governance.approval_ref,
+            "campaign_approved_by": governance.approved_by,
+            "campaign_approved_at": governance.approved_at,
+            "campaign_access_purpose": governance.access_purpose,
+            "campaign_expiry_state": expiry_state,
+            "campaign_expires_on": governance.expires_on,
+            "campaign_actor_entitlement_state": actor_entitlement_state,
+        },
+        governance_refs,
+    )

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -5,7 +5,7 @@ from datetime import date
 from decimal import Decimal
 from typing import Annotated, Literal, cast
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, Query, status
 
 from src.api.observability import record_wave_supportability
 from src.api.dependencies import (
@@ -30,7 +30,6 @@ from src.api.routers.wave_response_contracts import (
     wave_response,
 )
 from src.api.routers.wave_request_models import (
-    DpmWavePortfolioInput,
     DpmWavePreviewRequest,
     DpmWaveSelectionRequest,
     DpmWaveSimulationRequest,
@@ -46,10 +45,6 @@ from src.api.routers.wave_campaign_definition_http import (
     get_campaign_definition_or_404,
     invalid_campaign_discovery_date_http_exception,
 )
-from src.api.routers.wave_campaign_hashing import (
-    campaign_governance_hash,
-    campaign_membership_hash,
-)
 from src.api.routers.wave_campaign_models import (
     DpmBulkReviewCampaignDefinitionApprovalDecisionRequest,
     DpmBulkReviewCampaignDefinitionAssignmentActionRequest,
@@ -61,15 +56,10 @@ from src.api.routers.wave_campaign_models import (
     DpmBulkReviewCampaignDefinitionRequest,
     DpmBulkReviewCampaignDefinitionRetirementRequest,
     DpmBulkReviewCampaignDefinitionSupersessionRequest,
-    DpmBulkReviewCampaignGovernanceInput,
 )
-from src.api.routers.wave_campaign_candidate_selection import (
-    select_bulk_review_campaign_candidates,
-)
-from src.api.routers.wave_campaign_governance_validation import (
-    campaign_actor_entitlement_state,
-    campaign_approval_status,
-    campaign_expiry_state,
+from src.api.routers.wave_campaign_source_resolution import (
+    request_with_campaign_definition,
+    resolve_bulk_review_campaign_portfolios,
 )
 from src.api.routers.wave_cio_model_change_projection import (
     build_cio_model_change_resolved_portfolios,
@@ -96,8 +86,6 @@ from src.api.routers.wave_source_dependency_http import (
     upstream_unavailable_http_exception,
 )
 from src.api.routers.wave_source_refs import (
-    bulk_review_campaign_member_ref,
-    bulk_review_campaign_membership_ref,
     source_refs_payload,
 )
 from src.api.routers.wave_tactical_candidate_selection import (
@@ -140,7 +128,6 @@ from src.core.waves import (
     DpmBulkReviewCampaignDefinitionRepository,
     DpmWaveReportInput,
     DpmWaveRepository,
-    DpmWaveSourceRef,
     build_bulk_review_campaign_discovery_item,
     build_bulk_review_campaign_definition_preview_readiness,
     build_bulk_review_campaign_definition_launch_package,
@@ -325,90 +312,12 @@ def _portfolio_inputs_for_request(
             advise_authority_client=advise_authority_client,
         )
     if request.trigger_type == "BULK_REVIEW_CAMPAIGN":
-        resolved_request = _request_with_campaign_definition(
+        resolved_request = request_with_campaign_definition(
             request=request,
             repository=campaign_definition_repository,
         )
-        return _resolve_bulk_review_campaign_portfolios(request=resolved_request)
+        return resolve_bulk_review_campaign_portfolios(request=resolved_request)
     return [portfolio.model_dump(mode="json") for portfolio in request.portfolios]
-
-
-def _request_with_campaign_definition(
-    *,
-    request: DpmWavePreviewRequest,
-    repository: DpmBulkReviewCampaignDefinitionRepository,
-) -> DpmWavePreviewRequest:
-    if request.campaign_definition_id is None and request.campaign_definition_version is None:
-        return request
-    if not request.campaign_definition_id or not request.campaign_definition_version:
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_DEFINITION_REF_INCOMPLETE",
-            "campaign_definition_id and campaign_definition_version must be supplied together.",
-        )
-    if request.portfolios:
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_DEFINITION_REJECTS_CALLER_PORTFOLIOS",
-            "Persisted campaign definitions supply the candidate portfolio set.",
-        )
-    definition = repository.get_definition(
-        campaign_id=request.campaign_definition_id,
-        campaign_version=request.campaign_definition_version,
-    )
-    if definition is None:
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND",
-            "Persisted bulk-review campaign definition was not found.",
-        )
-    if definition.status == "RETIRED":
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_DEFINITION_RETIRED",
-            "Retired bulk-review campaign definitions cannot be used for new wave preview/create.",
-        )
-    if definition.status == "SUPERSEDED":
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_DEFINITION_SUPERSEDED",
-            "Superseded bulk-review campaign definitions cannot be used for new wave preview/create.",
-        )
-    if definition.as_of_date != request.as_of_date:
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_DEFINITION_AS_OF_DATE_MISMATCH",
-            "campaign definition as_of_date must match the wave request as_of_date.",
-        )
-    definition_ref = DpmWaveSourceRef(
-        source_system="lotus-manage",
-        source_type="BulkReviewCampaignDefinition",
-        source_id=f"campaign-definition:{definition.campaign_id}:{definition.campaign_version}",
-        source_version=definition.product_version,
-        supportability_state="READY",
-        content_hash=definition.content_hash,
-    )
-    portfolios = [
-        DpmWavePortfolioInput(
-            portfolio_id=candidate.portfolio_id,
-            mandate_id=candidate.mandate_id,
-            portfolio_manager_id=candidate.portfolio_manager_id,
-            portfolio_type=candidate.portfolio_type,
-            source_refs=[definition_ref, *candidate.source_refs],
-        )
-        for candidate in definition.candidates
-    ]
-    governance = (
-        DpmBulkReviewCampaignGovernanceInput.model_validate(
-            definition.governance.model_dump(mode="json")
-        )
-        if definition.governance is not None
-        else request.campaign_governance
-    )
-    return request.model_copy(
-        update={
-            "trigger_id": definition.campaign_id,
-            "rationale": definition.rationale,
-            "portfolios": portfolios,
-            "portfolio_types": definition.eligible_portfolio_types,
-            "campaign_governance": governance,
-        },
-        deep=True,
-    )
 
 
 def _resolve_pm_book_portfolios(
@@ -650,151 +559,6 @@ def _resolve_risk_event_portfolios(
         cohort=cohort,
         candidate_by_portfolio_id=candidate_payloads.candidate_by_portfolio_id,
         fallback_risk_event_id=risk_event_id,
-    )
-
-
-def _resolve_bulk_review_campaign_portfolios(
-    *,
-    request: DpmWavePreviewRequest,
-) -> list[dict[str, object]]:
-    if not request.portfolios:
-        raise wave_service.DpmWaveValidationError(
-            "BULK_REVIEW_CAMPAIGN_CANDIDATE_PORTFOLIOS_REQUIRED",
-            "BULK_REVIEW_CAMPAIGN requires source-backed candidate portfolios.",
-        )
-    campaign_as_of_date = parse_wave_as_of_date(request.as_of_date)
-    governance_diagnostics, governance_refs = _resolve_bulk_review_campaign_governance(
-        request=request,
-        campaign_as_of_date=campaign_as_of_date,
-    )
-    eligible_portfolio_types = set(
-        normalize_required_portfolio_types(
-            request.portfolio_types,
-            required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPES_REQUIRED",
-            required_message=(
-                "BULK_REVIEW_CAMPAIGN requires at least one eligible portfolio type."
-            ),
-        )
-    )
-
-    selection = select_bulk_review_campaign_candidates(
-        candidates=request.portfolios,
-        eligible_portfolio_types=eligible_portfolio_types,
-    )
-    included_candidates = selection.included_candidates
-
-    if not included_candidates:
-        raise HTTPException(
-            status_code=status.HTTP_424_FAILED_DEPENDENCY,
-            detail={
-                "code": "BULK_REVIEW_CAMPAIGN_MEMBERSHIP_EMPTY",
-                "message": "Bulk-review campaign membership returned no eligible DPM portfolios.",
-            },
-        )
-
-    membership_hash = campaign_membership_hash(
-        trigger_id=request.trigger_id,
-        as_of_date=campaign_as_of_date,
-        portfolio_types=sorted(eligible_portfolio_types),
-        portfolios=[candidate.model_dump(mode="json") for candidate in included_candidates],
-    )
-    membership_ref = bulk_review_campaign_membership_ref(
-        trigger_id=request.trigger_id,
-        campaign_as_of_date=campaign_as_of_date,
-        membership_hash=membership_hash,
-    )
-    return [
-        {
-            "portfolio_id": candidate.portfolio_id,
-            "mandate_id": candidate.mandate_id,
-            "source_refs": [
-                membership_ref,
-                *governance_refs,
-                bulk_review_campaign_member_ref(
-                    trigger_id=request.trigger_id,
-                    portfolio_id=candidate.portfolio_id,
-                    campaign_as_of_date=campaign_as_of_date,
-                    membership_hash=membership_hash,
-                ),
-                *source_refs_payload(candidate.source_refs),
-            ],
-            "diagnostics": {
-                "source_owner": "lotus-manage",
-                "source_product": "BulkReviewCampaignMembership:v1",
-                "campaign_id": request.trigger_id,
-                "campaign_as_of_date": campaign_as_of_date.isoformat(),
-                "portfolio_type": candidate.portfolio_type.strip().upper()
-                if candidate.portfolio_type
-                else None,
-                "eligible_portfolio_types": sorted(eligible_portfolio_types),
-                "excluded_candidate_count": selection.excluded_count,
-                "membership_supportability_state": "READY",
-                **governance_diagnostics,
-            },
-        }
-        for candidate in included_candidates
-    ]
-
-
-def _resolve_bulk_review_campaign_governance(
-    *,
-    request: DpmWavePreviewRequest,
-    campaign_as_of_date: date,
-) -> tuple[dict[str, object], list[dict[str, object]]]:
-    governance = request.campaign_governance
-    if governance is None:
-        return (
-            {
-                "campaign_governance_status": "NOT_SUPPLIED",
-                "campaign_access_purpose": None,
-                "campaign_expiry_state": "NOT_SUPPLIED",
-                "campaign_actor_entitlement_state": "NOT_SUPPLIED",
-            },
-            [],
-        )
-
-    approval_status = campaign_approval_status(
-        approval_ref=governance.approval_ref,
-        approved_by=governance.approved_by,
-        approved_at=governance.approved_at,
-    )
-    expiry_state = campaign_expiry_state(
-        expires_on=governance.expires_on,
-        campaign_as_of_date=campaign_as_of_date,
-    )
-    actor_entitlement_state = campaign_actor_entitlement_state(
-        entitled_actor_ids=governance.entitled_actor_ids,
-        actor_id=request.actor_id,
-    )
-
-    governance_hash = campaign_governance_hash(
-        trigger_id=request.trigger_id,
-        actor_id=request.actor_id,
-        governance=governance.model_dump(mode="json"),
-    )
-    governance_refs: list[dict[str, object]] = [
-        {
-            "source_system": "lotus-manage",
-            "source_type": "BulkReviewCampaignGovernance",
-            "source_id": f"campaign-governance:{request.trigger_id}",
-            "source_version": governance.approved_at or campaign_as_of_date.isoformat(),
-            "supportability_state": "READY",
-            "content_hash": governance_hash,
-        },
-        *source_refs_payload(governance.source_refs),
-    ]
-    return (
-        {
-            "campaign_governance_status": approval_status,
-            "campaign_approval_ref": governance.approval_ref,
-            "campaign_approved_by": governance.approved_by,
-            "campaign_approved_at": governance.approved_at,
-            "campaign_access_purpose": governance.access_purpose,
-            "campaign_expiry_state": expiry_state,
-            "campaign_expires_on": governance.expires_on,
-            "campaign_actor_entitlement_state": actor_entitlement_state,
-        },
-        governance_refs,
     )
 
 


### PR DESCRIPTION
## Summary
- extract bulk-review campaign source-resolution behavior from the monolithic waves router into `wave_campaign_source_resolution.py`
- keep router ownership focused on dispatch and endpoint wiring while preserving persisted campaign-definition hydration, membership refs, governance diagnostics, and fail-closed validation behavior
- no OpenAPI/schema/docs/wiki truth changed

## WTBD / Governance Posture
- Supports RFC41-WTBD-003 maintainability for Manage-owned bulk-review campaign workflows.
- Does not add global portfolio-universe discovery, external workflow orchestration, Gateway/Workbench behavior, order generation, execution, OMS, or client-contact claims.

## Validation
- `python -m ruff check src\\api\\routers\\waves.py src\\api\\routers\\wave_campaign_source_resolution.py`
- `python -m pytest tests\\unit\\api\\test_wave_campaign_candidate_selection.py tests\\unit\\api\\test_wave_campaign_governance_validation.py tests\\unit\\api\\test_wave_campaign_definition_http.py tests\\unit\\api\\test_wave_campaign_hashing.py tests\\unit\\dpm\\waves\\test_campaign_definition_repository.py -q` (68 passed)
- `python -m pytest tests\\unit\\dpm\\api\\test_waves_api.py tests\\unit\\dpm\\waves\\test_campaign_discovery.py tests\\unit\\dpm\\waves\\test_campaign_definition_repository.py tests\\unit\\api\\test_wave_campaign_candidate_selection.py tests\\unit\\api\\test_wave_campaign_governance_validation.py tests\\unit\\api\\test_wave_campaign_definition_http.py tests\\unit\\api\\test_wave_campaign_hashing.py -q` (254 passed)
- `make lint`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make test-unit` (1451 passed, 2 existing deprecation warnings)
- `make test-integration` (168 passed)
- `make test-e2e` (28 passed)
- `python ..\\lotus-platform\\automation\\validate_engineering_context_system.py`
- `python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py`
- `powershell -NoProfile -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)