### PR TITLE
Normalize portfolio memory search filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ portfolio-level source-system coverage from the specific event that satisfied an
 event/source/supportability filter without loading every portfolio timeline. Pagination metadata
 also returns `has_more`, `next_offset`, and the normalized `applied_filters` echo so consumers can
 continue bounded searches without reconstructing continuation logic or filter posture from counts.
+Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
+are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
+query-string formatting.
 `GET /api/v1/rebalance/portfolio-memory/{portfolio_id}/events/{event_id}` provides the bounded
 drilldown counterpart for those search hits: it returns the exact source-backed memory event,
 event identity, memory content hash, and no-claim boundary without querying external source-owner

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T16:08:54.347728+00:00",
+  "generatedAt": "2026-05-21T16:24:52.194560+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -19005,7 +19005,7 @@
       "location": "query",
       "required": false,
       "type": "object",
-      "description": "Optional aggregate supportability-state filter.",
+      "description": "Optional aggregate supportability-state filter. Leading and trailing whitespace is normalized before matching.",
       "example": "STANDARD_VALUE",
       "allowedValues": [],
       "semanticId": "lotus.supportability_state",
@@ -19017,7 +19017,7 @@
       "location": "query",
       "required": false,
       "type": "object",
-      "description": "Optional represented source-system filter.",
+      "description": "Optional represented source-system filter. Leading and trailing whitespace is normalized before matching.",
       "example": "STANDARD_VALUE",
       "allowedValues": [],
       "semanticId": "lotus.source_system",

--- a/src/api/routers/portfolio_memory.py
+++ b/src/api/routers/portfolio_memory.py
@@ -29,7 +29,11 @@ from src.core.portfolio_memory.models import (
     PortfolioMemoryEventType,
     PortfolioMemorySupportabilityState,
 )
-from src.core.portfolio_memory.service import build_portfolio_memory, search_portfolio_memory
+from src.core.portfolio_memory.service import (
+    build_portfolio_memory,
+    normalize_portfolio_memory_search_filter,
+    search_portfolio_memory,
+)
 from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.waves.campaign_repository import DpmBulkReviewCampaignDefinitionRepository
 from src.core.waves.repository import DpmWaveRepository
@@ -82,13 +86,19 @@ def search_portfolio_memory_index(
     ),
     supportability_state: str | None = Query(
         default=None,
-        pattern="^(READY|PENDING_REVIEW|DEGRADED|BLOCKED|EMPTY)$",
-        description="Optional aggregate supportability-state filter.",
+        pattern=r"^\s*(READY|PENDING_REVIEW|DEGRADED|BLOCKED|EMPTY)\s*$",
+        description=(
+            "Optional aggregate supportability-state filter. Leading and trailing whitespace is "
+            "normalized before matching."
+        ),
         examples=["READY"],
     ),
     source_system: str | None = Query(
         default=None,
-        description="Optional represented source-system filter.",
+        description=(
+            "Optional represented source-system filter. Leading and trailing whitespace is "
+            "normalized before matching."
+        ),
         examples=["lotus-manage"],
     ),
     limit: int = Query(default=50, ge=1, le=200, description="Maximum summaries to return."),
@@ -117,11 +127,17 @@ def search_portfolio_memory_index(
         get_campaign_definition_repository
     ),
 ) -> DpmPortfolioMemorySearchPage:
-    if event_type is not None and event_type not in _PORTFOLIO_MEMORY_EVENT_TYPE_SET:
+    normalized_event_type = normalize_portfolio_memory_search_filter(event_type)
+    normalized_supportability_state = normalize_portfolio_memory_search_filter(supportability_state)
+    normalized_source_system = normalize_portfolio_memory_search_filter(source_system)
+    if (
+        normalized_event_type is not None
+        and normalized_event_type not in _PORTFOLIO_MEMORY_EVENT_TYPE_SET
+    ):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=(
-                f"UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE: {event_type}; "
+                f"UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE: {normalized_event_type}; "
                 f"supported_event_types={','.join(_PORTFOLIO_MEMORY_EVENT_TYPES)}"
             ),
         )
