### PR TITLE
Add portfolio memory context to AI evidence handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ also returns `has_more`, `next_offset`, the normalized `applied_filters` echo, a
 bounded searches without reconstructing continuation logic, filter posture, or scan-cap posture
 from counts. Each portfolio-memory view and search page carries a deterministic `content_hash`
 that excludes `generated_at` so audit review can reconcile equivalent source-backed views and
-result pages without timestamp churn. Report and AI handoff contexts preserve the source memory
-view hash, expose an explicit no-claim `support_boundary`, and also expose a bounded
-`context_content_hash` over the report-safe event refs so downstream consumers can reconcile
-lineage context without loading the full memory view or inferring raw source, OMS, client
-communication, global-discovery, or source-methodology support.
+result pages without timestamp churn. Proof-pack and outcome-review report and AI evidence
+handoff contexts preserve the source memory view hash, expose an explicit no-claim
+`support_boundary`, and also expose a bounded `context_content_hash` over the report-safe event
+refs so downstream consumers can reconcile lineage context without loading the full memory view or
+inferring raw source, OMS, client communication, global-discovery, or source-methodology support.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T18:20:32.555300+00:00",
+  "generatedAt": "2026-05-21T18:38:00.951234+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -65941,6 +65941,174 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolio_memory_context",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_memory_context",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_memory_context"
+          },
+          {
+            "name": "portfolio_memory_context.portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "portfolio_memory_context.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "portfolio_memory_context.event_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_count",
+            "attributeRef": "#/attributeCatalog/lotus.event_count"
+          },
+          {
+            "name": "portfolio_memory_context.source_systems",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.source_systems",
+            "attributeRef": "#/attributeCatalog/lotus.source_systems"
+          },
+          {
+            "name": "portfolio_memory_context.reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "portfolio_memory_context.content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.support_boundary",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_boundary",
+            "attributeRef": "#/attributeCatalog/lotus.support_boundary"
+          },
+          {
+            "name": "portfolio_memory_context.context_content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.context_content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.context_content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.governance_policy",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.governance_policy",
+            "attributeRef": "#/attributeCatalog/lotus.governance_policy"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.event_refs",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].event_identity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_identity",
+            "attributeRef": "#/attributeCatalog/lotus.event_identity"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].event_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_type",
+            "attributeRef": "#/attributeCatalog/lotus.event_type"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].source_system",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "#/attributeCatalog/lotus.source_system"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].source_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_type",
+            "attributeRef": "#/attributeCatalog/lotus.source_type"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].source_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_id",
+            "attributeRef": "#/attributeCatalog/lotus.source_id"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].content_hash",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].retention_policy",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.retention_policy",
+            "attributeRef": "#/attributeCatalog/lotus.retention_policy"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].redaction_policy",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.redaction_policy",
+            "attributeRef": "#/attributeCatalog/lotus.redaction_policy"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].audit_policy",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.audit_policy",
+            "attributeRef": "#/attributeCatalog/lotus.audit_policy"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].access_classification",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.access_classification",
+            "attributeRef": "#/attributeCatalog/lotus.access_classification"
+          },
+          {
             "name": "client_communication_boundary",
             "location": "body",
             "required": true,
@@ -114274,6 +114442,174 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_memory_context",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_memory_context"
+          },
+          {
+            "name": "portfolio_memory_context.portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "portfolio_memory_context.supportability_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_state",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_state"
+          },
+          {
+            "name": "portfolio_memory_context.event_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_count",
+            "attributeRef": "#/attributeCatalog/lotus.event_count"
+          },
+          {
+            "name": "portfolio_memory_context.source_systems",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.source_systems",
+            "attributeRef": "#/attributeCatalog/lotus.source_systems"
+          },
+          {
+            "name": "portfolio_memory_context.reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "portfolio_memory_context.content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.support_boundary",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.support_boundary",
+            "attributeRef": "#/attributeCatalog/lotus.support_boundary"
+          },
+          {
+            "name": "portfolio_memory_context.context_content_hash",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.context_content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.context_content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.governance_policy",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.governance_policy",
+            "attributeRef": "#/attributeCatalog/lotus.governance_policy"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.event_refs",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].event_identity",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_identity",
+            "attributeRef": "#/attributeCatalog/lotus.event_identity"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].event_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_type",
+            "attributeRef": "#/attributeCatalog/lotus.event_type"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].source_system",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "#/attributeCatalog/lotus.source_system"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].source_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_type",
+            "attributeRef": "#/attributeCatalog/lotus.source_type"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].source_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_id",
+            "attributeRef": "#/attributeCatalog/lotus.source_id"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].content_hash",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].retention_policy",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.retention_policy",
+            "attributeRef": "#/attributeCatalog/lotus.retention_policy"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].redaction_policy",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.redaction_policy",
+            "attributeRef": "#/attributeCatalog/lotus.redaction_policy"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].audit_policy",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.audit_policy",
+            "attributeRef": "#/attributeCatalog/lotus.audit_policy"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].access_classification",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.access_classification",
+            "attributeRef": "#/attributeCatalog/lotus.access_classification"
           },
           {
             "name": "external_execution_boundary",

--- a/src/api/routers/outcome_reviews.py
+++ b/src/api/routers/outcome_reviews.py
@@ -408,9 +408,18 @@ def get_outcome_review_report_input_endpoint(
 def get_outcome_review_ai_evidence_input_endpoint(
     outcome_review_id: str,
     repository: DpmOutcomeReviewRepository = Depends(get_outcome_review_repository),
+    proof_pack_repository: DpmProofPackRepository = Depends(get_proof_pack_repository),
+    wave_repository: DpmWaveRepository = Depends(get_wave_repository),
+    mandate_repository: DpmMandateRepository = Depends(get_mandate_repository),
 ) -> DpmOutcomeAiEvidenceInput:
     try:
-        return get_ai_evidence_input(outcome_review_id=outcome_review_id, repository=repository)
+        return get_ai_evidence_input(
+            outcome_review_id=outcome_review_id,
+            repository=repository,
+            proof_pack_repository=proof_pack_repository,
+            wave_repository=wave_repository,
+            mandate_repository=mandate_repository,
+        )
     except DpmOutcomeReviewNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="OUTCOME_REVIEW_NOT_FOUND"

--- a/src/api/routers/proof_packs.py
+++ b/src/api/routers/proof_packs.py
@@ -348,11 +348,17 @@ def get_proof_pack_ai_evidence_input(
         Path(description="Proof-pack identifier.", examples=["dpp_rr_001"]),
     ],
     proof_pack_repository: DpmProofPackRepository = Depends(get_proof_pack_repository),
+    wave_repository: DpmWaveRepository = Depends(get_wave_repository),
+    outcome_review_repository: DpmOutcomeReviewRepository = Depends(get_outcome_review_repository),
+    mandate_repository: DpmMandateRepository = Depends(get_mandate_repository),
 ) -> DpmProofPackAiEvidenceInput:
     try:
         return proof_pack_service.get_ai_evidence_input(
             proof_pack_id=proof_pack_id,
             proof_pack_repository=proof_pack_repository,
+            wave_repository=wave_repository,
+            outcome_review_repository=outcome_review_repository,
+            mandate_repository=mandate_repository,
         )
     except Exception as exc:
         http_exc = proof_pack_service.to_api_http_exception(exc)

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -196,9 +196,20 @@ def get_ai_evidence_input(
     *,
     outcome_review_id: str,
     repository: DpmOutcomeReviewRepository,
+    proof_pack_repository: DpmProofPackRepository | None = None,
+    wave_repository: DpmWaveRepository | None = None,
+    mandate_repository: DpmMandateRepository | None = None,
 ) -> DpmOutcomeAiEvidenceInput:
+    review = get_outcome_review(outcome_review_id=outcome_review_id, repository=repository)
     return build_ai_evidence_input(
-        get_outcome_review(outcome_review_id=outcome_review_id, repository=repository)
+        review,
+        portfolio_memory_context=_portfolio_memory_context_for_report(
+            review=review,
+            proof_pack_repository=proof_pack_repository,
+            wave_repository=wave_repository,
+            outcome_review_repository=repository,
+            mandate_repository=mandate_repository,
+        ),
     )
 
 

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -272,12 +272,23 @@ def get_ai_evidence_input(
     *,
     proof_pack_id: str,
     proof_pack_repository: DpmProofPackRepository,
+    wave_repository: DpmWaveRepository | None = None,
+    outcome_review_repository: DpmOutcomeReviewRepository | None = None,
+    mandate_repository: DpmMandateRepository | None = None,
 ) -> DpmProofPackAiEvidenceInput:
+    proof_pack = get_proof_pack(
+        proof_pack_id=proof_pack_id,
+        proof_pack_repository=proof_pack_repository,
+    )
     return build_ai_evidence_input(
-        get_proof_pack(
-            proof_pack_id=proof_pack_id,
+        proof_pack,
+        portfolio_memory_context=_portfolio_memory_context_for_report(
+            portfolio_id=proof_pack.portfolio_id,
             proof_pack_repository=proof_pack_repository,
-        )
+            wave_repository=wave_repository,
+            outcome_review_repository=outcome_review_repository,
+            mandate_repository=mandate_repository,
+        ),
     )
 
 

--- a/src/core/outcomes/handoffs.py
+++ b/src/core/outcomes/handoffs.py
@@ -141,6 +141,14 @@ class DpmOutcomeAiEvidenceInput(BaseModel):
         description="AI-safe dimension evidence."
     )
     source_refs: list[DpmOutcomeSourceRef] = Field(description="AI-safe source references.")
