### PR TITLE
Stabilize portfolio memory view hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ archive handoff evidence is not hidden from audit search facets. Pagination meta
 also returns `has_more`, `next_offset`, the normalized `applied_filters` echo, and the
 `source_scan_limit` used for each Manage-local evidence repository so consumers can continue
 bounded searches without reconstructing continuation logic, filter posture, or scan-cap posture
-from counts. Each search page carries a deterministic `content_hash` that excludes `generated_at`
-so audit review can reconcile equivalent result pages without timestamp churn.
+from counts. Each portfolio-memory view and search page carries a deterministic `content_hash`
+that excludes `generated_at` so audit review can reconcile equivalent source-backed views and
+result pages without timestamp churn.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T17:11:46.013484+00:00",
+  "generatedAt": "2026-05-21T17:28:11.254378+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -324,7 +324,12 @@ class DpmPortfolioMemory(BaseModel):
     events: list[DpmPortfolioMemoryEvent] = Field(
         description="Ordered source-backed portfolio-memory events."
     )
-    content_hash: str = Field(description="Canonical hash of the returned memory view.")
+    content_hash: str = Field(
+        description=(
+            "Canonical hash of the returned memory view excluding generated_at, so audit "
+            "consumers can reconcile equivalent source-backed views without timestamp churn."
+        )
+    )
     generated_at: str = Field(description="UTC timestamp when the read model was generated.")
 
 
@@ -431,7 +436,12 @@ class DpmPortfolioMemorySearchItem(BaseModel):
         default=None,
         description="Canonical source content hash for the latest matching event when available.",
     )
-    content_hash: str = Field(description="Canonical hash of the portfolio-memory view.")
+    content_hash: str = Field(
+        description=(
+            "Canonical hash of the portfolio-memory view excluding generated_at, so search rows "
+            "remain replay-stable when the underlying source-backed memory is unchanged."
+        )
+    )
 
 
 class DpmPortfolioMemorySearchAppliedFilters(BaseModel):

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -205,7 +205,9 @@ def build_portfolio_memory(
         generated_at=generated_at.isoformat(),
     )
     payload = memory.model_dump(mode="json")
-    payload["content_hash"] = hash_canonical_payload(strip_keys(payload, exclude={"content_hash"}))
+    payload["content_hash"] = hash_canonical_payload(
+        strip_keys(payload, exclude={"content_hash", "generated_at"})
+    )
     return DpmPortfolioMemory.model_validate(payload)
 
 

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -923,6 +923,55 @@ def test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events() 
     )
 
 
+def test_portfolio_memory_hashes_exclude_generated_at_for_audit_replay() -> None:
+    proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
+    first_generated_at = datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc)
+    later_generated_at = datetime(2026, 5, 21, 11, 0, tzinfo=timezone.utc)
+
+    first_memory = build_portfolio_memory(
+        portfolio_id=PORTFOLIO_ID,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        generated_at=first_generated_at,
+    )
+    later_memory = build_portfolio_memory(
+        portfolio_id=PORTFOLIO_ID,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        generated_at=later_generated_at,
+    )
+    first_page = search_portfolio_memory(
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        portfolio_ids=[PORTFOLIO_ID],
+        event_type="WAVE_HANDOFF_READY",
+        source_system="lotus-manage",
+        generated_at=first_generated_at,
+    )
+    later_page = search_portfolio_memory(
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        portfolio_ids=[PORTFOLIO_ID],
+        event_type="WAVE_HANDOFF_READY",
+        source_system="lotus-manage",
+        generated_at=later_generated_at,
+    )
+
+    assert first_memory.generated_at != later_memory.generated_at
+    assert first_memory.content_hash == later_memory.content_hash
+    assert first_page.generated_at != later_page.generated_at
+    assert first_page.content_hash == later_page.content_hash
+    assert first_page.items[0].content_hash == later_page.items[0].content_hash
+
+
 def test_portfolio_memory_api_returns_queryable_source_backed_memory() -> None:
     proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
     construction_repository = _construction_repository()

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2042,6 +2042,8 @@ Functional behavior:
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
   the event identity, memory content hash, and explicit no-claim boundary for audit drilldown from
   a search hit,
+- emits portfolio-memory view and search-page content hashes that exclude `generated_at`, so
+  equivalent source-backed views remain replay-stable for audit reconciliation,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,
 - preserves source system, source type, source id, supportability state, reason codes, source refs,


### PR DESCRIPTION
## Summary
- exclude generated_at from portfolio-memory detail content_hash so equivalent source-backed views replay with the same hash
- preserve non-empty portfolio-memory search page stability by stabilizing row-level memory hashes
- update schema descriptions, README, endpoint certification wiki, and API vocabulary inventory for the hash contract

## Validation
- python -m pytest tests\\unit\\dpm\\api\\test_portfolio_memory_api.py -q
- python scripts\\api_vocabulary_inventory.py --output docs\\standards\\api-vocabulary\\lotus-manage-api-vocabulary.v1.json
- make lint
- make typecheck
- make no-alias-gate
- make openapi-gate
- make api-vocabulary-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- git diff --check

## Wiki
- Repo wiki source updated: wiki/Endpoint-Certification.md
- Pre-merge wiki check intentionally reports Endpoint-Certification.md drift; publish after merge.