### PR TITLE
Extract wave selection HTTP helper

### DIFF
--- a/src/api/routers/wave_selection_http.py
+++ b/src/api/routers/wave_selection_http.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from src.api.routers.wave_http_errors import (
+    wave_lookup_http_exception,
+    wave_validation_http_exception,
+)
+from src.api.routers.wave_request_models import DpmWaveSelectionRequest
+from src.api.routers.wave_response_contracts import DpmWaveResponse, wave_response
+from src.api.services import wave_service
+from src.core.construction.repository import ConstructionRepository
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.proof_packs.repository import DpmProofPackRepository
+from src.core.rebalance_runs.service import DpmRunSupportService
+from src.core.waves import DpmWaveRepository
+
+
+def select_wave_item_alternative_response(
+    *,
+    wave_id: str,
+    wave_item_id: str,
+    request: DpmWaveSelectionRequest,
+    correlation_id: str,
+    construction_repository: ConstructionRepository,
+    proof_pack_repository: DpmProofPackRepository,
+    mandate_repository: DpmMandateRepository,
+    run_service: DpmRunSupportService,
+    wave_repository: DpmWaveRepository,
+) -> DpmWaveResponse:
+    try:
+        wave = wave_service.select_wave_item_alternative(
+            wave_id=wave_id,
+            wave_item_id=wave_item_id,
+            alternative_id=request.alternative_id,
+            actor_id=request.actor_id,
+            reason_code=request.reason_code,
+            comment=request.comment,
+            correlation_id=correlation_id,
+            generate_proof_pack=request.generate_proof_pack,
+            construction_repository=construction_repository,
+            proof_pack_repository=proof_pack_repository,
+            mandate_repository=mandate_repository,
+            run_service=run_service,
+            wave_repository=wave_repository,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        raise wave_lookup_http_exception(exc) from exc
+    except wave_service.DpmWaveValidationError as exc:
+        raise wave_validation_http_exception(exc) from exc
+    return wave_response(wave=wave, durable=True)

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -69,6 +69,7 @@ from src.api.routers.wave_read_http import (
     get_wave_items_response,
     get_wave_proof_pack_posture_response,
 )
+from src.api.routers.wave_selection_http import select_wave_item_alternative_response
 from src.api.routers.wave_simulation_http import build_wave_simulation_item_inputs
 from src.api.routers.wave_source_check_http import source_check_wave_response
 from src.api.routers.wave_supportability_http import get_wave_supportability_response
@@ -1931,27 +1932,17 @@ def select_wave_item_alternative(
     run_service: DpmRunSupportService = Depends(get_dpm_run_support_service),
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
-    try:
-        wave = wave_service.select_wave_item_alternative(
-            wave_id=wave_id,
-            wave_item_id=wave_item_id,
-            alternative_id=request.alternative_id,
-            actor_id=request.actor_id,
-            reason_code=request.reason_code,
-            comment=request.comment,
-            correlation_id=x_correlation_id or f"corr_wave_select_{wave_id}_{wave_item_id}",
-            generate_proof_pack=request.generate_proof_pack,
-            construction_repository=construction_repository,
-            proof_pack_repository=proof_pack_repository,
-            mandate_repository=mandate_repository,
-            run_service=run_service,
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc) from exc
-    return wave_response(wave=wave, durable=True)
+    return select_wave_item_alternative_response(
+        wave_id=wave_id,
+        wave_item_id=wave_item_id,
+        request=request,
+        correlation_id=x_correlation_id or f"corr_wave_select_{wave_id}_{wave_item_id}",
+        construction_repository=construction_repository,
+        proof_pack_repository=proof_pack_repository,
+        mandate_repository=mandate_repository,
+        run_service=run_service,
+        wave_repository=wave_repository,
+    )
 
 
 @router.post(


### PR DESCRIPTION
## Summary
- Extract wave item alternative selection HTTP adaptation into `wave_selection_http.py`
- Keep the FastAPI route contract unchanged while moving domain invocation and HTTP error mapping out of `waves.py`
- Preserve proof-pack selection behavior, durable response shaping, and conflict/error semantics

## Validation
- `python -m ruff check src/api/routers/wave_selection_http.py src/api/routers/waves.py`
- `python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_simulate_selects_alternative_and_links_proof_pack_after_reload tests/unit/dpm/api/test_waves_api.py::test_wave_selection_degrades_when_proof_pack_generation_is_not_requested tests/unit/dpm/api/test_waves_api.py::test_wave_selection_reports_invalid_item_and_alternative_errors tests/unit/dpm/api/test_waves_api.py::test_wave_selection_rejects_items_without_generated_alternatives tests/unit/dpm/api/test_waves_api.py::test_wave_selection_degrades_when_proof_pack_generation_fails tests/unit/dpm/api/test_waves_api.py::test_wave_selection_translates_durable_write_conflict_to_governed_error -q`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `python -m pytest tests/unit/dpm/api/test_waves_api.py -q`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`

## Governance
- Code-only refactor; no API/schema, vocabulary, docs, RFC, wiki, or context truth changed.
- Gateway, Workbench, and Advise not touched.