### PR TITLE
Expose portfolio memory search scan limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ system plus matching-event context and stable matching-event identity/source coo
 consumers can distinguish the latest overall memory event, aggregate portfolio posture, and
 portfolio-level source-system coverage from the specific event that satisfied an
 event/source/supportability filter without loading every portfolio timeline. Pagination metadata
-also returns `has_more`, `next_offset`, and the normalized `applied_filters` echo so consumers can
-continue bounded searches without reconstructing continuation logic or filter posture from counts.
+also returns `has_more`, `next_offset`, the normalized `applied_filters` echo, and the
+`source_scan_limit` used for each Manage-local evidence repository so consumers can continue
+bounded searches without reconstructing continuation logic, filter posture, or scan-cap posture
+from counts.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T16:24:52.194560+00:00",
+  "generatedAt": "2026-05-21T16:40:02.504195+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -12743,7 +12743,8 @@
       "example": null,
       "type": "integer",
       "locations": [
-        "query"
+        "query",
+        "body"
       ],
       "observedTypes": [
         "integer"
@@ -117200,6 +117201,14 @@
             "type": "integer",
             "semanticId": "lotus.scanned_portfolio_count",
             "attributeRef": "#/attributeCatalog/lotus.scanned_portfolio_count"
+          },
+          {
+            "name": "source_scan_limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.source_scan_limit",
+            "attributeRef": "#/attributeCatalog/lotus.source_scan_limit"
           },
           {
             "name": "applied_filters",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -493,6 +493,13 @@ class DpmPortfolioMemorySearchPage(BaseModel):
         description="Number of candidate portfolio identifiers scanned from Manage-local evidence.",
         examples=[3],
     )
+    source_scan_limit: int = Field(
+        description=(
+            "Maximum rows requested from each Manage-local evidence repository while building this "
+            "bounded search page."
+        ),
+        examples=[500],
+    )
     applied_filters: DpmPortfolioMemorySearchAppliedFilters = Field(
         description=(
             "Normalized portfolio-memory search filters applied to this bounded page. This echo "

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -400,6 +400,7 @@ def search_portfolio_memory(
         has_more=has_more,
         next_offset=next_offset if has_more else None,
         scanned_portfolio_count=len(candidate_ids),
+        source_scan_limit=source_scan_limit,
         applied_filters=DpmPortfolioMemorySearchAppliedFilters(
             portfolio_ids=sorted(explicit_candidate_ids),
             event_type=normalized_event_type,

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1293,6 +1293,7 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert payload["has_more"] is False
     assert payload["next_offset"] is None
     assert payload["scanned_portfolio_count"] == 2
+    assert payload["source_scan_limit"] == 500
     assert payload["applied_filters"] == {
         "portfolio_ids": [],
         "event_type": "WAVE_HANDOFF_READY",
@@ -1340,6 +1341,7 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert "has_more" in search_schema["properties"]
     assert "next_offset" in search_schema["properties"]
     assert "event_type_counts" in search_schema["properties"]
+    assert "source_scan_limit" in search_schema["properties"]
     assert "applied_filters" in search_schema["properties"]
     assert "matching_event_supportability_state_counts" in search_schema["properties"]
     assert "matching_event_source_system_counts" in search_schema["properties"]
@@ -1634,10 +1636,12 @@ def test_portfolio_memory_search_requires_source_system_on_matching_event_type()
         pm_quality_summary_invocation_repository=pm_quality_summary_repository,
         event_type="PM_QUALITY_SUMMARY_INVOCATION",
         source_system="lotus-core",
+        source_scan_limit=25,
     )
 
     assert page.returned_count == 0
     assert page.total_count == 0
+    assert page.source_scan_limit == 25
     assert page.applied_filters.event_type == "PM_QUALITY_SUMMARY_INVOCATION"
     assert page.applied_filters.source_system == "lotus-core"
     assert page.event_type_counts == {}
@@ -1804,6 +1808,7 @@ def test_portfolio_memory_search_empty_filter_returns_explicit_empty_portfolios(
     assert empty_filtered.has_more is False
     assert empty_filtered.next_offset is None
     assert empty_filtered.scanned_portfolio_count == 1
+    assert empty_filtered.source_scan_limit == 500
     assert empty_filtered.applied_filters.portfolio_ids == ["EMPTY_PORTFOLIO"]
     assert empty_filtered.applied_filters.event_type is None
     assert empty_filtered.applied_filters.supportability_state == "EMPTY"

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2034,7 +2034,7 @@ Functional behavior:
   limit/offset, `has_more`, `next_offset`, scanned portfolio count, pre-pagination portfolio
   aggregate supportability-state, matched-event-type, matched-event supportability-state,
   matched-event source-system, portfolio-summary source-system facet counts, normalized applied
-  filters, and an explicit support boundary,
+  filters, the applied source scan limit, and an explicit support boundary,
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
   the event identity, memory content hash, and explicit no-claim boundary for audit drilldown from
   a search hit,


### PR DESCRIPTION
## Summary
- expose `source_scan_limit` on bounded portfolio-memory search responses
- make the per-repository Manage-local scan cap auditable alongside pagination, scanned portfolio count, and applied filters
- update API vocabulary inventory, README, and repo-authored wiki endpoint certification truth

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py -q`
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- Repo-authored wiki source changed: `wiki/Endpoint-Certification.md`.
- Pre-merge `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reports expected drift for `Endpoint-Certification.md`; publish after merge.