### PR TITLE
Support explicit empty portfolio memory search

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,10 @@ outcome-review, PM-quality, and explicit caller-supplied portfolio identifiers. 
 include pre-pagination facet counts for supportability state, event type, and represented source
 system so consumers can triage the bounded result set without loading every portfolio timeline.
 Unsupported event-type filters are rejected at the API boundary instead of being interpreted as an
-empty source result; the search route is not global portfolio-universe discovery and does not
-project OMS acknowledgement, fill, settlement, or execution-status events. Persisted bulk-review
-campaign definitions now project
+empty source result. Empty supportability summaries are returned only for explicit caller-supplied
+portfolio identifiers when `supportability_state=EMPTY` is requested; the search route is not
+global portfolio-universe discovery and does not project OMS acknowledgement, fill, settlement, or
+execution-status events. Persisted bulk-review campaign definitions now project
 bounded portfolio memory events for definition, approval-decision, assignment-action,
 assignment-task, and maker-checker control evidence without copying raw campaign payloads,
 recalculating membership, or claiming external workflow orchestration, client contact, order

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -230,6 +230,9 @@ def search_portfolio_memory(
     """Build a bounded Manage-local index over persisted portfolio-memory evidence."""
 
     generated_at = generated_at or datetime.now(timezone.utc)
+    explicit_candidate_ids = {
+        portfolio_id.strip() for portfolio_id in (portfolio_ids or []) if portfolio_id.strip()
+    }
     candidate_ids = _memory_candidate_portfolio_ids(
         proof_pack_repository=proof_pack_repository,
         wave_repository=wave_repository,
@@ -257,7 +260,8 @@ def search_portfolio_memory(
             generated_at=generated_at,
         )
         if memory.event_count == 0:
-            continue
+            if supportability_state != "EMPTY" or portfolio_id not in explicit_candidate_ids:
+                continue
         if event_type is not None and event_type not in memory.event_type_counts:
             continue
         if supportability_state is not None and memory.supportability_state != supportability_state:

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1553,6 +1553,77 @@ def test_portfolio_memory_search_filters_empty_type_state_and_source_candidates(
     assert source_filtered.returned_count == 0
 
 
+def test_portfolio_memory_search_empty_filter_returns_explicit_empty_portfolios() -> None:
+    empty_filtered = search_portfolio_memory(
+        proof_pack_repository=InMemoryDpmProofPackRepository(),
+        wave_repository=InMemoryDpmWaveRepository(),
+        outcome_review_repository=InMemoryDpmOutcomeReviewRepository(),
+        mandate_repository=InMemoryDpmMandateRepository(),
+        portfolio_ids=["EMPTY_PORTFOLIO", " "],
+        supportability_state="EMPTY",
+    )
+    default_filtered = search_portfolio_memory(
+        proof_pack_repository=InMemoryDpmProofPackRepository(),
+        wave_repository=InMemoryDpmWaveRepository(),
+        outcome_review_repository=InMemoryDpmOutcomeReviewRepository(),
+        mandate_repository=InMemoryDpmMandateRepository(),
+        portfolio_ids=["EMPTY_PORTFOLIO"],
+    )
+
+    assert empty_filtered.returned_count == 1
+    assert empty_filtered.total_count == 1
+    assert empty_filtered.scanned_portfolio_count == 1
+    assert empty_filtered.supportability_state_counts == {"EMPTY": 1}
+    assert empty_filtered.event_type_counts == {}
+    assert empty_filtered.source_system_counts == {}
+    assert empty_filtered.items[0].portfolio_id == "EMPTY_PORTFOLIO"
+    assert empty_filtered.items[0].event_count == 0
+    assert empty_filtered.items[0].supportability_state == "EMPTY"
+    assert empty_filtered.items[0].latest_event_time is None
+    assert empty_filtered.items[0].latest_event_type is None
+    assert default_filtered.returned_count == 0
+
+
+def test_portfolio_memory_search_api_returns_explicit_empty_portfolio_when_requested() -> None:
+    app.dependency_overrides[get_proof_pack_repository] = lambda: InMemoryDpmProofPackRepository()
+    app.dependency_overrides[get_construction_repository] = lambda: InMemoryConstructionRepository()
+    app.dependency_overrides[get_wave_repository] = lambda: InMemoryDpmWaveRepository()
+    app.dependency_overrides[get_outcome_review_repository] = lambda: (
+        InMemoryDpmOutcomeReviewRepository()
+    )
+    app.dependency_overrides[get_mandate_repository] = lambda: InMemoryDpmMandateRepository()
+    app.dependency_overrides[get_pm_quality_score_run_repository] = lambda: (
+        InMemoryDpmPmQualityScoreRunRepository()
+    )
+    app.dependency_overrides[get_pm_quality_review_action_repository] = lambda: (
+        InMemoryDpmPmQualityReviewActionRepository()
+    )
+    app.dependency_overrides[get_pm_quality_summary_invocation_repository] = lambda: (
+        InMemoryDpmPmQualitySummaryInvocationRepository()
+    )
+    app.dependency_overrides[get_campaign_definition_repository] = lambda: (
+        InMemoryDpmBulkReviewCampaignDefinitionRepository()
+    )
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/v1/rebalance/portfolio-memory/search",
+            params={
+                "portfolio_ids": "EMPTY_PORTFOLIO",
+                "supportability_state": "EMPTY",
+            },
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["returned_count"] == 1
+    assert payload["supportability_state_counts"] == {"EMPTY": 1}
+    assert payload["items"][0]["portfolio_id"] == "EMPTY_PORTFOLIO"
+    assert payload["items"][0]["event_count"] == 0
+    assert payload["items"][0]["supportability_state"] == "EMPTY"
+    assert payload["items"][0]["latest_event_time"] is None
+
+
 def test_portfolio_memory_helper_edges_preserve_source_safe_states() -> None:
     wave = _wave()
     outcome_ref = DpmOutcomeSourceRef(

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2023,6 +2023,8 @@ Functional behavior:
 - filters the search index by event type, supportability state, and represented source system,
 - rejects unsupported event-type filters with an explicit
   `UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE` error instead of returning a misleading empty page,
+- returns `EMPTY` search summaries only for explicit caller-supplied portfolio ids when
+  `supportability_state=EMPTY` is requested, preserving the no-global-universe-discovery boundary,
 - returns search summaries with event counts, event-type counts, latest event posture, source
   systems, reason codes, content hash, total count, scanned portfolio count, pre-pagination
   supportability-state, event-type, and source-system facet counts, and an explicit support


### PR DESCRIPTION
## Summary
- make supportability_state=EMPTY meaningful for explicit caller-supplied portfolio_ids in portfolio-memory search
- keep default search bounded to portfolios with Manage-local evidence, preserving no global portfolio-universe discovery
- update README and endpoint certification wiki source for the EMPTY search boundary

## Validation
- python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Wiki
- Repo-local wiki source changed: wiki/Endpoint-Certification.md
- Pre-merge wiki check reports expected drift for Endpoint-Certification.md; publish after merge with Sync-RepoWikis.ps1 -Publish -Repository lotus-manage.