### PR TITLE
Validate portfolio memory aggregate metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ also returns `has_more`, `next_offset`, the normalized `applied_filters` echo, a
 bounded searches without reconstructing continuation logic, filter posture, or scan-cap posture
 from counts. Each portfolio-memory view and search page carries a deterministic `content_hash`
 that excludes `generated_at` so audit review can reconcile equivalent source-backed views and
-result pages without timestamp churn. Proof-pack and outcome-review report and AI evidence
+result pages without timestamp churn. Portfolio-memory aggregate event count, event-type counts,
+source-system coverage, reason-code rollups, supportability state, and governance posture are
+validated against returned event rows so audit consumers do not receive inconsistent summary truth.
+Proof-pack and outcome-review report and AI evidence
 handoff contexts preserve the source memory view hash, expose an explicit no-claim
 `support_boundary`, and also expose a bounded `context_content_hash` over the report-safe event
 refs with event timestamps and selection ranks plus explicit event-ref limit, selection policy,

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -1,6 +1,6 @@
 """Domain models for source-backed portfolio memory."""
 
-from typing import Any, Literal
+from typing import Any, Iterable, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -50,6 +50,22 @@ PORTFOLIO_MEMORY_SOURCE_AUTHORITY_POLICY = (
     "portfolio memory projects source-owned facts; consumers must not reconstruct risk, "
     "performance, mandate-health, execution, tax, cash, FX, report, or AI truth"
 )
+PORTFOLIO_MEMORY_REQUIRED_GOVERNANCE_KEYS = frozenset(
+    {
+        "event_identity_scheme",
+        "retention_policy",
+        "redaction_policy",
+        "audit_policy",
+        "access_classification",
+        "source_authority_policy",
+    }
+)
+PORTFOLIO_MEMORY_EVENT_GOVERNANCE_FIELDS = {
+    "retention_policy": "retention_policy",
+    "redaction_policy": "redaction_policy",
+    "audit_policy": "audit_policy",
+    "access_classification": "access_classification",
+}
 
 
 class DpmPortfolioMemoryExternalExecutionBoundaryEvidence(BaseModel):
@@ -332,6 +348,69 @@ class DpmPortfolioMemory(BaseModel):
     )
     generated_at: str = Field(description="UTC timestamp when the read model was generated.")
 
+    @model_validator(mode="after")
+    def validate_aggregate_metadata(self) -> "DpmPortfolioMemory":
+        if self.event_count != len(self.events):
+            raise ValueError("event_count must equal the number of events.")
+
+        expected_event_type_counts = _counts(event.event_type for event in self.events)
+        if self.event_type_counts != expected_event_type_counts:
+            raise ValueError("event_type_counts must match the returned events.")
+
+        expected_source_systems = sorted(
+            {
+                source_system
+                for event in self.events
+                for source_system in _event_source_systems(event)
+            }
+        )
+        if self.source_systems != expected_source_systems:
+            raise ValueError("source_systems must match the returned events.")
+
+        expected_reason_codes = sorted(
+            {reason for event in self.events for reason in event.reason_codes}
+        )
+        if self.reason_codes != expected_reason_codes:
+            raise ValueError("reason_codes must match the returned events.")
+
+        expected_supportability_state = _portfolio_memory_supportability_state(self.events)
+        if self.supportability_state != expected_supportability_state:
+            raise ValueError("supportability_state must match the returned events.")
+
+        missing_governance_keys = (
+            PORTFOLIO_MEMORY_REQUIRED_GOVERNANCE_KEYS - self.governance_policy.keys()
+        )
+        if missing_governance_keys:
+            raise ValueError(
+                "governance_policy missing required keys: "
+                f"{', '.join(sorted(missing_governance_keys))}."
+            )
+
+        blank_governance_keys = [
+            key for key, value in self.governance_policy.items() if not value.strip()
+        ]
+        if blank_governance_keys:
+            raise ValueError(
+                "governance_policy values must be non-blank for keys: "
+                f"{', '.join(sorted(blank_governance_keys))}."
+            )
+
+        for event_field, governance_key in PORTFOLIO_MEMORY_EVENT_GOVERNANCE_FIELDS.items():
+            expected_value = self.governance_policy[governance_key]
+            mismatched_events = [
+                event.event_identity
+                for event in self.events
+                if getattr(event, event_field) != expected_value
+            ]
+            if mismatched_events:
+                raise ValueError(
+                    "events must match governance_policy."
+                    f"{governance_key} for {event_field}: "
+                    f"{', '.join(mismatched_events)}."
+                )
+
+        return self
+
 
 class DpmPortfolioMemoryEventLookup(BaseModel):
     portfolio_id: str = Field(description="Portfolio identifier used for the memory lookup.")
@@ -583,3 +662,34 @@ class DpmPortfolioMemorySearchPage(BaseModel):
             "Manage-local memory search does not discover the global portfolio universe or project OMS events."
         ],
     )
