### PR TITLE
Extract campaign discovery date parsing

### DIFF
--- a/src/api/routers/wave_campaign_definition_http.py
+++ b/src/api/routers/wave_campaign_definition_http.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date
+
 from fastapi import HTTPException, status
 
 from src.core.waves import (
@@ -93,6 +95,19 @@ def invalid_campaign_discovery_date_http_exception(field_name: str) -> HTTPExcep
             "message": f"{field_name} must be an ISO date.",
         },
     )
+
+
+def parse_optional_campaign_discovery_date(
+    *,
+    value: str | None,
+    field_name: str,
+) -> date | None:
+    if value is None:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise invalid_campaign_discovery_date_http_exception(field_name) from exc
 
 
 def _campaign_definition_lifecycle_status_code(code: str) -> int:

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import date
 from decimal import Decimal
 from typing import Annotated, Literal, cast
 
@@ -43,7 +42,7 @@ from src.api.routers.wave_campaign_definition_http import (
     campaign_definition_not_found_http_exception,
     campaign_definition_value_http_exception,
     get_campaign_definition_or_404,
-    invalid_campaign_discovery_date_http_exception,
+    parse_optional_campaign_discovery_date,
 )
 from src.api.routers.wave_campaign_models import (
     DpmBulkReviewCampaignDefinitionApprovalDecisionRequest,
@@ -653,7 +652,7 @@ def discover_bulk_review_campaigns(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDiscoveryPage:
-    active_on_date = _parse_optional_campaign_discovery_date(
+    active_on_date = parse_optional_campaign_discovery_date(
         value=active_on,
         field_name="active_on",
     )
@@ -723,7 +722,7 @@ def list_bulk_review_campaign_operating_queue(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignOperatingQueuePage:
-    active_on_date = _parse_optional_campaign_discovery_date(
+    active_on_date = parse_optional_campaign_discovery_date(
         value=active_on,
         field_name="active_on",
     )
@@ -790,7 +789,7 @@ def list_bulk_review_campaign_approval_inbox(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignApprovalInboxPage:
-    active_on_date = _parse_optional_campaign_discovery_date(
+    active_on_date = parse_optional_campaign_discovery_date(
         value=active_on,
         field_name="active_on",
     )
@@ -863,7 +862,7 @@ def list_bulk_review_campaign_workflow_board(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignWorkflowBoardPage:
-    active_on_date = _parse_optional_campaign_discovery_date(
+    active_on_date = parse_optional_campaign_discovery_date(
         value=active_on,
         field_name="active_on",
     )
@@ -936,7 +935,7 @@ def list_bulk_review_campaign_assignment_plan(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignAssignmentPlanPage:
-    active_on_date = _parse_optional_campaign_discovery_date(
+    active_on_date = parse_optional_campaign_discovery_date(
         value=active_on,
         field_name="active_on",
     )
@@ -1014,7 +1013,7 @@ def list_bulk_review_campaign_workflow_automation(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignWorkflowAutomationPage:
-    active_on_date = _parse_optional_campaign_discovery_date(
+    active_on_date = parse_optional_campaign_discovery_date(
         value=active_on,
         field_name="active_on",
     )
@@ -1553,7 +1552,7 @@ def get_bulk_review_campaign_definition_workflow_overview(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
     )
-    active_on_date = _parse_optional_campaign_discovery_date(
+    active_on_date = parse_optional_campaign_discovery_date(
         value=active_on,
         field_name="active_on",
     )
@@ -1734,19 +1733,6 @@ def launch_bulk_review_campaign_definition(
             message="Bulk-review campaign definition launch audit could not be recorded.",
         ) from exc
     return wave_response(wave=wave, durable=True, idempotent_replay=replay)
-
-
-def _parse_optional_campaign_discovery_date(
-    *,
-    value: str | None,
-    field_name: str,
-) -> date | None:
-    if value is None:
-        return None
-    try:
-        return date.fromisoformat(value)
-    except ValueError as exc:
-        raise invalid_campaign_discovery_date_http_exception(field_name) from exc
 
 
 @router.post(

--- a/tests/unit/api/test_wave_campaign_definition_http.py
+++ b/tests/unit/api/test_wave_campaign_definition_http.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from datetime import date
+
+import pytest
 from fastapi import status
+from fastapi import HTTPException
 
 from src.api.routers.wave_campaign_definition_http import (
     campaign_definition_conflict_http_exception,
@@ -9,6 +13,7 @@ from src.api.routers.wave_campaign_definition_http import (
     campaign_definition_not_found_http_exception,
     campaign_definition_value_http_exception,
     invalid_campaign_discovery_date_http_exception,
+    parse_optional_campaign_discovery_date,
 )
 from src.core.waves.campaign_definition_launch_execution import (
     DpmBulkReviewCampaignDefinitionLaunchBlocked,
@@ -145,6 +150,25 @@ def test_invalid_campaign_discovery_date_http_exception_maps_field_name() -> Non
 
     assert http_exc.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
     assert http_exc.detail == {
+        "code": "BULK_REVIEW_CAMPAIGN_DISCOVERY_DATE_INVALID",
+        "message": "active_on must be an ISO date.",
+    }
+
+
+def test_parse_optional_campaign_discovery_date_accepts_empty_and_iso_date() -> None:
+    assert parse_optional_campaign_discovery_date(value=None, field_name="active_on") is None
+    assert parse_optional_campaign_discovery_date(
+        value="2026-05-10",
+        field_name="active_on",
+    ) == date(2026, 5, 10)
+
+
+def test_parse_optional_campaign_discovery_date_maps_invalid_date_to_http_error() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        parse_optional_campaign_discovery_date(value="2026/05/10", field_name="active_on")
+
+    assert exc_info.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert exc_info.value.detail == {
         "code": "BULK_REVIEW_CAMPAIGN_DISCOVERY_DATE_INVALID",
         "message": "active_on must be an ISO date.",
     }


### PR DESCRIPTION
## Summary
- move campaign discovery active_on ISO-date parsing into the campaign-definition HTTP helper module
- keep the waves router focused on route orchestration by consuming the shared parser
- add focused parser tests for empty, valid ISO, and invalid-date HTTP error mapping

## Validation
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- python -m pytest tests/unit/api/test_wave_campaign_definition_http.py tests/unit/dpm/api/test_waves_api.py -q
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py

## Docs / Wiki
- No docs/wiki change: internal router-helper refactor only; public API behavior and contract remain unchanged.