### PR TITLE
Expose portfolio memory matching event identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ portfolio-memory API also exposes `GET /api/v1/rebalance/portfolio-memory/search
 Manage-local index over persisted proof-pack, wave, monitoring-exception, campaign-definition,
 outcome-review, PM-quality, and explicit caller-supplied portfolio identifiers. Search responses
 include pre-pagination facet counts for supportability state, event type, and represented source
-system plus matching-event context so consumers can distinguish the latest overall memory event
-from the specific event that satisfied an event/source/supportability filter without loading every
-portfolio timeline.
+system plus matching-event context and stable matching-event identity/source coordinates so
+consumers can distinguish the latest overall memory event from the specific event that satisfied an
+event/source/supportability filter without loading every portfolio timeline.
 Unsupported event-type filters are rejected at the API boundary instead of being interpreted as an
 empty source result. Empty supportability summaries are returned only for explicit caller-supplied
 portfolio identifiers when `supportability_state=EMPTY` is requested; the search route is not

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T14:16:08.402923+00:00",
+  "generatedAt": "2026-05-21T14:31:32.926921+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -6841,6 +6841,90 @@
       "preferredName": "latest_launched_at",
       "description": "Most recent launch timestamp, when launch history exists.",
       "example": "latest_launched_at_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_matching_event_content_hash",
+      "canonicalTerm": "latest_matching_event_content_hash",
+      "preferredName": "latest_matching_event_content_hash",
+      "description": "Canonical source content hash for the latest matching event when available.",
+      "example": "latest_matching_event_content_hash_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_matching_event_id",
+      "canonicalTerm": "latest_matching_event_id",
+      "preferredName": "latest_matching_event_id",
+      "description": "Stable event id for the latest matching portfolio-memory event so audit and operator consumers can load or reconcile the exact matching timeline row.",
+      "example": "LATEST_MATCHING_EVENT_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_matching_event_identity",
+      "canonicalTerm": "latest_matching_event_identity",
+      "preferredName": "latest_matching_event_identity",
+      "description": "Cross-app event identity for the latest matching event, derived from source system, source type, source id, and content-hash posture.",
+      "example": "latest_matching_event_identity_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_matching_event_source_id",
+      "canonicalTerm": "latest_matching_event_source_id",
+      "preferredName": "latest_matching_event_source_id",
+      "description": "Source identifier for the latest matching portfolio-memory event.",
+      "example": "LATEST_MATCHING_EVENT_SOURCE_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_matching_event_source_system",
+      "canonicalTerm": "latest_matching_event_source_system",
+      "preferredName": "latest_matching_event_source_system",
+      "description": "Source system that owns the latest matching portfolio-memory event.",
+      "example": "latest_matching_event_source_system_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.latest_matching_event_source_type",
+      "canonicalTerm": "latest_matching_event_source_type",
+      "preferredName": "latest_matching_event_source_type",
+      "description": "Source artifact or event type for the latest matching portfolio-memory event.",
+      "example": "latest_matching_event_source_type_example",
       "type": "object",
       "locations": [
         "body"
@@ -116874,6 +116958,54 @@
             "type": "object",
             "semanticId": "lotus.latest_matching_event_type",
             "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_type"
+          },
+          {
+            "name": "items[].latest_matching_event_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_matching_event_id",
+            "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_id"
+          },
+          {
+            "name": "items[].latest_matching_event_identity",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_matching_event_identity",
+            "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_identity"
+          },
+          {
+            "name": "items[].latest_matching_event_source_system",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_matching_event_source_system",
+            "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_source_system"
+          },
+          {
+            "name": "items[].latest_matching_event_source_type",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_matching_event_source_type",
+            "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_source_type"
+          },
+          {
+            "name": "items[].latest_matching_event_source_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_matching_event_source_id",
+            "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_source_id"
+          },
+          {
+            "name": "items[].latest_matching_event_content_hash",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.latest_matching_event_content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.latest_matching_event_content_hash"
           },
           {
             "name": "items[].content_hash",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -374,6 +374,36 @@ class DpmPortfolioMemorySearchItem(BaseModel):
             "search result matched without changing the latest overall event posture."
         ),
     )
+    latest_matching_event_id: str | None = Field(
+        default=None,
+        description=(
+            "Stable event id for the latest matching portfolio-memory event so audit and operator "
+            "consumers can load or reconcile the exact matching timeline row."
+        ),
+    )
+    latest_matching_event_identity: str | None = Field(
+        default=None,
+        description=(
+            "Cross-app event identity for the latest matching event, derived from source system, "
+            "source type, source id, and content-hash posture."
+        ),
+    )
+    latest_matching_event_source_system: str | None = Field(
+        default=None,
+        description="Source system that owns the latest matching portfolio-memory event.",
+    )
+    latest_matching_event_source_type: str | None = Field(
+        default=None,
+        description="Source artifact or event type for the latest matching portfolio-memory event.",
+    )
+    latest_matching_event_source_id: str | None = Field(
+        default=None,
+        description="Source identifier for the latest matching portfolio-memory event.",
+    )
+    latest_matching_event_content_hash: str | None = Field(
+        default=None,
+        description="Canonical source content hash for the latest matching event when available.",
+    )
     content_hash: str = Field(description="Canonical hash of the portfolio-memory view.")
 
 

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -307,6 +307,24 @@ def search_portfolio_memory(
                 latest_matching_event_type=(
                     latest_matching_event.event_type if latest_matching_event else None
                 ),
+                latest_matching_event_id=(
+                    latest_matching_event.event_id if latest_matching_event else None
+                ),
+                latest_matching_event_identity=(
+                    latest_matching_event.event_identity if latest_matching_event else None
+                ),
+                latest_matching_event_source_system=(
+                    latest_matching_event.source_system if latest_matching_event else None
+                ),
+                latest_matching_event_source_type=(
+                    latest_matching_event.source_type if latest_matching_event else None
+                ),
+                latest_matching_event_source_id=(
+                    latest_matching_event.source_id if latest_matching_event else None
+                ),
+                latest_matching_event_content_hash=(
+                    latest_matching_event.content_hash if latest_matching_event else None
+                ),
                 content_hash=memory.content_hash,
             )
         )

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1299,6 +1299,16 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert payload["items"][0]["matching_event_count"] == 1
     assert payload["items"][0]["latest_matching_event_time"] is not None
     assert payload["items"][0]["latest_matching_event_type"] == "WAVE_HANDOFF_READY"
+    assert payload["items"][0]["latest_matching_event_id"] == "memory:wave:dwv_001:handoff:dwh_001"
+    assert payload["items"][0]["latest_matching_event_identity"].startswith(
+        "lotus-manage:DPM_WAVE_INTERNAL_OPERATIONS_HANDOFF:dwh_001:"
+    )
+    assert payload["items"][0]["latest_matching_event_source_system"] == "lotus-manage"
+    assert payload["items"][0]["latest_matching_event_source_type"] == (
+        "DPM_WAVE_INTERNAL_OPERATIONS_HANDOFF"
+    )
+    assert payload["items"][0]["latest_matching_event_source_id"] == "dwh_001"
+    assert payload["items"][0]["latest_matching_event_content_hash"] == "sha256:handoff-memory"
     assert payload["items"][0]["content_hash"].startswith("sha256:")
     assert payload["supportability_state_counts"] == {"DEGRADED": 1}
     assert payload["event_type_counts"]["WAVE_HANDOFF_READY"] == 1
@@ -1320,6 +1330,8 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     search_item_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemorySearchItem"]
     assert "matching_event_count" in search_item_schema["properties"]
     assert "latest_matching_event_type" in search_item_schema["properties"]
+    assert "latest_matching_event_identity" in search_item_schema["properties"]
+    assert "latest_matching_event_source_system" in search_item_schema["properties"]
     event_type_parameter = next(
         parameter
         for parameter in openapi_json["paths"]["/api/v1/rebalance/portfolio-memory/search"]["get"][
@@ -1372,6 +1384,10 @@ def test_portfolio_memory_search_can_include_explicit_portfolio_for_manage_only_
     }
     assert payload["items"][0]["matching_event_count"] == 1
     assert payload["items"][0]["latest_matching_event_type"] == "CONSTRUCTION_ALTERNATIVE_SELECTED"
+    assert payload["items"][0]["latest_matching_event_source_type"] == (
+        "DPM_CONSTRUCTION_ALTERNATIVE_SELECTION"
+    )
+    assert payload["items"][0]["latest_matching_event_source_id"] == "casel_memory_001"
     assert "lotus-manage" in payload["items"][0]["source_systems"]
 
 
@@ -1445,6 +1461,11 @@ def test_portfolio_memory_search_indexes_pm_quality_summary_invocations_by_book_
     assert all(
         item.latest_matching_event_type == "PM_QUALITY_SUMMARY_INVOCATION" for item in page.items
     )
+    assert all(
+        item.latest_matching_event_source_type == "DPM_PM_OPERATING_QUALITY_SUMMARY_INVOCATION"
+        for item in page.items
+    )
+    assert all(item.latest_matching_event_identity is not None for item in page.items)
 
 
 def test_portfolio_memory_search_requires_source_system_on_matching_event_type() -> None:
@@ -1620,6 +1641,12 @@ def test_portfolio_memory_search_empty_filter_returns_explicit_empty_portfolios(
     assert empty_filtered.items[0].matching_event_count == 0
     assert empty_filtered.items[0].latest_matching_event_time is None
     assert empty_filtered.items[0].latest_matching_event_type is None
+    assert empty_filtered.items[0].latest_matching_event_id is None
+    assert empty_filtered.items[0].latest_matching_event_identity is None
+    assert empty_filtered.items[0].latest_matching_event_source_system is None
+    assert empty_filtered.items[0].latest_matching_event_source_type is None
+    assert empty_filtered.items[0].latest_matching_event_source_id is None
+    assert empty_filtered.items[0].latest_matching_event_content_hash is None
     assert default_filtered.returned_count == 0
 
 

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2026,9 +2026,10 @@ Functional behavior:
 - returns `EMPTY` search summaries only for explicit caller-supplied portfolio ids when
   `supportability_state=EMPTY` is requested, preserving the no-global-universe-discovery boundary,
 - returns search summaries with event counts, event-type counts, latest overall event posture,
-  matching-event count, latest matching-event posture, source systems, reason codes, content hash,
-  total count, scanned portfolio count, pre-pagination supportability-state, event-type, and
-  source-system facet counts, and an explicit support boundary,
+  matching-event count, latest matching-event posture, latest matching-event id/identity/source
+  coordinates, source systems, reason codes, content hash, total count, scanned portfolio count,
+  pre-pagination supportability-state, event-type, and source-system facet counts, and an explicit
+  support boundary,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,
 - preserves source system, source type, source id, supportability state, reason codes, source refs,


### PR DESCRIPTION
## Summary
- expose latest matching portfolio-memory event id, event identity, source coordinates, and content hash on search result items
- keep latest overall event posture separate from the event that satisfied the search filters
- update API vocabulary inventory plus README/wiki endpoint-certification truth

## Validation
- python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected drift: Endpoint-Certification.md until post-merge publish)

## Boundaries
- Manage-only backend/API/docs slice
- no Gateway, Workbench, or Advise changes
- no OMS, execution, client-contact, PM ranking, score recalculation, or source-owner methodology claim