### PR TITLE
Harden portfolio memory report context validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ result pages without timestamp churn. Proof-pack and outcome-review report and A
 handoff contexts preserve the source memory view hash, expose an explicit no-claim
 `support_boundary`, and also expose a bounded `context_content_hash` over the report-safe event
 refs with event timestamps and selection ranks plus explicit event-ref limit, selection policy,
-returned-count, omitted-count, and truncation posture so downstream consumers can reconcile lineage
+returned-count, omitted-count, and truncation posture. Those bounded counters are non-negative,
+and selection ranks are contiguous and one-based, so downstream consumers can reconcile lineage
 context without loading the full memory view or inferring raw source, OMS, client communication,
 global-discovery, or source-methodology support.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters

--- a/src/core/portfolio_memory/handoffs.py
+++ b/src/core/portfolio_memory/handoffs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.core.common.canonical import hash_canonical_payload, strip_keys
 from src.core.portfolio_memory.models import DpmPortfolioMemory, DpmPortfolioMemoryEvent
@@ -25,9 +25,10 @@ class DpmPortfolioMemoryReportEventRef(BaseModel):
     event_type: str = Field(description="Portfolio-memory event type.")
     event_time: str = Field(description="UTC event timestamp used for bounded ref selection.")
     event_ref_selection_rank: int = Field(
+        ge=1,
         description=(
             "One-based rank assigned by the bounded event-ref selection policy after sorting."
-        )
+        ),
     )
     source_system: str = Field(description="System that owns the source event.")
     source_type: str = Field(description="Source artifact or event type.")
@@ -47,12 +48,16 @@ class DpmPortfolioMemoryReportContext(BaseModel):
     supportability_state: str = Field(
         description="Aggregate portfolio-memory supportability state."
     )
