### PR TITLE
Extract campaign definition HTTP helper

### DIFF
--- a/src/api/routers/wave_campaign_definition_http.py
+++ b/src/api/routers/wave_campaign_definition_http.py
@@ -4,6 +4,12 @@ from datetime import date
 
 from fastapi import HTTPException, status
 
+from src.api.routers.wave_campaign_models import (
+    DpmBulkReviewCampaignDefinitionPage,
+    DpmBulkReviewCampaignDefinitionRequest,
+    DpmBulkReviewCampaignDefinitionRetirementRequest,
+    DpmBulkReviewCampaignDefinitionSupersessionRequest,
+)
 from src.core.waves import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionConflictError,
@@ -12,6 +18,8 @@ from src.core.waves import (
 )
 from src.core.waves.campaign_definition_lifecycle import (
     DpmBulkReviewCampaignDefinitionLifecycleError,
+    retire_bulk_review_campaign_definition,
+    supersede_bulk_review_campaign_definition,
 )
 
 
@@ -37,6 +45,128 @@ def get_campaign_definition_or_404(
             detail=_CAMPAIGN_DEFINITION_NOT_FOUND_DETAIL,
         )
     return definition
+
+
+def get_campaign_definition_response(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    repository: DpmBulkReviewCampaignDefinitionRepository,
+) -> DpmBulkReviewCampaignDefinition:
+    return get_campaign_definition_or_404(
+        repository=repository,
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+    )
+
+
+def put_campaign_definition_response(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmBulkReviewCampaignDefinitionRequest,
+    repository: DpmBulkReviewCampaignDefinitionRepository,
+) -> DpmBulkReviewCampaignDefinition:
+    try:
+        definition = DpmBulkReviewCampaignDefinition(
+            campaign_id=campaign_id,
+            campaign_version=campaign_version,
+            display_name=request.display_name,
+            status=request.status,
+            as_of_date=request.as_of_date,
+            rationale=request.rationale,
+            eligible_portfolio_types=request.eligible_portfolio_types,
+            candidates=request.candidates,
+            governance=request.governance,
+            source_refs=request.source_refs,
+            created_by=request.created_by,
+            correlation_id=request.correlation_id,
+        )
+        repository.save_definition(definition=definition)
+    except DpmBulkReviewCampaignDefinitionConflictError as exc:
+        raise campaign_definition_conflict_http_exception(exc) from exc
+    except ValueError as exc:
+        raise campaign_definition_value_http_exception(exc) from exc
+    return definition
+
+
+def list_campaign_definitions_response(
+    *,
+    campaign_id: str | None,
+    campaign_status: str | None,
+    as_of_date: str | None,
+    limit: int,
+    offset: int,
+    repository: DpmBulkReviewCampaignDefinitionRepository,
+) -> DpmBulkReviewCampaignDefinitionPage:
+    items = repository.list_definitions(
+        campaign_id=campaign_id,
+        status=campaign_status,
+        as_of_date=as_of_date,
+        limit=limit,
+        offset=offset,
+    )
+    return DpmBulkReviewCampaignDefinitionPage(
+        items=items,
+        limit=limit,
+        offset=offset,
+        count=len(items),
+    )
+
+
+def retire_campaign_definition_response(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmBulkReviewCampaignDefinitionRetirementRequest,
+    repository: DpmBulkReviewCampaignDefinitionRepository,
+) -> DpmBulkReviewCampaignDefinition:
+    try:
+        retired = retire_bulk_review_campaign_definition(
+            repository=repository,
+            campaign_id=campaign_id,
+            campaign_version=campaign_version,
+            retired_by=request.retired_by,
+            retirement_reason=request.retirement_reason,
+            correlation_id=request.correlation_id,
+        )
+    except DpmBulkReviewCampaignDefinitionConflictError as exc:
+        raise campaign_definition_conflict_http_exception(exc) from exc
+    except DpmBulkReviewCampaignDefinitionLifecycleError as exc:
+        raise campaign_definition_lifecycle_http_exception(exc) from exc
+    except ValueError as exc:
+        raise campaign_definition_value_http_exception(exc) from exc
+    if retired is None:
+        raise campaign_definition_not_found_http_exception()
+    return retired
+
+
+def supersede_campaign_definition_response(
+    *,
+    campaign_id: str,
+    campaign_version: str,
+    request: DpmBulkReviewCampaignDefinitionSupersessionRequest,
+    repository: DpmBulkReviewCampaignDefinitionRepository,
+) -> DpmBulkReviewCampaignDefinition:
+    try:
+        superseded = supersede_bulk_review_campaign_definition(
+            repository=repository,
+            campaign_id=campaign_id,
+            campaign_version=campaign_version,
+            replacement_version=request.superseded_by_campaign_version,
+            superseded_by=request.superseded_by,
+            supersession_reason=request.supersession_reason,
+            correlation_id=request.correlation_id,
+        )
+    except DpmBulkReviewCampaignDefinitionConflictError as exc:
+        raise campaign_definition_conflict_http_exception(exc) from exc
+    except DpmBulkReviewCampaignDefinitionLifecycleError as exc:
+        raise campaign_definition_lifecycle_http_exception(exc) from exc
+    except ValueError as exc:
+        raise campaign_definition_value_http_exception(exc) from exc
+    if superseded is None:
+        raise campaign_definition_not_found_http_exception()
+    return superseded
 
 
 def campaign_definition_not_found_http_exception() -> HTTPException:

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -31,12 +31,12 @@ from src.api.routers.wave_request_models import (
     DpmWaveWorkflowCommandRequest,
 )
 from src.api.routers.wave_campaign_definition_http import (
-    campaign_definition_conflict_http_exception,
-    campaign_definition_lifecycle_http_exception,
-    campaign_definition_not_found_http_exception,
-    campaign_definition_value_http_exception,
-    get_campaign_definition_or_404,
+    get_campaign_definition_response,
+    list_campaign_definitions_response,
     parse_optional_campaign_discovery_date,
+    put_campaign_definition_response,
+    retire_campaign_definition_response,
+    supersede_campaign_definition_response,
 )
 from src.api.routers.wave_campaign_models import (
     DpmBulkReviewCampaignDefinitionApprovalDecisionRequest,
@@ -111,7 +111,6 @@ from src.core.waves import (
     DpmBulkReviewCampaignDefinitionAssignmentActionPage,
     DpmBulkReviewCampaignDefinitionAssignmentTaskPage,
     DpmBulkReviewCampaignDefinitionMakerCheckerControlPage,
-    DpmBulkReviewCampaignDefinitionConflictError,
     DpmBulkReviewCampaignDiscoveryPage,
     DpmBulkReviewCampaignDefinitionLaunchHistoryPage,
     DpmBulkReviewCampaignDefinitionLaunchPackage,
@@ -129,11 +128,6 @@ from src.core.waves import (
     build_bulk_review_campaign_operating_queue_page,
     build_bulk_review_campaign_workflow_board_page,
     build_bulk_review_campaign_workflow_automation_page,
-)
-from src.core.waves.campaign_definition_lifecycle import (
-    DpmBulkReviewCampaignDefinitionLifecycleError,
-    retire_bulk_review_campaign_definition as retire_campaign_definition,
-    supersede_bulk_review_campaign_definition as supersede_campaign_definition,
 )
 from src.core.waves.campaign_definition_events import (
     DpmBulkReviewCampaignDefinitionLifecycleEventPage,
@@ -170,27 +164,12 @@ def put_bulk_review_campaign_definition(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinition:
-    try:
-        definition = DpmBulkReviewCampaignDefinition(
-            campaign_id=campaign_id,
-            campaign_version=campaign_version,
-            display_name=request.display_name,
-            status=request.status,
-            as_of_date=request.as_of_date,
-            rationale=request.rationale,
-            eligible_portfolio_types=request.eligible_portfolio_types,
-            candidates=request.candidates,
-            governance=request.governance,
-            source_refs=request.source_refs,
-            created_by=request.created_by,
-            correlation_id=request.correlation_id,
-        )
-        repository.save_definition(definition=definition)
-    except DpmBulkReviewCampaignDefinitionConflictError as exc:
-        raise campaign_definition_conflict_http_exception(exc) from exc
-    except ValueError as exc:
-        raise campaign_definition_value_http_exception(exc) from exc
-    return definition
+    return put_campaign_definition_response(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        request=request,
+        repository=repository,
+    )
 
 
 @router.get(
@@ -210,18 +189,13 @@ def list_bulk_review_campaign_definitions(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinitionPage:
-    items = repository.list_definitions(
+    return list_campaign_definitions_response(
         campaign_id=campaign_id,
-        status=campaign_status,
+        campaign_status=campaign_status,
         as_of_date=as_of_date,
         limit=limit,
         offset=offset,
-    )
-    return DpmBulkReviewCampaignDefinitionPage(
-        items=items,
-        limit=limit,
-        offset=offset,
-        count=len(items),
+        repository=repository,
     )
 
 
@@ -245,24 +219,12 @@ def retire_bulk_review_campaign_definition(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinition:
-    try:
-        retired = retire_campaign_definition(
-            repository=repository,
-            campaign_id=campaign_id,
-            campaign_version=campaign_version,
-            retired_by=request.retired_by,
-            retirement_reason=request.retirement_reason,
-            correlation_id=request.correlation_id,
-        )
-    except DpmBulkReviewCampaignDefinitionConflictError as exc:
-        raise campaign_definition_conflict_http_exception(exc) from exc
-    except DpmBulkReviewCampaignDefinitionLifecycleError as exc:
-        raise campaign_definition_lifecycle_http_exception(exc) from exc
-    except ValueError as exc:
-        raise campaign_definition_value_http_exception(exc) from exc
-    if retired is None:
-        raise campaign_definition_not_found_http_exception()
-    return retired
+    return retire_campaign_definition_response(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        request=request,
+        repository=repository,
+    )
 
 
 @router.post(
@@ -286,25 +248,12 @@ def supersede_bulk_review_campaign_definition(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinition:
-    try:
-        superseded = supersede_campaign_definition(
-            repository=repository,
-            campaign_id=campaign_id,
-            campaign_version=campaign_version,
-            replacement_version=request.superseded_by_campaign_version,
-            superseded_by=request.superseded_by,
-            supersession_reason=request.supersession_reason,
-            correlation_id=request.correlation_id,
-        )
-    except DpmBulkReviewCampaignDefinitionConflictError as exc:
-        raise campaign_definition_conflict_http_exception(exc) from exc
-    except DpmBulkReviewCampaignDefinitionLifecycleError as exc:
-        raise campaign_definition_lifecycle_http_exception(exc) from exc
-    except ValueError as exc:
-        raise campaign_definition_value_http_exception(exc) from exc
-    if superseded is None:
-        raise campaign_definition_not_found_http_exception()
-    return superseded
+    return supersede_campaign_definition_response(
+        campaign_id=campaign_id,
+        campaign_version=campaign_version,
+        request=request,
+        repository=repository,
+    )
 
 
 @router.get(
@@ -740,12 +689,11 @@ def get_bulk_review_campaign_definition(
         get_campaign_definition_repository
     ),
 ) -> DpmBulkReviewCampaignDefinition:
-    definition = get_campaign_definition_or_404(
-        repository=repository,
+    return get_campaign_definition_response(
         campaign_id=campaign_id,
         campaign_version=campaign_version,
+        repository=repository,
     )
-    return definition
 
 
 @router.post(


### PR DESCRIPTION
## Summary
- move campaign definition get, persist, list, retire, and supersede response handling into `wave_campaign_definition_http.py`
- leave `waves.py` route decorators and OpenAPI descriptions intact while reducing controller business logic
- preserve existing API shape, error mapping, and lifecycle behavior

## Validation
- `python -m ruff check src/api/routers/waves.py src/api/routers/wave_campaign_definition_http.py`
- `python -m mypy src/api/routers/waves.py src/api/routers/wave_campaign_definition_http.py`
- `python -m pytest tests/unit/api/test_wave_campaign_definition_http.py tests/unit/dpm/api/test_waves_api.py -q`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`

## Docs / contracts
- Code-only router modularity cleanup.
- No API schema, vocabulary, docs, wiki, context, or contract truth changed.
