### PR TITLE
Add portfolio memory search page hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ event/source/supportability filter without loading every portfolio timeline. Pag
 also returns `has_more`, `next_offset`, the normalized `applied_filters` echo, and the
 `source_scan_limit` used for each Manage-local evidence repository so consumers can continue
 bounded searches without reconstructing continuation logic, filter posture, or scan-cap posture
-from counts.
+from counts. Each search page carries a deterministic `content_hash` that excludes `generated_at`
+so audit review can reconcile equivalent result pages without timestamp churn.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T16:40:02.504195+00:00",
+  "generatedAt": "2026-05-21T16:55:24.706393+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -117289,6 +117289,14 @@
             "type": "object",
             "semanticId": "lotus.source_system_counts",
             "attributeRef": "#/attributeCatalog/lotus.source_system_counts"
+          },
+          {
+            "name": "content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
             "name": "generated_at",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -551,6 +551,12 @@ class DpmPortfolioMemorySearchPage(BaseModel):
         ),
         examples=[{"lotus-manage": 2, "lotus-core": 1}],
     )
+    content_hash: str = Field(
+        description=(
+            "Canonical hash of the bounded search page excluding generated_at, so audit consumers "
+            "can reconcile the page posture without timestamp churn."
+        )
+    )
     generated_at: str = Field(description="UTC timestamp when the search page was generated.")
     support_boundary: str = Field(
         description=("Explicit no-claim boundary for the bounded memory search surface."),

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -391,39 +391,46 @@ def search_portfolio_memory(
     page = [item for item, _events in page_rows]
     next_offset = offset + len(page)
     has_more = next_offset < total_count
-    return DpmPortfolioMemorySearchPage(
-        items=page,
-        limit=limit,
-        offset=offset,
-        returned_count=len(page),
-        total_count=total_count,
-        has_more=has_more,
-        next_offset=next_offset if has_more else None,
-        scanned_portfolio_count=len(candidate_ids),
-        source_scan_limit=source_scan_limit,
-        applied_filters=DpmPortfolioMemorySearchAppliedFilters(
+    page_payload = {
+        "items": page,
+        "limit": limit,
+        "offset": offset,
+        "returned_count": len(page),
+        "total_count": total_count,
+        "has_more": has_more,
+        "next_offset": next_offset if has_more else None,
+        "scanned_portfolio_count": len(candidate_ids),
+        "source_scan_limit": source_scan_limit,
+        "applied_filters": DpmPortfolioMemorySearchAppliedFilters(
             portfolio_ids=sorted(explicit_candidate_ids),
             event_type=normalized_event_type,
             supportability_state=normalized_supportability_state,
             source_system=normalized_source_system,
         ),
-        supportability_state_counts=dict(sorted(supportability_state_counts.items())),
-        event_type_counts=dict(sorted(event_type_counts.items())),
-        matching_event_supportability_state_counts=dict(
+        "supportability_state_counts": dict(sorted(supportability_state_counts.items())),
+        "event_type_counts": dict(sorted(event_type_counts.items())),
+        "matching_event_supportability_state_counts": dict(
             sorted(matching_event_supportability_state_counts.items())
         ),
-        matching_event_source_system_counts=dict(
+        "matching_event_source_system_counts": dict(
             sorted(matching_event_source_system_counts.items())
         ),
-        source_system_counts=dict(sorted(source_system_counts.items())),
-        generated_at=generated_at.isoformat(),
-        support_boundary=(
+        "source_system_counts": dict(sorted(source_system_counts.items())),
+        "generated_at": generated_at.isoformat(),
+        "support_boundary": (
             "Manage-local memory search indexes persisted Manage evidence and explicit "
             "caller-supplied portfolio identifiers only; it does not discover the global "
             "portfolio universe, query external source-owner event stores, project OMS "
             "acknowledgement/fill/settlement events, or recalculate source truth."
         ),
+    }
+    page_for_hash = DpmPortfolioMemorySearchPage.model_validate(
+        {**page_payload, "content_hash": "sha256:pending"}
     )
+    page_payload["content_hash"] = hash_canonical_payload(
+        strip_keys(page_for_hash.model_dump(mode="json"), exclude={"content_hash", "generated_at"})
+    )
+    return DpmPortfolioMemorySearchPage.model_validate(page_payload)
 
 
 def _memory_candidate_portfolio_ids(

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1294,6 +1294,7 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert payload["next_offset"] is None
     assert payload["scanned_portfolio_count"] == 2
     assert payload["source_scan_limit"] == 500
+    assert payload["content_hash"].startswith("sha256:")
     assert payload["applied_filters"] == {
         "portfolio_ids": [],
         "event_type": "WAVE_HANDOFF_READY",
@@ -1342,6 +1343,7 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert "next_offset" in search_schema["properties"]
     assert "event_type_counts" in search_schema["properties"]
     assert "source_scan_limit" in search_schema["properties"]
+    assert "content_hash" in search_schema["properties"]
     assert "applied_filters" in search_schema["properties"]
     assert "matching_event_supportability_state_counts" in search_schema["properties"]
     assert "matching_event_source_system_counts" in search_schema["properties"]
@@ -1637,11 +1639,26 @@ def test_portfolio_memory_search_requires_source_system_on_matching_event_type()
         event_type="PM_QUALITY_SUMMARY_INVOCATION",
         source_system="lotus-core",
         source_scan_limit=25,
+        generated_at=datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc),
+    )
+    later_page = search_portfolio_memory(
+        proof_pack_repository=InMemoryDpmProofPackRepository(),
+        wave_repository=InMemoryDpmWaveRepository(),
+        outcome_review_repository=InMemoryDpmOutcomeReviewRepository(),
+        pm_quality_score_run_repository=pm_quality_repository,
+        pm_quality_summary_invocation_repository=pm_quality_summary_repository,
+        event_type="PM_QUALITY_SUMMARY_INVOCATION",
+        source_system="lotus-core",
+        source_scan_limit=25,
+        generated_at=datetime(2026, 5, 21, 11, 0, tzinfo=timezone.utc),
     )
 
     assert page.returned_count == 0
     assert page.total_count == 0
     assert page.source_scan_limit == 25
+    assert page.content_hash.startswith("sha256:")
+    assert later_page.generated_at != page.generated_at
+    assert later_page.content_hash == page.content_hash
     assert page.applied_filters.event_type == "PM_QUALITY_SUMMARY_INVOCATION"
     assert page.applied_filters.source_system == "lotus-core"
     assert page.event_type_counts == {}

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2034,7 +2034,8 @@ Functional behavior:
   limit/offset, `has_more`, `next_offset`, scanned portfolio count, pre-pagination portfolio
   aggregate supportability-state, matched-event-type, matched-event supportability-state,
   matched-event source-system, portfolio-summary source-system facet counts, normalized applied
-  filters, the applied source scan limit, and an explicit support boundary,
+  filters, the applied source scan limit, deterministic page content hash that excludes
+  `generated_at`, and an explicit support boundary,
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
   the event identity, memory content hash, and explicit no-claim boundary for audit drilldown from
   a search hit,


### PR DESCRIPTION
## Summary
- add deterministic `content_hash` to bounded portfolio-memory search responses
- exclude `generated_at` from the page hash so equivalent result pages can be reconciled without timestamp churn
- update API vocabulary inventory, README, and repo-authored wiki endpoint certification truth

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py -q`
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- Repo-authored wiki source changed: `wiki/Endpoint-Certification.md`.
- Pre-merge `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reports expected drift for `Endpoint-Certification.md`; publish after merge.