### PR TITLE
Add portfolio memory report context hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ also returns `has_more`, `next_offset`, the normalized `applied_filters` echo, a
 bounded searches without reconstructing continuation logic, filter posture, or scan-cap posture
 from counts. Each portfolio-memory view and search page carries a deterministic `content_hash`
 that excludes `generated_at` so audit review can reconcile equivalent source-backed views and
-result pages without timestamp churn.
+result pages without timestamp churn. Report and AI handoff contexts preserve the source memory
+view hash and also expose a bounded `context_content_hash` over the report-safe event refs so
+downstream consumers can reconcile lineage context without loading the full memory view.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T17:43:53.793556+00:00",
+  "generatedAt": "2026-05-21T18:00:58.564727+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -2435,6 +2435,20 @@
       ],
       "observedTypes": [
         "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.context_content_hash",
+      "canonicalTerm": "context_content_hash",
+      "preferredName": "context_content_hash",
+      "description": "Canonical hash of this bounded report-context envelope, including event refs and the source memory content hash, so downstream report and AI consumers can reconcile equivalent lineage contexts without relying on the full memory view.",
+      "example": "sample_context_content_hash",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
         "string"
       ]
     },
@@ -65392,6 +65406,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolio_memory_context.context_content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.context_content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.context_content_hash"
+          },
+          {
             "name": "portfolio_memory_context.governance_policy",
             "location": "body",
             "required": true,
@@ -106551,6 +106573,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolio_memory_context.context_content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.context_content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.context_content_hash"
+          },
+          {
             "name": "portfolio_memory_context.governance_policy",
             "location": "body",
             "required": true,
@@ -113789,6 +113819,14 @@
             "type": "string",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.context_content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.context_content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.context_content_hash"
           },
           {
             "name": "portfolio_memory_context.governance_policy",

--- a/src/core/portfolio_memory/handoffs.py
+++ b/src/core/portfolio_memory/handoffs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from src.core.common.canonical import hash_canonical_payload, strip_keys
 from src.core.portfolio_memory.models import DpmPortfolioMemory, DpmPortfolioMemoryEvent
 
 PORTFOLIO_MEMORY_REPORT_CONTEXT_EVENT_LIMIT = 12
@@ -34,6 +35,13 @@ class DpmPortfolioMemoryReportContext(BaseModel):
     source_systems: list[str] = Field(description="Source systems represented by the memory view.")
     reason_codes: list[str] = Field(description="Aggregate bounded reason codes.")
     content_hash: str = Field(description="Canonical source-backed memory view hash.")
+    context_content_hash: str = Field(
+        description=(
+            "Canonical hash of this bounded report-context envelope, including event refs and "
+            "the source memory content hash, so downstream report and AI consumers can reconcile "
+            "equivalent lineage contexts without relying on the full memory view."
+        )
+    )
     governance_policy: dict[str, str] = Field(
         description="Portfolio-memory retention, redaction, access, audit, and source policy."
     )
@@ -49,16 +57,21 @@ def build_portfolio_memory_report_context(
 ) -> DpmPortfolioMemoryReportContext:
     """Project portfolio memory into report-safe lineage without raw source payloads."""
 
-    return DpmPortfolioMemoryReportContext(
+    payload = DpmPortfolioMemoryReportContext(
         portfolio_id=memory.portfolio_id,
         supportability_state=memory.supportability_state,
         event_count=memory.event_count,
         source_systems=memory.source_systems,
         reason_codes=memory.reason_codes,
         content_hash=memory.content_hash,
+        context_content_hash="sha256:pending",
         governance_policy=memory.governance_policy,
         event_refs=[_event_ref(event) for event in memory.events[: max(0, event_limit)]],
+    ).model_dump(mode="json")
+    payload["context_content_hash"] = hash_canonical_payload(
+        strip_keys(payload, exclude={"context_content_hash"})
     )
+    return DpmPortfolioMemoryReportContext.model_validate(payload)
 
 
 def _event_ref(event: DpmPortfolioMemoryEvent) -> DpmPortfolioMemoryReportEventRef:

--- a/tests/unit/core/test_outcome_handoffs.py
+++ b/tests/unit/core/test_outcome_handoffs.py
@@ -67,6 +67,7 @@ def test_outcome_report_input_carries_portfolio_memory_without_changing_hash() -
             "source_systems": ["lotus-manage"],
             "reason_codes": ["outcome_review_ready"],
             "content_hash": "sha256:portfolio-memory",
+            "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
                 "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
                 "redaction_policy": "NO_RAW_PAYLOADS",

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -44,6 +44,7 @@ from src.core.pm_quality.models import (
 from src.core.pm_quality.review_actions import build_pm_quality_review_action
 from src.core.pm_quality.summary_history import build_pm_quality_summary_invocation
 from src.core.portfolio_memory import service as portfolio_memory_service
+from src.core.portfolio_memory.handoffs import build_portfolio_memory_report_context
 from src.core.portfolio_memory.service import (
     build_portfolio_memory,
     build_portfolio_memory_event_lookup,
@@ -1024,6 +1025,28 @@ def test_portfolio_memory_event_lookup_hash_excludes_generated_at() -> None:
     )
 
 
+def test_portfolio_memory_report_context_hash_covers_bounded_event_refs() -> None:
+    proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
+    memory = build_portfolio_memory(
+        portfolio_id=PORTFOLIO_ID,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        generated_at=datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc),
+    )
+
+    full_context = build_portfolio_memory_report_context(memory, event_limit=12)
+    narrower_context = build_portfolio_memory_report_context(memory, event_limit=1)
+
+    assert full_context.content_hash == memory.content_hash
+    assert narrower_context.content_hash == memory.content_hash
+    assert full_context.context_content_hash.startswith("sha256:")
+    assert narrower_context.context_content_hash.startswith("sha256:")
+    assert full_context.context_content_hash != narrower_context.context_content_hash
+    assert len(full_context.event_refs) > len(narrower_context.event_refs)
+
+
 def test_portfolio_memory_api_returns_queryable_source_backed_memory() -> None:
     proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
     construction_repository = _construction_repository()
@@ -1638,6 +1661,12 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
         "excluding generated_at" in event_lookup_schema["properties"]["content_hash"]["description"]
     )
     assert "support_boundary" in event_lookup_schema["properties"]
+    report_context_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemoryReportContext"]
+    assert "context_content_hash" in report_context_schema["properties"]
+    assert (
+        "bounded report-context envelope"
+        in report_context_schema["properties"]["context_content_hash"]["description"]
+    )
 
 
 def test_portfolio_memory_search_can_include_explicit_portfolio_for_manage_only_events() -> None:

--- a/tests/unit/dpm/api/test_proof_pack_api.py
+++ b/tests/unit/dpm/api/test_proof_pack_api.py
@@ -201,6 +201,7 @@ def test_generate_get_and_render_direct_run_proof_pack(client: TestClient) -> No
     )
     assert report_input["portfolio_memory_context"]["portfolio_id"] == "pf_1"
     assert report_input["portfolio_memory_context"]["content_hash"].startswith("sha256:")
