### PR TITLE
Harden campaign discovery universe posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,10 @@ also exposes persisted campaign discovery at
 `GET /api/v1/rebalance/waves/campaign-discovery`, summarizing `BulkReviewCampaignDefinition:v1`
 identity, governance posture, expiry posture, source-ref count, and source-backed candidate counts
 without discovering the global portfolio universe or recalculating membership. Each row carries
-hashed `BulkReviewCampaignUniversePosture:v1` evidence naming deferred source ownership, required
-future `GlobalPortfolioUniverseCampaignCandidateSet:v1`, and blocked bank-wide candidate-discovery
-capabilities. Manage also supports
+hashed `BulkReviewCampaignUniversePosture:v1` evidence naming `PERSISTED_DEFINITION_ONLY`
+discovery mode, deferred source ownership, required future
+`GlobalPortfolioUniverseCampaignCandidateSet:v1`, blocked bank-wide candidate-discovery
+capabilities, and promotion requirements for any future global-universe support. Manage also supports
 an operating queue at `GET /api/v1/rebalance/waves/campaign-operating-queue`, classifying persisted
 definitions as ready to launch, attention required, or closed from existing discovery,
 preview-readiness, lifecycle, and launch-history posture without creating maker-checker or OMS

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -3384,10 +3384,11 @@ persisted campaign discovery through `BulkReviewCampaignDiscovery:v1` at
 `GET /api/v1/rebalance/waves/campaign-discovery`, summarizing campaign identity, governance
 posture, expiry posture, source-ref count, source-backed candidate counts, and preview references
 without discovering the global portfolio universe or recalculating membership. Each item carries
-hashed `BulkReviewCampaignUniversePosture:v1` boundary evidence that names deferred global
-portfolio-universe source ownership, required future
-`GlobalPortfolioUniverseCampaignCandidateSet:v1`, blocked bank-wide candidate-discovery
-capabilities, and the persisted-candidate-only source scope. `lotus-gateway` PR
+hashed `BulkReviewCampaignUniversePosture:v1` boundary evidence that names
+`PERSISTED_DEFINITION_ONLY` discovery mode, deferred global portfolio-universe source ownership,
+required future `GlobalPortfolioUniverseCampaignCandidateSet:v1`, blocked bank-wide
+candidate-discovery capabilities, promotion requirements for any future global-universe support,
+and the persisted-candidate-only source scope. `lotus-gateway` PR
 #212 now composes the manage-owned campaign-definition list/get/upsert APIs under
 `/api/v1/dpm/command-center/waves/campaign-definitions*`, and PR #231 (`ea6c036`, Main
 Releasability Gate `25989936539`) extends bounded lifecycle-events, launch-history, launch-package,

