### PR TITLE
Add portfolio memory context truncation posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ that excludes `generated_at` so audit review can reconcile equivalent source-bac
 result pages without timestamp churn. Proof-pack and outcome-review report and AI evidence
 handoff contexts preserve the source memory view hash, expose an explicit no-claim
 `support_boundary`, and also expose a bounded `context_content_hash` over the report-safe event
-refs so downstream consumers can reconcile lineage context without loading the full memory view or
-inferring raw source, OMS, client communication, global-discovery, or source-methodology support.
+refs plus explicit event-ref limit, returned-count, and truncation posture so downstream consumers
+can reconcile lineage context without loading the full memory view or inferring raw source, OMS,
+client communication, global-discovery, or source-methodology support.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T18:38:00.951234+00:00",
+  "generatedAt": "2026-05-21T18:52:05.496408+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -4050,6 +4050,20 @@
       ]
     },
     {
+      "semanticId": "lotus.event_ref_limit",
+      "canonicalTerm": "event_ref_limit",
+      "preferredName": "event_ref_limit",
+      "description": "Maximum number of event refs projected into this bounded handoff context.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.event_refs",
       "canonicalTerm": "event_refs",
       "preferredName": "event_refs",
@@ -4063,6 +4077,34 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.event_refs_returned",
+      "canonicalTerm": "event_refs_returned",
+      "preferredName": "event_refs_returned",
+      "description": "Number of event refs actually projected into this handoff context.",
+      "example": 10,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.event_refs_truncated",
+      "canonicalTerm": "event_refs_truncated",
+      "preferredName": "event_refs_truncated",
+      "description": "Whether the source memory view contains more events than this bounded handoff context projects.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
       ]
     },
     {
@@ -65406,6 +65448,30 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolio_memory_context.event_ref_limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_ref_limit",
+            "attributeRef": "#/attributeCatalog/lotus.event_ref_limit"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_returned",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_refs_returned",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_returned"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_truncated",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.event_refs_truncated",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_truncated"
+          },
+          {
             "name": "portfolio_memory_context.support_boundary",
             "location": "body",
             "required": true,
@@ -65995,6 +66061,30 @@
             "type": "string",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.event_ref_limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_ref_limit",
+            "attributeRef": "#/attributeCatalog/lotus.event_ref_limit"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_returned",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_refs_returned",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_returned"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_truncated",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.event_refs_truncated",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_truncated"
           },
           {
             "name": "portfolio_memory_context.support_boundary",
@@ -106749,6 +106839,30 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolio_memory_context.event_ref_limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_ref_limit",
+            "attributeRef": "#/attributeCatalog/lotus.event_ref_limit"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_returned",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_refs_returned",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_returned"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_truncated",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.event_refs_truncated",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_truncated"
+          },
+          {
             "name": "portfolio_memory_context.support_boundary",
             "location": "body",
             "required": true,
@@ -114005,6 +114119,30 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolio_memory_context.event_ref_limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_ref_limit",
+            "attributeRef": "#/attributeCatalog/lotus.event_ref_limit"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_returned",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_refs_returned",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_returned"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_truncated",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.event_refs_truncated",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_truncated"
+          },
+          {
             "name": "portfolio_memory_context.support_boundary",
             "location": "body",
             "required": true,
@@ -114498,6 +114636,30 @@
             "type": "string",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "portfolio_memory_context.event_ref_limit",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_ref_limit",
+            "attributeRef": "#/attributeCatalog/lotus.event_ref_limit"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_returned",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.event_refs_returned",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_returned"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs_truncated",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.event_refs_truncated",
+            "attributeRef": "#/attributeCatalog/lotus.event_refs_truncated"
           },
           {
             "name": "portfolio_memory_context.support_boundary",

--- a/src/core/portfolio_memory/handoffs.py
+++ b/src/core/portfolio_memory/handoffs.py
@@ -42,6 +42,18 @@ class DpmPortfolioMemoryReportContext(BaseModel):
     source_systems: list[str] = Field(description="Source systems represented by the memory view.")
     reason_codes: list[str] = Field(description="Aggregate bounded reason codes.")
     content_hash: str = Field(description="Canonical source-backed memory view hash.")
+    event_ref_limit: int = Field(
+        description="Maximum number of event refs projected into this bounded handoff context."
+    )
+    event_refs_returned: int = Field(
+        description="Number of event refs actually projected into this handoff context."
+    )
+    event_refs_truncated: bool = Field(
+        description=(
+            "Whether the source memory view contains more events than this bounded handoff "
+            "context projects."
+        )
+    )
     support_boundary: str = Field(
         description=(
             "Explicit no-claim boundary for a bounded portfolio-memory surface, including "
@@ -71,6 +83,8 @@ def build_portfolio_memory_report_context(
 ) -> DpmPortfolioMemoryReportContext:
     """Project portfolio memory into report-safe lineage without raw source payloads."""
 
+    bounded_event_limit = max(0, event_limit)
+    event_refs = [_event_ref(event) for event in memory.events[:bounded_event_limit]]
     payload = DpmPortfolioMemoryReportContext(
         portfolio_id=memory.portfolio_id,
         supportability_state=memory.supportability_state,
@@ -78,10 +92,13 @@ def build_portfolio_memory_report_context(
         source_systems=memory.source_systems,
         reason_codes=memory.reason_codes,
         content_hash=memory.content_hash,
+        event_ref_limit=bounded_event_limit,
+        event_refs_returned=len(event_refs),
+        event_refs_truncated=memory.event_count > len(event_refs),
         support_boundary=PORTFOLIO_MEMORY_REPORT_CONTEXT_SUPPORT_BOUNDARY,
         context_content_hash="sha256:pending",
         governance_policy=memory.governance_policy,
-        event_refs=[_event_ref(event) for event in memory.events[: max(0, event_limit)]],
+        event_refs=event_refs,
     ).model_dump(mode="json")
     payload["context_content_hash"] = hash_canonical_payload(
         strip_keys(payload, exclude={"context_content_hash"})

--- a/tests/unit/api/test_outcome_reviews_api.py
+++ b/tests/unit/api/test_outcome_reviews_api.py
@@ -135,6 +135,13 @@ def test_outcome_review_api_preview_create_lookup_supportability_and_events() ->
             assert report_input["portfolio_memory_context"]["portfolio_id"] == (
                 "PB_SG_GLOBAL_BAL_001"
             )
+            assert report_input["portfolio_memory_context"]["event_ref_limit"] == 12
+            assert report_input["portfolio_memory_context"]["event_refs_returned"] == len(
+                report_input["portfolio_memory_context"]["event_refs"]
+            )
+            assert isinstance(
+                report_input["portfolio_memory_context"]["event_refs_truncated"], bool
+            )
             assert any(
                 event["event_type"] == "OUTCOME_REVIEW_CREATED"
                 for event in report_input["portfolio_memory_context"]["event_refs"]

--- a/tests/unit/core/test_outcome_handoffs.py
+++ b/tests/unit/core/test_outcome_handoffs.py
@@ -67,6 +67,9 @@ def test_outcome_report_input_carries_portfolio_memory_without_changing_hash() -
             "source_systems": ["lotus-manage"],
             "reason_codes": ["outcome_review_ready"],
             "content_hash": "sha256:portfolio-memory",
+            "event_ref_limit": 12,
+            "event_refs_returned": 1,
+            "event_refs_truncated": False,
             "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
@@ -110,6 +113,9 @@ def test_outcome_ai_evidence_input_carries_portfolio_memory_without_changing_has
             "source_systems": ["lotus-manage"],
             "reason_codes": ["outcome_review_ready"],
             "content_hash": "sha256:portfolio-memory",
+            "event_ref_limit": 12,
+            "event_refs_returned": 1,
+            "event_refs_truncated": False,
             "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1044,6 +1044,12 @@ def test_portfolio_memory_report_context_hash_covers_bounded_event_refs() -> Non
     assert full_context.context_content_hash.startswith("sha256:")
     assert narrower_context.context_content_hash.startswith("sha256:")
     assert full_context.context_content_hash != narrower_context.context_content_hash
+    assert full_context.event_ref_limit == 12
+    assert full_context.event_refs_returned == len(full_context.event_refs)
+    assert full_context.event_refs_truncated is False
+    assert narrower_context.event_ref_limit == 1
+    assert narrower_context.event_refs_returned == 1
+    assert narrower_context.event_refs_truncated is True
     assert "does not project raw source payloads" in full_context.support_boundary
     assert "project OMS acknowledgement/fill/settlement events" in full_context.support_boundary
     assert "project client communication events" in full_context.support_boundary
@@ -1667,6 +1673,9 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
     report_context_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemoryReportContext"]
     assert "context_content_hash" in report_context_schema["properties"]
     assert "support_boundary" in report_context_schema["properties"]
+    assert "event_ref_limit" in report_context_schema["properties"]
+    assert "event_refs_returned" in report_context_schema["properties"]
+    assert "event_refs_truncated" in report_context_schema["properties"]
     assert (
         "Explicit no-claim boundary"
         in report_context_schema["properties"]["support_boundary"]["description"]

--- a/tests/unit/dpm/api/test_proof_pack_api.py
+++ b/tests/unit/dpm/api/test_proof_pack_api.py
@@ -202,6 +202,11 @@ def test_generate_get_and_render_direct_run_proof_pack(client: TestClient) -> No
     assert report_input["portfolio_memory_context"]["portfolio_id"] == "pf_1"
     assert report_input["portfolio_memory_context"]["content_hash"].startswith("sha256:")
     assert report_input["portfolio_memory_context"]["context_content_hash"].startswith("sha256:")
+    assert report_input["portfolio_memory_context"]["event_ref_limit"] == 12
+    assert report_input["portfolio_memory_context"]["event_refs_returned"] == len(
+        report_input["portfolio_memory_context"]["event_refs"]
+    )
+    assert isinstance(report_input["portfolio_memory_context"]["event_refs_truncated"], bool)
     assert (
         "does not project raw source payloads"
         in (report_input["portfolio_memory_context"]["support_boundary"])

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -5633,6 +5633,11 @@ def test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_postur
     assert report_payload["portfolio_memory_context"]["portfolio_id"] == PORTFOLIO_ID
     assert report_payload["portfolio_memory_context"]["event_count"] >= 1
     assert report_payload["portfolio_memory_context"]["context_content_hash"].startswith("sha256:")
+    assert report_payload["portfolio_memory_context"]["event_ref_limit"] == 12
+    assert report_payload["portfolio_memory_context"]["event_refs_returned"] == len(
+        report_payload["portfolio_memory_context"]["event_refs"]
+    )
+    assert isinstance(report_payload["portfolio_memory_context"]["event_refs_truncated"], bool)
     assert (
         "does not project raw source payloads"
         in (report_payload["portfolio_memory_context"]["support_boundary"])

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
@@ -122,6 +122,9 @@ def test_report_input_carries_portfolio_memory_without_changing_evidence_hash() 
             "source_systems": ["lotus-manage"],
             "reason_codes": ["proof_pack_ready"],
             "content_hash": "sha256:portfolio-memory",
+            "event_ref_limit": 12,
+            "event_refs_returned": 1,
+            "event_refs_truncated": False,
             "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
@@ -165,6 +168,9 @@ def test_ai_evidence_input_carries_portfolio_memory_without_changing_evidence_ha
             "source_systems": ["lotus-manage"],
             "reason_codes": ["proof_pack_ready"],
             "content_hash": "sha256:portfolio-memory",
+            "event_ref_limit": 12,
+            "event_refs_returned": 1,
+            "event_refs_truncated": False,
             "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -1590,8 +1590,8 @@ Non-functional posture:
   not inferred from these refs.
 - Proof-pack report-input and AI-evidence payloads can carry bounded
   `portfolio_memory_context` lineage with source memory view hash, no-claim support boundary, and
-  context envelope hash while excluding that recursive lineage context from the handoff evidence
-  hash.
+  context envelope hash plus explicit event-ref limit, returned-count, and truncation posture while
+  excluding that recursive lineage context from the handoff evidence hash.
 - Proof-pack report-input and AI-evidence handoffs carry structured
   `DPM_PROOF_PACK_CLIENT_COMMUNICATION_BOUNDARY` evidence. The boundary names blocked
   client-contact, client-message-generation, client-approval, delivery-confirmation, and
@@ -1941,10 +1941,11 @@ Functional behavior:
   dimension-results, and metric-level evidence, structured
   `DPM_OUTCOME_EXTERNAL_EXECUTION_BOUNDARY` and
   `DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY` evidence, optional bounded `portfolio_memory_context`
-  lineage with its own support boundary and context hash, and a canonical handoff hash without
-  generating prompts, memos, recommendations, approvals, client communications, or execution
-  instructions. Recursive portfolio-memory lineage is excluded from the AI evidence hash, matching
-  the report-input contract posture.
+  lineage with its own support boundary, context hash, event-ref limit, returned-count, and
+  truncation posture, and a canonical handoff hash without generating prompts, memos,
+  recommendations, approvals, client communications, or execution instructions. Recursive
+  portfolio-memory lineage is excluded from the AI evidence hash, matching the report-input
+  contract posture.
 - Run and wave lookup routes are read-side conveniences over persisted outcome-review truth.
 
 Non-functional posture:
@@ -2051,9 +2052,10 @@ Functional behavior:
 - emits portfolio-memory view and search-page content hashes that exclude `generated_at`, so
   equivalent source-backed views remain replay-stable for audit reconciliation,
 - emits report/AI handoff portfolio-memory contexts with the source memory view hash, an explicit
-  no-claim support boundary, and a bounded context envelope hash over report-safe event refs, so
-  downstream report consumers can reconcile lineage context without loading the full memory view or
-  inferring raw source, OMS, client communication, global-discovery, or source-methodology support,
+  no-claim support boundary, bounded context envelope hash over report-safe event refs, and
+  explicit event-ref limit, returned-count, and truncation posture, so downstream report and AI
+  consumers can reconcile lineage context without loading the full memory view or inferring raw
+  source, OMS, client communication, global-discovery, or source-methodology support,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,
 - preserves source system, source type, source id, supportability state, reason codes, source refs,


### PR DESCRIPTION
## Summary
- add explicit `event_ref_limit`, `event_refs_returned`, and `event_refs_truncated` posture to bounded portfolio-memory report/AI handoff contexts
- include the truncation posture in `context_content_hash` so consumers can reconcile equivalent bounded lineage envelopes
- update API vocabulary, README/wiki endpoint certification, and focused API/domain tests

## Validation
- `python -m pytest tests\\unit\\dpm\\api\\test_portfolio_memory_api.py tests\\unit\\dpm\\api\\test_proof_pack_api.py tests\\unit\\dpm\\api\\test_waves_api.py tests\\unit\\api\\test_outcome_reviews_api.py tests\\unit\\core\\test_outcome_handoffs.py tests\\unit\\dpm\\proof_packs\\test_proof_pack_handoffs.py -q`
- `python scripts\\api_vocabulary_inventory.py --output docs\\standards\\api-vocabulary\\lotus-manage-api-vocabulary.v1.json`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make no-alias-gate`
- `make lint`
- `make typecheck`
- `make test-unit`
- `make test-integration`
- `make test-e2e`
- `python ..\\lotus-platform\\automation\\validate_engineering_context_system.py`
- `python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- Repo-authored wiki source changed: `wiki/Endpoint-Certification.md`
- Pre-merge wiki check intentionally reports `Endpoint-Certification.md` drift until this PR lands and the wiki is published from `main`.