### PR TITLE
Add portfolio memory search continuation metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ type, matched-event supportability state, matched-event source systems, and repr
 system plus matching-event context and stable matching-event identity/source coordinates so
 consumers can distinguish the latest overall memory event, aggregate portfolio posture, and
 portfolio-level source-system coverage from the specific event that satisfied an
-event/source/supportability filter without loading every portfolio timeline.
+event/source/supportability filter without loading every portfolio timeline. Pagination metadata
+also returns `has_more` and `next_offset` so consumers can continue bounded searches without
+reconstructing continuation logic from counts.
 `GET /api/v1/rebalance/portfolio-memory/{portfolio_id}/events/{event_id}` provides the bounded
 drilldown counterpart for those search hits: it returns the exact source-backed memory event,
 event identity, memory content hash, and no-claim boundary without querying external source-owner

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T15:36:55.674994+00:00",
+  "generatedAt": "2026-05-21T15:51:54.360611+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -5741,6 +5741,20 @@
       ]
     },
     {
+      "semanticId": "lotus.has_more",
+      "canonicalTerm": "has_more",
+      "preferredName": "has_more",
+      "description": "Whether additional matching Manage-local portfolio-memory summaries are available after this page.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
       "semanticId": "lotus.hashes",
       "canonicalTerm": "hashes",
       "preferredName": "hashes",
@@ -8430,6 +8444,20 @@
       "preferredName": "next_cursor",
       "description": "Opaque cursor for retrieving the next result page.",
       "example": "next_cursor_example",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.next_offset",
+      "canonicalTerm": "next_offset",
+      "preferredName": "next_offset",
+      "description": "Offset to request the next page when has_more is true; null when this page exhausts the bounded Manage-local result set.",
+      "example": "next_offset_example",
       "type": "object",
       "locations": [
         "body"
@@ -117130,6 +117158,22 @@
             "type": "integer",
             "semanticId": "lotus.total_count",
             "attributeRef": "#/attributeCatalog/lotus.total_count"
+          },
+          {
+            "name": "has_more",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.has_more",
+            "attributeRef": "#/attributeCatalog/lotus.has_more"
+          },
+          {
+            "name": "next_offset",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.next_offset",
+            "attributeRef": "#/attributeCatalog/lotus.next_offset"
           },
           {
             "name": "scanned_portfolio_count",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -446,6 +446,21 @@ class DpmPortfolioMemorySearchPage(BaseModel):
         description="Total matching Manage-local portfolio-memory summaries before pagination.",
         examples=[1],
     )
+    has_more: bool = Field(
+        description=(
+            "Whether additional matching Manage-local portfolio-memory summaries are available "
+            "after this page."
+        ),
+        examples=[False],
+    )
+    next_offset: int | None = Field(
+        default=None,
+        description=(
+            "Offset to request the next page when has_more is true; null when this page exhausts "
+            "the bounded Manage-local result set."
+        ),
+        examples=[50],
+    )
     scanned_portfolio_count: int = Field(
         description="Number of candidate portfolio identifiers scanned from Manage-local evidence.",
         examples=[3],

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -359,12 +359,16 @@ def search_portfolio_memory(
             source_system_counts[source_system] = source_system_counts.get(source_system, 0) + 1
     page_rows = search_rows[offset : offset + limit]
     page = [item for item, _events in page_rows]
+    next_offset = offset + len(page)
+    has_more = next_offset < total_count
     return DpmPortfolioMemorySearchPage(
         items=page,
         limit=limit,
         offset=offset,
         returned_count=len(page),
         total_count=total_count,
+        has_more=has_more,
+        next_offset=next_offset if has_more else None,
         scanned_portfolio_count=len(candidate_ids),
         supportability_state_counts=dict(sorted(supportability_state_counts.items())),
         event_type_counts=dict(sorted(event_type_counts.items())),

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1290,6 +1290,8 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     payload = response.json()
     assert payload["returned_count"] == 1
     assert payload["total_count"] == 1
+    assert payload["has_more"] is False
+    assert payload["next_offset"] is None
     assert payload["scanned_portfolio_count"] == 2
     assert payload["items"][0]["portfolio_id"] == PORTFOLIO_ID
     assert payload["items"][0]["event_count"] >= 6
@@ -1329,6 +1331,8 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
         in (search_schema["properties"]["items"]["description"])
     )
     assert "supportability_state_counts" in search_schema["properties"]
+    assert "has_more" in search_schema["properties"]
+    assert "next_offset" in search_schema["properties"]
     assert "event_type_counts" in search_schema["properties"]
     assert "matching_event_supportability_state_counts" in search_schema["properties"]
     assert "matching_event_source_system_counts" in search_schema["properties"]
@@ -1584,6 +1588,8 @@ def test_portfolio_memory_search_facets_cover_filtered_results_before_pagination
 
     assert page.returned_count == 1
     assert page.total_count == 2
+    assert page.has_more is True
+    assert page.next_offset == 1
     assert page.supportability_state_counts == {"READY": 2}
     assert page.event_type_counts == {"PM_QUALITY_SUMMARY_INVOCATION": 2}
     assert page.matching_event_supportability_state_counts == {"READY": 2}
@@ -1703,6 +1709,8 @@ def test_portfolio_memory_search_empty_filter_returns_explicit_empty_portfolios(
 
     assert empty_filtered.returned_count == 1
     assert empty_filtered.total_count == 1
+    assert empty_filtered.has_more is False
+    assert empty_filtered.next_offset is None
     assert empty_filtered.scanned_portfolio_count == 1
     assert empty_filtered.supportability_state_counts == {"EMPTY": 1}
     assert empty_filtered.event_type_counts == {}

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2028,10 +2028,11 @@ Functional behavior:
   `supportability_state=EMPTY` is requested, preserving the no-global-universe-discovery boundary,
 - returns search summaries with event counts, event-type counts, latest overall event posture,
   matching-event count, latest matching-event posture, latest matching-event id/identity/source
-  coordinates, source systems, reason codes, content hash, total count, scanned portfolio count,
-  pre-pagination portfolio aggregate supportability-state, matched-event-type, matched-event
-  supportability-state, matched-event source-system, and portfolio-summary source-system facet
-  counts, and an explicit support boundary,
+  coordinates, source systems, reason codes, content hash, total count, returned count, requested
+  limit/offset, `has_more`, `next_offset`, scanned portfolio count, pre-pagination portfolio
+  aggregate supportability-state, matched-event-type, matched-event supportability-state,
+  matched-event source-system, and portfolio-summary source-system facet counts, and an explicit
+  support boundary,
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
   the event identity, memory content hash, and explicit no-claim boundary for audit drilldown from
   a search hit,


### PR DESCRIPTION
## Summary
- Add `has_more` and `next_offset` to bounded portfolio-memory search responses.
- Compute continuation metadata from the actual returned page and total matched Manage-local result count.
- Update focused tests, OpenAPI vocabulary inventory, README, and repo-authored wiki endpoint certification truth.

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py -q` -> 14 passed, 1 warning
- `make lint` -> passed
- `make typecheck` -> passed
- `make no-alias-gate` -> passed
- `make openapi-gate` -> passed
- `make api-vocabulary-gate` -> passed
- `make test-unit` -> 1461 passed, 3 warnings
- `make test-integration` -> 168 passed
- `make test-e2e` -> 28 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` -> passed
- `git diff --check` -> passed
- `pwsh -NoProfile -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> expected pre-merge drift: `Endpoint-Certification.md`

## Boundary
- Manage-local backend/API slice only.
- No Gateway, Workbench, or Advise changes.
- Does not add global portfolio-universe discovery, OMS execution, client communication, or external source-owner event-store search.