### PR TITLE
docs: align WTBD control snapshot counts

### DIFF
--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -144,9 +144,9 @@ methodology, performance benchmark analytics, or unsupported ESG approval.
 | Control | Count | Meaning |
 | --- | ---: | --- |
 | Total WTBD items | 59 | RFC-0036 through RFC-0042 follow-up items tracked in this ledger. |
-| Done on merged/published Lotus-owned truth | 47 | Implementation-backed Lotus-owned items merged to owning `main` branches, validated, and published where wiki truth changed; external bank-system promotion dependencies remain explicit non-claims. |
-| Partial / in progress | 6 | Items with meaningful implementation-backed progress but remaining Lotus-owned source, Manage, downstream, methodology, or product-surface gaps. |
-| Remaining / open | 6 | Items still deferred, proposed, conditional, unsupported, or awaiting ownership. |
+| Done on merged/published Lotus-owned truth | 48 | Implementation-backed Lotus-owned items merged to owning `main` branches, validated, and published where wiki truth changed; external bank-system promotion dependencies remain explicit non-claims. |
+| Partial / in progress | 7 | Items with meaningful implementation-backed progress but remaining Lotus-owned source, Manage, downstream, methodology, or product-surface gaps. |
+| Remaining / open | 4 | Items still deferred, proposed, conditional, unsupported, or awaiting ownership. |
 
 Recently closed in this snapshot:
 

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -1519,9 +1519,9 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     assert "`e03be66c58e881024938eb5a63f4fb373e914c00`" in work_to_be_done
     assert "`lotus-performance` PR #168 (`781415f`, wiki `6fb7209`)" in (work_to_be_done)
     assert "| Total WTBD items | 59 |" in work_to_be_done
-    assert "| Done on merged/published Lotus-owned truth | 47 |" in work_to_be_done
-    assert "| Partial / in progress | 6 |" in work_to_be_done
-    assert "| Remaining / open | 6 |" in work_to_be_done
+    assert "| Done on merged/published Lotus-owned truth | 48 |" in work_to_be_done
+    assert "| Partial / in progress | 7 |" in work_to_be_done
+    assert "| Remaining / open | 4 |" in work_to_be_done
     assert "RFC36-WTBD-006 is now closed as a no-migration-required" in work_to_be_done
     assert "`lotus-platform` PR #316" in work_to_be_done
     assert "RFC38-WTBD-004 - PM-Book Discovery" in work_to_be_done


### PR DESCRIPTION
## Summary
- align the RFC WTBD control snapshot with the row-level current-state count truth
- update the pinned documentation-current-state test assertions from 47/6/6 to 48/7/4
- no WTBD status changes, source-owner claims, API changes, or wiki source changes

## Validation
- `python -m ruff check docs\rfcs\RFC-worktobedone.md tests\unit\test_documentation_current_state.py`
- `python -m ruff format --check tests\unit\test_documentation_current_state.py`
- `python -m pytest tests\unit\test_documentation_current_state.py -q`