### PR TITLE
Validate portfolio memory event ref governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ handoff contexts preserve the source memory view hash, expose an explicit no-cla
 refs with event timestamps and selection ranks plus explicit event-ref limit, selection policy,
 returned-count, omitted-count, and truncation posture. Those bounded counters are non-negative,
 selection ranks are contiguous and one-based, and the governance policy must carry identity-scheme,
-retention, redaction, audit, access, and source-authority posture, so downstream consumers can
-reconcile lineage context without loading the full memory view or inferring raw source, OMS,
-client communication, global-discovery, or source-methodology support.
+retention, redaction, audit, access, and source-authority posture. Per-event retention, redaction,
+audit, and access fields must match that governance envelope, so downstream consumers can reconcile
+lineage context without loading the full memory view or inferring raw source, OMS, client
+communication, global-discovery, or source-methodology support.
 Portfolio-memory text filters are trimmed before validation and matching, and blank text filters
 are treated as absent, so audit consumers can rely on the echoed filter posture rather than raw
 query-string formatting.

--- a/src/core/portfolio_memory/handoffs.py
+++ b/src/core/portfolio_memory/handoffs.py
@@ -28,6 +28,12 @@ PORTFOLIO_MEMORY_REPORT_CONTEXT_REQUIRED_GOVERNANCE_KEYS = frozenset(
         "source_authority_policy",
     }
 )
+PORTFOLIO_MEMORY_REPORT_CONTEXT_EVENT_REF_GOVERNANCE_FIELDS = {
+    "retention_policy": "retention_policy",
+    "redaction_policy": "redaction_policy",
+    "audit_policy": "audit_policy",
+    "access_classification": "access_classification",
+}
 
 
 class DpmPortfolioMemoryReportEventRef(BaseModel):
@@ -150,6 +156,23 @@ class DpmPortfolioMemoryReportContext(BaseModel):
                 "governance_policy values must be non-blank for keys: "
                 f"{', '.join(sorted(blank_governance_keys))}."
             )
+
+        for (
+            event_ref_field,
+            governance_key,
+        ) in PORTFOLIO_MEMORY_REPORT_CONTEXT_EVENT_REF_GOVERNANCE_FIELDS.items():
+            expected_value = self.governance_policy[governance_key]
+            mismatched_refs = [
+                event_ref.event_identity
+                for event_ref in self.event_refs
+                if getattr(event_ref, event_ref_field) != expected_value
+            ]
+            if mismatched_refs:
+                raise ValueError(
+                    "event_refs must match governance_policy."
+                    f"{governance_key} for {event_ref_field}: "
+                    f"{', '.join(mismatched_refs)}."
+                )
 
         return self
 

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -1133,6 +1133,22 @@ def test_portfolio_memory_report_context_rejects_inconsistent_bounded_metadata()
     ):
         DpmPortfolioMemoryReportContext.model_validate(blank_governance)
 
+    mismatched_retention = context.model_dump(mode="json")
+    mismatched_retention["event_refs"][0]["retention_policy"] = "OTHER_RETENTION"
+    with pytest.raises(
+        ValidationError,
+        match="event_refs must match governance_policy.retention_policy",
+    ):
+        DpmPortfolioMemoryReportContext.model_validate(mismatched_retention)
+
+    mismatched_access = context.model_dump(mode="json")
+    mismatched_access["event_refs"][0]["access_classification"] = "PUBLIC"
+    with pytest.raises(
+        ValidationError,
+        match="event_refs must match governance_policy.access_classification",
+    ):
+        DpmPortfolioMemoryReportContext.model_validate(mismatched_access)
+
 
 def test_portfolio_memory_api_returns_queryable_source_backed_memory() -> None:
     proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2058,9 +2058,10 @@ Functional behavior:
   explicit event timestamps, selection ranks, event-ref limit, selection policy, returned-count,
   omitted-count, and truncation posture. Bounded counters are non-negative, and selection ranks
   are contiguous and one-based. The governance policy must carry identity-scheme, retention,
-  redaction, audit, access, and source-authority posture, so downstream report and AI consumers
-  can reconcile lineage context without loading the full memory view or inferring raw source, OMS, client communication,
-  global-discovery, or source-methodology support,
+  redaction, audit, access, and source-authority posture. Per-event retention, redaction, audit,
+  and access fields must match that governance envelope, so downstream report and AI consumers can
+  reconcile lineage context without loading the full memory view or inferring raw source, OMS,
+  client communication, global-discovery, or source-methodology support,
 - filters portfolio memory by source portfolio id,
 - returns bounded events sorted newest first,
 - preserves source system, source type, source id, supportability state, reason codes, source refs,


### PR DESCRIPTION
## Summary
- require bounded portfolio-memory report event refs to match the report-context governance policy for retention, redaction, audit, and access posture
- add regression coverage for mismatched retention and access-classification event refs
- update README and repo-authored wiki endpoint certification wording for the stricter governance envelope

## Validation
- python -m pytest tests\\unit\\dpm\\api\\test_portfolio_memory_api.py tests\\unit\\dpm\\api\\test_proof_pack_api.py tests\\unit\\dpm\\api\\test_waves_api.py tests\\unit\\api\\test_outcome_reviews_api.py tests\\unit\\core\\test_outcome_handoffs.py tests\\unit\\dpm\\proof_packs\\test_proof_pack_handoffs.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- pwsh -NoProfile -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected pre-merge drift: Endpoint-Certification.md)
- git diff --check

## Ownership
- Manage-only backend/API governance hardening
- No lotus-gateway, lotus-workbench, or lotus-advise changes