### PR TITLE
Expose portfolio memory event ref timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ that excludes `generated_at` so audit review can reconcile equivalent source-bac
 result pages without timestamp churn. Proof-pack and outcome-review report and AI evidence
 handoff contexts preserve the source memory view hash, expose an explicit no-claim
 `support_boundary`, and also expose a bounded `context_content_hash` over the report-safe event
-refs plus explicit event-ref limit, selection policy, returned-count, omitted-count, and
-truncation posture so downstream consumers can reconcile lineage context without loading the full
-memory view or inferring raw source, OMS, client communication, global-discovery, or
+refs with event timestamps plus explicit event-ref limit, selection policy, returned-count,
+omitted-count, and truncation posture so downstream consumers can reconcile lineage context without
+loading the full memory view or inferring raw source, OMS, client communication, global-discovery, or
 source-methodology support.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T19:26:44.901377+00:00",
+  "generatedAt": "2026-05-21T19:43:54.881718+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -65564,6 +65564,14 @@
             "attributeRef": "#/attributeCatalog/lotus.event_type"
           },
           {
+            "name": "portfolio_memory_context.event_refs[].event_time",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_time",
+            "attributeRef": "#/attributeCatalog/lotus.event_time"
+          },
+          {
             "name": "portfolio_memory_context.event_refs[].source_system",
             "location": "body",
             "required": true,
@@ -66193,6 +66201,14 @@
             "type": "string",
             "semanticId": "lotus.event_type",
             "attributeRef": "#/attributeCatalog/lotus.event_type"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].event_time",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_time",
