### PR TITLE
Reject unsupported portfolio memory event filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ portfolio-memory API also exposes `GET /api/v1/rebalance/portfolio-memory/search
 Manage-local index over persisted proof-pack, wave, monitoring-exception, campaign-definition,
 outcome-review, PM-quality, and explicit caller-supplied portfolio identifiers. Search responses
 include pre-pagination facet counts for supportability state, event type, and represented source
-system so consumers can triage the bounded result set without loading every portfolio timeline; it
-is not global portfolio-universe discovery and does not project OMS acknowledgement, fill,
-settlement, or execution-status events. Persisted bulk-review campaign definitions now project
+system so consumers can triage the bounded result set without loading every portfolio timeline.
+Unsupported event-type filters are rejected at the API boundary instead of being interpreted as an
+empty source result; the search route is not global portfolio-universe discovery and does not
+project OMS acknowledgement, fill, settlement, or execution-status events. Persisted bulk-review
+campaign definitions now project
 bounded portfolio memory events for definition, approval-decision, assignment-action,
 assignment-task, and maker-checker control evidence without copying raw campaign payloads,
 recalculating membership, or claiming external workflow orchestration, client contact, order

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T13:18:52.510593+00:00",
+  "generatedAt": "2026-05-21T13:44:23.073494+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -18773,7 +18773,7 @@
       "location": "query",
       "required": false,
       "type": "object",
-      "description": "Optional portfolio-memory event type filter.",
+      "description": "Optional portfolio-memory event type filter. Unsupported event types are rejected instead of being interpreted as an empty source result.",
       "example": "STANDARD_VALUE",
       "allowedValues": [],
       "semanticId": "lotus.event_type",

--- a/src/api/routers/portfolio_memory.py
+++ b/src/api/routers/portfolio_memory.py
@@ -1,8 +1,8 @@
 """API routes for RFC-0040 portfolio memory."""
 
-from typing import cast
+from typing import cast, get_args
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from src.api.dependencies import (
     get_construction_repository,
@@ -24,7 +24,10 @@ from src.core.pm_quality.repository import (
     DpmPmQualitySummaryInvocationRepository,
 )
 from src.core.portfolio_memory import DpmPortfolioMemory, DpmPortfolioMemorySearchPage
-from src.core.portfolio_memory.models import PortfolioMemorySupportabilityState
+from src.core.portfolio_memory.models import (
+    PortfolioMemoryEventType,
+    PortfolioMemorySupportabilityState,
+)
 from src.core.portfolio_memory.service import build_portfolio_memory, search_portfolio_memory
 from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.waves.campaign_repository import DpmBulkReviewCampaignDefinitionRepository
@@ -35,6 +38,8 @@ router = APIRouter(
     prefix="/rebalance/portfolio-memory",
     tags=["lotus-manage Portfolio Memory"],
 )
+_PORTFOLIO_MEMORY_EVENT_TYPES = tuple(get_args(PortfolioMemoryEventType))
+_PORTFOLIO_MEMORY_EVENT_TYPE_SET = set(_PORTFOLIO_MEMORY_EVENT_TYPES)
 
 
 @router.get(
@@ -68,7 +73,10 @@ def search_portfolio_memory_index(
     ),
     event_type: str | None = Query(
         default=None,
-        description="Optional portfolio-memory event type filter.",
+        description=(
+            "Optional portfolio-memory event type filter. Unsupported event types are rejected "
+            "instead of being interpreted as an empty source result."
+        ),
         examples=["WAVE_HANDOFF_READY"],
     ),
     supportability_state: str | None = Query(
@@ -108,6 +116,14 @@ def search_portfolio_memory_index(
         get_campaign_definition_repository
     ),
 ) -> DpmPortfolioMemorySearchPage:
+    if event_type is not None and event_type not in _PORTFOLIO_MEMORY_EVENT_TYPE_SET:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE: {event_type}; "
+                f"supported_event_types={','.join(_PORTFOLIO_MEMORY_EVENT_TYPES)}"
+            ),
+        )
     return search_portfolio_memory(
         proof_pack_repository=proof_pack_repository,
         wave_repository=wave_repository,

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1314,6 +1314,14 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert "supportability_state_counts" in search_schema["properties"]
     assert "event_type_counts" in search_schema["properties"]
     assert "source_system_counts" in search_schema["properties"]
+    event_type_parameter = next(
+        parameter
+        for parameter in openapi_json["paths"]["/api/v1/rebalance/portfolio-memory/search"]["get"][
+            "parameters"
+        ]
+        if parameter["name"] == "event_type"
+    )
+    assert "Unsupported event types are rejected" in event_type_parameter["description"]
 
 
 def test_portfolio_memory_search_can_include_explicit_portfolio_for_manage_only_events() -> None:
@@ -1357,6 +1365,41 @@ def test_portfolio_memory_search_can_include_explicit_portfolio_for_manage_only_
         "CONSTRUCTION_ALTERNATIVE_SELECTED": 1,
     }
     assert "lotus-manage" in payload["items"][0]["source_systems"]
+
+
+def test_portfolio_memory_search_rejects_unsupported_event_type_filter() -> None:
+    app.dependency_overrides[get_proof_pack_repository] = lambda: InMemoryDpmProofPackRepository()
+    app.dependency_overrides[get_construction_repository] = lambda: InMemoryConstructionRepository()
+    app.dependency_overrides[get_wave_repository] = lambda: InMemoryDpmWaveRepository()
+    app.dependency_overrides[get_outcome_review_repository] = lambda: (
+        InMemoryDpmOutcomeReviewRepository()
+    )
+    app.dependency_overrides[get_mandate_repository] = lambda: InMemoryDpmMandateRepository()
+    app.dependency_overrides[get_pm_quality_score_run_repository] = lambda: (
+        InMemoryDpmPmQualityScoreRunRepository()
+    )
+    app.dependency_overrides[get_pm_quality_review_action_repository] = lambda: (
+        InMemoryDpmPmQualityReviewActionRepository()
+    )
+    app.dependency_overrides[get_pm_quality_summary_invocation_repository] = lambda: (
+        InMemoryDpmPmQualitySummaryInvocationRepository()
+    )
+    app.dependency_overrides[get_campaign_definition_repository] = lambda: (
+        InMemoryDpmBulkReviewCampaignDefinitionRepository()
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/v1/rebalance/portfolio-memory/search",
+            params={"event_type": "NOT_A_MEMORY_EVENT"},
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"].startswith(
+        "UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE: NOT_A_MEMORY_EVENT"
+    )
+    assert "PROOF_PACK_CREATED" in response.json()["detail"]
+    assert "PM_QUALITY_SUMMARY_INVOCATION" in response.json()["detail"]
 
 
 def test_portfolio_memory_search_indexes_pm_quality_summary_invocations_by_book_scope() -> None:

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2021,6 +2021,8 @@ Functional behavior:
 - searches a bounded Manage-local portfolio-memory index across persisted proof packs, rebalance
   waves, monitoring exceptions, outcome reviews, and optional caller-supplied portfolio ids,
 - filters the search index by event type, supportability state, and represented source system,
+- rejects unsupported event-type filters with an explicit
+  `UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE` error instead of returning a misleading empty page,
 - returns search summaries with event counts, event-type counts, latest event posture, source
   systems, reason codes, content hash, total count, scanned portfolio count, pre-pagination
   supportability-state, event-type, and source-system facet counts, and an explicit support


### PR DESCRIPTION
## Summary
- reject unsupported portfolio-memory search event_type filters with an explicit 422 error
- document the fail-closed filter behavior in README and endpoint certification wiki source
- refresh the API vocabulary inventory for the updated parameter contract

## Validation
- python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Wiki
- Repo-local wiki source changed: wiki/Endpoint-Certification.md
- Pre-merge wiki check reports expected drift for Endpoint-Certification.md; publish after merge with Sync-RepoWikis.ps1 -Publish -Repository lotus-manage.