### PR TITLE
Add portfolio memory search facets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,15 @@ score payloads, raw review rationale, generated summary text, prompt bodies, mod
 creating portfolio-level rankings or downstream summary UX. The
 portfolio-memory API also exposes `GET /api/v1/rebalance/portfolio-memory/search` as a bounded
 Manage-local index over persisted proof-pack, wave, monitoring-exception, campaign-definition,
-outcome-review, and explicit caller-supplied portfolio identifiers; it is not global
-portfolio-universe discovery and does not project OMS acknowledgement, fill, settlement, or
-execution-status events. Persisted bulk-review campaign definitions now project bounded portfolio
-memory events for definition, approval-decision, assignment-action, assignment-task, and
-maker-checker control evidence without copying raw campaign payloads, recalculating membership,
-or claiming external workflow orchestration, client contact, order routing, or OMS execution. The
+outcome-review, PM-quality, and explicit caller-supplied portfolio identifiers. Search responses
+include pre-pagination facet counts for supportability state, event type, and represented source
+system so consumers can triage the bounded result set without loading every portfolio timeline; it
+is not global portfolio-universe discovery and does not project OMS acknowledgement, fill,
+settlement, or execution-status events. Persisted bulk-review campaign definitions now project
+bounded portfolio memory events for definition, approval-decision, assignment-action,
+assignment-task, and maker-checker control evidence without copying raw campaign payloads,
+recalculating membership, or claiming external workflow orchestration, client contact, order
+routing, or OMS execution. The
 portfolio-memory response also carries structured
 `DPM_PORTFOLIO_MEMORY_EXTERNAL_EXECUTION_BOUNDARY` evidence naming blocked OMS capabilities, the
 required future execution/OMS owner, and `ExternalOrderExecutionAcknowledgement:v1` as the required

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T12:46:22.738348+00:00",
+  "generatedAt": "2026-05-21T13:18:52.510593+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -12604,6 +12604,22 @@
       ]
     },
     {
+      "semanticId": "lotus.source_system_counts",
+      "canonicalTerm": "source_system_counts",
+      "preferredName": "source_system_counts",
+      "description": "Aggregate count of matching portfolio-memory summaries by represented source system before pagination. Counts are derived from Manage-local evidence only.",
+      "example": {
+        "sample_key": "sample_value"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.source_systems",
       "canonicalTerm": "source_systems",
       "preferredName": "source_systems",
@@ -13242,6 +13258,22 @@
       "observedTypes": [
         "object",
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.supportability_state_counts",
+      "canonicalTerm": "supportability_state_counts",
+      "preferredName": "supportability_state_counts",
+      "description": "Aggregate count of matching portfolio-memory summaries by supportability state before pagination. Counts are derived from Manage-local search results only and are not a global portfolio-universe census.",
+      "example": {
+        "sample_key": "sample_value"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -116824,6 +116856,30 @@
             "type": "integer",
             "semanticId": "lotus.scanned_portfolio_count",
             "attributeRef": "#/attributeCatalog/lotus.scanned_portfolio_count"
+          },
+          {
+            "name": "supportability_state_counts",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.supportability_state_counts",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state_counts"
+          },
+          {
+            "name": "event_type_counts",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.event_type_counts",
+            "attributeRef": "#/attributeCatalog/lotus.event_type_counts"
+          },
+          {
+            "name": "source_system_counts",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_system_counts",
+            "attributeRef": "#/attributeCatalog/lotus.source_system_counts"
           },
           {
             "name": "generated_at",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -374,6 +374,32 @@ class DpmPortfolioMemorySearchPage(BaseModel):
         description="Number of candidate portfolio identifiers scanned from Manage-local evidence.",
         examples=[3],
     )
+    supportability_state_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Aggregate count of matching portfolio-memory summaries by supportability state before "
+            "pagination. Counts are derived from Manage-local search results only and are not a "
+            "global portfolio-universe census."
+        ),
+        examples=[{"READY": 2, "PENDING_REVIEW": 1}],
+    )
+    event_type_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Aggregate count of matching portfolio-memory events by event type before pagination. "
+            "Counts are derived from returned Manage-local memory evidence and do not imply "
+            "external source-owner event search."
+        ),
+        examples=[{"WAVE_HANDOFF_READY": 1, "OUTCOME_REVIEW_CREATED": 1}],
+    )
+    source_system_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Aggregate count of matching portfolio-memory summaries by represented source system "
+            "before pagination. Counts are derived from Manage-local evidence only."
+        ),
+        examples=[{"lotus-manage": 2, "lotus-core": 1}],
+    )
     generated_at: str = Field(description="UTC timestamp when the search page was generated.")
     support_boundary: str = Field(
         description=("Explicit no-claim boundary for the bounded memory search surface."),

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -285,6 +285,14 @@ def search_portfolio_memory(
         reverse=True,
     )
     total_count = len(items)
+    supportability_state_counts = _counts(item.supportability_state for item in items)
+    event_type_counts: dict[str, int] = {}
+    source_system_counts: dict[str, int] = {}
+    for item in items:
+        for event_type, count in item.event_type_counts.items():
+            event_type_counts[event_type] = event_type_counts.get(event_type, 0) + count
+        for source_system in item.source_systems:
+            source_system_counts[source_system] = source_system_counts.get(source_system, 0) + 1
     page = items[offset : offset + limit]
     return DpmPortfolioMemorySearchPage(
         items=page,
@@ -293,6 +301,9 @@ def search_portfolio_memory(
         returned_count=len(page),
         total_count=total_count,
         scanned_portfolio_count=len(candidate_ids),
+        supportability_state_counts=dict(sorted(supportability_state_counts.items())),
+        event_type_counts=dict(sorted(event_type_counts.items())),
+        source_system_counts=dict(sorted(source_system_counts.items())),
         generated_at=generated_at.isoformat(),
         support_boundary=(
             "Manage-local memory search indexes persisted Manage evidence and explicit "

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1297,6 +1297,10 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert payload["items"][0]["event_type_counts"]["BULK_REVIEW_CAMPAIGN_DEFINITION"] == 1
     assert payload["items"][0]["latest_event_time"] is not None
     assert payload["items"][0]["content_hash"].startswith("sha256:")
+    assert payload["supportability_state_counts"] == {"DEGRADED": 1}
+    assert payload["event_type_counts"]["WAVE_HANDOFF_READY"] == 1
+    assert payload["event_type_counts"]["BULK_REVIEW_CAMPAIGN_DEFINITION"] == 1
+    assert payload["source_system_counts"]["lotus-manage"] == 1
     assert "does not discover the global portfolio universe" in payload["support_boundary"]
     assert "project OMS" in payload["support_boundary"]
     assert openapi.status_code == 200
@@ -1307,6 +1311,9 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
         "global portfolio-universe discovery product"
         in (search_schema["properties"]["items"]["description"])
     )
+    assert "supportability_state_counts" in search_schema["properties"]
+    assert "event_type_counts" in search_schema["properties"]
+    assert "source_system_counts" in search_schema["properties"]
 
 
 def test_portfolio_memory_search_can_include_explicit_portfolio_for_manage_only_events() -> None:
@@ -1383,6 +1390,38 @@ def test_portfolio_memory_search_indexes_pm_quality_summary_invocations_by_book_
         }
         for item in page.items
     )
+
+
+def test_portfolio_memory_search_facets_cover_filtered_results_before_pagination() -> None:
+    pm_quality_repository = InMemoryDpmPmQualityScoreRunRepository()
+    pm_quality_repository.save_score_run(score_run=_pm_quality_score_run())
+    pm_quality_summary_repository = InMemoryDpmPmQualitySummaryInvocationRepository()
+    pm_quality_summary_repository.save_summary_invocation(
+        invocation=_pm_quality_summary_invocation()
+    )
+
+    page = search_portfolio_memory(
+        proof_pack_repository=InMemoryDpmProofPackRepository(),
+        wave_repository=InMemoryDpmWaveRepository(),
+        outcome_review_repository=InMemoryDpmOutcomeReviewRepository(),
+        pm_quality_score_run_repository=pm_quality_repository,
+        pm_quality_summary_invocation_repository=pm_quality_summary_repository,
+        event_type="PM_QUALITY_SUMMARY_INVOCATION",
+        limit=1,
+    )
+
+    assert page.returned_count == 1
+    assert page.total_count == 2
+    assert page.supportability_state_counts == {"READY": 2}
+    assert page.event_type_counts == {
+        "PM_QUALITY_SCORE_RUN": 2,
+        "PM_QUALITY_SUMMARY_INVOCATION": 2,
+    }
+    assert page.source_system_counts == {
+        "lotus-ai": 2,
+        "lotus-core": 2,
+        "lotus-manage": 2,
+    }
 
 
 def test_portfolio_memory_search_indexes_campaign_definition_candidates_without_global_discovery() -> (

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2022,7 +2022,8 @@ Functional behavior:
   waves, monitoring exceptions, outcome reviews, and optional caller-supplied portfolio ids,
 - filters the search index by event type, supportability state, and represented source system,
 - returns search summaries with event counts, event-type counts, latest event posture, source
-  systems, reason codes, content hash, total count, scanned portfolio count, and an explicit support
+  systems, reason codes, content hash, total count, scanned portfolio count, pre-pagination
+  supportability-state, event-type, and source-system facet counts, and an explicit support
   boundary,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,


### PR DESCRIPTION
## Summary
- add pre-pagination supportability-state, event-type, and source-system facet counts to the bounded portfolio-memory search response
- preserve Manage-local search boundaries: no global portfolio universe discovery, no external source-owner event search, no OMS/client communication projection
- update portfolio-memory API docs/wiki source and regenerate the API vocabulary inventory

## Validation
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py -q
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Wiki
- Repo-local wiki source changed: wiki/Endpoint-Certification.md
- Pre-merge wiki check reports expected drift for Endpoint-Certification.md; publish after merge with Sync-RepoWikis.ps1 -Publish -Repository lotus-manage.