+            "attributeRef": "#/attributeCatalog/lotus.event_time"
           },
           {
             "name": "portfolio_memory_context.event_refs[].source_system",
@@ -106987,6 +107003,14 @@
             "attributeRef": "#/attributeCatalog/lotus.event_type"
           },
           {
+            "name": "portfolio_memory_context.event_refs[].event_time",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_time",
+            "attributeRef": "#/attributeCatalog/lotus.event_time"
+          },
+          {
             "name": "portfolio_memory_context.event_refs[].source_system",
             "location": "body",
             "required": true,
@@ -114283,6 +114307,14 @@
             "attributeRef": "#/attributeCatalog/lotus.event_type"
           },
           {
+            "name": "portfolio_memory_context.event_refs[].event_time",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_time",
+            "attributeRef": "#/attributeCatalog/lotus.event_time"
+          },
+          {
             "name": "portfolio_memory_context.event_refs[].source_system",
             "location": "body",
             "required": true,
@@ -114816,6 +114848,14 @@
             "type": "string",
             "semanticId": "lotus.event_type",
             "attributeRef": "#/attributeCatalog/lotus.event_type"
+          },
+          {
+            "name": "portfolio_memory_context.event_refs[].event_time",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.event_time",
+            "attributeRef": "#/attributeCatalog/lotus.event_time"
           },
           {
             "name": "portfolio_memory_context.event_refs[].source_system",

--- a/src/core/portfolio_memory/handoffs.py
+++ b/src/core/portfolio_memory/handoffs.py
@@ -23,6 +23,7 @@ PORTFOLIO_MEMORY_REPORT_CONTEXT_EVENT_REF_SELECTION_POLICY = (
 class DpmPortfolioMemoryReportEventRef(BaseModel):
     event_identity: str = Field(description="Stable source-backed portfolio-memory event identity.")
     event_type: str = Field(description="Portfolio-memory event type.")
+    event_time: str = Field(description="UTC event timestamp used for bounded ref selection.")
     source_system: str = Field(description="System that owns the source event.")
     source_type: str = Field(description="Source artifact or event type.")
     source_id: str = Field(description="Source identifier.")
@@ -128,6 +129,7 @@ def _event_ref(event: DpmPortfolioMemoryEvent) -> DpmPortfolioMemoryReportEventR
     return DpmPortfolioMemoryReportEventRef(
         event_identity=event.event_identity,
         event_type=event.event_type,
+        event_time=event.event_time,
         source_system=event.source_system,
         source_type=event.source_type,
         source_id=event.source_id,

--- a/tests/unit/api/test_outcome_reviews_api.py
+++ b/tests/unit/api/test_outcome_reviews_api.py
@@ -154,6 +154,10 @@ def test_outcome_review_api_preview_create_lookup_supportability_and_events() ->
                 event["event_type"] == "OUTCOME_REVIEW_CREATED"
                 for event in report_input["portfolio_memory_context"]["event_refs"]
             )
+            assert all(
+                event["event_time"]
+                for event in report_input["portfolio_memory_context"]["event_refs"]
+            )
 
             ai = client.get(
                 f"/api/v1/rebalance/outcome-reviews/{outcome_review_id}/ai-evidence-input"

--- a/tests/unit/core/test_outcome_handoffs.py
+++ b/tests/unit/core/test_outcome_handoffs.py
@@ -84,6 +84,7 @@ def test_outcome_report_input_carries_portfolio_memory_without_changing_hash() -
                 {
                     "event_identity": "lotus-manage:DPM_POST_TRADE_OUTCOME_REVIEW:dor_001:sha256:review",
                     "event_type": "OUTCOME_REVIEW_CREATED",
+                    "event_time": "2026-05-03T09:00:00+00:00",
                     "source_system": "lotus-manage",
                     "source_type": "DPM_POST_TRADE_OUTCOME_REVIEW",
                     "source_id": review.outcome_review_id,
@@ -132,6 +133,7 @@ def test_outcome_ai_evidence_input_carries_portfolio_memory_without_changing_has
                 {
                     "event_identity": "lotus-manage:DPM_POST_TRADE_OUTCOME_REVIEW:dor_001:sha256:review",
                     "event_type": "OUTCOME_REVIEW_CREATED",
+                    "event_time": "2026-05-03T09:00:00+00:00",
                     "source_system": "lotus-manage",
                     "source_type": "DPM_POST_TRADE_OUTCOME_REVIEW",
                     "source_id": review.outcome_review_id,

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1052,10 +1052,14 @@ def test_portfolio_memory_report_context_hash_covers_bounded_event_refs() -> Non
     assert full_context.event_refs_returned == len(full_context.event_refs)
     assert full_context.event_refs_omitted == 0
     assert full_context.event_refs_truncated is False
+    assert all(event_ref.event_time for event_ref in full_context.event_refs)
     assert narrower_context.event_ref_limit == 1
     assert narrower_context.event_refs_returned == 1
     assert narrower_context.event_refs_omitted == narrower_context.event_count - 1
     assert narrower_context.event_refs_truncated is True
+    assert [event_ref.event_time for event_ref in narrower_context.event_refs] == [
+        memory.events[0].event_time
+    ]
     assert "does not project raw source payloads" in full_context.support_boundary
     assert "project OMS acknowledgement/fill/settlement events" in full_context.support_boundary
     assert "project client communication events" in full_context.support_boundary
@@ -1692,6 +1696,8 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
         "bounded report-context envelope"
         in report_context_schema["properties"]["context_content_hash"]["description"]
     )
+    event_ref_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemoryReportEventRef"]
+    assert "event_time" in event_ref_schema["properties"]
 
 
 def test_portfolio_memory_search_can_include_explicit_portfolio_for_manage_only_events() -> None:

--- a/tests/unit/dpm/api/test_proof_pack_api.py
+++ b/tests/unit/dpm/api/test_proof_pack_api.py
@@ -222,6 +222,9 @@ def test_generate_get_and_render_direct_run_proof_pack(client: TestClient) -> No
     assert report_input["portfolio_memory_context"]["governance_policy"]["audit_policy"] == (
         "AUDIT_READ_AND_EXPORT"
     )
+    assert all(
+        event["event_time"] for event in report_input["portfolio_memory_context"]["event_refs"]
+    )
     assert (
         report_input["client_communication_boundary"]["boundary_id"]
         == "DPM_PROOF_PACK_CLIENT_COMMUNICATION_BOUNDARY"

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -5650,6 +5650,9 @@ def test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_postur
         "does not project raw source payloads"
         in (report_payload["portfolio_memory_context"]["support_boundary"])
     )
+    assert all(
+        event["event_time"] for event in report_payload["portfolio_memory_context"]["event_refs"]
+    )
     assert any(
         event["event_type"] == "WAVE_CREATED"
         for event in report_payload["portfolio_memory_context"]["event_refs"]

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
@@ -139,6 +139,7 @@ def test_report_input_carries_portfolio_memory_without_changing_evidence_hash() 
                 {
                     "event_identity": "lotus-manage:DPM_PRE_TRADE_PROOF_PACK:dpp_001:sha256:proof-pack",
                     "event_type": "PROOF_PACK_CREATED",
+                    "event_time": "2026-05-03T09:00:00+00:00",
                     "source_system": "lotus-manage",
                     "source_type": "DPM_PRE_TRADE_PROOF_PACK",
                     "source_id": proof_pack.proof_pack_id,
@@ -187,6 +188,7 @@ def test_ai_evidence_input_carries_portfolio_memory_without_changing_evidence_ha
                 {
                     "event_identity": "lotus-manage:DPM_PRE_TRADE_PROOF_PACK:dpp_001:sha256:proof-pack",
                     "event_type": "PROOF_PACK_CREATED",
+                    "event_time": "2026-05-03T09:00:00+00:00",
                     "source_system": "lotus-manage",
                     "source_type": "DPM_PRE_TRADE_PROOF_PACK",
                     "source_id": proof_pack.proof_pack_id,

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -1590,9 +1590,9 @@ Non-functional posture:
   not inferred from these refs.
 - Proof-pack report-input and AI-evidence payloads can carry bounded
   `portfolio_memory_context` lineage with source memory view hash, no-claim support boundary, and
-  context envelope hash plus explicit event-ref limit, selection policy, returned-count,
-  omitted-count, and truncation posture while excluding that recursive lineage context from the
-  handoff evidence hash.
+  context envelope hash over report-safe event refs with event timestamps plus explicit event-ref
+  limit, selection policy, returned-count, omitted-count, and truncation posture while excluding
+  that recursive lineage context from the handoff evidence hash.
 - Proof-pack report-input and AI-evidence handoffs carry structured
   `DPM_PROOF_PACK_CLIENT_COMMUNICATION_BOUNDARY` evidence. The boundary names blocked
   client-contact, client-message-generation, client-approval, delivery-confirmation, and
@@ -1942,9 +1942,10 @@ Functional behavior:
   dimension-results, and metric-level evidence, structured
   `DPM_OUTCOME_EXTERNAL_EXECUTION_BOUNDARY` and
   `DPM_OUTCOME_CLIENT_COMMUNICATION_BOUNDARY` evidence, optional bounded `portfolio_memory_context`
-  lineage with its own support boundary, context hash, event-ref limit, selection policy,
-  returned-count, omitted-count, and truncation posture, and a canonical handoff hash without generating prompts, memos,
-  recommendations, approvals, client communications, or execution instructions. Recursive
+  lineage with its own support boundary, context hash over report-safe event refs with event
+  timestamps, event-ref limit, selection policy, returned-count, omitted-count, and truncation
+  posture, and a canonical handoff hash without generating prompts, memos, recommendations,
+  approvals, client communications, or execution instructions. Recursive
   portfolio-memory lineage is excluded from the AI evidence hash, matching the report-input
   contract posture.
 - Run and wave lookup routes are read-side conveniences over persisted outcome-review truth.
@@ -2054,9 +2055,10 @@ Functional behavior:
   equivalent source-backed views remain replay-stable for audit reconciliation,
 - emits report/AI handoff portfolio-memory contexts with the source memory view hash, an explicit
   no-claim support boundary, bounded context envelope hash over report-safe event refs, and
-  explicit event-ref limit, selection policy, returned-count, omitted-count, and truncation
-  posture, so downstream report and AI consumers can reconcile lineage context without loading the full memory view or inferring raw
-  source, OMS, client communication, global-discovery, or source-methodology support,
+  explicit event timestamps, event-ref limit, selection policy, returned-count, omitted-count, and
+  truncation posture, so downstream report and AI consumers can reconcile lineage context without
+  loading the full memory view or inferring raw source, OMS, client communication,
+  global-discovery, or source-methodology support,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,
 - preserves source system, source type, source id, supportability state, reason codes, source refs,


### PR DESCRIPTION
## Summary
- Add `event_time` to bounded `DpmPortfolioMemoryReportEventRef` records.
- Keep the selected event timestamp inside the report-context `context_content_hash` so downstream report/AI consumers can audit the newest-first lineage window without loading full portfolio memory.
- Update endpoint certification, README truth, API vocabulary inventory, and focused handoff/API tests.

## Validation
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py tests\unit\dpm\api\test_proof_pack_api.py tests\unit\dpm\api\test_waves_api.py tests\unit\api\test_outcome_reviews_api.py tests\unit\core\test_outcome_handoffs.py tests\unit\dpm\proof_packs\test_proof_pack_handoffs.py -q` - 164 passed, 4 warnings
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json` - regenerated inventory
- `make openapi-gate` - passed
- `make api-vocabulary-gate` - passed
- `make no-alias-gate` - passed
- `make lint` - passed
- `make typecheck` - passed
- `make test-unit` - 1468 passed, 4 warnings
- `make test-integration` - 168 passed
- `make test-e2e` - 28 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` - passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` - passed
- `pwsh -NoProfile -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` - expected branch drift: `Endpoint-Certification.md`
- `git diff --check` - no whitespace errors; CRLF conversion warnings for README/wiki only

## Governance
- Pre-PR stranded-truth check: no unmerged remote branches.
- Open PR check before create: none.
- Scope is Manage-owned backend/API documentation and tests only; no Gateway, Workbench, or Advise changes.