### PR TITLE
Extract wave report input HTTP helper

### DIFF
--- a/src/api/routers/wave_report_input_http.py
+++ b/src/api/routers/wave_report_input_http.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from src.api.routers.wave_http_errors import (
+    wave_lookup_http_exception,
+    wave_validation_http_exception,
+)
+from src.api.services import wave_service
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.outcomes.repository import DpmOutcomeReviewRepository
+from src.core.proof_packs.repository import DpmProofPackRepository
+from src.core.waves import DpmWaveReportInput, DpmWaveRepository
+
+
+def get_wave_report_input_response(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+    proof_pack_repository: DpmProofPackRepository,
+    outcome_review_repository: DpmOutcomeReviewRepository,
+    mandate_repository: DpmMandateRepository,
+) -> DpmWaveReportInput:
+    try:
+        return wave_service.get_report_input(
+            wave_id=wave_id,
+            wave_repository=wave_repository,
+            proof_pack_repository=proof_pack_repository,
+            outcome_review_repository=outcome_review_repository,
+            mandate_repository=mandate_repository,
+        )
+    except wave_service.DpmWaveLookupError as exc:
+        raise wave_lookup_http_exception(exc) from exc
+    except wave_service.DpmWaveValidationError as exc:
+        raise wave_validation_http_exception(exc) from exc

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -53,10 +53,7 @@ from src.api.routers.wave_campaign_models import (
     DpmBulkReviewCampaignDefinitionRetirementRequest,
     DpmBulkReviewCampaignDefinitionSupersessionRequest,
 )
-from src.api.routers.wave_http_errors import (
-    wave_lookup_http_exception,
-    wave_validation_http_exception,
-)
+from src.api.routers.wave_http_errors import wave_validation_http_exception
 from src.api.routers.wave_openapi_examples import (
     SOURCE_CHECK_WAVE_EXAMPLE,
     WAVE_EXAMPLE,
@@ -69,6 +66,7 @@ from src.api.routers.wave_read_http import (
     get_wave_items_response,
     get_wave_proof_pack_posture_response,
 )
+from src.api.routers.wave_report_input_http import get_wave_report_input_response
 from src.api.routers.wave_selection_http import select_wave_item_alternative_response
 from src.api.routers.wave_simulation_http import simulate_wave_response
 from src.api.routers.wave_source_check_http import source_check_wave_response
@@ -2149,18 +2147,13 @@ def get_wave_report_input(
     outcome_review_repository: DpmOutcomeReviewRepository = Depends(get_outcome_review_repository),
     mandate_repository: DpmMandateRepository = Depends(get_mandate_repository),
 ) -> DpmWaveReportInput:
-    try:
-        return wave_service.get_report_input(
-            wave_id=wave_id,
-            wave_repository=wave_repository,
-            proof_pack_repository=proof_pack_repository,
-            outcome_review_repository=outcome_review_repository,
-            mandate_repository=mandate_repository,
-        )
-    except wave_service.DpmWaveLookupError as exc:
-        raise wave_lookup_http_exception(exc) from exc
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc) from exc
+    return get_wave_report_input_response(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        proof_pack_repository=proof_pack_repository,
+        outcome_review_repository=outcome_review_repository,
+        mandate_repository=mandate_repository,
+    )
 
 
 @router.get(


### PR DESCRIPTION
## Summary
- Extract wave report-input HTTP adaptation into `wave_report_input_http.py`
- Keep the FastAPI route contract unchanged while moving service invocation and governed error mapping out of `waves.py`
- Remove the now-dead direct `wave_lookup_http_exception` import from the large wave router

## Validation
- `python -m ruff check src/api/routers/wave_report_input_http.py src/api/routers/waves.py`
- `python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_report_input_returns_not_found_for_unknown_wave tests/unit/dpm/api/test_waves_api.py::test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_posture tests/unit/dpm/api/test_waves_api.py::test_wave_report_input_rejects_external_execution_claims -q`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `python -m pytest tests/unit/dpm/api/test_waves_api.py -q`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`

## Governance
- Code-only refactor; no API/schema, vocabulary, docs, RFC, wiki, or context truth changed.
- Gateway, Workbench, and Advise not touched.