### PR TITLE
Extract wave simulation HTTP helper

### DIFF
--- a/src/api/routers/wave_simulation_http.py
+++ b/src/api/routers/wave_simulation_http.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
 from src.api.request_models import RebalanceRequest
+from src.api.routers.wave_http_errors import (
+    wave_lookup_http_exception,
+    wave_validation_http_exception,
+)
 from src.api.routers.wave_request_models import DpmWaveSimulationRequest
+from src.api.routers.wave_response_contracts import DpmWaveResponse, wave_response
 from src.api.services import wave_service
+from src.core.construction.repository import ConstructionRepository
+from src.core.rebalance_runs.service import DpmRunSupportService
+from src.core.waves import DpmWaveRepository
+from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 
 def build_wave_simulation_item_inputs(
@@ -19,3 +28,32 @@ def build_wave_simulation_item_inputs(
         if item_input.portfolio_id:
             item_inputs[item_input.portfolio_id] = simulation_input
     return item_inputs
+
+
+def simulate_wave_response(
+    *,
+    wave_id: str,
+    request: DpmWaveSimulationRequest,
+    correlation_id: str,
+    construction_repository: ConstructionRepository,
+    run_service: DpmRunSupportService,
+    wave_repository: DpmWaveRepository,
+    risk_authority_client: LotusRiskAuthorityClient | None,
+) -> DpmWaveResponse:
+    try:
+        wave, replayed = wave_service.simulate_wave(
+            wave_id=wave_id,
+            actor_id=request.actor_id,
+            correlation_id=correlation_id,
+            item_inputs=build_wave_simulation_item_inputs(request),
+            methods=request.methods,
+            construction_repository=construction_repository,
+            run_service=run_service,
+            wave_repository=wave_repository,
+            risk_authority_client=risk_authority_client,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        raise wave_lookup_http_exception(exc) from exc
+    except wave_service.DpmWaveValidationError as exc:
+        raise wave_validation_http_exception(exc) from exc
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -70,7 +70,7 @@ from src.api.routers.wave_read_http import (
     get_wave_proof_pack_posture_response,
 )
 from src.api.routers.wave_selection_http import select_wave_item_alternative_response
-from src.api.routers.wave_simulation_http import build_wave_simulation_item_inputs
+from src.api.routers.wave_simulation_http import simulate_wave_response
 from src.api.routers.wave_source_check_http import source_check_wave_response
 from src.api.routers.wave_supportability_http import get_wave_supportability_response
 from src.api.routers.wave_workflow_command_http import run_wave_workflow_command_response
@@ -1878,23 +1878,15 @@ def simulate_wave(
     run_service: DpmRunSupportService = Depends(get_dpm_run_support_service),
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
-    try:
-        wave, replayed = wave_service.simulate_wave(
-            wave_id=wave_id,
-            actor_id=request.actor_id,
-            correlation_id=x_correlation_id or f"corr_wave_simulate_{wave_id}",
-            item_inputs=build_wave_simulation_item_inputs(request),
-            methods=request.methods,
-            construction_repository=construction_repository,
-            run_service=run_service,
-            wave_repository=wave_repository,
-            risk_authority_client=risk_authority_client,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc) from exc
-    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return simulate_wave_response(
+        wave_id=wave_id,
+        request=request,
+        correlation_id=x_correlation_id or f"corr_wave_simulate_{wave_id}",
+        construction_repository=construction_repository,
+        run_service=run_service,
+        wave_repository=wave_repository,
+        risk_authority_client=risk_authority_client,
+    )
 
 
 @router.post(


### PR DESCRIPTION
## Summary
- Extract wave simulation HTTP adaptation into `wave_simulation_http.py`
- Keep the FastAPI route contract unchanged while moving domain invocation, item-input adaptation, durable response shaping, and HTTP error mapping out of `waves.py`
- Preserve simulation idempotent replay, risk-authority dependency wiring, and wave validation semantics

## Validation
- `python -m ruff check src/api/routers/wave_simulation_http.py src/api/routers/waves.py`
- `python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_simulate_selects_alternative_and_links_proof_pack_after_reload tests/unit/dpm/api/test_waves_api.py::test_wave_selection_translates_durable_write_conflict_to_governed_error -q`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `python -m pytest tests/unit/dpm/api/test_waves_api.py -q`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`

## Governance
- Code-only refactor; no API/schema, vocabulary, docs, RFC, wiki, or context truth changed.
- Gateway, Workbench, and Advise not touched.