### PR TITLE
fix: accept market-scoped FX forward curve source

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ fail-closed `UNAVAILABLE` route. `lotus-core` PR #371 (`9774bc40`, wiki publishe
 `ExternalOrderExecutionAcknowledgement:v1` as an active fail-closed `UNAVAILABLE` route for external
 OMS acknowledgement posture. `lotus-platform` PR #333 (`c46d581`), PR #334 (`ae4f707`), and
 PR #335 (`72be854`) mirror the first active treasury source-product postures. Manage now consumes
-the readiness, currency-exposure, hedge-policy, eligible-hedge-instrument, and FX forward-curve
-postures through stateful core sourcing and preserves them in currency-overlay construction
+the readiness, currency-exposure, hedge-policy, eligible-hedge-instrument, and market-data-scoped
+FX forward-curve postures through stateful core sourcing and preserves them in currency-overlay construction
 diagnostics as blocked external treasury evidence, including empty exposure/policy/
 eligible-instrument/forward-curve rows, exposure/policy-rule/eligible-instrument/curve-point
 counts, missing data families, blocked capabilities, lineage, and source hashes. Manage also

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -128,7 +128,8 @@ Current repository posture:
     `lotus-platform` PR #333 (`c46d581`), PR #334 (`ae4f707`), and PR #335 (`72be854`) mirror the
     first active source-product postures. Manage now consumes the readiness, currency-exposure,
     hedge-policy, eligible-hedge-instrument, and FX forward-curve routes through stateful core
-    sourcing, preserves empty exposure/policy/eligible-instrument/forward-curve rows, exposure
+    sourcing, accepts the market-data-scoped `ExternalFXForwardCurve:v1` payload shape returned by
+    core, preserves empty exposure/policy/eligible-instrument/forward-curve rows, exposure
     count, policy-rule count, eligible-instrument count, curve-point count, missing external
     treasury data families, blocked capabilities, lineage, and source hashes in currency-overlay
     construction diagnostics, and blocks hedge realization while continuing to avoid FX

--- a/src/core/dpm_source_context.py
+++ b/src/core/dpm_source_context.py
@@ -1157,12 +1157,31 @@ class DpmCoreExternalFXForwardCurveResponse(BaseModel):
         description="Core source-data product name."
     )
     product_version: Literal["v1"] = Field(description="Core source-data product version.")
-    portfolio_id: str = Field(description="Core-governed portfolio identifier.")
-    client_id: str = Field(description="Core-governed client identifier.")
+    portfolio_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional core-governed portfolio identifier. The ExternalFXForwardCurve source "
+            "product is market-data scoped and may be returned without a portfolio identifier."
+        ),
+    )
+    client_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional core-governed client identifier. The ExternalFXForwardCurve source "
+            "product is market-data scoped and may be returned without a client identifier."
+        ),
+    )
     mandate_id: Optional[str] = Field(default=None, description="Optional mandate identifier.")
     as_of_date: date = Field(description="Business date used to resolve FX forward-curve posture.")
     reporting_currency: Optional[str] = Field(default=None)
-    exposure_currencies: list[str] = Field(default_factory=list)
+    exposure_currencies: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("exposure_currencies", "currency_pairs"),
+        description=(
+            "Exposure currencies or source-owned currency-pair selectors returned by core. "
+            "Manage treats these as source evidence only and never as forward-pricing authority."
+        ),
+    )
     curve_points: list[dict[str, str]] = Field(
         default_factory=list,
         description=(

--- a/tests/unit/dpm/infrastructure/test_core_sourcing_client.py
+++ b/tests/unit/dpm/infrastructure/test_core_sourcing_client.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 import httpx
 import pytest
 
-from src.core.dpm_source_context import DpmStatefulInput
+from src.core.dpm_source_context import DpmCoreExternalFXForwardCurveResponse, DpmStatefulInput
 from src.infrastructure.core_sourcing import (
     DpmCoreResolverClient,
     DpmCoreResolverConfig,
@@ -1850,6 +1850,21 @@ def test_core_resolver_fetches_external_fx_forward_curve_from_dedicated_route():
     assert response.supportability.reason == "EXTERNAL_TREASURY_SOURCE_NOT_INGESTED"
     assert response.supportability.curve_point_count == 0
     assert response.curve_points == []
+    assert "forward_pricing" in response.supportability.blocked_capabilities
+
+
+def test_core_resolver_accepts_market_scoped_external_fx_forward_curve_payload():
+    payload = _external_fx_forward_curve_payload()
+    payload.pop("portfolio_id")
+    payload.pop("client_id")
+    payload["currency_pairs"] = payload.pop("exposure_currencies")
+
+    response = DpmCoreExternalFXForwardCurveResponse.model_validate(payload)
+
+    assert response.portfolio_id is None
+    assert response.client_id is None
+    assert response.exposure_currencies == ["USD"]
+    assert response.supportability.state == "UNAVAILABLE"
     assert "forward_pricing" in response.supportability.blocked_capabilities
 
 

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -44,9 +44,9 @@ storage-layer constraint.
   breaches. Currency-overlay alternatives preserve fail-closed `lotus-core`
   `ExternalHedgeExecutionReadiness:v1`, `ExternalCurrencyExposure:v1`,
   `ExternalHedgePolicy:v1`, `ExternalEligibleHedgeInstrument:v1`, and
-  `ExternalFXForwardCurve:v1` posture as blocked external treasury evidence without claiming
-  eligible-instrument selection, suitability approval, product recommendation, forward pricing,
-  hedge advice, execution, OMS, fills, or settlement. Construction authority diagnostics also
+  market-data-scoped `ExternalFXForwardCurve:v1` posture as blocked external treasury evidence
+  without claiming eligible-instrument selection, suitability approval, product recommendation,
+  forward pricing, hedge advice, execution, OMS, fills, or settlement. Construction authority diagnostics also
   preserve fail-closed `lotus-core` `ExternalOrderExecutionAcknowledgement:v1` posture as
   execution-boundary evidence without claiming order generation, venue routing, best execution,
   OMS acknowledgement ingestion, fills, settlement, execution-status certification, or autonomous


### PR DESCRIPTION
## Summary
- Accept Core's current market-data-scoped `ExternalFXForwardCurve:v1` payload in Manage stateful sourcing.
- Preserve fail-closed forward-curve evidence without requiring portfolio/client identifiers on the market-data source product.
- Update Manage README, repository context, and wiki API surface for the source-contract boundary.

## Evidence
- `python -m pytest tests\unit\dpm\infrastructure\test_core_sourcing_client.py -q` -> 37 passed
- `python -m pytest tests\unit\dpm\infrastructure\test_core_sourcing_client.py tests\unit\test_documentation_current_state.py -q` -> 59 passed
- `python -m ruff check src\core\dpm_source_context.py tests\unit\dpm\infrastructure\test_core_sourcing_client.py` -> passed
- Live stateful `/api/v1/rebalance/simulate` for `PB_SG_GLOBAL_BAL_001` on 2026-04-10 returned `PENDING_REVIEW`, `input_mode=stateful`, `source_system=lotus-core`, `source_supportability_state=READY`
- Live `/api/v1/rebalance/supportability/summary` returned `state=ready`, `freshness_bucket=current`

## Wiki
- Repo-authored wiki source changed: `wiki/API-Surface.md`.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reports expected drift for `API-Surface.md` until this PR is merged and published.