### PR TITLE
Validate portfolio memory search page metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ archive handoff evidence is not hidden from audit search facets. Pagination meta
 also returns `has_more`, `next_offset`, the normalized `applied_filters` echo, and the
 `source_scan_limit` used for each Manage-local evidence repository so consumers can continue
 bounded searches without reconstructing continuation logic, filter posture, or scan-cap posture
-from counts. Each portfolio-memory view and search page carries a deterministic `content_hash`
+from counts. Search pages validate returned-count, total-count, has-more, next-offset,
+supportability-count, source-system-count, and matching-event-count posture against the returned
+rows. Each portfolio-memory view and search page carries a deterministic `content_hash`
 that excludes `generated_at` so audit review can reconcile equivalent source-backed views and
 result pages without timestamp churn. Portfolio-memory aggregate event count, event-type counts,
 source-system coverage, reason-code rollups, supportability state, and governance posture are

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -447,7 +447,7 @@ class DpmPortfolioMemorySearchItem(BaseModel):
         description="Portfolio identifier represented in the Manage-local memory index.",
         examples=["PB_SG_GLOBAL_BAL_001"],
     )
-    event_count: int = Field(description="Returned memory event count for this portfolio.")
+    event_count: int = Field(ge=0, description="Returned memory event count for this portfolio.")
     supportability_state: PortfolioMemorySupportabilityState = Field(
         description="Worst supportability state represented by this portfolio's memory events."
     )
@@ -470,6 +470,7 @@ class DpmPortfolioMemorySearchItem(BaseModel):
         description="Latest event type in the returned portfolio-memory view.",
     )
     matching_event_count: int = Field(
+        ge=0,
         description=(
             "Number of events in this portfolio-memory view that match the applied event, source "
             "system, and supportability filters. When no filters are supplied this equals "
@@ -528,6 +529,60 @@ class DpmPortfolioMemorySearchItem(BaseModel):
         )
     )
 
+    @model_validator(mode="after")
+    def validate_search_item_metadata(self) -> "DpmPortfolioMemorySearchItem":
+        expected_event_count = sum(self.event_type_counts.values())
+        if self.event_count != expected_event_count:
+            raise ValueError("event_count must equal the sum of event_type_counts.")
+
+        if self.matching_event_count > self.event_count:
+            raise ValueError("matching_event_count must not exceed event_count.")
+
+        if self.source_systems != sorted(set(self.source_systems)):
+            raise ValueError("source_systems must be sorted and unique.")
+
+        if self.reason_codes != sorted(set(self.reason_codes)):
+            raise ValueError("reason_codes must be sorted and unique.")
+
+        latest_event_fields = [self.latest_event_time, self.latest_event_type]
+        if self.event_count == 0:
+            if self.supportability_state != "EMPTY":
+                raise ValueError("empty search items must use EMPTY supportability_state.")
+            if self.event_type_counts or self.source_systems or self.reason_codes:
+                raise ValueError("empty search items must not carry aggregate event metadata.")
+            if any(value is not None for value in latest_event_fields):
+                raise ValueError("empty search items must not carry latest event metadata.")
+        else:
+            if self.supportability_state == "EMPTY":
+                raise ValueError("non-empty search items must not use EMPTY supportability_state.")
+            if any(value is None for value in latest_event_fields):
+                raise ValueError("non-empty search items must carry latest event metadata.")
+
+        latest_matching_fields = [
+            self.latest_matching_event_time,
+            self.latest_matching_event_type,
+            self.latest_matching_event_id,
+            self.latest_matching_event_identity,
+            self.latest_matching_event_source_system,
+            self.latest_matching_event_source_type,
+            self.latest_matching_event_source_id,
+        ]
+        if self.matching_event_count == 0:
+            if any(value is not None for value in latest_matching_fields):
+                raise ValueError(
+                    "search items with no matching events must not carry latest matching event metadata."
+                )
+            if self.latest_matching_event_content_hash is not None:
+                raise ValueError(
+                    "search items with no matching events must not carry latest matching event content hash."
+                )
+        elif any(value is None for value in latest_matching_fields):
+            raise ValueError(
+                "search items with matching events must carry latest matching event metadata."
+            )
+
+        return self
+
 
 class DpmPortfolioMemorySearchAppliedFilters(BaseModel):
     portfolio_ids: list[str] = Field(
@@ -565,10 +620,11 @@ class DpmPortfolioMemorySearchPage(BaseModel):
             "global portfolio-universe discovery product."
         )
     )
-    limit: int = Field(description="Requested page size.", examples=[50])
-    offset: int = Field(description="Requested page offset.", examples=[0])
-    returned_count: int = Field(description="Number of search items returned.", examples=[1])
+    limit: int = Field(ge=1, description="Requested page size.", examples=[50])
+    offset: int = Field(ge=0, description="Requested page offset.", examples=[0])
+    returned_count: int = Field(ge=0, description="Number of search items returned.", examples=[1])
     total_count: int = Field(
+        ge=0,
         description="Total matching Manage-local portfolio-memory summaries before pagination.",
         examples=[1],
     )
