### PR TITLE
Make portfolio memory search facets truthful

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ creating portfolio-level rankings or downstream summary UX. The
 portfolio-memory API also exposes `GET /api/v1/rebalance/portfolio-memory/search` as a bounded
 Manage-local index over persisted proof-pack, wave, monitoring-exception, campaign-definition,
 outcome-review, PM-quality, and explicit caller-supplied portfolio identifiers. Search responses
-include pre-pagination facet counts for supportability state, event type, and represented source
-system plus matching-event context and stable matching-event identity/source coordinates so
+include pre-pagination facet counts for supportability state, matched event type, and represented
+source system plus matching-event context and stable matching-event identity/source coordinates so
 consumers can distinguish the latest overall memory event from the specific event that satisfied an
 event/source/supportability filter without loading every portfolio timeline.
 `GET /api/v1/rebalance/portfolio-memory/{portfolio_id}/events/{event_id}` provides the bounded

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -243,7 +243,7 @@ def search_portfolio_memory(
         portfolio_ids=portfolio_ids,
         source_scan_limit=source_scan_limit,
     )
-    items: list[DpmPortfolioMemorySearchItem] = []
+    search_rows: list[tuple[DpmPortfolioMemorySearchItem, list[DpmPortfolioMemoryEvent]]] = []
     for portfolio_id in candidate_ids:
         memory = build_portfolio_memory(
             portfolio_id=portfolio_id,
@@ -290,60 +290,66 @@ def search_portfolio_memory(
             continue
         latest_event = memory.events[0] if memory.events else None
         latest_matching_event = matching_events[0] if matching_events else None
-        items.append(
-            DpmPortfolioMemorySearchItem(
-                portfolio_id=memory.portfolio_id,
-                event_count=memory.event_count,
-                supportability_state=memory.supportability_state,
-                event_type_counts=memory.event_type_counts,
-                source_systems=memory.source_systems,
-                reason_codes=memory.reason_codes,
-                latest_event_time=latest_event.event_time if latest_event else None,
-                latest_event_type=latest_event.event_type if latest_event else None,
-                matching_event_count=len(matching_events),
-                latest_matching_event_time=(
-                    latest_matching_event.event_time if latest_matching_event else None
+        search_rows.append(
+            (
+                DpmPortfolioMemorySearchItem(
+                    portfolio_id=memory.portfolio_id,
+                    event_count=memory.event_count,
+                    supportability_state=memory.supportability_state,
+                    event_type_counts=memory.event_type_counts,
+                    source_systems=memory.source_systems,
+                    reason_codes=memory.reason_codes,
+                    latest_event_time=latest_event.event_time if latest_event else None,
+                    latest_event_type=latest_event.event_type if latest_event else None,
+                    matching_event_count=len(matching_events),
+                    latest_matching_event_time=(
+                        latest_matching_event.event_time if latest_matching_event else None
+                    ),
+                    latest_matching_event_type=(
+                        latest_matching_event.event_type if latest_matching_event else None
+                    ),
+                    latest_matching_event_id=(
+                        latest_matching_event.event_id if latest_matching_event else None
+                    ),
+                    latest_matching_event_identity=(
+                        latest_matching_event.event_identity if latest_matching_event else None
+                    ),
+                    latest_matching_event_source_system=(
+                        latest_matching_event.source_system if latest_matching_event else None
+                    ),
+                    latest_matching_event_source_type=(
+                        latest_matching_event.source_type if latest_matching_event else None
+                    ),
+                    latest_matching_event_source_id=(
+                        latest_matching_event.source_id if latest_matching_event else None
+                    ),
+                    latest_matching_event_content_hash=(
+                        latest_matching_event.content_hash if latest_matching_event else None
+                    ),
+                    content_hash=memory.content_hash,
                 ),
-                latest_matching_event_type=(
-                    latest_matching_event.event_type if latest_matching_event else None
-                ),
-                latest_matching_event_id=(
-                    latest_matching_event.event_id if latest_matching_event else None
-                ),
-                latest_matching_event_identity=(
-                    latest_matching_event.event_identity if latest_matching_event else None
-                ),
-                latest_matching_event_source_system=(
-                    latest_matching_event.source_system if latest_matching_event else None
-                ),
-                latest_matching_event_source_type=(
-                    latest_matching_event.source_type if latest_matching_event else None
-                ),
-                latest_matching_event_source_id=(
-                    latest_matching_event.source_id if latest_matching_event else None
-                ),
-                latest_matching_event_content_hash=(
-                    latest_matching_event.content_hash if latest_matching_event else None
-                ),
-                content_hash=memory.content_hash,
+                matching_events,
             )
         )
 
-    items = sorted(
-        items,
-        key=lambda item: (item.latest_event_time or "", item.portfolio_id),
+    search_rows = sorted(
+        search_rows,
+        key=lambda row: (row[0].latest_event_time or "", row[0].portfolio_id),
         reverse=True,
     )
-    total_count = len(items)
-    supportability_state_counts = _counts(item.supportability_state for item in items)
+    total_count = len(search_rows)
+    supportability_state_counts = _counts(
+        item.supportability_state for item, _events in search_rows
+    )
     event_type_counts: dict[str, int] = {}
     source_system_counts: dict[str, int] = {}
-    for item in items:
-        for event_type, count in item.event_type_counts.items():
-            event_type_counts[event_type] = event_type_counts.get(event_type, 0) + count
+    for item, matching_events in search_rows:
+        for event in matching_events:
+            event_type_counts[event.event_type] = event_type_counts.get(event.event_type, 0) + 1
         for source_system in item.source_systems:
             source_system_counts[source_system] = source_system_counts.get(source_system, 0) + 1
-    page = items[offset : offset + limit]
+    page_rows = search_rows[offset : offset + limit]
+    page = [item for item, _events in page_rows]
     return DpmPortfolioMemorySearchPage(
         items=page,
         limit=limit,

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1311,8 +1311,7 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert payload["items"][0]["latest_matching_event_content_hash"] == "sha256:handoff-memory"
     assert payload["items"][0]["content_hash"].startswith("sha256:")
     assert payload["supportability_state_counts"] == {"DEGRADED": 1}
-    assert payload["event_type_counts"]["WAVE_HANDOFF_READY"] == 1
-    assert payload["event_type_counts"]["BULK_REVIEW_CAMPAIGN_DEFINITION"] == 1
+    assert payload["event_type_counts"] == {"WAVE_HANDOFF_READY": 1}
     assert payload["source_system_counts"]["lotus-manage"] == 1
     assert "does not discover the global portfolio universe" in payload["support_boundary"]
     assert "project OMS" in payload["support_boundary"]
@@ -1577,10 +1576,7 @@ def test_portfolio_memory_search_facets_cover_filtered_results_before_pagination
     assert page.returned_count == 1
     assert page.total_count == 2
     assert page.supportability_state_counts == {"READY": 2}
-    assert page.event_type_counts == {
-        "PM_QUALITY_SCORE_RUN": 2,
-        "PM_QUALITY_SUMMARY_INVOCATION": 2,
-    }
+    assert page.event_type_counts == {"PM_QUALITY_SUMMARY_INVOCATION": 2}
     assert page.source_system_counts == {
         "lotus-ai": 2,
         "lotus-core": 2,

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2029,8 +2029,8 @@ Functional behavior:
 - returns search summaries with event counts, event-type counts, latest overall event posture,
   matching-event count, latest matching-event posture, latest matching-event id/identity/source
   coordinates, source systems, reason codes, content hash, total count, scanned portfolio count,
-  pre-pagination supportability-state, event-type, and source-system facet counts, and an explicit
-  support boundary,
+  pre-pagination supportability-state, matched-event-type, and source-system facet counts, and an
+  explicit support boundary,
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
   the event identity, memory content hash, and explicit no-claim boundary for audit drilldown from
   a search hit,


### PR DESCRIPTION
## Summary
- derive portfolio-memory search page event-type facets from events that actually match the applied filters
- keep per-item event_type_counts as the full returned memory-view summary for each portfolio
- update focused tests plus README/wiki wording so audit consumers can distinguish matched-event facets from per-portfolio memory counts

## Validation
- python -m pytest tests/unit/dpm/api/test_portfolio_memory_api.py -q
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected drift: Endpoint-Certification.md updated in this PR; publish after merge)

## Boundary
- no Gateway, Workbench, or Advise changes
- no new source-owner, OMS, execution, client-communication, risk, performance, report, archive, or AI claims