### PR TITLE
Require portfolio memory governance policy posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ handoff contexts preserve the source memory view hash, expose an explicit no-cla
 `support_boundary`, and also expose a bounded `context_content_hash` over the report-safe event
 refs with event timestamps and selection ranks plus explicit event-ref limit, selection policy,
 returned-count, omitted-count, and truncation posture. Those bounded counters are non-negative,
-and selection ranks are contiguous and one-based, so downstream consumers can reconcile lineage
-context without loading the full memory view or inferring raw source, OMS, client communication,
-global-discovery, or source-methodology support.
+selection ranks are contiguous and one-based, and the governance policy must carry identity-scheme,
+retention, redaction, audit, access, and source-authority posture, so downstream consumers can
+reconcile lineage context without loading the full memory view or inferring raw source, OMS,
+client communication, global-discovery, or source-methodology support.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-21T19:59:33.629168+00:00",
+  "generatedAt": "2026-05-21T20:31:51.010249+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -5723,7 +5723,7 @@
       "semanticId": "lotus.governance_policy",
       "canonicalTerm": "governance_policy",
       "preferredName": "governance_policy",
-      "description": "Portfolio-memory retention, redaction, access, audit, and source policy.",
+      "description": "Portfolio-memory governance policy carrying event_identity_scheme, retention_policy, redaction_policy, audit_policy, access_classification, and source_authority_policy.",
       "example": {
         "sample_key": "sample_value"
       },

