### PR TITLE
Add portfolio memory report context boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ bounded searches without reconstructing continuation logic, filter posture, or s
 from counts. Each portfolio-memory view and search page carries a deterministic `content_hash`
 that excludes `generated_at` so audit review can reconcile equivalent source-backed views and
 result pages without timestamp churn. Report and AI handoff contexts preserve the source memory
-view hash and also expose a bounded `context_content_hash` over the report-safe event refs so
-downstream consumers can reconcile lineage context without loading the full memory view.
+view hash, expose an explicit no-claim `support_boundary`, and also expose a bounded
+`context_content_hash` over the report-safe event refs so downstream consumers can reconcile
+lineage context without loading the full memory view or inferring raw source, OMS, client
+communication, global-discovery, or source-methodology support.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T18:00:58.564727+00:00",
+  "generatedAt": "2026-05-21T18:20:32.555300+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -13406,7 +13406,7 @@
       "semanticId": "lotus.support_boundary",
       "canonicalTerm": "support_boundary",
       "preferredName": "support_boundary",
-      "description": "Explicit no-claim boundary for the bounded memory search surface.",
+      "description": "Explicit no-claim boundary for a bounded portfolio-memory surface, including unsupported source payload, global discovery, source-owner methodology, OMS, and client-communication projections.",
       "example": "sample_support_boundary",
       "type": "string",
       "locations": [
@@ -65406,6 +65406,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolio_memory_context.support_boundary",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_boundary",
+            "attributeRef": "#/attributeCatalog/lotus.support_boundary"
+          },
+          {
             "name": "portfolio_memory_context.context_content_hash",
             "location": "body",
             "required": true,
@@ -106573,6 +106581,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolio_memory_context.support_boundary",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_boundary",
+            "attributeRef": "#/attributeCatalog/lotus.support_boundary"
+          },
+          {
             "name": "portfolio_memory_context.context_content_hash",
             "location": "body",
             "required": true,
@@ -113819,6 +113835,14 @@
             "type": "string",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.support_boundary",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_boundary",
+            "attributeRef": "#/attributeCatalog/lotus.support_boundary"
           },
           {
             "name": "portfolio_memory_context.context_content_hash",

--- a/src/core/portfolio_memory/handoffs.py
+++ b/src/core/portfolio_memory/handoffs.py
@@ -8,6 +8,13 @@ from src.core.common.canonical import hash_canonical_payload, strip_keys
 from src.core.portfolio_memory.models import DpmPortfolioMemory, DpmPortfolioMemoryEvent
 
 PORTFOLIO_MEMORY_REPORT_CONTEXT_EVENT_LIMIT = 12
+PORTFOLIO_MEMORY_REPORT_CONTEXT_SUPPORT_BOUNDARY = (
+    "Portfolio-memory report context is bounded lineage evidence for downstream report and AI "
+    "handoffs. It preserves report-safe event refs and hashes only; it does not project raw "
+    "source payloads, query external source-owner event stores, discover the global portfolio "
+    "universe, reconstruct source-owner methodology, project OMS acknowledgement/fill/settlement "
+    "events, or project client communication events."
+)
 
 
 class DpmPortfolioMemoryReportEventRef(BaseModel):
@@ -35,6 +42,13 @@ class DpmPortfolioMemoryReportContext(BaseModel):
     source_systems: list[str] = Field(description="Source systems represented by the memory view.")
     reason_codes: list[str] = Field(description="Aggregate bounded reason codes.")
     content_hash: str = Field(description="Canonical source-backed memory view hash.")
+    support_boundary: str = Field(
+        description=(
+            "Explicit no-claim boundary for a bounded portfolio-memory surface, including "
+            "unsupported source payload, global discovery, source-owner methodology, OMS, "
+            "and client-communication projections."
+        )
+    )
     context_content_hash: str = Field(
         description=(
             "Canonical hash of this bounded report-context envelope, including event refs and "
@@ -64,6 +78,7 @@ def build_portfolio_memory_report_context(
         source_systems=memory.source_systems,
         reason_codes=memory.reason_codes,
         content_hash=memory.content_hash,
+        support_boundary=PORTFOLIO_MEMORY_REPORT_CONTEXT_SUPPORT_BOUNDARY,
         context_content_hash="sha256:pending",
         governance_policy=memory.governance_policy,
         event_refs=[_event_ref(event) for event in memory.events[: max(0, event_limit)]],

--- a/tests/unit/core/test_outcome_handoffs.py
+++ b/tests/unit/core/test_outcome_handoffs.py
@@ -67,6 +67,7 @@ def test_outcome_report_input_carries_portfolio_memory_without_changing_hash() -
             "source_systems": ["lotus-manage"],
             "reason_codes": ["outcome_review_ready"],
             "content_hash": "sha256:portfolio-memory",
+            "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
                 "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1044,6 +1044,9 @@ def test_portfolio_memory_report_context_hash_covers_bounded_event_refs() -> Non
     assert full_context.context_content_hash.startswith("sha256:")
     assert narrower_context.context_content_hash.startswith("sha256:")
     assert full_context.context_content_hash != narrower_context.context_content_hash
+    assert "does not project raw source payloads" in full_context.support_boundary
+    assert "project OMS acknowledgement/fill/settlement events" in full_context.support_boundary
+    assert "project client communication events" in full_context.support_boundary
     assert len(full_context.event_refs) > len(narrower_context.event_refs)
 
 
@@ -1663,6 +1666,11 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
     assert "support_boundary" in event_lookup_schema["properties"]
     report_context_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemoryReportContext"]
     assert "context_content_hash" in report_context_schema["properties"]
+    assert "support_boundary" in report_context_schema["properties"]
+    assert (
+        "Explicit no-claim boundary"
+        in report_context_schema["properties"]["support_boundary"]["description"]
+    )
     assert (
         "bounded report-context envelope"
         in report_context_schema["properties"]["context_content_hash"]["description"]

--- a/tests/unit/dpm/api/test_proof_pack_api.py
+++ b/tests/unit/dpm/api/test_proof_pack_api.py
@@ -202,6 +202,10 @@ def test_generate_get_and_render_direct_run_proof_pack(client: TestClient) -> No
     assert report_input["portfolio_memory_context"]["portfolio_id"] == "pf_1"
     assert report_input["portfolio_memory_context"]["content_hash"].startswith("sha256:")
     assert report_input["portfolio_memory_context"]["context_content_hash"].startswith("sha256:")
+    assert (
+        "does not project raw source payloads"
+        in (report_input["portfolio_memory_context"]["support_boundary"])
+    )
     assert report_input["portfolio_memory_context"]["governance_policy"]["audit_policy"] == (
         "AUDIT_READ_AND_EXPORT"
     )

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -5633,6 +5633,10 @@ def test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_postur
     assert report_payload["portfolio_memory_context"]["portfolio_id"] == PORTFOLIO_ID
     assert report_payload["portfolio_memory_context"]["event_count"] >= 1
     assert report_payload["portfolio_memory_context"]["context_content_hash"].startswith("sha256:")
+    assert (
+        "does not project raw source payloads"
+        in (report_payload["portfolio_memory_context"]["support_boundary"])
+    )
     assert any(
         event["event_type"] == "WAVE_CREATED"
         for event in report_payload["portfolio_memory_context"]["event_refs"]

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
@@ -122,6 +122,7 @@ def test_report_input_carries_portfolio_memory_without_changing_evidence_hash() 
             "source_systems": ["lotus-manage"],
             "reason_codes": ["proof_pack_ready"],
             "content_hash": "sha256:portfolio-memory",
+            "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
                 "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2044,9 +2044,10 @@ Functional behavior:
   no-claim boundary for audit drilldown from a search hit,
 - emits portfolio-memory view and search-page content hashes that exclude `generated_at`, so
   equivalent source-backed views remain replay-stable for audit reconciliation,
-- emits report/AI handoff portfolio-memory contexts with the source memory view hash plus a bounded
-  context envelope hash over report-safe event refs, so downstream report consumers can reconcile
-  lineage context without loading the full memory view,
+- emits report/AI handoff portfolio-memory contexts with the source memory view hash, an explicit
+  no-claim support boundary, and a bounded context envelope hash over report-safe event refs, so
+  downstream report consumers can reconcile lineage context without loading the full memory view or
+  inferring raw source, OMS, client communication, global-discovery, or source-methodology support,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,
 - preserves source system, source type, source id, supportability state, reason codes, source refs,


### PR DESCRIPTION
## Summary
- add an explicit `support_boundary` to bounded portfolio-memory report contexts
- include the boundary in the report-context content hash so downstream report/AI handoffs can reconcile no-claim posture
- update API vocabulary, endpoint certification docs, and focused tests for proof-pack and wave report inputs

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py tests\unit\dpm\api\test_proof_pack_api.py tests\unit\dpm\api\test_waves_api.py tests\unit\dpm\proof_packs\test_proof_pack_handoffs.py tests\unit\core\test_outcome_handoffs.py -q`
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json`
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- Repo-authored wiki source changed: `wiki/Endpoint-Certification.md`
- Pre-merge wiki check intentionally reports `Endpoint-Certification.md` drift until this PR lands and the wiki is published from `main`.