@@ -136,9 +152,11 @@ def search_portfolio_memory_index(
         pm_quality_summary_invocation_repository=pm_quality_summary_invocation_repository,
         campaign_definition_repository=campaign_definition_repository,
         portfolio_ids=portfolio_ids,
-        event_type=event_type,
-        supportability_state=cast(PortfolioMemorySupportabilityState | None, supportability_state),
-        source_system=source_system,
+        event_type=normalized_event_type,
+        supportability_state=cast(
+            PortfolioMemorySupportabilityState | None, normalized_supportability_state
+        ),
+        source_system=normalized_source_system,
         limit=limit,
         offset=offset,
         source_scan_limit=source_scan_limit,

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -1,7 +1,7 @@
 """Source-backed portfolio memory read-model assembly."""
 
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Iterable, cast
 
 from src.core.common.boundary_promotion import (
     CLIENT_COMMUNICATION_PROMOTION_REQUIREMENTS,
@@ -72,6 +72,15 @@ from src.core.waves.campaign_definitions import (
 )
 from src.core.waves.campaign_repository import DpmBulkReviewCampaignDefinitionRepository
 from src.core.waves.repository import DpmWaveRepository
+
+
+def normalize_portfolio_memory_search_filter(value: str | None) -> str | None:
+    """Normalize optional string search filters without inventing aliases."""
+
+    if value is None:
+        return None
+    stripped_value = value.strip()
+    return stripped_value or None
 
 
 def build_portfolio_memory(
@@ -231,6 +240,12 @@ def search_portfolio_memory(
     """Build a bounded Manage-local index over persisted portfolio-memory evidence."""
 
     generated_at = generated_at or datetime.now(timezone.utc)
+    normalized_event_type = normalize_portfolio_memory_search_filter(event_type)
+    normalized_supportability_state = cast(
+        PortfolioMemorySupportabilityState | None,
+        normalize_portfolio_memory_search_filter(cast(str | None, supportability_state)),
+    )
+    normalized_source_system = normalize_portfolio_memory_search_filter(source_system)
     explicit_candidate_ids = {
         portfolio_id.strip() for portfolio_id in (portfolio_ids or []) if portfolio_id.strip()
     }
@@ -261,31 +276,43 @@ def search_portfolio_memory(
             generated_at=generated_at,
         )
         if memory.event_count == 0:
-            if supportability_state != "EMPTY" or portfolio_id not in explicit_candidate_ids:
+            if (
+                normalized_supportability_state != "EMPTY"
+                or portfolio_id not in explicit_candidate_ids
+            ):
                 continue
-        if event_type is not None and event_type not in memory.event_type_counts:
+        if (
+            normalized_event_type is not None
+            and normalized_event_type not in memory.event_type_counts
+        ):
             continue
-        if supportability_state is not None and memory.supportability_state != supportability_state:
+        if (
+            normalized_supportability_state is not None
+            and memory.supportability_state != normalized_supportability_state
+        ):
             continue
-        if source_system is not None and source_system not in memory.source_systems:
+        if (
+            normalized_source_system is not None
+            and normalized_source_system not in memory.source_systems
+        ):
             continue
         matching_events = [
             event
             for event in memory.events
             if _event_matches_search_filters(
                 event=event,
-                event_type=event_type,
-                supportability_state=supportability_state,
-                source_system=source_system,
+                event_type=normalized_event_type,
+                supportability_state=normalized_supportability_state,
+                source_system=normalized_source_system,
             )
         ]
         if (
             (
-                event_type is not None
-                or source_system is not None
-                or supportability_state is not None
+                normalized_event_type is not None
+                or normalized_source_system is not None
+                or normalized_supportability_state is not None
             )
-            and supportability_state != "EMPTY"
+            and normalized_supportability_state != "EMPTY"
             and not matching_events
         ):
             continue
@@ -375,9 +402,9 @@ def search_portfolio_memory(
         scanned_portfolio_count=len(candidate_ids),
         applied_filters=DpmPortfolioMemorySearchAppliedFilters(
             portfolio_ids=sorted(explicit_candidate_ids),
-            event_type=event_type,
-            supportability_state=supportability_state,
-            source_system=source_system,
+            event_type=normalized_event_type,
+            supportability_state=normalized_supportability_state,
+            source_system=normalized_source_system,
         ),
         supportability_state_counts=dict(sorted(supportability_state_counts.items())),
         event_type_counts=dict(sorted(event_type_counts.items())),

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1364,6 +1364,70 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert "Unsupported event types are rejected" in event_type_parameter["description"]
 
 
+def test_portfolio_memory_search_normalizes_text_filters_before_matching() -> None:
+    proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
+    construction_repository = _construction_repository()
+    campaign_repository = InMemoryDpmBulkReviewCampaignDefinitionRepository()
+    app.dependency_overrides[get_proof_pack_repository] = lambda: proof_pack_repository
+    app.dependency_overrides[get_construction_repository] = lambda: construction_repository
+    app.dependency_overrides[get_wave_repository] = lambda: wave_repository
+    app.dependency_overrides[get_outcome_review_repository] = lambda: outcome_repository
+    app.dependency_overrides[get_mandate_repository] = lambda: mandate_repository
+    app.dependency_overrides[get_pm_quality_score_run_repository] = lambda: (
+        InMemoryDpmPmQualityScoreRunRepository()
+    )
+    app.dependency_overrides[get_pm_quality_review_action_repository] = lambda: (
+        InMemoryDpmPmQualityReviewActionRepository()
+    )
+    app.dependency_overrides[get_pm_quality_summary_invocation_repository] = lambda: (
+        InMemoryDpmPmQualitySummaryInvocationRepository()
+    )
+    app.dependency_overrides[get_campaign_definition_repository] = lambda: campaign_repository
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/v1/rebalance/portfolio-memory/search",
+            params={
+                "event_type": " WAVE_HANDOFF_READY ",
+                "source_system": " lotus-manage ",
+            },
+        )
+        empty_response = client.get(
+            "/api/v1/rebalance/portfolio-memory/search",
+            params={
+                "portfolio_ids": "EMPTY_PORTFOLIO",
+                "supportability_state": " EMPTY ",
+            },
+        )
+        unsupported_response = client.get(
+            "/api/v1/rebalance/portfolio-memory/search",
+            params={"event_type": " NOT_A_MEMORY_EVENT "},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["returned_count"] == 1
+    assert payload["applied_filters"] == {
+        "portfolio_ids": [],
+        "event_type": "WAVE_HANDOFF_READY",
+        "supportability_state": None,
+        "source_system": "lotus-manage",
+    }
+    assert payload["items"][0]["latest_matching_event_type"] == "WAVE_HANDOFF_READY"
+    assert empty_response.status_code == 200
+    assert empty_response.json()["returned_count"] == 1
+    assert empty_response.json()["applied_filters"] == {
+        "portfolio_ids": ["EMPTY_PORTFOLIO"],
+        "event_type": None,
+        "supportability_state": "EMPTY",
+        "source_system": None,
+    }
+    assert unsupported_response.status_code == 422
+    assert unsupported_response.json()["detail"].startswith(
+        "UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE: NOT_A_MEMORY_EVENT"
+    )
+
+
 def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> None:
     proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
     construction_repository = _construction_repository()
@@ -1701,11 +1765,21 @@ def test_portfolio_memory_search_filters_empty_type_state_and_source_candidates(
         portfolio_ids=[PORTFOLIO_ID],
         source_system="not-a-source-system",
     )
+    blank_source_unfiltered = search_portfolio_memory(
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        portfolio_ids=[PORTFOLIO_ID],
+        source_system=" ",
+    )
 
     assert empty_filtered.returned_count == 0
     assert event_type_filtered.returned_count == 0
     assert state_filtered.returned_count == 0
     assert source_filtered.returned_count == 0
+    assert blank_source_unfiltered.returned_count == 1
+    assert blank_source_unfiltered.applied_filters.source_system is None
 
 
 def test_portfolio_memory_search_empty_filter_returns_explicit_empty_portfolios() -> None:

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2022,6 +2022,8 @@ Functional behavior:
 - searches a bounded Manage-local portfolio-memory index across persisted proof packs, rebalance
   waves, monitoring exceptions, outcome reviews, and optional caller-supplied portfolio ids,
 - filters the search index by event type, supportability state, and represented source system,
+- normalizes leading/trailing whitespace on event-type, supportability-state, and represented
+  source-system filters before validation and matching, treating blank text filters as absent,
 - rejects unsupported event-type filters with an explicit
   `UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE` error instead of returning a misleading empty page,
 - returns `EMPTY` search summaries only for explicit caller-supplied portfolio ids when


### PR DESCRIPTION
## Summary
- normalize portfolio-memory search text filters before validation and matching
- trim event-type, supportability-state, and source-system filters; treat blank text filters as absent
- keep unsupported event-type rejection fail-closed, but report the normalized unsupported value
- update API vocabulary inventory, README, and repo-authored wiki endpoint certification truth

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py -q`
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- Repo-authored wiki source changed: `wiki/Endpoint-Certification.md`.
- Pre-merge `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reports expected drift for `Endpoint-Certification.md`; publish after merge.