### PR TITLE
Extract wave supportability HTTP helper

### DIFF
--- a/src/api/routers/wave_supportability_http.py
+++ b/src/api/routers/wave_supportability_http.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+from src.api.observability import record_wave_supportability
+from src.api.routers.wave_http_errors import wave_lookup_http_exception
+from src.api.routers.wave_response_contracts import DpmWaveSupportabilityResponse
+from src.api.services import wave_service
+from src.core.waves import DpmWaveRepository
+
+WAVE_SUPPORTABILITY_SURFACE = "rebalance/waves/supportability"
+
+
+def get_wave_supportability_response(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+    logger: logging.Logger,
+) -> DpmWaveSupportabilityResponse:
+    try:
+        payload = wave_service.wave_supportability(
+            wave_id=wave_id,
+            wave_repository=wave_repository,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        record_wave_supportability(
+            surface=WAVE_SUPPORTABILITY_SURFACE,
+            supportability_state="not_found",
+            reason="wave_not_found",
+        )
+        raise wave_lookup_http_exception(exc) from exc
+
+    supportability_state = str(payload["supportability_state"])
+    reason = str(payload["reason"])
+    record_wave_supportability(
+        surface=WAVE_SUPPORTABILITY_SURFACE,
+        supportability_state=supportability_state,
+        reason=reason,
+    )
+    logger.info(
+        "wave.supportability.inspected",
+        extra={
+            "extra_fields": {
+                "wave_state": payload["wave_state"],
+                "supportability_state": supportability_state,
+                "reason": reason,
+                "issue_count": len(cast(list[object], payload["issues"])),
+            }
+        },
+    )
+    return DpmWaveSupportabilityResponse.model_validate(payload)

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, Header, Query, status
 
-from src.api.observability import record_wave_supportability
 from src.api.dependencies import (
     get_advise_authority_client,
     get_campaign_definition_repository,
@@ -66,6 +65,7 @@ from src.api.routers.wave_openapi_examples import (
 from src.api.routers.wave_portfolio_resolution import (
     resolve_portfolio_inputs_for_request,
 )
+from src.api.routers.wave_supportability_http import get_wave_supportability_response
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
 from src.api.services import wave_service
@@ -2249,34 +2249,8 @@ def get_wave_supportability(
     wave_id: str,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveSupportabilityResponse:
-    try:
-        payload = wave_service.wave_supportability(
-            wave_id=wave_id,
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        record_wave_supportability(
-            surface="rebalance/waves/supportability",
-            supportability_state="not_found",
-            reason="wave_not_found",
-        )
-        raise wave_lookup_http_exception(exc) from exc
-    supportability_state = str(payload["supportability_state"])
-    reason = str(payload["reason"])
-    record_wave_supportability(
-        surface="rebalance/waves/supportability",
-        supportability_state=supportability_state,
-        reason=reason,
+    return get_wave_supportability_response(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        logger=logger,
     )
-    logger.info(
-        "wave.supportability.inspected",
-        extra={
-            "extra_fields": {
-                "wave_state": payload["wave_state"],
-                "supportability_state": supportability_state,
-                "reason": reason,
-                "issue_count": len(cast(list[object], payload["issues"])),
-            }
-        },
-    )
-    return DpmWaveSupportabilityResponse.model_validate(payload)


### PR DESCRIPTION
## Summary
- extract wave supportability response adaptation, metrics, lookup error mapping, and structured logging into a dedicated router helper
- keep the public endpoint contract and wave service behavior unchanged
- reduce responsibility inside the monolithic waves router as part of backend maintainability cleanup

## Validation
- python -m ruff format src/api/routers/wave_supportability_http.py src/api/routers/waves.py
- python -m ruff check src/api/routers/wave_supportability_http.py src/api/routers/waves.py
- python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_supportability_reports_product_safe_operator_diagnostics -q
- python -m pytest tests/unit/dpm/api/test_waves_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Documentation
- No docs/wiki/API contract change: behavior-preserving internal HTTP helper extraction.