--- a/src/api/routers/waves.py
+++ b/src/api/routers/waves.py
@@ -267,9 +267,11 @@ def supersede_bulk_review_campaign_definition(
         "posture, expiry posture, source-ref count, and source-backed candidate counts. It does not "
         "discover the global portfolio universe, calculate source facts, run maker-checker workflow, "
         "or claim OMS execution. Each item includes `BulkReviewCampaignUniversePosture:v1` so the "
-        "persisted-candidate source scope, unsupported global portfolio-universe boundary, required "
-        "future `GlobalPortfolioUniverseCampaignCandidateSet:v1` source product, blocked global "
-        "candidate-discovery capabilities, and deterministic posture hash are machine-readable."
+        "persisted-definition-only discovery mode, persisted-candidate source scope, unsupported "
+        "global portfolio-universe boundary, required future "
+        "`GlobalPortfolioUniverseCampaignCandidateSet:v1` source product, blocked global "
+        "candidate-discovery capabilities, promotion requirements, and deterministic posture hash "
+        "are machine-readable."
     ),
 )
 def discover_bulk_review_campaigns(

--- a/src/core/waves/campaign_discovery.py
+++ b/src/core/waves/campaign_discovery.py
@@ -16,6 +16,15 @@ GLOBAL_CAMPAIGN_UNIVERSE_BLOCKED_CAPABILITIES = [
     "source_fact_recalculation",
     "membership_recomputation",
 ]
+GLOBAL_CAMPAIGN_UNIVERSE_PROMOTION_REQUIREMENTS = [
+    "certified_source_owner",
+    "GlobalPortfolioUniverseCampaignCandidateSet:v1",
+    "source_product_contract",
+    "producer_lineage_and_freshness_controls",
+    "manage_consumer_declaration",
+    "gateway_bff_realization",
+    "workbench_gateway_only_realization",
+]
 
 
 def _campaign_universe_posture_payload(
@@ -26,6 +35,7 @@ def _campaign_universe_posture_payload(
     payload: dict[str, object] = {
         "product_name": "BulkReviewCampaignUniversePosture",
         "product_version": "v1",
+        "discovery_mode": "PERSISTED_DEFINITION_ONLY",
         "source_scope": "PERSISTED_CAMPAIGN_DEFINITION_CANDIDATES",
         "global_portfolio_universe_discovery": "UNSUPPORTED",
         "global_portfolio_universe_owner_posture": "DEFERRED_SOURCE_OWNER",
@@ -33,6 +43,7 @@ def _campaign_universe_posture_payload(
         "candidate_source_ref_posture": candidate_source_ref_posture,
         "source_systems": source_systems,
         "blocked_capabilities": GLOBAL_CAMPAIGN_UNIVERSE_BLOCKED_CAPABILITIES,
+        "promotion_requirements": GLOBAL_CAMPAIGN_UNIVERSE_PROMOTION_REQUIREMENTS,
         "operating_boundaries": [
             "NO_GLOBAL_PORTFOLIO_UNIVERSE_DISCOVERY",
             "NO_SOURCE_FACT_RECALCULATION",
@@ -51,6 +62,13 @@ class DpmBulkReviewCampaignUniversePosture(BaseModel):
 
     product_name: Literal["BulkReviewCampaignUniversePosture"] = "BulkReviewCampaignUniversePosture"
     product_version: Literal["v1"] = "v1"
+    discovery_mode: Literal["PERSISTED_DEFINITION_ONLY"] = Field(
+        default="PERSISTED_DEFINITION_ONLY",
+        description=(
+            "Manage discovery mode for this row. Manage only lists persisted campaign definitions "
+            "and never scans the bank-wide portfolio universe."
+        ),
+    )
     source_scope: Literal["PERSISTED_CAMPAIGN_DEFINITION_CANDIDATES"] = Field(
         default="PERSISTED_CAMPAIGN_DEFINITION_CANDIDATES",
         description=(
@@ -94,6 +112,13 @@ class DpmBulkReviewCampaignUniversePosture(BaseModel):
         description=(
             "Capability families explicitly not provided by the persisted campaign-discovery "
             "read model."
+        ),
+    )
+    promotion_requirements: list[str] = Field(
+        default_factory=lambda: list(GLOBAL_CAMPAIGN_UNIVERSE_PROMOTION_REQUIREMENTS),
+        description=(
+            "Machine-readable requirements that must be satisfied before bank-wide campaign "
+            "candidate discovery can be promoted beyond persisted definition rows."
         ),
     )
     operating_boundaries: list[str] = Field(

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -2122,6 +2122,7 @@ def test_bulk_review_campaign_discovery_summarizes_persisted_definitions() -> No
     assert item["universe_posture"] == {
         "product_name": "BulkReviewCampaignUniversePosture",
         "product_version": "v1",
+        "discovery_mode": "PERSISTED_DEFINITION_ONLY",
         "source_scope": "PERSISTED_CAMPAIGN_DEFINITION_CANDIDATES",
         "global_portfolio_universe_discovery": "UNSUPPORTED",
         "global_portfolio_universe_owner_posture": "DEFERRED_SOURCE_OWNER",
@@ -2134,6 +2135,15 @@ def test_bulk_review_campaign_discovery_summarizes_persisted_definitions() -> No
             "candidate_eligibility_calculation",
             "source_fact_recalculation",
             "membership_recomputation",
+        ],
+        "promotion_requirements": [
+            "certified_source_owner",
+            "GlobalPortfolioUniverseCampaignCandidateSet:v1",
+            "source_product_contract",
+            "producer_lineage_and_freshness_controls",
+            "manage_consumer_declaration",
+            "gateway_bff_realization",
+            "workbench_gateway_only_realization",
         ],
         "operating_boundaries": [
             "NO_GLOBAL_PORTFOLIO_UNIVERSE_DISCOVERY",

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -133,6 +133,7 @@ def test_campaign_discovery_item_projects_governance_and_candidate_posture() -> 
     assert item.candidate_count == 2
     assert item.eligible_candidate_count == 1
     assert item.source_ref_count == 2
+    assert item.universe_posture.discovery_mode == "PERSISTED_DEFINITION_ONLY"
     assert item.universe_posture.source_scope == "PERSISTED_CAMPAIGN_DEFINITION_CANDIDATES"
     assert item.universe_posture.global_portfolio_universe_discovery == "UNSUPPORTED"
     assert item.universe_posture.global_portfolio_universe_owner_posture == (
@@ -144,6 +145,11 @@ def test_campaign_discovery_item_projects_governance_and_candidate_posture() -> 
     assert item.universe_posture.candidate_source_ref_posture == "SOURCE_BACKED"
     assert item.universe_posture.source_systems == ["lotus-core"]
     assert "candidate_portfolio_discovery" in item.universe_posture.blocked_capabilities
+    assert "certified_source_owner" in item.universe_posture.promotion_requirements
+    assert (
+        "GlobalPortfolioUniverseCampaignCandidateSet:v1"
+        in item.universe_posture.promotion_requirements
+    )
     assert "NO_GLOBAL_PORTFOLIO_UNIVERSE_DISCOVERY" in item.universe_posture.operating_boundaries
     assert item.universe_posture.content_hash.startswith("sha256:")
     assert item.preview_reference == {
@@ -174,6 +180,7 @@ def test_campaign_universe_posture_is_machine_readable_boundary() -> None:
 
     assert posture.product_name == "BulkReviewCampaignUniversePosture"
     assert posture.product_version == "v1"
+    assert posture.discovery_mode == "PERSISTED_DEFINITION_ONLY"
     assert posture.source_scope == "PERSISTED_CAMPAIGN_DEFINITION_CANDIDATES"
     assert posture.global_portfolio_universe_discovery == "UNSUPPORTED"
     assert posture.global_portfolio_universe_owner_posture == "DEFERRED_SOURCE_OWNER"
@@ -186,6 +193,15 @@ def test_campaign_universe_posture_is_machine_readable_boundary() -> None:
         "candidate_eligibility_calculation",
         "source_fact_recalculation",
         "membership_recomputation",
+    ]
+    assert posture.promotion_requirements == [
+        "certified_source_owner",
+        "GlobalPortfolioUniverseCampaignCandidateSet:v1",
+        "source_product_contract",
+        "producer_lineage_and_freshness_controls",
+        "manage_consumer_declaration",
+        "gateway_bff_realization",
+        "workbench_gateway_only_realization",
     ]
     assert posture.operating_boundaries == [
         "NO_GLOBAL_PORTFOLIO_UNIVERSE_DISCOVERY",

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -69,11 +69,13 @@ mutation, maker-checker control-state mutation, trade approval, order generation
 external workflow orchestration, OMS execution, or global portfolio-universe discovery.
 
 Campaign universe-boundary posture addendum: `BulkReviewCampaignUniversePosture:v1` now carries a
-deterministic content hash, deferred global portfolio-universe source-owner posture, required future
-`GlobalPortfolioUniverseCampaignCandidateSet:v1`, and blocked capability codes for bank-wide
-portfolio scans, candidate discovery, eligibility calculation, source-fact recalculation, and
-membership recomputation. This keeps `GET /api/v1/rebalance/waves/campaign-discovery` bounded to
-persisted source-backed campaign candidates while making the global discovery gap machine-readable.
+deterministic content hash, `PERSISTED_DEFINITION_ONLY` discovery mode, deferred global
+portfolio-universe source-owner posture, required future
+`GlobalPortfolioUniverseCampaignCandidateSet:v1`, blocked capability codes for bank-wide portfolio
+scans, candidate discovery, eligibility calculation, source-fact recalculation, and membership
+recomputation, plus promotion requirements for any future global-universe support. This keeps
+`GET /api/v1/rebalance/waves/campaign-discovery` bounded to persisted source-backed campaign
+candidates while making the global discovery gap machine-readable.
 
 PM operating quality portfolio-memory review-action projection addendum: Portfolio memory now
 projects bounded `PM_QUALITY_REVIEW_ACTION` events for immutable review actions whose reviewed


### PR DESCRIPTION
## Summary
- hardens `BulkReviewCampaignUniversePosture:v1` with explicit `PERSISTED_DEFINITION_ONLY` discovery mode
- adds machine-readable promotion requirements before any future global portfolio-universe campaign discovery support can be claimed
- updates campaign-discovery OpenAPI descriptions, API vocabulary inventory, focused tests, README, WTBD ledger, and wiki source

## Validation
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `python -m pytest tests/unit/test_documentation_current_state.py tests/unit/dpm/waves/test_campaign_discovery.py tests/unit/dpm/api/test_waves_api.py::test_bulk_review_campaign_discovery_summarizes_persisted_definitions`
- `make test-unit` (1453 passed, 2 warnings)
- `make test-integration` (168 passed)
- `make test-e2e` (28 passed)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` expected pre-merge drift: `Supported-Features.md`

## Boundaries
- no global portfolio-universe discovery is claimed
- no source-fact recalculation, membership recomputation, workflow orchestration, order generation, OMS, or execution claim is added
- Gateway/Workbench/Advise were not modified