### PR TITLE
Fix portfolio memory artifact source coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ type, matched-event supportability state, matched-event source systems, and repr
 system plus matching-event context and stable matching-event identity/source coordinates so
 consumers can distinguish the latest overall memory event, aggregate portfolio posture, and
 portfolio-level source-system coverage from the specific event that satisfied an
-event/source/supportability filter without loading every portfolio timeline. Pagination metadata
+event/source/supportability filter without loading every portfolio timeline. Portfolio-level
+source-system coverage includes event owners, source refs, and artifact refs so report, AI, and
+archive handoff evidence is not hidden from audit search facets. Pagination metadata
 also returns `has_more`, `next_offset`, the normalized `applied_filters` echo, and the
 `source_scan_limit` used for each Manage-local evidence repository so consumers can continue
 bounded searches without reconstructing continuation logic, filter posture, or scan-cap posture

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T16:55:24.706393+00:00",
+  "generatedAt": "2026-05-21T17:11:46.013484+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -365,7 +365,10 @@ class DpmPortfolioMemorySearchItem(BaseModel):
         description="Returned event count by portfolio-memory event type."
     )
     source_systems: list[str] = Field(
-        description="Source systems represented by this portfolio's returned events."
+        description=(
+            "Source systems represented by this portfolio's returned events, including event "
+            "owners, source refs, and artifact refs."
+        )
     )
     reason_codes: list[str] = Field(description="Bounded aggregate reason codes.")
     latest_event_time: str | None = Field(

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -187,15 +187,7 @@ def build_portfolio_memory(
     event_type_counts = _counts(event.event_type for event in events)
     reason_codes = sorted({reason for event in events for reason in event.reason_codes})
     source_systems = sorted(
-        {
-            source_system
-            for event in events
-            for source_system in [
-                event.source_system,
-                *(ref.source_system for ref in event.source_refs),
-            ]
-            if source_system
-        }
+        {source_system for event in events for source_system in _event_source_systems(event)}
     )
     memory = DpmPortfolioMemory(
         portfolio_id=portfolio_id,

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1358,6 +1358,7 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
     assert "latest_matching_event_type" in search_item_schema["properties"]
     assert "latest_matching_event_identity" in search_item_schema["properties"]
     assert "latest_matching_event_source_system" in search_item_schema["properties"]
+    assert "artifact refs" in search_item_schema["properties"]["source_systems"]["description"]
     event_type_parameter = next(
         parameter
         for parameter in openapi_json["paths"]["/api/v1/rebalance/portfolio-memory/search"]["get"][
@@ -1430,6 +1431,43 @@ def test_portfolio_memory_search_normalizes_text_filters_before_matching() -> No
     assert unsupported_response.json()["detail"].startswith(
         "UNSUPPORTED_PORTFOLIO_MEMORY_EVENT_TYPE: NOT_A_MEMORY_EVENT"
     )
+
+
+def test_portfolio_memory_search_counts_artifact_only_source_systems() -> None:
+    proof_pack_repository = InMemoryDpmProofPackRepository()
+    proof_pack_repository.save_proof_pack(
+        proof_pack=_proof_pack().model_copy(
+            update={
+                "portfolio_id": PORTFOLIO_ID,
+                "report_input_ref": DpmProofPackEvidenceRef(
+                    ref_type="REPORT_INPUT",
+                    ref_id="report-input-memory-001",
+                    source_system="lotus-report",
+                    content_hash="sha256:report-input-memory-001",
+                ),
+            }
+        ),
+        idempotency_key=None,
+        retention_expires_at=None,
+    )
+
+    page = search_portfolio_memory(
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=InMemoryDpmWaveRepository(),
+        outcome_review_repository=InMemoryDpmOutcomeReviewRepository(),
+        event_type="PROOF_PACK_CREATED",
+        source_system="lotus-report",
+    )
+
+    assert page.returned_count == 1
+    assert page.total_count == 1
+    assert page.applied_filters.source_system == "lotus-report"
+    assert page.items[0].portfolio_id == PORTFOLIO_ID
+    assert page.items[0].matching_event_count == 1
+    assert page.items[0].latest_matching_event_type == "PROOF_PACK_CREATED"
+    assert "lotus-report" in page.items[0].source_systems
+    assert page.source_system_counts["lotus-report"] == 1
+    assert page.matching_event_source_system_counts["lotus-report"] == 1
 
 
 def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> None:

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2036,6 +2036,9 @@ Functional behavior:
   matched-event source-system, portfolio-summary source-system facet counts, normalized applied
   filters, the applied source scan limit, deterministic page content hash that excludes
   `generated_at`, and an explicit support boundary,
+- counts represented portfolio-memory source systems from event owners, source refs, and artifact
+  refs, so report, AI, and archive handoff evidence remains visible to audit search without
+  projecting raw downstream payloads,
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
   the event identity, memory content hash, and explicit no-claim boundary for audit drilldown from
   a search hit,


### PR DESCRIPTION
## Summary
- include artifact refs in portfolio-memory source-system aggregation so report/AI/archive handoff systems stay visible in search coverage
- prove artifact-only source-system filtering/facets with a focused portfolio-memory test
- update endpoint certification and README wording for the source-system coverage contract

## Validation
- python -m pytest tests\\unit\\dpm\\api\\test_portfolio_memory_api.py -q
- python scripts\\api_vocabulary_inventory.py --output docs\\standards\\api-vocabulary\\lotus-manage-api-vocabulary.v1.json
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- git diff --check

## Wiki
- Repo wiki source updated: wiki/Endpoint-Certification.md
- Pre-merge wiki check intentionally reports Endpoint-Certification.md drift; publish after merge.