+    portfolio_memory_context: DpmPortfolioMemoryReportContext | None = Field(
+        default=None,
+        description=(
+            "Optional Manage-owned portfolio-memory lineage context for downstream AI evidence. "
+            "This context carries its own content hash and support boundary and is excluded from "
+            "the outcome AI-evidence hash to avoid recursive lineage."
+        ),
+    )
     external_execution_boundary: DpmOutcomeExternalExecutionBoundaryEvidence = Field(
         description=(
             "Fail-closed external execution/OMS boundary evidence carried for downstream AI "
@@ -207,7 +215,11 @@ def build_report_input(
     return DpmOutcomeReportInput.model_validate(payload)
 
 
-def build_ai_evidence_input(review: DpmPostTradeOutcomeReview) -> DpmOutcomeAiEvidenceInput:
+def build_ai_evidence_input(
+    review: DpmPostTradeOutcomeReview,
+    *,
+    portfolio_memory_context: DpmPortfolioMemoryReportContext | None = None,
+) -> DpmOutcomeAiEvidenceInput:
     removed: set[str] = set()
     review_window = _sanitize_for_ai(review.review_window.model_dump(mode="json"), removed)
     dimensions = [
@@ -240,6 +252,7 @@ def build_ai_evidence_input(review: DpmPostTradeOutcomeReview) -> DpmOutcomeAiEv
         reason_codes=review.supportability.reason_codes,
         dimensions=dimensions,
         source_refs=_dedupe_source_refs(review),
+        portfolio_memory_context=portfolio_memory_context,
         external_execution_boundary=build_outcome_external_execution_boundary(review),
         client_communication_boundary=build_outcome_client_communication_boundary(review),
         evidence_ref=_handoff_ref(
@@ -249,7 +262,9 @@ def build_ai_evidence_input(review: DpmPostTradeOutcomeReview) -> DpmOutcomeAiEv
         content_hash="",
     ).model_dump(mode="json")
     assert_no_ai_forbidden_fields(payload)
-    payload["content_hash"] = hash_canonical_payload(strip_keys(payload, exclude={"content_hash"}))
+    payload["content_hash"] = hash_canonical_payload(
+        strip_keys(payload, exclude={"content_hash", "portfolio_memory_context"})
+    )
     payload["evidence_ref"]["content_hash"] = payload["content_hash"]
     return DpmOutcomeAiEvidenceInput.model_validate(payload)
 

--- a/src/core/proof_packs/handoffs.py
+++ b/src/core/proof_packs/handoffs.py
@@ -115,6 +115,14 @@ class DpmProofPackAiEvidenceInput(BaseModel):
     reason_codes: list[str] = Field(description="Aggregate proof-pack reason codes.")
     sections: list[DpmProofPackAiEvidenceSection] = Field(description="AI-safe evidence sections.")
     source_refs: list[DpmProofPackSourceRef] = Field(description="AI-safe source references.")
+    portfolio_memory_context: DpmPortfolioMemoryReportContext | None = Field(
+        default=None,
+        description=(
+            "Optional Manage-owned portfolio-memory lineage context for downstream AI evidence. "
+            "This context carries its own content hash and support boundary and is excluded from "
+            "the proof-pack AI-evidence hash to avoid recursive lineage."
+        ),
+    )
     client_communication_boundary: "DpmProofPackClientCommunicationBoundaryEvidence" = Field(
         description=(
             "Structured fail-closed evidence proving this AI evidence input cannot be used for "
@@ -245,7 +253,11 @@ def build_report_input(
     return DpmProofPackReportInput.model_validate(payload)
 
 
-def build_ai_evidence_input(proof_pack: DpmPreTradeProofPack) -> DpmProofPackAiEvidenceInput:
+def build_ai_evidence_input(
+    proof_pack: DpmPreTradeProofPack,
+    *,
+    portfolio_memory_context: DpmPortfolioMemoryReportContext | None = None,
+) -> DpmProofPackAiEvidenceInput:
     removed: set[str] = set()
     sections = [
         DpmProofPackAiEvidenceSection(
@@ -287,6 +299,7 @@ def build_ai_evidence_input(proof_pack: DpmPreTradeProofPack) -> DpmProofPackAiE
         reason_codes=proof_pack.supportability.reason_codes,
         sections=sections,
         source_refs=_dedupe_source_refs(proof_pack),
+        portfolio_memory_context=portfolio_memory_context,
         client_communication_boundary=_client_communication_boundary(),
         evidence_ref=_placeholder_ref(
             ref_type=AI_EVIDENCE_REF_TYPE,
@@ -295,7 +308,9 @@ def build_ai_evidence_input(proof_pack: DpmPreTradeProofPack) -> DpmProofPackAiE
         content_hash="",
     ).model_dump(mode="json")
     assert_no_ai_forbidden_fields(payload)
-    payload["content_hash"] = hash_canonical_payload(strip_keys(payload, exclude={"content_hash"}))
+    payload["content_hash"] = hash_canonical_payload(
+        strip_keys(payload, exclude={"content_hash", "portfolio_memory_context"})
+    )
     payload["evidence_ref"]["content_hash"] = payload["content_hash"]
     return DpmProofPackAiEvidenceInput.model_validate(payload)
 

--- a/tests/unit/api/test_outcome_reviews_api.py
+++ b/tests/unit/api/test_outcome_reviews_api.py
@@ -155,6 +155,11 @@ def test_outcome_review_api_preview_create_lookup_supportability_and_events() ->
             assert ai_input["client_communication_boundary"]["boundary_id"] == (
                 "DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY"
             )
+            assert ai_input["portfolio_memory_context"] == report_input["portfolio_memory_context"]
+            assert (
+                "does not project raw source payloads"
+                in ai_input["portfolio_memory_context"]["support_boundary"]
+            )
             assert {ref["source_id"] for ref in ai_input["source_refs"]} >= {
                 "expected",
                 "realized",
@@ -224,6 +229,11 @@ def test_outcome_review_openapi_contract_is_grouped_and_guided() -> None:
     assert all(marker in ai["description"] for marker in ["What:", "When:", "How:"])
     ai_schema = schema["components"]["schemas"]["DpmOutcomeAiEvidenceInput"]
     assert "client_communication_boundary" in ai_schema["properties"]
+    assert "portfolio_memory_context" in ai_schema["properties"]
+    assert (
+        "downstream AI evidence"
+        in ai_schema["properties"]["portfolio_memory_context"]["description"]
+    )
 
     guided_get_paths = [
         ("/api/v1/rebalance/outcome-reviews", "get"),

--- a/tests/unit/core/test_outcome_handoffs.py
+++ b/tests/unit/core/test_outcome_handoffs.py
@@ -99,6 +99,49 @@ def test_outcome_report_input_carries_portfolio_memory_without_changing_hash() -
     assert with_context.evidence_ref.content_hash == without_context.evidence_ref.content_hash
 
 
+def test_outcome_ai_evidence_input_carries_portfolio_memory_without_changing_hash() -> None:
+    review = _review()
+    without_context = build_ai_evidence_input(review)
+    memory_context = DpmPortfolioMemoryReportContext.model_validate(
+        {
+            "portfolio_id": review.portfolio_id,
+            "supportability_state": "READY",
+            "event_count": 1,
+            "source_systems": ["lotus-manage"],
+            "reason_codes": ["outcome_review_ready"],
+            "content_hash": "sha256:portfolio-memory",
+            "support_boundary": "Portfolio-memory report context test boundary.",
+            "context_content_hash": "sha256:portfolio-memory-report-context",
+            "governance_policy": {
+                "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
+                "redaction_policy": "NO_RAW_PAYLOADS",
+                "audit_policy": "AUDIT_READ_AND_EXPORT",
+                "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+            },
+            "event_refs": [
+                {
+                    "event_identity": "lotus-manage:DPM_POST_TRADE_OUTCOME_REVIEW:dor_001:sha256:review",
+                    "event_type": "OUTCOME_REVIEW_CREATED",
+                    "source_system": "lotus-manage",
+                    "source_type": "DPM_POST_TRADE_OUTCOME_REVIEW",
+                    "source_id": review.outcome_review_id,
+                    "content_hash": review.content_hash,
+                    "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
+                    "redaction_policy": "NO_RAW_PAYLOADS",
+                    "audit_policy": "AUDIT_READ_AND_EXPORT",
+                    "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+                }
+            ],
+        }
+    )
+
+    with_context = build_ai_evidence_input(review, portfolio_memory_context=memory_context)
+
+    assert with_context.portfolio_memory_context == memory_context
+    assert with_context.content_hash == without_context.content_hash
+    assert with_context.evidence_ref.content_hash == without_context.evidence_ref.content_hash
+
+
 def test_outcome_ai_evidence_input_is_bounded_and_forbids_actions() -> None:
     ai_input = build_ai_evidence_input(_review())
 

--- a/tests/unit/dpm/api/test_proof_pack_api.py
+++ b/tests/unit/dpm/api/test_proof_pack_api.py
@@ -251,6 +251,11 @@ def test_generate_get_and_render_direct_run_proof_pack(client: TestClient) -> No
     assert (
         ai_input["client_communication_boundary"] == report_input["client_communication_boundary"]
     )
+    assert ai_input["portfolio_memory_context"] == report_input["portfolio_memory_context"]
+    assert (
+        "does not project raw source payloads"
+        in ai_input["portfolio_memory_context"]["support_boundary"]
+    )
 
 
 def test_generate_selected_alternative_proof_pack(client: TestClient) -> None:
@@ -480,4 +485,9 @@ def test_proof_pack_openapi_documents_endpoints(client: TestClient) -> None:
     ai_schema = openapi["components"]["schemas"]["DpmProofPackAiEvidenceInput"]
     assert "client_communication_boundary" in report_schema["properties"]
     assert "client_communication_boundary" in ai_schema["properties"]
+    assert "portfolio_memory_context" in ai_schema["properties"]
+    assert (
+        "downstream AI evidence"
+        in ai_schema["properties"]["portfolio_memory_context"]["description"]
+    )
     assert "DpmProofPackClientCommunicationBoundaryEvidence" in openapi["components"]["schemas"]

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
@@ -154,6 +154,52 @@ def test_report_input_carries_portfolio_memory_without_changing_evidence_hash() 
     assert with_context.evidence_ref.content_hash == without_context.evidence_ref.content_hash
 
 
+def test_ai_evidence_input_carries_portfolio_memory_without_changing_evidence_hash() -> None:
+    proof_pack = _proof_pack()
+    without_context = build_ai_evidence_input(proof_pack)
+    memory_context = DpmPortfolioMemoryReportContext.model_validate(
+        {
+            "portfolio_id": proof_pack.portfolio_id,
+            "supportability_state": "READY",
+            "event_count": 1,
+            "source_systems": ["lotus-manage"],
+            "reason_codes": ["proof_pack_ready"],
+            "content_hash": "sha256:portfolio-memory",
+            "support_boundary": "Portfolio-memory report context test boundary.",
+            "context_content_hash": "sha256:portfolio-memory-report-context",
+            "governance_policy": {
+                "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
+                "redaction_policy": "NO_RAW_PAYLOADS",
+                "audit_policy": "AUDIT_READ_AND_EXPORT",
+                "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+            },
+            "event_refs": [
+                {
+                    "event_identity": "lotus-manage:DPM_PRE_TRADE_PROOF_PACK:dpp_001:sha256:proof-pack",
+                    "event_type": "PROOF_PACK_CREATED",
+                    "source_system": "lotus-manage",
+                    "source_type": "DPM_PRE_TRADE_PROOF_PACK",
+                    "source_id": proof_pack.proof_pack_id,
+                    "content_hash": proof_pack.content_hash,
+                    "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
+                    "redaction_policy": "NO_RAW_PAYLOADS",
+                    "audit_policy": "AUDIT_READ_AND_EXPORT",
+                    "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+                }
+            ],
+        }
+    )
+
+    with_context = build_ai_evidence_input(
+        proof_pack,
+        portfolio_memory_context=memory_context,
+    )
+
+    assert with_context.portfolio_memory_context == memory_context
+    assert with_context.content_hash == without_context.content_hash
+    assert with_context.evidence_ref.content_hash == without_context.evidence_ref.content_hash
+
+
 def test_ai_evidence_input_is_bounded_and_removes_forbidden_fields() -> None:
     proof_pack = _proof_pack()
     section = proof_pack.sections[0]

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -1588,6 +1588,10 @@ Non-functional posture:
 - Report-input and AI-evidence refs are deterministic manage-owned handoff records when requested.
   `lotus-report` materialization and `lotus-ai` PM memo generation remain downstream-owned and are
   not inferred from these refs.
+- Proof-pack report-input and AI-evidence payloads can carry bounded
+  `portfolio_memory_context` lineage with source memory view hash, no-claim support boundary, and
+  context envelope hash while excluding that recursive lineage context from the handoff evidence
+  hash.
 - Proof-pack report-input and AI-evidence handoffs carry structured
   `DPM_PROOF_PACK_CLIENT_COMMUNICATION_BOUNDARY` evidence. The boundary names blocked
   client-contact, client-message-generation, client-approval, delivery-confirmation, and
@@ -1936,9 +1940,11 @@ Functional behavior:
   refs deduplicated across persisted review lineage, expected/realized snapshots,
   dimension-results, and metric-level evidence, structured
   `DPM_OUTCOME_EXTERNAL_EXECUTION_BOUNDARY` and
-  `DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY` evidence, and a canonical handoff hash without
+  `DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY` evidence, optional bounded `portfolio_memory_context`
+  lineage with its own support boundary and context hash, and a canonical handoff hash without
   generating prompts, memos, recommendations, approvals, client communications, or execution
-  instructions.
+  instructions. Recursive portfolio-memory lineage is excluded from the AI evidence hash, matching
+  the report-input contract posture.
 - Run and wave lookup routes are read-side conveniences over persisted outcome-review truth.
 
 Non-functional posture:


### PR DESCRIPTION
## Summary
- add optional bounded `portfolio_memory_context` to proof-pack and outcome-review AI evidence inputs
- keep portfolio-memory lineage excluded from AI evidence hashes while preserving its own context hash and support boundary
- update API vocabulary, README/wiki endpoint certification, and focused API/domain tests

## Validation
- `python -m pytest tests\\unit\\dpm\\api\\test_proof_pack_api.py tests\\unit\\api\\test_outcome_reviews_api.py tests\\unit\\dpm\\proof_packs\\test_proof_pack_handoffs.py tests\\unit\\core\\test_outcome_handoffs.py -q`
- `python scripts\\api_vocabulary_inventory.py --output docs\\standards\\api-vocabulary\\lotus-manage-api-vocabulary.v1.json`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make lint`
- `make typecheck`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\\lotus-platform\\automation\\validate_engineering_context_system.py`
- `python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- Repo-authored wiki source changed: `wiki/Endpoint-Certification.md`
- Pre-merge wiki check intentionally reports `Endpoint-Certification.md` drift until this PR lands and the wiki is published from `main`.