### PR TITLE
Add portfolio memory matched supportability facets

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ creating portfolio-level rankings or downstream summary UX. The
 portfolio-memory API also exposes `GET /api/v1/rebalance/portfolio-memory/search` as a bounded
 Manage-local index over persisted proof-pack, wave, monitoring-exception, campaign-definition,
 outcome-review, PM-quality, and explicit caller-supplied portfolio identifiers. Search responses
-include pre-pagination facet counts for supportability state, matched event type, and represented
-source system plus matching-event context and stable matching-event identity/source coordinates so
-consumers can distinguish the latest overall memory event from the specific event that satisfied an
+include pre-pagination facet counts for portfolio aggregate supportability state, matched event
+type, matched-event supportability state, and represented source system plus matching-event context
+and stable matching-event identity/source coordinates so consumers can distinguish the latest
+overall memory event and aggregate portfolio posture from the specific event that satisfied an
 event/source/supportability filter without loading every portfolio timeline.
 `GET /api/v1/rebalance/portfolio-memory/{portfolio_id}/events/{event_id}` provides the bounded
 drilldown counterpart for those search hits: it returns the exact source-backed memory event,

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T14:48:18.195415+00:00",
+  "generatedAt": "2026-05-21T15:20:38.940119+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -7588,6 +7588,22 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.matching_event_supportability_state_counts",
+      "canonicalTerm": "matching_event_supportability_state_counts",
+      "preferredName": "matching_event_supportability_state_counts",
+      "description": "Aggregate count of matching portfolio-memory events by supportability state before pagination. Counts are derived from events that satisfied the applied search filters, not from the portfolio aggregate supportability state.",
+      "example": {
+        "sample_key": "sample_value"
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -117122,6 +117138,14 @@
             "type": "object",
             "semanticId": "lotus.event_type_counts",
             "attributeRef": "#/attributeCatalog/lotus.event_type_counts"
+          },
+          {
+            "name": "matching_event_supportability_state_counts",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.matching_event_supportability_state_counts",
+            "attributeRef": "#/attributeCatalog/lotus.matching_event_supportability_state_counts"
           },
           {
             "name": "source_system_counts",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -468,6 +468,15 @@ class DpmPortfolioMemorySearchPage(BaseModel):
         ),
         examples=[{"WAVE_HANDOFF_READY": 1, "OUTCOME_REVIEW_CREATED": 1}],
     )
