### PR TITLE
Extract wave create preview HTTP helper

### DIFF
--- a/src/api/routers/wave_create_preview_http.py
+++ b/src/api/routers/wave_create_preview_http.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from src.api.routers.wave_http_errors import wave_validation_http_exception
+from src.api.routers.wave_portfolio_resolution import resolve_portfolio_inputs_for_request
+from src.api.routers.wave_request_models import DpmWavePreviewRequest
+from src.api.routers.wave_response_contracts import DpmWaveResponse, wave_response
+from src.api.services import wave_service
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.waves import DpmBulkReviewCampaignDefinitionRepository, DpmWaveRepository
+from src.infrastructure.advise_authority import LotusAdviseAuthorityClient
+from src.infrastructure.risk_authority import LotusRiskAuthorityClient
+
+
+def preview_wave_response(
+    *,
+    request: DpmWavePreviewRequest,
+    correlation_id: str,
+    mandate_repository: DpmMandateRepository,
+    advise_authority_client: LotusAdviseAuthorityClient | None,
+    risk_authority_client: LotusRiskAuthorityClient | None,
+    campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository,
+    core_resolver_factory: Callable[[], object],
+) -> DpmWaveResponse:
+    try:
+        portfolios = resolve_portfolio_inputs_for_request(
+            request=request,
+            correlation_id=correlation_id,
+            advise_authority_client=advise_authority_client,
+            risk_authority_client=risk_authority_client,
+            campaign_definition_repository=campaign_definition_repository,
+            core_resolver_factory=core_resolver_factory,
+        )
+        wave = wave_service.preview_wave(
+            trigger_type=request.trigger_type,
+            trigger_id=request.trigger_id,
+            rationale=request.rationale,
+            as_of_date=request.as_of_date,
+            actor_id=request.actor_id,
+            correlation_id=correlation_id,
+            portfolios=portfolios,
+            mandate_repository=mandate_repository,
+        )
+    except wave_service.DpmWaveValidationError as exc:
+        raise wave_validation_http_exception(exc, conflict_codes=()) from exc
+    return wave_response(wave=wave, durable=False)
+
+
+def create_wave_response(
+    *,
+    request: DpmWavePreviewRequest,
+    idempotency_key: str,
+    correlation_id: str,
+    mandate_repository: DpmMandateRepository,
+    wave_repository: DpmWaveRepository,
+    advise_authority_client: LotusAdviseAuthorityClient | None,
+    risk_authority_client: LotusRiskAuthorityClient | None,
+    campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository,
+    core_resolver_factory: Callable[[], object],
+) -> DpmWaveResponse:
+    try:
+        portfolios = resolve_portfolio_inputs_for_request(
+            request=request,
+            correlation_id=correlation_id,
+            advise_authority_client=advise_authority_client,
+            risk_authority_client=risk_authority_client,
+            campaign_definition_repository=campaign_definition_repository,
+            core_resolver_factory=core_resolver_factory,
+        )
+        wave, replayed = wave_service.create_wave(
+            trigger_type=request.trigger_type,
+            trigger_id=request.trigger_id,
+            rationale=request.rationale,
+            as_of_date=request.as_of_date,
+            actor_id=request.actor_id,
+            correlation_id=correlation_id,
+            portfolios=portfolios,
+            idempotency_key=idempotency_key,
+            mandate_repository=mandate_repository,
+            wave_repository=wave_repository,
+        )
+    except wave_service.DpmWaveValidationError as exc:
+        raise wave_validation_http_exception(exc, conflict_codes=("WAVE_CREATE_CONFLICT",)) from exc
+    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -53,6 +53,7 @@ from src.api.routers.wave_campaign_models import (
     DpmBulkReviewCampaignDefinitionRetirementRequest,
     DpmBulkReviewCampaignDefinitionSupersessionRequest,
 )
+from src.api.routers.wave_create_preview_http import create_wave_response, preview_wave_response
 from src.api.routers.wave_http_errors import wave_validation_http_exception
 from src.api.routers.wave_openapi_examples import (
     SOURCE_CHECK_WAVE_EXAMPLE,
@@ -1484,28 +1485,15 @@ def preview_wave(
     ),
 ) -> DpmWaveResponse:
     correlation_id = x_correlation_id or f"corr_wave_preview_{request.trigger_id}"
