### PR TITLE
Extract wave read HTTP helpers

### DIFF
--- a/src/api/routers/wave_read_http.py
+++ b/src/api/routers/wave_read_http.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from src.api.routers.wave_http_errors import wave_lookup_http_exception
+from src.api.routers.wave_response_contracts import (
+    DpmWaveDetailResponse,
+    DpmWaveItemsResponse,
+    DpmWaveProofPackPostureResponse,
+)
+from src.api.services import wave_service
+from src.core.waves import DpmWaveRepository
+
+
+def get_wave_detail_response(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+) -> DpmWaveDetailResponse:
+    try:
+        payload = wave_service.retrieve_wave_detail(
+            wave_id=wave_id,
+            wave_repository=wave_repository,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        raise wave_lookup_http_exception(exc) from exc
+    return DpmWaveDetailResponse.model_validate(payload)
+
+
+def get_wave_items_response(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+) -> DpmWaveItemsResponse:
+    try:
+        payload = wave_service.list_wave_items(
+            wave_id=wave_id,
+            wave_repository=wave_repository,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        raise wave_lookup_http_exception(exc) from exc
+    return DpmWaveItemsResponse.model_validate(payload)
+
+
+def get_wave_proof_pack_posture_response(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+) -> DpmWaveProofPackPostureResponse:
+    try:
+        payload = wave_service.proof_pack_posture(
+            wave_id=wave_id,
+            wave_repository=wave_repository,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        raise wave_lookup_http_exception(exc) from exc
+    return DpmWaveProofPackPostureResponse.model_validate(payload)

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -65,6 +65,11 @@ from src.api.routers.wave_openapi_examples import (
 from src.api.routers.wave_portfolio_resolution import (
     resolve_portfolio_inputs_for_request,
 )
+from src.api.routers.wave_read_http import (
+    get_wave_detail_response,
+    get_wave_items_response,
+    get_wave_proof_pack_posture_response,
+)
 from src.api.routers.wave_supportability_http import get_wave_supportability_response
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
@@ -1724,14 +1729,10 @@ def get_wave_detail(
     wave_id: str,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveDetailResponse:
-    try:
-        payload = wave_service.retrieve_wave_detail(
-            wave_id=wave_id,
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    return DpmWaveDetailResponse.model_validate(payload)
+    return get_wave_detail_response(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+    )
 
 
 @router.get(
@@ -1753,14 +1754,10 @@ def get_wave_items(
     wave_id: str,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveItemsResponse:
-    try:
-        payload = wave_service.list_wave_items(
-            wave_id=wave_id,
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    return DpmWaveItemsResponse.model_validate(payload)
+    return get_wave_items_response(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+    )
 
 
 @router.post(
@@ -2175,14 +2172,10 @@ def get_wave_proof_pack_posture(
     wave_id: str,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveProofPackPostureResponse:
-    try:
-        payload = wave_service.proof_pack_posture(
-            wave_id=wave_id,
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    return DpmWaveProofPackPostureResponse.model_validate(payload)
+    return get_wave_proof_pack_posture_response(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+    )
 
 
 @router.get(


### PR DESCRIPTION
## Summary
- extract wave detail, item-list, and proof-pack posture response adaptation into a dedicated read helper
- preserve existing lookup-error mapping and response contracts
- continue reducing controller responsibility in the monolithic waves router without changing public API behavior

## Validation
- python -m ruff format src/api/routers/wave_read_http.py src/api/routers/waves.py
- python -m ruff check src/api/routers/wave_read_http.py src/api/routers/waves.py
- python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_posture -q
- python -m pytest tests/unit/dpm/api/test_waves_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Documentation
- No docs/wiki/API contract change: behavior-preserving internal HTTP helper extraction.