+    matching_event_supportability_state_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Aggregate count of matching portfolio-memory events by supportability state before "
+            "pagination. Counts are derived from events that satisfied the applied search filters, "
+            "not from the portfolio aggregate supportability state."
+        ),
+        examples=[{"READY": 2, "PENDING_REVIEW": 1}],
+    )
     source_system_counts: dict[str, int] = Field(
         default_factory=dict,
         description=(

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -342,10 +342,14 @@ def search_portfolio_memory(
         item.supportability_state for item, _events in search_rows
     )
     event_type_counts: dict[str, int] = {}
+    matching_event_supportability_state_counts: dict[str, int] = {}
     source_system_counts: dict[str, int] = {}
     for item, matching_events in search_rows:
         for event in matching_events:
             event_type_counts[event.event_type] = event_type_counts.get(event.event_type, 0) + 1
+            matching_event_supportability_state_counts[event.supportability_state] = (
+                matching_event_supportability_state_counts.get(event.supportability_state, 0) + 1
+            )
         for source_system in item.source_systems:
             source_system_counts[source_system] = source_system_counts.get(source_system, 0) + 1
     page_rows = search_rows[offset : offset + limit]
@@ -359,6 +363,9 @@ def search_portfolio_memory(
         scanned_portfolio_count=len(candidate_ids),
         supportability_state_counts=dict(sorted(supportability_state_counts.items())),
         event_type_counts=dict(sorted(event_type_counts.items())),
+        matching_event_supportability_state_counts=dict(
+            sorted(matching_event_supportability_state_counts.items())
+        ),
         source_system_counts=dict(sorted(source_system_counts.items())),
         generated_at=generated_at.isoformat(),
         support_boundary=(

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1312,6 +1312,7 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert payload["items"][0]["content_hash"].startswith("sha256:")
     assert payload["supportability_state_counts"] == {"DEGRADED": 1}
     assert payload["event_type_counts"] == {"WAVE_HANDOFF_READY": 1}
+    assert payload["matching_event_supportability_state_counts"] == {"READY": 1}
     assert payload["source_system_counts"]["lotus-manage"] == 1
     assert "does not discover the global portfolio universe" in payload["support_boundary"]
     assert "project OMS" in payload["support_boundary"]
@@ -1325,6 +1326,7 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     )
     assert "supportability_state_counts" in search_schema["properties"]
     assert "event_type_counts" in search_schema["properties"]
+    assert "matching_event_supportability_state_counts" in search_schema["properties"]
     assert "source_system_counts" in search_schema["properties"]
     search_item_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemorySearchItem"]
     assert "matching_event_count" in search_item_schema["properties"]
@@ -1552,6 +1554,7 @@ def test_portfolio_memory_search_requires_source_system_on_matching_event_type()
     assert page.returned_count == 0
     assert page.total_count == 0
     assert page.event_type_counts == {}
+    assert page.matching_event_supportability_state_counts == {}
     assert page.source_system_counts == {}
 
 
@@ -1577,6 +1580,7 @@ def test_portfolio_memory_search_facets_cover_filtered_results_before_pagination
     assert page.total_count == 2
     assert page.supportability_state_counts == {"READY": 2}
     assert page.event_type_counts == {"PM_QUALITY_SUMMARY_INVOCATION": 2}
+    assert page.matching_event_supportability_state_counts == {"READY": 2}
     assert page.source_system_counts == {
         "lotus-ai": 2,
         "lotus-core": 2,
@@ -1692,6 +1696,7 @@ def test_portfolio_memory_search_empty_filter_returns_explicit_empty_portfolios(
     assert empty_filtered.scanned_portfolio_count == 1
     assert empty_filtered.supportability_state_counts == {"EMPTY": 1}
     assert empty_filtered.event_type_counts == {}
+    assert empty_filtered.matching_event_supportability_state_counts == {}
     assert empty_filtered.source_system_counts == {}
     assert empty_filtered.items[0].portfolio_id == "EMPTY_PORTFOLIO"
     assert empty_filtered.items[0].event_count == 0
@@ -1744,6 +1749,7 @@ def test_portfolio_memory_search_api_returns_explicit_empty_portfolio_when_reque
     payload = response.json()
     assert payload["returned_count"] == 1
     assert payload["supportability_state_counts"] == {"EMPTY": 1}
+    assert payload["matching_event_supportability_state_counts"] == {}
     assert payload["items"][0]["portfolio_id"] == "EMPTY_PORTFOLIO"
     assert payload["items"][0]["event_count"] == 0
     assert payload["items"][0]["supportability_state"] == "EMPTY"

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2029,8 +2029,8 @@ Functional behavior:
 - returns search summaries with event counts, event-type counts, latest overall event posture,
   matching-event count, latest matching-event posture, latest matching-event id/identity/source
   coordinates, source systems, reason codes, content hash, total count, scanned portfolio count,
-  pre-pagination supportability-state, matched-event-type, and source-system facet counts, and an
-  explicit support boundary,
+  pre-pagination portfolio aggregate supportability-state, matched-event-type, matched-event
+  supportability-state, and source-system facet counts, and an explicit support boundary,
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
   the event identity, memory content hash, and explicit no-claim boundary for audit drilldown from
   a search hit,


### PR DESCRIPTION
## Summary
- Add `matching_event_supportability_state_counts` to the bounded portfolio-memory search page.
- Compute the new facet from events that satisfy the active search filters, separately from aggregate portfolio supportability.
- Update focused portfolio-memory tests, OpenAPI vocabulary inventory, README, and repo-authored wiki endpoint certification truth.

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py -q` -> 14 passed, 1 warning
- `make lint` -> passed
- `make typecheck` -> passed
- `make no-alias-gate` -> passed
- `make openapi-gate` -> passed
- `make api-vocabulary-gate` -> passed
- `make test-unit` -> 1461 passed, 3 warnings
- `make test-integration` -> 168 passed
- `make test-e2e` -> 28 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` -> passed
- `git diff --check` -> passed
- `pwsh -NoProfile -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> expected pre-merge drift: `Endpoint-Certification.md`

## Boundary
- Manage-local backend/API slice only.
- No Gateway, Workbench, or Advise changes.
- Does not add global portfolio-universe discovery, OMS execution, client communication, or source-owner event-store search.