-    event_count: int = Field(description="Total event count in the source memory projection.")
+    event_count: int = Field(
+        ge=0,
+        description="Total event count in the source memory projection.",
+    )
     source_systems: list[str] = Field(description="Source systems represented by the memory view.")
     reason_codes: list[str] = Field(description="Aggregate bounded reason codes.")
     content_hash: str = Field(description="Canonical source-backed memory view hash.")
     event_ref_limit: int = Field(
-        description="Maximum number of event refs projected into this bounded handoff context."
+        ge=0,
+        description="Maximum number of event refs projected into this bounded handoff context.",
     )
     event_ref_selection_policy: str = Field(
         description=(
@@ -60,13 +65,14 @@ class DpmPortfolioMemoryReportContext(BaseModel):
         )
     )
     event_refs_returned: int = Field(
-        description="Number of event refs actually projected into this handoff context."
+        ge=0, description="Number of event refs actually projected into this handoff context."
     )
     event_refs_omitted: int = Field(
+        ge=0,
         description=(
             "Number of source memory events omitted from this bounded handoff context after "
             "applying the event-ref limit."
-        )
+        ),
     )
     event_refs_truncated: bool = Field(
         description=(
@@ -94,6 +100,26 @@ class DpmPortfolioMemoryReportContext(BaseModel):
     event_refs: list[DpmPortfolioMemoryReportEventRef] = Field(
         description="Bounded event refs for report lineage."
     )
+
+    @model_validator(mode="after")
+    def validate_bounded_event_ref_metadata(self) -> "DpmPortfolioMemoryReportContext":
+        expected_returned = len(self.event_refs)
+        if self.event_refs_returned != expected_returned:
+            raise ValueError("event_refs_returned must equal the number of event_refs.")
+
+        expected_omitted = max(0, self.event_count - self.event_refs_returned)
+        if self.event_refs_omitted != expected_omitted:
+            raise ValueError("event_refs_omitted must equal event_count minus event_refs_returned.")
+
+        if self.event_refs_truncated != (self.event_refs_omitted > 0):
+            raise ValueError("event_refs_truncated must match event_refs_omitted posture.")
+
+        expected_ranks = list(range(1, expected_returned + 1))
+        observed_ranks = [event_ref.event_ref_selection_rank for event_ref in self.event_refs]
+        if observed_ranks != expected_ranks:
+            raise ValueError("event_ref_selection_rank values must be contiguous one-based ranks.")
+
+        return self
 
 
 def build_portfolio_memory_report_context(

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from decimal import Decimal
 
+import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from src.api.dependencies import (
     get_campaign_definition_repository,
@@ -44,7 +46,10 @@ from src.core.pm_quality.models import (
 from src.core.pm_quality.review_actions import build_pm_quality_review_action
 from src.core.pm_quality.summary_history import build_pm_quality_summary_invocation
 from src.core.portfolio_memory import service as portfolio_memory_service
-from src.core.portfolio_memory.handoffs import build_portfolio_memory_report_context
+from src.core.portfolio_memory.handoffs import (
+    DpmPortfolioMemoryReportContext,
+    build_portfolio_memory_report_context,
+)
 from src.core.portfolio_memory.service import (
     build_portfolio_memory,
     build_portfolio_memory_event_lookup,
@@ -1070,6 +1075,49 @@ def test_portfolio_memory_report_context_hash_covers_bounded_event_refs() -> Non
     assert len(full_context.event_refs) > len(narrower_context.event_refs)
 
 
+def test_portfolio_memory_report_context_rejects_inconsistent_bounded_metadata() -> None:
+    proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
+    memory = build_portfolio_memory(
+        portfolio_id=PORTFOLIO_ID,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        generated_at=datetime(2026, 5, 21, 10, 0, tzinfo=timezone.utc),
+    )
+    context = build_portfolio_memory_report_context(memory, event_limit=2)
+
+    inconsistent_returned = context.model_dump(mode="json")
+    inconsistent_returned["event_refs_returned"] = 1
+    with pytest.raises(ValidationError, match="event_refs_returned must equal"):
+        DpmPortfolioMemoryReportContext.model_validate(inconsistent_returned)
+
+    inconsistent_omitted = context.model_dump(mode="json")
+    inconsistent_omitted["event_refs_omitted"] = 0
+    with pytest.raises(ValidationError, match="event_refs_omitted must equal"):
+        DpmPortfolioMemoryReportContext.model_validate(inconsistent_omitted)
+
+    inconsistent_truncation = context.model_dump(mode="json")
+    inconsistent_truncation["event_refs_truncated"] = not context.event_refs_truncated
+    with pytest.raises(ValidationError, match="event_refs_truncated must match"):
+        DpmPortfolioMemoryReportContext.model_validate(inconsistent_truncation)
+
+    invalid_rank = context.model_dump(mode="json")
+    invalid_rank["event_refs"][0]["event_ref_selection_rank"] = 2
+    with pytest.raises(ValidationError, match="contiguous one-based ranks"):
+        DpmPortfolioMemoryReportContext.model_validate(invalid_rank)
+
+    non_positive_rank = context.model_dump(mode="json")
+    non_positive_rank["event_refs"][0]["event_ref_selection_rank"] = 0
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        DpmPortfolioMemoryReportContext.model_validate(non_positive_rank)
+
+    negative_count = context.model_dump(mode="json")
+    negative_count["event_count"] = -1
+    with pytest.raises(ValidationError, match="greater than or equal to 0"):
+        DpmPortfolioMemoryReportContext.model_validate(negative_count)
+
+
 def test_portfolio_memory_api_returns_queryable_source_backed_memory() -> None:
     proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
     construction_repository = _construction_repository()
@@ -1692,6 +1740,10 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
     assert "event_refs_returned" in report_context_schema["properties"]
     assert "event_refs_omitted" in report_context_schema["properties"]
     assert "event_refs_truncated" in report_context_schema["properties"]
+    assert report_context_schema["properties"]["event_count"]["minimum"] == 0
+    assert report_context_schema["properties"]["event_ref_limit"]["minimum"] == 0
+    assert report_context_schema["properties"]["event_refs_returned"]["minimum"] == 0
+    assert report_context_schema["properties"]["event_refs_omitted"]["minimum"] == 0
     assert (
         "Explicit no-claim boundary"
         in report_context_schema["properties"]["support_boundary"]["description"]
@@ -1703,6 +1755,7 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
     event_ref_schema = openapi_json["components"]["schemas"]["DpmPortfolioMemoryReportEventRef"]
     assert "event_time" in event_ref_schema["properties"]
     assert "event_ref_selection_rank" in event_ref_schema["properties"]
+    assert event_ref_schema["properties"]["event_ref_selection_rank"]["minimum"] == 1
 
 
 def test_portfolio_memory_search_can_include_explicit_portfolio_for_manage_only_events() -> None:

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2056,8 +2056,9 @@ Functional behavior:
 - emits report/AI handoff portfolio-memory contexts with the source memory view hash, an explicit
   no-claim support boundary, bounded context envelope hash over report-safe event refs, and
   explicit event timestamps, selection ranks, event-ref limit, selection policy, returned-count,
-  omitted-count, and truncation posture, so downstream report and AI consumers can reconcile
-  lineage context without loading the full memory view or inferring raw source, OMS, client communication,
+  omitted-count, and truncation posture. Bounded counters are non-negative, and selection ranks
+  are contiguous and one-based, so downstream report and AI consumers can reconcile lineage
+  context without loading the full memory view or inferring raw source, OMS, client communication,
   global-discovery, or source-methodology support,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,


### PR DESCRIPTION
## Summary
- Add fail-closed validation to bounded `DpmPortfolioMemoryReportContext` metadata.
- Constrain event counts and limits as non-negative and event-ref selection ranks as one-based.
- Validate returned/omitted/truncated posture and contiguous rank ordering against the actual bounded event refs.
- Update README, endpoint certification wiki source, and focused contract tests.

## Validation
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json` - regenerated inventory; timestamp-only, not committed
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py tests\unit\dpm\api\test_proof_pack_api.py tests\unit\dpm\api\test_waves_api.py tests\unit\api\test_outcome_reviews_api.py tests\unit\core\test_outcome_handoffs.py tests\unit\dpm\proof_packs\test_proof_pack_handoffs.py -q` - 165 passed, 4 warnings
- `make openapi-gate` - passed
- `make api-vocabulary-gate` - passed
- `make no-alias-gate` - passed
- `make typecheck` - passed
- `make lint` - passed
- `make test-unit` - 1469 passed, 4 warnings
- `make test-integration` - 168 passed
- `make test-e2e` - 28 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` - passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` - passed
- `pwsh -NoProfile -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` - expected branch drift: `Endpoint-Certification.md`
- `git diff --check` - no whitespace errors; CRLF conversion warnings for README/wiki only

## Governance
- Pre-PR stranded-truth check: no unmerged remote branches.
- Open PR check before create: none.
- Scope is Manage-owned backend/API documentation and tests only; no Gateway, Workbench, or Advise changes.