+    assert report_input["portfolio_memory_context"]["context_content_hash"].startswith("sha256:")
     assert report_input["portfolio_memory_context"]["governance_policy"]["audit_policy"] == (
         "AUDIT_READ_AND_EXPORT"
     )

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -5632,6 +5632,7 @@ def test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_postur
     assert report_payload["content_hash"].startswith("sha256:")
     assert report_payload["portfolio_memory_context"]["portfolio_id"] == PORTFOLIO_ID
     assert report_payload["portfolio_memory_context"]["event_count"] >= 1
+    assert report_payload["portfolio_memory_context"]["context_content_hash"].startswith("sha256:")
     assert any(
         event["event_type"] == "WAVE_CREATED"
         for event in report_payload["portfolio_memory_context"]["event_refs"]

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
@@ -122,6 +122,7 @@ def test_report_input_carries_portfolio_memory_without_changing_evidence_hash() 
             "source_systems": ["lotus-manage"],
             "reason_codes": ["proof_pack_ready"],
             "content_hash": "sha256:portfolio-memory",
+            "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
                 "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
                 "redaction_policy": "NO_RAW_PAYLOADS",

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2044,6 +2044,9 @@ Functional behavior:
   no-claim boundary for audit drilldown from a search hit,
 - emits portfolio-memory view and search-page content hashes that exclude `generated_at`, so
   equivalent source-backed views remain replay-stable for audit reconciliation,
+- emits report/AI handoff portfolio-memory contexts with the source memory view hash plus a bounded
+  context envelope hash over report-safe event refs, so downstream report consumers can reconcile
+  lineage context without loading the full memory view,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,
 - preserves source system, source type, source id, supportability state, reason codes, source refs,


### PR DESCRIPTION
## Summary
- add `context_content_hash` to `DpmPortfolioMemoryReportContext` while preserving existing `content_hash` as the source memory view hash
- compute the bounded report-context envelope hash over report-safe event refs and source memory hash
- update proof-pack, wave, and outcome handoff tests plus README, endpoint certification wiki source, and API vocabulary inventory

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py tests\unit\dpm\api\test_proof_pack_api.py tests\unit\dpm\api\test_waves_api.py tests\unit\dpm\proof_packs\test_proof_pack_handoffs.py -q`
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make typecheck`
- `make lint`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- Repo wiki source changed in `wiki/Endpoint-Certification.md`.
- Pre-merge wiki check reports expected drift for that authored source change; publish after merge and verify drift returns to 0.