--- a/src/core/portfolio_memory/handoffs.py
+++ b/src/core/portfolio_memory/handoffs.py
@@ -18,6 +18,16 @@ PORTFOLIO_MEMORY_REPORT_CONTEXT_SUPPORT_BOUNDARY = (
 PORTFOLIO_MEMORY_REPORT_CONTEXT_EVENT_REF_SELECTION_POLICY = (
     "LATEST_EVENTS_BY_EVENT_TIME_DESC_THEN_EVENT_ID_DESC"
 )
+PORTFOLIO_MEMORY_REPORT_CONTEXT_REQUIRED_GOVERNANCE_KEYS = frozenset(
+    {
+        "event_identity_scheme",
+        "retention_policy",
+        "redaction_policy",
+        "audit_policy",
+        "access_classification",
+        "source_authority_policy",
+    }
+)
 
 
 class DpmPortfolioMemoryReportEventRef(BaseModel):
@@ -95,7 +105,11 @@ class DpmPortfolioMemoryReportContext(BaseModel):
         )
     )
     governance_policy: dict[str, str] = Field(
-        description="Portfolio-memory retention, redaction, access, audit, and source policy."
+        description=(
+            "Portfolio-memory governance policy carrying event_identity_scheme, "
+            "retention_policy, redaction_policy, audit_policy, access_classification, and "
+            "source_authority_policy."
+        )
     )
     event_refs: list[DpmPortfolioMemoryReportEventRef] = Field(
         description="Bounded event refs for report lineage."
@@ -118,6 +132,24 @@ class DpmPortfolioMemoryReportContext(BaseModel):
         observed_ranks = [event_ref.event_ref_selection_rank for event_ref in self.event_refs]
         if observed_ranks != expected_ranks:
             raise ValueError("event_ref_selection_rank values must be contiguous one-based ranks.")
+
+        missing_governance_keys = (
+            PORTFOLIO_MEMORY_REPORT_CONTEXT_REQUIRED_GOVERNANCE_KEYS - self.governance_policy.keys()
+        )
+        if missing_governance_keys:
+            raise ValueError(
+                "governance_policy missing required keys: "
+                f"{', '.join(sorted(missing_governance_keys))}."
+            )
+
+        blank_governance_keys = [
+            key for key, value in self.governance_policy.items() if not value.strip()
+        ]
+        if blank_governance_keys:
+            raise ValueError(
+                "governance_policy values must be non-blank for keys: "
+                f"{', '.join(sorted(blank_governance_keys))}."
+            )
 
         return self
 

--- a/tests/unit/core/test_outcome_handoffs.py
+++ b/tests/unit/core/test_outcome_handoffs.py
@@ -75,10 +75,12 @@ def test_outcome_report_input_carries_portfolio_memory_without_changing_hash() -
             "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
+                "event_identity_scheme": "source_system:source_type:source_id:content_hash_or_content_hash_unavailable",
                 "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
                 "redaction_policy": "NO_RAW_PAYLOADS",
                 "audit_policy": "AUDIT_READ_AND_EXPORT",
                 "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+                "source_authority_policy": "portfolio memory projects source-owned facts",
             },
             "event_refs": [
                 {
@@ -125,10 +127,12 @@ def test_outcome_ai_evidence_input_carries_portfolio_memory_without_changing_has
             "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
+                "event_identity_scheme": "source_system:source_type:source_id:content_hash_or_content_hash_unavailable",
                 "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
                 "redaction_policy": "NO_RAW_PAYLOADS",
                 "audit_policy": "AUDIT_READ_AND_EXPORT",
                 "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+                "source_authority_policy": "portfolio memory projects source-owned facts",
             },
             "event_refs": [
                 {

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1117,6 +1117,22 @@ def test_portfolio_memory_report_context_rejects_inconsistent_bounded_metadata()
     with pytest.raises(ValidationError, match="greater than or equal to 0"):
         DpmPortfolioMemoryReportContext.model_validate(negative_count)
 
+    missing_governance = context.model_dump(mode="json")
+    missing_governance["governance_policy"].pop("source_authority_policy")
+    with pytest.raises(
+        ValidationError,
+        match="governance_policy missing required keys: source_authority_policy",
+    ):
+        DpmPortfolioMemoryReportContext.model_validate(missing_governance)
+
+    blank_governance = context.model_dump(mode="json")
+    blank_governance["governance_policy"]["audit_policy"] = " "
+    with pytest.raises(
+        ValidationError,
+        match="governance_policy values must be non-blank for keys: audit_policy",
+    ):
+        DpmPortfolioMemoryReportContext.model_validate(blank_governance)
+
 
 def test_portfolio_memory_api_returns_queryable_source_backed_memory() -> None:
     proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
@@ -1744,6 +1760,9 @@ def test_portfolio_memory_event_lookup_returns_exact_event_from_search_hit() -> 
     assert report_context_schema["properties"]["event_ref_limit"]["minimum"] == 0
     assert report_context_schema["properties"]["event_refs_returned"]["minimum"] == 0
     assert report_context_schema["properties"]["event_refs_omitted"]["minimum"] == 0
+    governance_description = report_context_schema["properties"]["governance_policy"]["description"]
+    assert "event_identity_scheme" in governance_description
+    assert "source_authority_policy" in governance_description
     assert (
         "Explicit no-claim boundary"
         in report_context_schema["properties"]["support_boundary"]["description"]

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoffs.py
@@ -130,10 +130,12 @@ def test_report_input_carries_portfolio_memory_without_changing_evidence_hash() 
             "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
+                "event_identity_scheme": "source_system:source_type:source_id:content_hash_or_content_hash_unavailable",
                 "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
                 "redaction_policy": "NO_RAW_PAYLOADS",
                 "audit_policy": "AUDIT_READ_AND_EXPORT",
                 "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+                "source_authority_policy": "portfolio memory projects source-owned facts",
             },
             "event_refs": [
                 {
@@ -180,10 +182,12 @@ def test_ai_evidence_input_carries_portfolio_memory_without_changing_evidence_ha
             "support_boundary": "Portfolio-memory report context test boundary.",
             "context_content_hash": "sha256:portfolio-memory-report-context",
             "governance_policy": {
+                "event_identity_scheme": "source_system:source_type:source_id:content_hash_or_content_hash_unavailable",
                 "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
                 "redaction_policy": "NO_RAW_PAYLOADS",
                 "audit_policy": "AUDIT_READ_AND_EXPORT",
                 "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+                "source_authority_policy": "portfolio memory projects source-owned facts",
             },
             "event_refs": [
                 {

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2057,8 +2057,9 @@ Functional behavior:
   no-claim support boundary, bounded context envelope hash over report-safe event refs, and
   explicit event timestamps, selection ranks, event-ref limit, selection policy, returned-count,
   omitted-count, and truncation posture. Bounded counters are non-negative, and selection ranks
-  are contiguous and one-based, so downstream report and AI consumers can reconcile lineage
-  context without loading the full memory view or inferring raw source, OMS, client communication,
+  are contiguous and one-based. The governance policy must carry identity-scheme, retention,
+  redaction, audit, access, and source-authority posture, so downstream report and AI consumers
+  can reconcile lineage context without loading the full memory view or inferring raw source, OMS, client communication,
   global-discovery, or source-methodology support,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,


### PR DESCRIPTION
## Summary
- Require bounded `DpmPortfolioMemoryReportContext.governance_policy` to carry the full source governance posture.
- Fail closed when event identity scheme, retention, redaction, audit, access classification, or source-authority policy is missing or blank.
- Update handoff fixtures, focused validation tests, README, endpoint certification wiki source, and API vocabulary inventory.

## Validation
- `python scripts\api_vocabulary_inventory.py --output docs\standards\api-vocabulary\lotus-manage-api-vocabulary.v1.json` - regenerated inventory
- `python -m pytest tests\unit\dpm\api\test_portfolio_memory_api.py tests\unit\dpm\api\test_proof_pack_api.py tests\unit\dpm\api\test_waves_api.py tests\unit\api\test_outcome_reviews_api.py tests\unit\core\test_outcome_handoffs.py tests\unit\dpm\proof_packs\test_proof_pack_handoffs.py -q` - 165 passed, 4 warnings
- `make openapi-gate` - passed
- `make api-vocabulary-gate` - passed
- `make no-alias-gate` - passed
- `make typecheck` - passed
- `make lint` - passed
- `make test-unit` - 1469 passed, 4 warnings
- `make test-integration` - 168 passed
- `make test-e2e` - 28 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` - passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` - passed
- `pwsh -NoProfile -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` - expected branch drift: `Endpoint-Certification.md`
- `git diff --check` - no whitespace errors; CRLF conversion warnings for README/wiki only

## Governance
- Pre-PR stranded-truth check: no unmerged remote branches.
- Open PR check before create: none.
- Scope is Manage-owned backend/API documentation and tests only; no Gateway, Workbench, or Advise changes.