### PR TITLE
Extract wave source-check HTTP helper

### DIFF
--- a/src/api/routers/wave_source_check_http.py
+++ b/src/api/routers/wave_source_check_http.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from src.api.routers.wave_http_errors import (
+    wave_lookup_http_exception,
+    wave_validation_http_exception,
+)
+from src.api.routers.wave_request_models import DpmWaveSourceCheckRequest
+from src.api.routers.wave_response_contracts import DpmWaveResponse, wave_response
+from src.api.services import wave_service
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.waves import DpmWaveRepository
+
+
+def source_check_wave_response(
+    *,
+    wave_id: str,
+    request: DpmWaveSourceCheckRequest,
+    correlation_id: str,
+    mandate_repository: DpmMandateRepository,
+    wave_repository: DpmWaveRepository,
+) -> DpmWaveResponse:
+    try:
+        wave, replayed = wave_service.source_check_wave(
+            wave_id=wave_id,
+            actor_id=request.actor_id,
+            correlation_id=correlation_id,
+            mandate_repository=mandate_repository,
+            wave_repository=wave_repository,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        raise wave_lookup_http_exception(exc) from exc
+    except wave_service.DpmWaveValidationError as exc:
+        raise wave_validation_http_exception(exc) from exc
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -70,6 +70,7 @@ from src.api.routers.wave_read_http import (
     get_wave_proof_pack_posture_response,
 )
 from src.api.routers.wave_simulation_http import build_wave_simulation_item_inputs
+from src.api.routers.wave_source_check_http import source_check_wave_response
 from src.api.routers.wave_supportability_http import get_wave_supportability_response
 from src.api.routers.wave_workflow_command_http import run_wave_workflow_command_response
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
@@ -1833,19 +1834,13 @@ def source_check_wave(
     mandate_repository: DpmMandateRepository = Depends(get_mandate_repository),
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
-    try:
-        wave, replayed = wave_service.source_check_wave(
-            wave_id=wave_id,
-            actor_id=request.actor_id,
-            correlation_id=x_correlation_id or f"corr_wave_source_check_{wave_id}",
-            mandate_repository=mandate_repository,
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc) from exc
-    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return source_check_wave_response(
+        wave_id=wave_id,
+        request=request,
+        correlation_id=x_correlation_id or f"corr_wave_source_check_{wave_id}",
+        mandate_repository=mandate_repository,
+        wave_repository=wave_repository,
+    )
 
 
 @router.post(


### PR DESCRIPTION
## Summary
- extract source-check service invocation, error mapping, and durable response construction into a dedicated HTTP helper
- preserve correlation-id defaults, endpoint contract, source-check behavior, and idempotent replay response semantics
- continue shrinking the monolithic waves router with a behavior-preserving adapter extraction

## Validation
- python -m ruff format src/api/routers/wave_source_check_http.py src/api/routers/waves.py
- python -m ruff check src/api/routers/wave_source_check_http.py src/api/routers/waves.py
- python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_source_check_classifies_mixed_items_and_attaches_authoritative_refs tests/unit/dpm/api/test_waves_api.py::test_wave_source_check_reports_missing_and_invalid_state_errors -q
- python -m pytest tests/unit/dpm/api/test_waves_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Documentation
- No docs/wiki/API contract change: behavior-preserving internal helper extraction.