### PR TITLE
Add portfolio memory event lookup hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ are treated as absent, so audit consumers can rely on the echoed filter posture 
 query-string formatting.
 `GET /api/v1/rebalance/portfolio-memory/{portfolio_id}/events/{event_id}` provides the bounded
 drilldown counterpart for those search hits: it returns the exact source-backed memory event,
-event identity, memory content hash, and no-claim boundary without querying external source-owner
-event stores or projecting OMS, client communication, risk, performance, report, archive, or AI
-truth.
+event identity, memory content hash, replay-stable lookup envelope hash, and no-claim boundary
+without querying external source-owner event stores or projecting OMS, client communication, risk,
+performance, report, archive, or AI truth.
 Unsupported event-type filters are rejected at the API boundary instead of being interpreted as an
 empty source result. Empty supportability summaries are returned only for explicit caller-supplied
 portfolio identifiers when `supportability_state=EMPTY` is requested; the search route is not

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T17:28:11.254378+00:00",
+  "generatedAt": "2026-05-21T17:43:53.793556+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -117648,6 +117648,14 @@
             "type": "string",
             "semanticId": "lotus.memory_content_hash",
             "attributeRef": "#/attributeCatalog/lotus.memory_content_hash"
+          },
+          {
+            "name": "content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
             "name": "generated_at",

--- a/src/api/routers/portfolio_memory.py
+++ b/src/api/routers/portfolio_memory.py
@@ -30,6 +30,7 @@ from src.core.portfolio_memory.models import (
     PortfolioMemorySupportabilityState,
 )
 from src.core.portfolio_memory.service import (
+    build_portfolio_memory_event_lookup,
     build_portfolio_memory,
     normalize_portfolio_memory_search_filter,
     search_portfolio_memory,
@@ -216,22 +217,18 @@ def get_portfolio_memory_event(
         campaign_definition_repository=campaign_definition_repository,
         limit=limit,
     )
-    for event in memory.events:
-        if event.event_id == event_id:
-            return DpmPortfolioMemoryEventLookup(
-                portfolio_id=portfolio_id,
-                event_id=event_id,
-                event_identity=event.event_identity,
-                event=event,
-                memory_content_hash=memory.content_hash,
-                generated_at=memory.generated_at,
-                support_boundary=(
-                    "Manage-local memory event lookup selects exact events from persisted Manage "
-                    "evidence only; it does not discover the global portfolio universe, query "
-                    "external source-owner event stores, project OMS acknowledgement/fill/"
-                    "settlement events, or recalculate source truth."
-                ),
-            )
+    lookup = build_portfolio_memory_event_lookup(
+        memory=memory,
+        event_id=event_id,
+        support_boundary=(
+            "Manage-local memory event lookup selects exact events from persisted Manage "
+            "evidence only; it does not discover the global portfolio universe, query "
+            "external source-owner event stores, project OMS acknowledgement/fill/"
+            "settlement events, or recalculate source truth."
+        ),
+    )
+    if lookup is not None:
+        return lookup
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=(

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -348,6 +348,12 @@ class DpmPortfolioMemoryEventLookup(BaseModel):
     memory_content_hash: str = Field(
         description="Canonical hash of the portfolio-memory view from which the event was selected."
     )
+    content_hash: str = Field(
+        description=(
+            "Canonical hash of the event lookup envelope excluding generated_at, so audit "
+            "consumers can reconcile equivalent drilldown responses without timestamp churn."
+        )
+    )
     generated_at: str = Field(description="UTC timestamp when the lookup view was generated.")
     support_boundary: str = Field(
         description="Explicit no-claim boundary for the bounded memory event lookup surface.",

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -35,6 +35,7 @@ from src.core.portfolio_memory.models import (
     DpmPortfolioMemory,
     DpmPortfolioMemoryClientCommunicationBoundaryEvidence,
     DpmPortfolioMemoryEvent,
+    DpmPortfolioMemoryEventLookup,
     DpmPortfolioMemoryExternalExecutionBoundaryEvidence,
     DpmPortfolioMemorySearchAppliedFilters,
     DpmPortfolioMemorySearchItem,
@@ -425,6 +426,35 @@ def search_portfolio_memory(
         strip_keys(page_for_hash.model_dump(mode="json"), exclude={"content_hash", "generated_at"})
     )
     return DpmPortfolioMemorySearchPage.model_validate(page_payload)
+
+
+def build_portfolio_memory_event_lookup(
+    *,
+    memory: DpmPortfolioMemory,
+    event_id: str,
+    support_boundary: str,
+) -> DpmPortfolioMemoryEventLookup | None:
+    """Select one portfolio-memory event and return a replay-stable lookup envelope."""
+
+    for event in memory.events:
+        if event.event_id != event_id:
+            continue
+        lookup = DpmPortfolioMemoryEventLookup(
+            portfolio_id=memory.portfolio_id,
+            event_id=event_id,
+            event_identity=event.event_identity,
+            event=event,
+            memory_content_hash=memory.content_hash,
+            content_hash="sha256:pending",
+            generated_at=memory.generated_at,
+            support_boundary=support_boundary,
+        )
+        payload = lookup.model_dump(mode="json")
+        payload["content_hash"] = hash_canonical_payload(
+            strip_keys(payload, exclude={"content_hash", "generated_at"})
+        )
+        return DpmPortfolioMemoryEventLookup.model_validate(payload)
+    return None
 
 
 def _memory_candidate_portfolio_ids(

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -44,7 +44,11 @@ from src.core.pm_quality.models import (
 from src.core.pm_quality.review_actions import build_pm_quality_review_action
 from src.core.pm_quality.summary_history import build_pm_quality_summary_invocation
 from src.core.portfolio_memory import service as portfolio_memory_service
-from src.core.portfolio_memory.service import build_portfolio_memory, search_portfolio_memory
+from src.core.portfolio_memory.service import (
+    build_portfolio_memory,
+    build_portfolio_memory_event_lookup,
+    search_portfolio_memory,
+)
 from src.core.proof_packs import DpmProofPackEvidenceRef
 from src.core.waves.models import (
     DpmRebalanceWave,
@@ -972,6 +976,54 @@ def test_portfolio_memory_hashes_exclude_generated_at_for_audit_replay() -> None
     assert first_page.items[0].content_hash == later_page.items[0].content_hash
 
 
+def test_portfolio_memory_event_lookup_hash_excludes_generated_at() -> None:
+    proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
+    first_memory = build_portfolio_memory(
+        portfolio_id=PORTFOLIO_ID,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        generated_at=datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc),
+    )
+    later_memory = build_portfolio_memory(
+        portfolio_id=PORTFOLIO_ID,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        generated_at=datetime(2026, 5, 21, 11, 0, tzinfo=timezone.utc),
+    )
+    event_id = "memory:wave:dwv_001:handoff:dwh_001"
+    support_boundary = "Manage-local lookup test boundary."
+
+    first_lookup = build_portfolio_memory_event_lookup(
+        memory=first_memory,
+        event_id=event_id,
+        support_boundary=support_boundary,
+    )
+    later_lookup = build_portfolio_memory_event_lookup(
+        memory=later_memory,
+        event_id=event_id,
+        support_boundary=support_boundary,
+    )
+
+    assert first_lookup is not None
+    assert later_lookup is not None
+    assert first_lookup.generated_at != later_lookup.generated_at
+    assert first_lookup.memory_content_hash == later_lookup.memory_content_hash
+    assert first_lookup.content_hash == later_lookup.content_hash
+    assert first_lookup.event_identity == later_lookup.event_identity
+    assert (
+        build_portfolio_memory_event_lookup(
+            memory=first_memory,
+            event_id="not-a-memory-event",
+            support_boundary=support_boundary,
+        )
+        is None
+    )
+
+
 def test_portfolio_memory_api_returns_queryable_source_backed_memory() -> None:
     proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
     construction_repository = _construction_repository()
@@ -1568,6 +1620,7 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
     assert payload["event"]["source_id"] == "dwh_001"
     assert payload["event"]["content_hash"] == "sha256:handoff-memory"
     assert payload["memory_content_hash"].startswith("sha256:")
+    assert payload["content_hash"].startswith("sha256:")
     assert "does not discover the global portfolio universe" in payload["support_boundary"]
     assert "external source-owner event stores" in payload["support_boundary"]
     assert missing_response.status_code == 404
@@ -1580,6 +1633,10 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
     )
     event_lookup_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemoryEventLookup"]
     assert "memory_content_hash" in event_lookup_schema["properties"]
+    assert "content_hash" in event_lookup_schema["properties"]
+    assert (
+        "excluding generated_at" in event_lookup_schema["properties"]["content_hash"]["description"]
+    )
     assert "support_boundary" in event_lookup_schema["properties"]
 
 

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2040,8 +2040,8 @@ Functional behavior:
   refs, so report, AI, and archive handoff evidence remains visible to audit search without
   projecting raw downstream payloads,
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
-  the event identity, memory content hash, and explicit no-claim boundary for audit drilldown from
-  a search hit,
+  the event identity, memory content hash, replay-stable lookup envelope hash, and explicit
+  no-claim boundary for audit drilldown from a search hit,
 - emits portfolio-memory view and search-page content hashes that exclude `generated_at`, so
   equivalent source-backed views remain replay-stable for audit reconciliation,
 - filters portfolio memory by source portfolio id,


### PR DESCRIPTION
## Summary
- add a replay-stable `content_hash` to `DpmPortfolioMemoryEventLookup`, excluding `generated_at`
- move exact event lookup envelope assembly into the portfolio-memory service
- update tests, API vocabulary inventory, README, and endpoint certification wiki source

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py -q`
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- Repo wiki source changed in `wiki/Endpoint-Certification.md`.
- Pre-merge wiki check reports expected drift for that authored source change; publish after merge and verify drift returns to 0.