+
+
+def _counts(values: Iterable[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values:
+        counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def _event_source_systems(event: DpmPortfolioMemoryEvent) -> set[str]:
+    return {
+        source_system
+        for source_system in [
+            event.source_system,
+            *(ref.source_system for ref in event.source_refs),
+            *(ref.source_system for ref in event.artifact_refs),
+        ]
+        if source_system
+    }
+
+
+def _portfolio_memory_supportability_state(
+    events: list[DpmPortfolioMemoryEvent],
+) -> PortfolioMemorySupportabilityState:
+    if not events:
+        return "EMPTY"
+    states = {event.supportability_state for event in events}
+    for state in ("BLOCKED", "DEGRADED", "PENDING_REVIEW"):
+        if state in states:
+            return state
+    return "READY"

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -46,6 +46,7 @@ from src.core.pm_quality.models import (
 from src.core.pm_quality.review_actions import build_pm_quality_review_action
 from src.core.pm_quality.summary_history import build_pm_quality_summary_invocation
 from src.core.portfolio_memory import service as portfolio_memory_service
+from src.core.portfolio_memory.models import DpmPortfolioMemory
 from src.core.portfolio_memory.handoffs import (
     DpmPortfolioMemoryReportContext,
     build_portfolio_memory_report_context,
@@ -931,6 +932,69 @@ def test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events() 
     assert not any(
         event.metadata.get("external_execution_claimed") is True for event in memory.events
     )
+
+
+def test_portfolio_memory_rejects_inconsistent_aggregate_metadata() -> None:
+    proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
+    construction_repository = _construction_repository()
+    memory = build_portfolio_memory(
+        portfolio_id=PORTFOLIO_ID,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        construction_repository=construction_repository,
+        generated_at=datetime(2026, 5, 22, 10, 0, tzinfo=timezone.utc),
+    )
+
+    inconsistent_count = memory.model_dump(mode="json")
+    inconsistent_count["event_count"] = memory.event_count + 1
+    with pytest.raises(ValidationError, match="event_count must equal"):
+        DpmPortfolioMemory.model_validate(inconsistent_count)
+
+    inconsistent_type_counts = memory.model_dump(mode="json")
+    inconsistent_type_counts["event_type_counts"]["PROOF_PACK_CREATED"] = 99
+    with pytest.raises(ValidationError, match="event_type_counts must match"):
+        DpmPortfolioMemory.model_validate(inconsistent_type_counts)
+
+    inconsistent_source_systems = memory.model_dump(mode="json")
+    inconsistent_source_systems["source_systems"] = ["lotus-manage"]
+    with pytest.raises(ValidationError, match="source_systems must match"):
+        DpmPortfolioMemory.model_validate(inconsistent_source_systems)
+
+    inconsistent_reason_codes = memory.model_dump(mode="json")
+    inconsistent_reason_codes["reason_codes"] = ["SOURCE_READY"]
+    with pytest.raises(ValidationError, match="reason_codes must match"):
+        DpmPortfolioMemory.model_validate(inconsistent_reason_codes)
+
+    inconsistent_supportability = memory.model_dump(mode="json")
+    inconsistent_supportability["supportability_state"] = "READY"
+    with pytest.raises(ValidationError, match="supportability_state must match"):
+        DpmPortfolioMemory.model_validate(inconsistent_supportability)
+
+    missing_governance = memory.model_dump(mode="json")
+    missing_governance["governance_policy"].pop("source_authority_policy")
+    with pytest.raises(
+        ValidationError,
+        match="governance_policy missing required keys: source_authority_policy",
+    ):
+        DpmPortfolioMemory.model_validate(missing_governance)
+
+    blank_governance = memory.model_dump(mode="json")
+    blank_governance["governance_policy"]["audit_policy"] = " "
+    with pytest.raises(
+        ValidationError,
+        match="governance_policy values must be non-blank for keys: audit_policy",
+    ):
+        DpmPortfolioMemory.model_validate(blank_governance)
+
+    mismatched_event_governance = memory.model_dump(mode="json")
+    mismatched_event_governance["events"][0]["audit_policy"] = "AUDIT_DISABLED"
+    with pytest.raises(
+        ValidationError,
+        match="events must match governance_policy.audit_policy",
+    ):
+        DpmPortfolioMemory.model_validate(mismatched_event_governance)
 
 
 def test_portfolio_memory_hashes_exclude_generated_at_for_audit_replay() -> None:

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2053,6 +2053,9 @@ Functional behavior:
   no-claim boundary for audit drilldown from a search hit,
 - emits portfolio-memory view and search-page content hashes that exclude `generated_at`, so
   equivalent source-backed views remain replay-stable for audit reconciliation,
+- validates portfolio-memory aggregate event count, event-type counts, source-system coverage,
+  reason-code rollups, supportability state, and governance posture against returned event rows,
+  so audit consumers do not receive inconsistent summary truth,
 - emits report/AI handoff portfolio-memory contexts with the source memory view hash, an explicit
   no-claim support boundary, bounded context envelope hash over report-safe event refs, and
   explicit event timestamps, selection ranks, event-ref limit, selection policy, returned-count,


### PR DESCRIPTION
## Summary
- validate DpmPortfolioMemory aggregate event count, event-type counts, source-system coverage, reason-code rollups, supportability state, and governance posture against returned event rows
- add regression coverage for inconsistent aggregate metadata and event governance posture
- update README and repo-authored wiki endpoint certification wording for the stricter audit contract

## Validation
- python -m pytest tests\\unit\\dpm\\api\\test_portfolio_memory_api.py tests\\unit\\dpm\\api\\test_proof_pack_api.py tests\\unit\\dpm\\api\\test_waves_api.py tests\\unit\\api\\test_outcome_reviews_api.py tests\\unit\\core\\test_outcome_handoffs.py tests\\unit\\dpm\\proof_packs\\test_proof_pack_handoffs.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- pwsh -NoProfile -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected pre-merge drift: Endpoint-Certification.md)
- git diff --check

## Ownership
- Manage-only backend/API governance hardening
- No lotus-gateway, lotus-workbench, or lotus-advise changes