### PR TITLE
Extract wave search HTTP helper

### DIFF
--- a/src/api/routers/wave_search_http.py
+++ b/src/api/routers/wave_search_http.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from src.api.routers.wave_response_contracts import DpmWaveSearchItem, DpmWaveSearchResponse
+from src.api.services import wave_service
+from src.core.waves import DpmWaveRepository
+
+
+def search_waves_response(
+    *,
+    wave_repository: DpmWaveRepository,
+    state: str | None,
+    trigger_type: str | None,
+    as_of_date: str | None,
+    supportability_state: Literal["ready", "degraded", "blocked"] | None,
+    limit: int,
+    offset: int,
+) -> DpmWaveSearchResponse:
+    items = wave_service.search_waves(
+        wave_repository=wave_repository,
+        state=state,
+        trigger_type=trigger_type,
+        as_of_date=as_of_date,
+        supportability_state=supportability_state,
+        limit=limit,
+        offset=offset,
+    )
+    return DpmWaveSearchResponse(
+        items=[DpmWaveSearchItem.model_validate(item) for item in items],
+        limit=limit,
+        offset=offset,
+        returned_count=len(items),
+    )

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -20,7 +20,6 @@ from src.api.routers.wave_response_contracts import (
     DpmWaveItemsResponse,
     DpmWaveProofPackPostureResponse,
     DpmWaveResponse,
-    DpmWaveSearchItem,
     DpmWaveSearchResponse,
     DpmWaveSupportabilityResponse,
     wave_response,
@@ -68,6 +67,7 @@ from src.api.routers.wave_read_http import (
     get_wave_proof_pack_posture_response,
 )
 from src.api.routers.wave_report_input_http import get_wave_report_input_response
+from src.api.routers.wave_search_http import search_waves_response
 from src.api.routers.wave_selection_http import select_wave_item_alternative_response
 from src.api.routers.wave_simulation_http import simulate_wave_response
 from src.api.routers.wave_source_check_http import source_check_wave_response
@@ -1669,7 +1669,7 @@ def search_waves(
     ] = 0,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveSearchResponse:
-    items = wave_service.search_waves(
+    return search_waves_response(
         wave_repository=wave_repository,
         state=state,
         trigger_type=trigger_type,
@@ -1677,12 +1677,6 @@ def search_waves(
         supportability_state=supportability_state,
         limit=limit,
         offset=offset,
-    )
-    return DpmWaveSearchResponse(
-        items=[DpmWaveSearchItem.model_validate(item) for item in items],
-        limit=limit,
-        offset=offset,
-        returned_count=len(items),
     )
 
 


### PR DESCRIPTION
## Summary
- Move durable wave search service invocation and response shaping into wave_search_http helper
- Keep the /rebalance/waves search route focused on FastAPI query metadata and dependency wiring
- Preserve the existing search response contract and supportability filters

## Validation
- python -m ruff format src/api/routers/waves.py src/api/routers/wave_search_http.py
- python -m ruff check src/api/routers/waves.py src/api/routers/wave_search_http.py
- python -m mypy src/api/routers/waves.py src/api/routers/wave_search_http.py
- python -m pytest tests/unit/dpm/api/test_waves_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Governance
- Code-only router modularity refactor; no API schema, OpenAPI, vocabulary, wiki, RFC, or context truth changed.
- No Gateway, Workbench, or Advise changes.