### PR TITLE
Validate campaign operating page metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,10 @@ workflow task creation, assignment, synchronization, escalation, and completion 
 requires future `ExternalWorkflowOrchestrationRecord:v1` source ownership, lists the promotion
 requirements for certified source ownership, source-product contracts, lineage/freshness,
 consumer declaration, Gateway/Workbench realization, and external workflow audit/reconciliation
-evidence, and carries a deterministic content hash. Manage also supports append-only
+evidence, and carries a deterministic content hash. Campaign operating queue, approval inbox,
+workflow board, assignment plan, and workflow automation pages validate returned row count, page
+limit/offset, and posture/action count maps against the returned rows so audit summaries cannot
+drift from the page payload. Manage also supports append-only
 assignment and escalation actions at
 `POST /api/v1/rebalance/waves/campaign-definitions/{campaign_id}/versions/{campaign_version}/assignment-actions`
 plus listing them at the same route with `GET`, mutating assignment posture evidence only with

--- a/src/core/waves/campaign_approval_inbox.py
+++ b/src/core/waves/campaign_approval_inbox.py
@@ -5,7 +5,7 @@ import json
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.core.waves.campaign_definition_readiness import (
     DpmBulkReviewCampaignDefinitionPreviewReadiness,
@@ -19,6 +19,7 @@ from src.core.waves.campaign_discovery import (
 from src.core.waves.campaign_operating_boundaries import (
     CAMPAIGN_APPROVAL_INBOX_OPERATING_BOUNDARIES,
 )
+from src.core.waves.campaign_page_validation import validate_count_map, validate_page_count
 
 
 CampaignApprovalInboxStatus = Literal[
@@ -84,13 +85,23 @@ class DpmBulkReviewCampaignApprovalInboxPage(BaseModel):
     product_name: Literal["BulkReviewCampaignApprovalInbox"] = "BulkReviewCampaignApprovalInbox"
     product_version: Literal["v1"] = "v1"
     items: list[DpmBulkReviewCampaignApprovalInboxItem]
-    limit: int
-    offset: int
-    count: int
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    count: int = Field(ge=0)
     status_counts: dict[str, int] = Field(
         description="Inbox item counts by approval-attention posture for the returned page."
     )
     content_hash: str = Field(description="Canonical hash over the approval inbox page.")
+
+    @model_validator(mode="after")
+    def validate_page_metadata(self) -> DpmBulkReviewCampaignApprovalInboxPage:
+        validate_page_count(count=self.count, item_count=len(self.items))
+        validate_count_map(
+            counts=self.status_counts,
+            observed_values=(item.inbox_status for item in self.items),
+            field_name="status_counts",
+        )
+        return self
 
 
 def build_bulk_review_campaign_approval_inbox_item(

--- a/src/core/waves/campaign_assignment_plan.py
+++ b/src/core/waves/campaign_assignment_plan.py
@@ -5,7 +5,7 @@ import json
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.core.waves.campaign_definitions import DpmBulkReviewCampaignDefinition
 from src.core.waves.campaign_workflow_board import (
@@ -16,6 +16,7 @@ from src.core.waves.campaign_workflow_board import (
 from src.core.waves.campaign_operating_boundaries import (
     CAMPAIGN_ASSIGNMENT_PLAN_OPERATING_BOUNDARIES,
 )
+from src.core.waves.campaign_page_validation import validate_count_map, validate_page_count
 
 
 CampaignAssignmentEscalationTier = Literal["NONE", "PM", "OPS", "GOVERNANCE"]
@@ -71,9 +72,9 @@ class DpmBulkReviewCampaignAssignmentPlanPage(BaseModel):
     product_name: Literal["BulkReviewCampaignAssignmentPlan"] = "BulkReviewCampaignAssignmentPlan"
     product_version: Literal["v1"] = "v1"
     items: list[DpmBulkReviewCampaignAssignmentPlanItem]
-    limit: int
-    offset: int
-    count: int
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    count: int = Field(ge=0)
     escalation_tier_counts: dict[str, int] = Field(
         description="Assignment-plan row counts by escalation tier for the returned page."
     )
@@ -81,6 +82,21 @@ class DpmBulkReviewCampaignAssignmentPlanPage(BaseModel):
         description="Assignment-plan row counts by SLA posture for the returned page."
     )
     content_hash: str = Field(description="Canonical hash over the assignment-plan page.")
+
+    @model_validator(mode="after")
+    def validate_page_metadata(self) -> DpmBulkReviewCampaignAssignmentPlanPage:
+        validate_page_count(count=self.count, item_count=len(self.items))
+        validate_count_map(
+            counts=self.escalation_tier_counts,
+            observed_values=(item.escalation_tier for item in self.items),
+            field_name="escalation_tier_counts",
+        )
+        validate_count_map(
+            counts=self.sla_posture_counts,
+            observed_values=(item.sla_posture for item in self.items),
+            field_name="sla_posture_counts",
+        )
+        return self
 
 
 def build_bulk_review_campaign_assignment_plan_item(

--- a/src/core/waves/campaign_operating_queue.py
+++ b/src/core/waves/campaign_operating_queue.py
@@ -5,7 +5,7 @@ import json
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.core.waves.campaign_definition_events import (
     build_bulk_review_campaign_definition_lifecycle_events,
@@ -25,6 +25,7 @@ from src.core.waves.campaign_discovery import (
 from src.core.waves.campaign_operating_boundaries import (
     CAMPAIGN_OPERATING_QUEUE_BOUNDARIES,
 )
+from src.core.waves.campaign_page_validation import validate_count_map, validate_page_count
 
 
 class DpmBulkReviewCampaignOperatingQueueItem(BaseModel):
@@ -81,13 +82,23 @@ class DpmBulkReviewCampaignOperatingQueuePage(BaseModel):
     product_name: Literal["BulkReviewCampaignOperatingQueue"] = "BulkReviewCampaignOperatingQueue"
     product_version: Literal["v1"] = "v1"
     items: list[DpmBulkReviewCampaignOperatingQueueItem]
-    limit: int
-    offset: int
-    count: int
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    count: int = Field(ge=0)
     status_counts: dict[str, int] = Field(
         description="Queue item counts by operating posture for the returned page."
     )
     content_hash: str = Field(description="Canonical hash over the queue page payload.")
+
+    @model_validator(mode="after")
+    def validate_page_metadata(self) -> DpmBulkReviewCampaignOperatingQueuePage:
+        validate_page_count(count=self.count, item_count=len(self.items))
+        validate_count_map(
+            counts=self.status_counts,
+            observed_values=(item.queue_status for item in self.items),
+            field_name="status_counts",
+        )
+        return self
 
 
 def build_bulk_review_campaign_operating_queue_item(

--- a/src/core/waves/campaign_page_validation.py
+++ b/src/core/waves/campaign_page_validation.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def validate_page_count(*, count: int, item_count: int, field_name: str = "count") -> None:
+    """Validate that a page count reflects the returned rows."""
+
+    if count != item_count:
+        raise ValueError(f"{field_name} must equal the returned item count")
+
+
+def validate_count_map(
+    *,
+    counts: dict[str, int],
+    observed_values: Iterable[str],
+    field_name: str,
+) -> None:
+    """Validate that a page count map exactly summarizes the returned rows."""
+
+    expected: dict[str, int] = {}
+    for value in observed_values:
+        expected[value] = expected.get(value, 0) + 1
+    if any(count < 0 for count in counts.values()):
+        raise ValueError(f"{field_name} values must be non-negative")
+    if counts != expected:
+        raise ValueError(f"{field_name} must match the returned page items")

--- a/src/core/waves/campaign_workflow_automation.py
+++ b/src/core/waves/campaign_workflow_automation.py
@@ -4,7 +4,7 @@ import hashlib
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.core.common.canonical import hash_canonical_payload, strip_keys
 from src.core.waves.campaign_assignment_plan import (
@@ -21,6 +21,7 @@ from src.core.waves.campaign_definitions import (
 from src.core.waves.campaign_operating_boundaries import (
     CAMPAIGN_WORKFLOW_AUTOMATION_OPERATING_BOUNDARIES,
 )
+from src.core.waves.campaign_page_validation import validate_count_map, validate_page_count
 
 
 CampaignWorkflowAutomationStatus = Literal[
@@ -250,9 +251,9 @@ class DpmBulkReviewCampaignWorkflowAutomationPage(BaseModel):
     )
     product_version: Literal["v1"] = "v1"
     items: list[DpmBulkReviewCampaignWorkflowAutomationItem]
-    limit: int
-    offset: int
-    count: int
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    count: int = Field(ge=0)
     automation_status_counts: dict[str, int] = Field(
         description="Automation row counts by status for the returned page."
     )
@@ -268,6 +269,21 @@ class DpmBulkReviewCampaignWorkflowAutomationPage(BaseModel):
         ),
     )
     content_hash: str = Field(description="Canonical hash over the automation page.")
+
+    @model_validator(mode="after")
+    def validate_page_metadata(self) -> DpmBulkReviewCampaignWorkflowAutomationPage:
+        validate_page_count(count=self.count, item_count=len(self.items))
+        validate_count_map(
+            counts=self.automation_status_counts,
+            observed_values=(item.automation_status for item in self.items),
+            field_name="automation_status_counts",
+        )
+        validate_count_map(
+            counts=self.automation_action_counts,
+            observed_values=(item.automation_action for item in self.items),
+            field_name="automation_action_counts",
+        )
+        return self
 
 
 def build_bulk_review_campaign_workflow_automation_item(

--- a/src/core/waves/campaign_workflow_board.py
+++ b/src/core/waves/campaign_workflow_board.py
@@ -5,7 +5,7 @@ import json
 from datetime import date
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from src.core.waves.campaign_approval_inbox import (
     DpmBulkReviewCampaignApprovalInboxItem,
@@ -19,6 +19,7 @@ from src.core.waves.campaign_operating_queue import (
 from src.core.waves.campaign_operating_boundaries import (
     CAMPAIGN_WORKFLOW_BOARD_OPERATING_BOUNDARIES,
 )
+from src.core.waves.campaign_page_validation import validate_count_map, validate_page_count
 
 
 CampaignWorkflowBoardStatus = Literal[
@@ -87,9 +88,9 @@ class DpmBulkReviewCampaignWorkflowBoardPage(BaseModel):
     product_name: Literal["BulkReviewCampaignWorkflowBoard"] = "BulkReviewCampaignWorkflowBoard"
     product_version: Literal["v1"] = "v1"
     items: list[DpmBulkReviewCampaignWorkflowBoardItem]
-    limit: int
-    offset: int
-    count: int
+    limit: int = Field(ge=1)
+    offset: int = Field(ge=0)
+    count: int = Field(ge=0)
     status_counts: dict[str, int] = Field(
         description="Workflow-board row counts by board status for the returned page."
     )
@@ -97,6 +98,21 @@ class DpmBulkReviewCampaignWorkflowBoardPage(BaseModel):
         description="Workflow-board row counts by derived next action for the returned page."
     )
     content_hash: str = Field(description="Canonical hash over the workflow-board page.")
+
+    @model_validator(mode="after")
+    def validate_page_metadata(self) -> DpmBulkReviewCampaignWorkflowBoardPage:
+        validate_page_count(count=self.count, item_count=len(self.items))
+        validate_count_map(
+            counts=self.status_counts,
+            observed_values=(item.board_status for item in self.items),
+            field_name="status_counts",
+        )
+        validate_count_map(
+            counts=self.next_action_counts,
+            observed_values=(item.next_action for item in self.items),
+            field_name="next_action_counts",
+        )
+        return self
 
 
 def build_bulk_review_campaign_workflow_board_item(

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 
 import pytest
+from pydantic import BaseModel, ValidationError
 
 from src.core.waves import DpmWaveSourceRef
 from src.core.common.canonical import hash_canonical_payload, strip_keys
@@ -20,22 +21,27 @@ from src.core.waves.campaign_definition_workflow_overview import (
     build_bulk_review_campaign_definition_workflow_overview,
 )
 from src.core.waves.campaign_operating_queue import (
+    DpmBulkReviewCampaignOperatingQueuePage,
     build_bulk_review_campaign_operating_queue_item,
     build_bulk_review_campaign_operating_queue_page,
 )
 from src.core.waves.campaign_approval_inbox import (
+    DpmBulkReviewCampaignApprovalInboxPage,
     build_bulk_review_campaign_approval_inbox_item,
     build_bulk_review_campaign_approval_inbox_page,
 )
 from src.core.waves.campaign_workflow_board import (
+    DpmBulkReviewCampaignWorkflowBoardPage,
     build_bulk_review_campaign_workflow_board_item,
     build_bulk_review_campaign_workflow_board_page,
 )
 from src.core.waves.campaign_assignment_plan import (
+    DpmBulkReviewCampaignAssignmentPlanPage,
     build_bulk_review_campaign_assignment_plan_item,
     build_bulk_review_campaign_assignment_plan_page,
 )
 from src.core.waves.campaign_workflow_automation import (
+    DpmBulkReviewCampaignWorkflowAutomationPage,
     build_bulk_review_campaign_workflow_automation_item,
     build_bulk_review_campaign_workflow_automation_page,
 )
@@ -948,6 +954,119 @@ def test_campaign_workflow_automation_filters_actions_and_closed_rows() -> None:
     assert closed_item.proposed_task_ref is None
     assert filtered.count == 1
     assert filtered.items[0].campaign_id == "campaign-holdings-retired-automation-20260510"
+
+
+def test_campaign_operating_pages_reject_inconsistent_summary_metadata() -> None:
+    definition = _definition()
+    active_on = date(2026, 5, 10)
+
+    operating_queue = build_bulk_review_campaign_operating_queue_page(
+        definitions=[definition],
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=active_on,
+        include_expired=False,
+        limit=50,
+        offset=0,
+    )
+    approval_inbox = build_bulk_review_campaign_approval_inbox_page(
+        definitions=[definition],
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=active_on,
+        include_closed=False,
+        inbox_status=None,
+        limit=50,
+        offset=0,
+    )
+    workflow_board = build_bulk_review_campaign_workflow_board_page(
+        definitions=[definition],
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=active_on,
+        include_closed=False,
+        board_status=None,
+        next_action=None,
+        limit=50,
+        offset=0,
+    )
+    assignment_plan = build_bulk_review_campaign_assignment_plan_page(
+        definitions=[definition],
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=active_on,
+        include_closed=False,
+        escalation_tier=None,
+        next_action=None,
+        limit=50,
+        offset=0,
+    )
+    automation = build_bulk_review_campaign_workflow_automation_page(
+        definitions=[definition],
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=active_on,
+        include_closed=False,
+        automation_status=None,
+        automation_action=None,
+        limit=50,
+        offset=0,
+    )
+
+    _assert_page_rejects(
+        DpmBulkReviewCampaignOperatingQueuePage,
+        operating_queue.model_dump(mode="json"),
+        "count",
+        2,
+        "count must equal the returned item count",
+    )
+    _assert_page_rejects(
+        DpmBulkReviewCampaignOperatingQueuePage,
+        operating_queue.model_dump(mode="json"),
+        "status_counts",
+        {"ATTENTION_REQUIRED": 1},
+        "status_counts must match the returned page items",
+    )
+    _assert_page_rejects(
+        DpmBulkReviewCampaignApprovalInboxPage,
+        approval_inbox.model_dump(mode="json"),
+        "status_counts",
+        {"APPROVAL_COMPLETE": -1},
+        "status_counts values must be non-negative",
+    )
+    _assert_page_rejects(
+        DpmBulkReviewCampaignWorkflowBoardPage,
+        workflow_board.model_dump(mode="json"),
+        "next_action_counts",
+        {"RECORD_APPROVAL_DECISION": 1},
+        "next_action_counts must match the returned page items",
+    )
+    _assert_page_rejects(
+        DpmBulkReviewCampaignAssignmentPlanPage,
+        assignment_plan.model_dump(mode="json"),
+        "sla_posture_counts",
+        {"ATTENTION": 1},
+        "sla_posture_counts must match the returned page items",
+    )
+    _assert_page_rejects(
+        DpmBulkReviewCampaignWorkflowAutomationPage,
+        automation.model_dump(mode="json"),
+        "automation_action_counts",
+        {"NO_AUTOMATION_BLOCKED": 1},
+        "automation_action_counts must match the returned page items",
+    )
+
+
+def _assert_page_rejects(
+    page_model: type[BaseModel],
+    payload: dict[str, object],
+    field_name: str,
+    invalid_value: object,
+    match: str,
+) -> None:
+    invalid_payload = {**payload, field_name: invalid_value}
+    with pytest.raises(ValidationError, match=match):
+        page_model.model_validate(invalid_payload)
 
 
 @pytest.mark.parametrize(

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -1748,6 +1748,9 @@ Functional coverage:
   approval-required, approval-incomplete, expiry-attention, entitlement-attention, and closed rows
   by composing governance evidence and preview-readiness posture without mutating approval state or
   adding maker-checker, trade-approval, order, or OMS claims,
+- campaign operating queue, approval inbox, workflow board, assignment plan, and workflow
+  automation pages validate returned row count, page limit/offset, and posture/action count maps
+  against the returned rows so audit summaries cannot drift from the page payload,
 - truthful `SOURCE_BLOCKED` item state when affected-portfolio evidence is missing,
 - preview, create, and workflow mutation responses include a manage-owned product-safe
   `supportability` envelope derived from current item states, so Gateway and Workbench can


### PR DESCRIPTION
## Summary
- add shared campaign page metadata validators for returned row counts and posture/action count maps
- enforce non-negative count fields and limit/offset bounds on campaign operating queue, approval inbox, workflow board, assignment plan, and workflow automation pages
- add regression coverage and update README/wiki endpoint-certification truth

## Validation
- python -m pytest tests\\unit\\dpm\\waves\\test_campaign_discovery.py tests\\unit\\dpm\\api\\test_waves_api.py -q
- make lint
- make typecheck
- make openapi-gate
- make api-vocabulary-gate
- make no-alias-gate
- make test-unit
- make test-integration
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- pwsh -NoProfile -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (expected pre-merge drift: Endpoint-Certification.md source changed)

## Stranded truth
- git fetch origin --prune
- git branch -r --no-merged origin/main: none before branch push
- gh pr list --state open --json number,headRefName,title,url,statusCheckRollup --limit 100: [] before this PR

## Boundary
- Manage-owned backend/domain hardening only
- no Gateway, Workbench, or Advise changes
- no OMS, trade approval, client contact, or external workflow orchestration claims