### PR TITLE
Extract wave workflow command HTTP helper

### DIFF
--- a/src/api/routers/wave_workflow_command_http.py
+++ b/src/api/routers/wave_workflow_command_http.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from src.api.routers.wave_http_errors import (
+    wave_lookup_http_exception,
+    wave_validation_http_exception,
+)
+from src.api.routers.wave_request_models import DpmWaveWorkflowCommandRequest
+from src.api.routers.wave_response_contracts import DpmWaveResponse, wave_response
+from src.api.services import wave_service
+from src.core.waves import DpmRebalanceWave, DpmWaveRepository
+
+WaveWorkflowCommand = Callable[
+    ...,
+    tuple[DpmRebalanceWave, bool],
+]
+
+
+def run_wave_workflow_command_response(
+    *,
+    command: WaveWorkflowCommand,
+    wave_id: str,
+    request: DpmWaveWorkflowCommandRequest,
+    correlation_id: str,
+    wave_repository: DpmWaveRepository,
+) -> DpmWaveResponse:
+    try:
+        wave, replayed = command(
+            wave_id=wave_id,
+            actor_id=request.actor_id,
+            reason_code=request.reason_code,
+            comment=request.comment,
+            correlation_id=correlation_id,
+            wave_repository=wave_repository,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        raise wave_lookup_http_exception(exc) from exc
+    except wave_service.DpmWaveValidationError as exc:
+        raise wave_validation_http_exception(exc) from exc
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -71,6 +71,7 @@ from src.api.routers.wave_read_http import (
     get_wave_proof_pack_posture_response,
 )
 from src.api.routers.wave_supportability_http import get_wave_supportability_response
+from src.api.routers.wave_workflow_command_http import run_wave_workflow_command_response
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services.rebalance_simulation_service import build_core_resolver_client
 from src.api.services import wave_service
@@ -1998,20 +1999,13 @@ def approve_wave(
     ] = None,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
-    try:
-        wave, replayed = wave_service.approve_wave(
-            wave_id=wave_id,
-            actor_id=request.actor_id,
-            reason_code=request.reason_code,
-            comment=request.comment,
-            correlation_id=x_correlation_id or f"corr_wave_approve_{wave_id}",
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc) from exc
-    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return run_wave_workflow_command_response(
+        command=wave_service.approve_wave,
+        wave_id=wave_id,
+        request=request,
+        correlation_id=x_correlation_id or f"corr_wave_approve_{wave_id}",
+        wave_repository=wave_repository,
+    )
 
 
 @router.post(
@@ -2044,20 +2038,13 @@ def stage_wave(
     ] = None,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
-    try:
-        wave, replayed = wave_service.stage_wave(
-            wave_id=wave_id,
-            actor_id=request.actor_id,
-            reason_code=request.reason_code,
-            comment=request.comment,
-            correlation_id=x_correlation_id or f"corr_wave_stage_{wave_id}",
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc) from exc
-    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return run_wave_workflow_command_response(
+        command=wave_service.stage_wave,
+        wave_id=wave_id,
+        request=request,
+        correlation_id=x_correlation_id or f"corr_wave_stage_{wave_id}",
+        wave_repository=wave_repository,
+    )
 
 
 @router.post(
@@ -2089,20 +2076,13 @@ def handoff_wave(
     ] = None,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
-    try:
-        wave, replayed = wave_service.handoff_wave(
-            wave_id=wave_id,
-            actor_id=request.actor_id,
-            reason_code=request.reason_code,
-            comment=request.comment,
-            correlation_id=x_correlation_id or f"corr_wave_handoff_{wave_id}",
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc) from exc
-    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return run_wave_workflow_command_response(
+        command=wave_service.handoff_wave,
+        wave_id=wave_id,
+        request=request,
+        correlation_id=x_correlation_id or f"corr_wave_handoff_{wave_id}",
+        wave_repository=wave_repository,
+    )
 
 
 @router.post(
@@ -2137,20 +2117,13 @@ def cancel_wave(
     ] = None,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
-    try:
-        wave, replayed = wave_service.cancel_wave(
-            wave_id=wave_id,
-            actor_id=request.actor_id,
-            reason_code=request.reason_code,
-            comment=request.comment,
-            correlation_id=x_correlation_id or f"corr_wave_cancel_{wave_id}",
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc) from exc
-    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return run_wave_workflow_command_response(
+        command=wave_service.cancel_wave,
+        wave_id=wave_id,
+        request=request,
+        correlation_id=x_correlation_id or f"corr_wave_cancel_{wave_id}",
+        wave_repository=wave_repository,
+    )
 
 
 @router.get(


### PR DESCRIPTION
## Summary
- extract repeated approve/stage/handoff/cancel HTTP command handling into a dedicated wave workflow helper
- preserve correlation-id defaults, lookup/validation error mapping, durable response construction, and idempotent replay behavior
- continue shrinking the monolithic waves router without changing public API contracts

## Validation
- python -m ruff format src/api/routers/wave_workflow_command_http.py src/api/routers/waves.py
- python -m ruff check src/api/routers/wave_workflow_command_http.py src/api/routers/waves.py
- python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_approval_staging_and_handoff_are_durable_and_idempotent tests/unit/dpm/api/test_waves_api.py::test_wave_cancel_is_durable_idempotent_and_rejects_handoff_ready_waves tests/unit/dpm/api/test_waves_api.py::test_wave_approval_excludes_blocked_items_and_stages_only_approved_items tests/unit/dpm/api/test_waves_api.py::test_wave_services_reject_no_eligible_approval_stage_and_handoff -q
- python -m pytest tests/unit/dpm/api/test_waves_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Documentation
- No docs/wiki/API contract change: behavior-preserving internal HTTP helper extraction.