-    try:
-        portfolios = resolve_portfolio_inputs_for_request(
-            request=request,
-            correlation_id=correlation_id,
-            advise_authority_client=advise_authority_client,
-            risk_authority_client=risk_authority_client,
-            campaign_definition_repository=campaign_definition_repository,
-            core_resolver_factory=build_core_resolver_client,
-        )
-        wave = wave_service.preview_wave(
-            trigger_type=request.trigger_type,
-            trigger_id=request.trigger_id,
-            rationale=request.rationale,
-            as_of_date=request.as_of_date,
-            actor_id=request.actor_id,
-            correlation_id=correlation_id,
-            portfolios=portfolios,
-            mandate_repository=mandate_repository,
-        )
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc, conflict_codes=()) from exc
-    return wave_response(wave=wave, durable=False)
+    return preview_wave_response(
+        request=request,
+        correlation_id=correlation_id,
+        mandate_repository=mandate_repository,
+        advise_authority_client=advise_authority_client,
+        risk_authority_client=risk_authority_client,
+        campaign_definition_repository=campaign_definition_repository,
+        core_resolver_factory=build_core_resolver_client,
+    )
 
 
 @router.post(
@@ -1583,30 +1571,17 @@ def create_wave(
     ),
 ) -> DpmWaveResponse:
     correlation_id = x_correlation_id or f"corr_wave_create_{request.trigger_id}"
-    try:
-        portfolios = resolve_portfolio_inputs_for_request(
-            request=request,
-            correlation_id=correlation_id,
-            advise_authority_client=advise_authority_client,
-            risk_authority_client=risk_authority_client,
-            campaign_definition_repository=campaign_definition_repository,
-            core_resolver_factory=build_core_resolver_client,
-        )
-        wave, replayed = wave_service.create_wave(
-            trigger_type=request.trigger_type,
-            trigger_id=request.trigger_id,
-            rationale=request.rationale,
-            as_of_date=request.as_of_date,
-            actor_id=request.actor_id,
-            correlation_id=correlation_id,
-            portfolios=portfolios,
-            idempotency_key=idempotency_key,
-            mandate_repository=mandate_repository,
-            wave_repository=wave_repository,
-        )
-    except wave_service.DpmWaveValidationError as exc:
-        raise wave_validation_http_exception(exc, conflict_codes=("WAVE_CREATE_CONFLICT",)) from exc
-    return wave_response(wave=wave, durable=True, idempotent_replay=replayed)
+    return create_wave_response(
+        request=request,
+        idempotency_key=idempotency_key,
+        correlation_id=correlation_id,
+        mandate_repository=mandate_repository,
+        wave_repository=wave_repository,
+        advise_authority_client=advise_authority_client,
+        risk_authority_client=risk_authority_client,
+        campaign_definition_repository=campaign_definition_repository,
+        core_resolver_factory=build_core_resolver_client,
+    )
 
 
 @router.get(


### PR DESCRIPTION
## Summary
- Extract wave preview/create HTTP adaptation into `wave_create_preview_http.py`
- Keep route contracts unchanged while moving source-cohort resolution, service invocation, response shaping, and validation-error mapping out of `waves.py`
- Preserve preview non-durable semantics and create idempotent replay semantics

## Validation
- `python -m ruff check src/api/routers/wave_create_preview_http.py src/api/routers/waves.py`
- `python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_preview_returns_source_backed_and_blocked_items_without_persistence tests/unit/dpm/api/test_waves_api.py::test_wave_create_persists_and_replays_by_idempotency_key tests/unit/dpm/api/test_waves_api.py::test_pm_book_wave_preview_resolves_source_owned_cohort tests/unit/dpm/api/test_waves_api.py::test_pm_book_wave_create_persists_resolved_source_owned_cohort tests/unit/dpm/api/test_waves_api.py::test_cio_model_change_wave_preview_resolves_source_owned_cohort tests/unit/dpm/api/test_waves_api.py::test_cio_model_change_wave_create_persists_resolved_source_owned_cohort tests/unit/dpm/api/test_waves_api.py::test_risk_event_wave_preview_resolves_source_owned_cohort tests/unit/dpm/api/test_waves_api.py::test_risk_event_wave_create_persists_resolved_source_owned_cohort tests/unit/dpm/api/test_waves_api.py::test_tactical_house_view_wave_preview_resolves_advise_owned_cohort tests/unit/dpm/api/test_waves_api.py::test_tactical_house_view_wave_create_persists_resolved_advise_owned_cohort -q`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `python -m pytest tests/unit/dpm/api/test_waves_api.py -q`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`

## Governance
- Code-only refactor; no API/schema, vocabulary, docs, RFC, wiki, or context truth changed.
- Gateway, Workbench, and Advise not touched.