@@ -581,6 +637,7 @@ class DpmPortfolioMemorySearchPage(BaseModel):
     )
     next_offset: int | None = Field(
         default=None,
+        ge=0,
         description=(
             "Offset to request the next page when has_more is true; null when this page exhausts "
             "the bounded Manage-local result set."
@@ -588,10 +645,12 @@ class DpmPortfolioMemorySearchPage(BaseModel):
         examples=[50],
     )
     scanned_portfolio_count: int = Field(
+        ge=0,
         description="Number of candidate portfolio identifiers scanned from Manage-local evidence.",
         examples=[3],
     )
     source_scan_limit: int = Field(
+        ge=1,
         description=(
             "Maximum rows requested from each Manage-local evidence repository while building this "
             "bounded search page."
@@ -663,12 +722,97 @@ class DpmPortfolioMemorySearchPage(BaseModel):
         ],
     )
 
+    @model_validator(mode="after")
+    def validate_search_page_metadata(self) -> "DpmPortfolioMemorySearchPage":
+        if self.returned_count != len(self.items):
+            raise ValueError("returned_count must equal the number of items.")
+
+        if self.returned_count > self.total_count:
+            raise ValueError("returned_count must not exceed total_count.")
+
+        expected_has_more = self.offset + self.returned_count < self.total_count
+        if self.has_more != expected_has_more:
+            raise ValueError("has_more must match pagination posture.")
+
+        if self.has_more:
+            expected_next_offset = self.offset + self.returned_count
+            if self.next_offset != expected_next_offset:
+                raise ValueError("next_offset must equal offset plus returned_count.")
+            if self.next_offset <= self.offset:
+                raise ValueError("next_offset must advance when has_more is true.")
+        elif self.next_offset is not None:
+            raise ValueError("next_offset must be null when has_more is false.")
+
+        _validate_non_negative_counts(
+            label="supportability_state_counts", counts=self.supportability_state_counts
+        )
+        _validate_non_negative_counts(label="event_type_counts", counts=self.event_type_counts)
+        _validate_non_negative_counts(
+            label="matching_event_supportability_state_counts",
+            counts=self.matching_event_supportability_state_counts,
+        )
+        _validate_non_negative_counts(
+            label="matching_event_source_system_counts",
+            counts=self.matching_event_source_system_counts,
+        )
+        _validate_non_negative_counts(
+            label="source_system_counts", counts=self.source_system_counts
+        )
+
+        if sum(self.supportability_state_counts.values()) != self.total_count:
+            raise ValueError("supportability_state_counts must sum to total_count.")
+
+        page_supportability_counts = _counts(item.supportability_state for item in self.items)
+        for state, count in page_supportability_counts.items():
+            if self.supportability_state_counts.get(state, 0) < count:
+                raise ValueError(
+                    "supportability_state_counts must cover returned page item states."
+                )
+
+        page_source_system_counts: dict[str, int] = {}
+        for item in self.items:
+            for source_system in item.source_systems:
+                page_source_system_counts[source_system] = (
+                    page_source_system_counts.get(source_system, 0) + 1
+                )
+        for source_system, count in page_source_system_counts.items():
+            if self.source_system_counts.get(source_system, 0) < count:
+                raise ValueError("source_system_counts must cover returned page item sources.")
+
+        if self.total_count == self.returned_count:
+            if self.supportability_state_counts != page_supportability_counts:
+                raise ValueError(
+                    "supportability_state_counts must match returned items when the page is complete."
+                )
+            if self.source_system_counts != page_source_system_counts:
+                raise ValueError(
+                    "source_system_counts must match returned items when the page is complete."
+                )
+            expected_matching_event_count = sum(item.matching_event_count for item in self.items)
+            if (
+                sum(self.matching_event_supportability_state_counts.values())
+                != expected_matching_event_count
+            ):
+                raise ValueError(
+                    "matching_event_supportability_state_counts must sum to matching events when the page is complete."
+                )
+
+        return self
+
 
 def _counts(values: Iterable[str]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for value in values:
         counts[value] = counts.get(value, 0) + 1
     return counts
+
+
+def _validate_non_negative_counts(*, label: str, counts: dict[str, int]) -> None:
+    negative_keys = [key for key, value in counts.items() if value < 0]
+    if negative_keys:
+        raise ValueError(
+            f"{label} values must be non-negative for keys: {', '.join(negative_keys)}."
+        )
 
 
 def _event_source_systems(event: DpmPortfolioMemoryEvent) -> set[str]:

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -46,7 +46,7 @@ from src.core.pm_quality.models import (
 from src.core.pm_quality.review_actions import build_pm_quality_review_action
 from src.core.pm_quality.summary_history import build_pm_quality_summary_invocation
 from src.core.portfolio_memory import service as portfolio_memory_service
-from src.core.portfolio_memory.models import DpmPortfolioMemory
+from src.core.portfolio_memory.models import DpmPortfolioMemory, DpmPortfolioMemorySearchPage
 from src.core.portfolio_memory.handoffs import (
     DpmPortfolioMemoryReportContext,
     build_portfolio_memory_report_context,
@@ -1658,6 +1658,58 @@ def test_portfolio_memory_search_indexes_manage_local_evidence_without_global_di
         if parameter["name"] == "event_type"
     )
     assert "Unsupported event types are rejected" in event_type_parameter["description"]
+
+
+def test_portfolio_memory_search_page_rejects_inconsistent_metadata() -> None:
+    proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
+    page = search_portfolio_memory(
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        portfolio_ids=[PORTFOLIO_ID],
+        event_type="WAVE_HANDOFF_READY",
+        source_system="lotus-manage",
+        generated_at=datetime(2026, 5, 22, 10, 30, tzinfo=timezone.utc),
+    )
+
+    inconsistent_returned = page.model_dump(mode="json")
+    inconsistent_returned["returned_count"] = page.returned_count + 1
+    with pytest.raises(ValidationError, match="returned_count must equal"):
+        DpmPortfolioMemorySearchPage.model_validate(inconsistent_returned)
+
+    inconsistent_has_more = page.model_dump(mode="json")
+    inconsistent_has_more["has_more"] = True
+    inconsistent_has_more["next_offset"] = page.offset + page.returned_count
+    with pytest.raises(ValidationError, match="has_more must match"):
+        DpmPortfolioMemorySearchPage.model_validate(inconsistent_has_more)
+
+    inconsistent_next_offset = page.model_dump(mode="json")
+    inconsistent_next_offset["total_count"] = page.returned_count + 1
+    inconsistent_next_offset["supportability_state_counts"] = {
+        page.items[0].supportability_state: page.returned_count + 1
+    }
+    inconsistent_next_offset["has_more"] = True
+    inconsistent_next_offset["next_offset"] = page.offset
+    with pytest.raises(ValidationError, match="next_offset must equal"):
+        DpmPortfolioMemorySearchPage.model_validate(inconsistent_next_offset)
+
+    inconsistent_supportability_counts = page.model_dump(mode="json")
+    inconsistent_supportability_counts["supportability_state_counts"] = {}
+    with pytest.raises(ValidationError, match="supportability_state_counts must sum"):
+        DpmPortfolioMemorySearchPage.model_validate(inconsistent_supportability_counts)
+
+    inconsistent_source_counts = page.model_dump(mode="json")
+    inconsistent_source_counts["source_system_counts"] = {}
+    with pytest.raises(ValidationError, match="source_system_counts must cover"):
+        DpmPortfolioMemorySearchPage.model_validate(inconsistent_source_counts)
+
+    inconsistent_item = page.model_dump(mode="json")
+    inconsistent_item["items"][0]["matching_event_count"] = (
+        inconsistent_item["items"][0]["event_count"] + 1
+    )
+    with pytest.raises(ValidationError, match="matching_event_count must not exceed"):
+        DpmPortfolioMemorySearchPage.model_validate(inconsistent_item)
 
 
 def test_portfolio_memory_search_normalizes_text_filters_before_matching() -> None:

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -2051,6 +2051,8 @@ Functional behavior:
 - returns one exact source-backed portfolio-memory event by portfolio id and event id, including
   the event identity, memory content hash, replay-stable lookup envelope hash, and explicit
   no-claim boundary for audit drilldown from a search hit,
+- validates portfolio-memory search-page returned-count, total-count, has-more, next-offset,
+  supportability-count, source-system-count, and matching-event-count posture against returned rows,
 - emits portfolio-memory view and search-page content hashes that exclude `generated_at`, so
   equivalent source-backed views remain replay-stable for audit reconciliation,
 - validates portfolio-memory aggregate event count, event-type counts, source-system coverage,


### PR DESCRIPTION
## Summary
- validate portfolio-memory search item and search page metadata at the domain model boundary
- enforce returned-count, has-more, next-offset, supportability-count, source-system-count, and matching-event-count consistency
- add regression coverage and update README/wiki endpoint certification wording

## Validation
- python -m pytest tests\\unit\\dpm\\api\\test_portfolio_memory_api.py tests\\unit\\dpm\\api\\test_proof_pack_api.py tests\\unit\\dpm\\api\\test_waves_api.py tests\\unit\\api\\test_outcome_reviews_api.py tests\\unit\\core\\test_outcome_handoffs.py tests\\unit\\dpm\\proof_packs\\test_proof_pack_handoffs.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- pwsh -NoProfile -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected pre-merge drift: Endpoint-Certification.md)
- git diff --check

## Ownership
- Manage-only backend/API governance hardening
- No lotus-gateway, lotus-workbench, or lotus-advise changes