### PR TITLE
Add portfolio memory search match context

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ portfolio-memory API also exposes `GET /api/v1/rebalance/portfolio-memory/search
 Manage-local index over persisted proof-pack, wave, monitoring-exception, campaign-definition,
 outcome-review, PM-quality, and explicit caller-supplied portfolio identifiers. Search responses
 include pre-pagination facet counts for supportability state, event type, and represented source
-system so consumers can triage the bounded result set without loading every portfolio timeline.
+system plus matching-event context so consumers can distinguish the latest overall memory event
+from the specific event that satisfied an event/source/supportability filter without loading every
+portfolio timeline.
 Unsupported event-type filters are rejected at the API boundary instead of being interpreted as an
 empty source result. Empty supportability summaries are returned only for explicit caller-supplied
 portfolio identifiers when `supportability_state=EMPTY` is requested; the search route is not

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T13:44:23.073494+00:00",
+  "generatedAt": "2026-05-21T14:16:08.402923+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -6850,6 +6850,34 @@
       ]
     },
     {
+      "semanticId": "lotus.latest_matching_event_time",
+      "canonicalTerm": "latest_matching_event_time",
+      "preferredName": "latest_matching_event_time",
+      "description": "Latest event timestamp among events that match the applied filters. This may differ from latest_event_time when an older event caused the search hit.",
+      "example": "2026-03-02T10:30:00Z",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_matching_event_type",
+      "canonicalTerm": "latest_matching_event_type",
+      "preferredName": "latest_matching_event_type",
+      "description": "Latest event type among events that match the applied filters. This preserves why a search result matched without changing the latest overall event posture.",
+      "example": "latest_matching_event_type_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.latest_monitoring_run",
       "canonicalTerm": "latest_monitoring_run",
       "preferredName": "latest_monitoring_run",
@@ -7460,6 +7488,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.matching_event_count",
+      "canonicalTerm": "matching_event_count",
+      "preferredName": "matching_event_count",
+      "description": "Number of events in this portfolio-memory view that match the applied event, source system, and supportability filters. When no filters are supplied this equals event_count.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
       ]
     },
     {
@@ -116808,6 +116850,30 @@
             "type": "object",
             "semanticId": "lotus.latest_event_type",
             "attributeRef": "#/attributeCatalog/lotus.latest_event_type"
+          },
+          {
+            "name": "items[].matching_event_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.matching_event_count",
+            "attributeRef": "#/attributeCatalog/lotus.matching_event_count"
+          },
+          {
+            "name": "items[].latest_matching_event_time",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_matching_event_time",
+            "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_time"
+          },
+          {
+            "name": "items[].latest_matching_event_type",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_matching_event_type",
+            "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_type"
           },
           {
             "name": "items[].content_hash",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -352,6 +352,28 @@ class DpmPortfolioMemorySearchItem(BaseModel):
         default=None,
         description="Latest event type in the returned portfolio-memory view.",
     )
+    matching_event_count: int = Field(
+        description=(
+            "Number of events in this portfolio-memory view that match the applied event, source "
+            "system, and supportability filters. When no filters are supplied this equals "
+            "event_count."
+        ),
+        examples=[1],
+    )
+    latest_matching_event_time: str | None = Field(
+        default=None,
+        description=(
+            "Latest event timestamp among events that match the applied filters. This may differ "
+            "from latest_event_time when an older event caused the search hit."
+        ),
+    )
+    latest_matching_event_type: PortfolioMemoryEventType | None = Field(
+        default=None,
+        description=(
+            "Latest event type among events that match the applied filters. This preserves why a "
+            "search result matched without changing the latest overall event posture."
+        ),
+    )
     content_hash: str = Field(description="Canonical hash of the portfolio-memory view.")
 
 

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -268,7 +268,28 @@ def search_portfolio_memory(
             continue
         if source_system is not None and source_system not in memory.source_systems:
             continue
+        matching_events = [
+            event
+            for event in memory.events
+            if _event_matches_search_filters(
+                event=event,
+                event_type=event_type,
+                supportability_state=supportability_state,
+                source_system=source_system,
+            )
+        ]
+        if (
+            (
+                event_type is not None
+                or source_system is not None
+                or supportability_state is not None
+            )
+            and supportability_state != "EMPTY"
+            and not matching_events
+        ):
+            continue
         latest_event = memory.events[0] if memory.events else None
+        latest_matching_event = matching_events[0] if matching_events else None
         items.append(
             DpmPortfolioMemorySearchItem(
                 portfolio_id=memory.portfolio_id,
@@ -279,6 +300,13 @@ def search_portfolio_memory(
                 reason_codes=memory.reason_codes,
                 latest_event_time=latest_event.event_time if latest_event else None,
                 latest_event_type=latest_event.event_type if latest_event else None,
+                matching_event_count=len(matching_events),
+                latest_matching_event_time=(
+                    latest_matching_event.event_time if latest_matching_event else None
+                ),
+                latest_matching_event_type=(
+                    latest_matching_event.event_type if latest_matching_event else None
+                ),
                 content_hash=memory.content_hash,
             )
         )
@@ -373,6 +401,34 @@ def _memory_candidate_portfolio_ids(
             for portfolio_id in score_run.book_scope_evidence.member_portfolio_ids
         )
     return sorted(candidates)
+
+
+def _event_matches_search_filters(
+    *,
+    event: DpmPortfolioMemoryEvent,
+    event_type: str | None,
+    supportability_state: PortfolioMemorySupportabilityState | None,
+    source_system: str | None,
+) -> bool:
+    if event_type is not None and event.event_type != event_type:
+        return False
+    if supportability_state is not None and event.supportability_state != supportability_state:
+        return False
+    if source_system is not None and source_system not in _event_source_systems(event):
+        return False
+    return True
+
+
+def _event_source_systems(event: DpmPortfolioMemoryEvent) -> set[str]:
+    return {
+        source_system
+        for source_system in [
+            event.source_system,
+            *(ref.source_system for ref in event.source_refs),
+            *(ref.source_system for ref in event.artifact_refs),
+        ]
+        if source_system
+    }
 
 
 def _portfolio_memory_governance_policy() -> dict[str, str]:

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1296,6 +1296,9 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert payload["items"][0]["event_type_counts"]["WAVE_HANDOFF_READY"] == 1
     assert payload["items"][0]["event_type_counts"]["BULK_REVIEW_CAMPAIGN_DEFINITION"] == 1
     assert payload["items"][0]["latest_event_time"] is not None
+    assert payload["items"][0]["matching_event_count"] == 1
+    assert payload["items"][0]["latest_matching_event_time"] is not None
+    assert payload["items"][0]["latest_matching_event_type"] == "WAVE_HANDOFF_READY"
     assert payload["items"][0]["content_hash"].startswith("sha256:")
     assert payload["supportability_state_counts"] == {"DEGRADED": 1}
     assert payload["event_type_counts"]["WAVE_HANDOFF_READY"] == 1
@@ -1314,6 +1317,9 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert "supportability_state_counts" in search_schema["properties"]
     assert "event_type_counts" in search_schema["properties"]
     assert "source_system_counts" in search_schema["properties"]
+    search_item_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemorySearchItem"]
+    assert "matching_event_count" in search_item_schema["properties"]
+    assert "latest_matching_event_type" in search_item_schema["properties"]
     event_type_parameter = next(
         parameter
         for parameter in openapi_json["paths"]["/api/v1/rebalance/portfolio-memory/search"]["get"][
@@ -1364,6 +1370,8 @@ def test_portfolio_memory_search_can_include_explicit_portfolio_for_manage_only_
         "CONSTRUCTION_ALTERNATIVE_SET": 1,
         "CONSTRUCTION_ALTERNATIVE_SELECTED": 1,
     }
+    assert payload["items"][0]["matching_event_count"] == 1
+    assert payload["items"][0]["latest_matching_event_type"] == "CONSTRUCTION_ALTERNATIVE_SELECTED"
     assert "lotus-manage" in payload["items"][0]["source_systems"]
 
 
@@ -1433,6 +1441,34 @@ def test_portfolio_memory_search_indexes_pm_quality_summary_invocations_by_book_
         }
         for item in page.items
     )
+    assert all(item.matching_event_count == 1 for item in page.items)
+    assert all(
+        item.latest_matching_event_type == "PM_QUALITY_SUMMARY_INVOCATION" for item in page.items
+    )
+
+
+def test_portfolio_memory_search_requires_source_system_on_matching_event_type() -> None:
+    pm_quality_repository = InMemoryDpmPmQualityScoreRunRepository()
+    pm_quality_repository.save_score_run(score_run=_pm_quality_score_run())
+    pm_quality_summary_repository = InMemoryDpmPmQualitySummaryInvocationRepository()
+    pm_quality_summary_repository.save_summary_invocation(
+        invocation=_pm_quality_summary_invocation()
+    )
+
+    page = search_portfolio_memory(
+        proof_pack_repository=InMemoryDpmProofPackRepository(),
+        wave_repository=InMemoryDpmWaveRepository(),
+        outcome_review_repository=InMemoryDpmOutcomeReviewRepository(),
+        pm_quality_score_run_repository=pm_quality_repository,
+        pm_quality_summary_invocation_repository=pm_quality_summary_repository,
+        event_type="PM_QUALITY_SUMMARY_INVOCATION",
+        source_system="lotus-core",
+    )
+
+    assert page.returned_count == 0
+    assert page.total_count == 0
+    assert page.event_type_counts == {}
+    assert page.source_system_counts == {}
 
 
 def test_portfolio_memory_search_facets_cover_filtered_results_before_pagination() -> None:
@@ -1581,6 +1617,9 @@ def test_portfolio_memory_search_empty_filter_returns_explicit_empty_portfolios(
     assert empty_filtered.items[0].supportability_state == "EMPTY"
     assert empty_filtered.items[0].latest_event_time is None
     assert empty_filtered.items[0].latest_event_type is None
+    assert empty_filtered.items[0].matching_event_count == 0
+    assert empty_filtered.items[0].latest_matching_event_time is None
+    assert empty_filtered.items[0].latest_matching_event_type is None
     assert default_filtered.returned_count == 0
 
 

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2025,10 +2025,10 @@ Functional behavior:
   `UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE` error instead of returning a misleading empty page,
 - returns `EMPTY` search summaries only for explicit caller-supplied portfolio ids when
   `supportability_state=EMPTY` is requested, preserving the no-global-universe-discovery boundary,
-- returns search summaries with event counts, event-type counts, latest event posture, source
-  systems, reason codes, content hash, total count, scanned portfolio count, pre-pagination
-  supportability-state, event-type, and source-system facet counts, and an explicit support
-  boundary,
+- returns search summaries with event counts, event-type counts, latest overall event posture,
+  matching-event count, latest matching-event posture, source systems, reason codes, content hash,
+  total count, scanned portfolio count, pre-pagination supportability-state, event-type, and
+  source-system facet counts, and an explicit support boundary,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,
 - preserves source system, source type, source id, supportability state, reason codes, source refs,


### PR DESCRIPTION
## Summary
- add matching-event context to portfolio-memory search summaries
- require combined event/source/supportability filters to match the same memory event before returning a portfolio summary
- update API vocabulary inventory plus README/wiki endpoint-certification truth

## Validation
- python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected drift: Endpoint-Certification.md until post-merge publish)

## Boundaries
- Manage-only backend/API/docs slice
- no Gateway, Workbench, or Advise changes
- no OMS, execution, client-contact, PM ranking, score recalculation, or source-owner methodology claim