### PR TITLE
Harden benchmark assignment source consumption

### DIFF
--- a/contracts/domain-data-products/README.md
+++ b/contracts/domain-data-products/README.md
@@ -86,5 +86,8 @@ Current watchlist:
    declares only the bounded `MarketDataCoverageWindow:v1` supportability product and must not
    treat it as raw market-data or valuation-methodology ownership.
 3. `BenchmarkAssignment:v1` is approved for bounded `lotus-manage` benchmark-identity lineage
-   consumption only. Keep benchmark composition, active-risk, performance attribution, benchmark
-   analytics, and model-approval methodology in their owning source services.
+   consumption only. Manage preserves only active assignments; missing, unavailable, incomplete, or
+   non-active assignments remain explicit degraded source posture through
+   `BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED`. Keep benchmark composition, active-risk, performance
+   attribution, benchmark analytics, and model-approval methodology in their owning source
+   services.

--- a/docs/rfcs/RFC-0038-source-data-field-map.md
+++ b/docs/rfcs/RFC-0038-source-data-field-map.md
@@ -24,7 +24,7 @@ classified as source-backed, derived, local policy, or a known gap.
 | `time_horizon` | `DiscretionaryMandateBinding:v1.investment_horizon` | Source-backed and normalized to uppercase. | None. |
 | `model_portfolio_id` | `DiscretionaryMandateBinding:v1.model_portfolio_id` | Source-backed. | None. |
 | `model_portfolio_version` | `DpmModelPortfolioTarget:v1.model_portfolio_version` | Source-backed. | None. |
-| `benchmark_id` | `BenchmarkAssignment:v1.benchmark_id` when available | Source-backed from core benchmark assignment; nullable only when the optional source product is unavailable. | Performance benchmark analytics remain future enrichment. |
+| `benchmark_id` | `BenchmarkAssignment:v1.benchmark_id` when the source assignment is active | Source-backed from core benchmark assignment; nullable when the optional source product is unavailable, incomplete, missing, or non-active. | Performance benchmark analytics remain future enrichment. |
 | `constraints.cash_band_min_weight` | `DiscretionaryMandateBinding:v1.rebalance_bands.cash_reserve_weight` | Source-backed. | None for MVP. |
 | `constraints.cash_band_max_weight` | Derived from cash reserve with conservative default | Local policy fallback set to at least `0.10`. | Needs explicit mandate cash-band source. |
 | `constraints.turnover_budget` | Not yet available | Local policy fallback `0.15`. | Policy-pack or mandate restriction source should own this. |

--- a/docs/rfcs/RFC-worktobedone.md
+++ b/docs/rfcs/RFC-worktobedone.md
@@ -1111,6 +1111,17 @@ Expected implementation wave:
 Add source depth as demanded by child RFCs and product-realization slices. Do not bundle unrelated
 source families into one large manage change.
 
+2026-05-24 bounded Manage consumer-hardening result:
+
+`lotus-manage` now preserves `BenchmarkAssignment:v1` only when the source-owned assignment is
+active. Missing, unavailable, incomplete, degraded, or non-active benchmark assignment evidence
+leaves `DpmMandateDigitalTwin.benchmark_id` unset, emits
+`BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED`, and degrades mandate-health source readiness instead of
+promoting stale benchmark identity. This advances RFC37-WTBD-004 consumer posture without closing
+the broader source-product-depth row and without claiming benchmark composition, active-risk,
+performance attribution, benchmark analytics, model approval, OMS, order routing, fills, settlement,
+or execution support.
+
 Promotion proof:
 
 1. owner API certification,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -31,7 +31,10 @@ from src.infrastructure.core_sourcing import (
     DpmCoreResolverError,
     DpmCoreResolverUnavailableError,
 )
-from src.core.dpm_source_context import DpmCorePortfolioManagerBookMembershipResponse
+from src.core.dpm_source_context import (
+    DpmCoreBenchmarkAssignmentResponse,
+    DpmCorePortfolioManagerBookMembershipResponse,
+)
 
 
 class DpmMandateNotFoundError(LookupError):
@@ -267,6 +270,10 @@ def refresh_mandate_from_core(
         unavailable_family=unavailable_benchmark_assignment,
         family_name="BENCHMARK_ASSIGNMENT",
     )
+    benchmark_assignment, unavailable_benchmark_assignment = _ready_benchmark_assignment_source(
+        source=benchmark_assignment,
+        unavailable_family=unavailable_benchmark_assignment,
+    )
     unavailable_source_families = [
         family
         for family in (
@@ -355,6 +362,18 @@ def _ready_optional_source(
         "ACCEPTED",
     }:
         return None, family_name
+    return source, unavailable_family
+
+
+def _ready_benchmark_assignment_source(
+    *,
+    source: DpmCoreBenchmarkAssignmentResponse | None,
+    unavailable_family: str | None,
+) -> tuple[DpmCoreBenchmarkAssignmentResponse | None, str | None]:
+    if source is None:
+        return None, unavailable_family
+    if source.assignment_status.upper() != "ACTIVE":
+        return None, "BENCHMARK_ASSIGNMENT"
     return source, unavailable_family
 
 

--- a/src/core/mandates.py
+++ b/src/core/mandates.py
@@ -609,6 +609,8 @@ def compile_mandate_digital_twin_from_core(
         field_gaps.append("SUSTAINABILITY_PREFERENCE_PROFILE_NOT_YET_SOURCED")
     if portfolio_cashflow_projection is None:
         field_gaps.append("PORTFOLIO_CASHFLOW_PROJECTION_NOT_YET_SOURCED")
+    if benchmark_assignment is None:
+        field_gaps.append("BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED")
     cash_reserve_weight = mandate.rebalance_bands.cash_reserve_weight or Decimal("0")
     constraints = DpmMandateConstraintSet(
         cash_band_min_weight=cash_reserve_weight,

--- a/tests/unit/dpm/api/test_mandates_api.py
+++ b/tests/unit/dpm/api/test_mandates_api.py
@@ -40,11 +40,13 @@ class FakeCoreResolver:
         incomplete: bool = False,
         optional_unavailable: bool = False,
         optional_incomplete: bool = False,
+        benchmark_inactive: bool = False,
     ) -> None:
         self.unavailable = unavailable
         self.incomplete = incomplete
         self.optional_unavailable = optional_unavailable
         self.optional_incomplete = optional_incomplete
+        self.benchmark_inactive = benchmark_inactive
         self.calls: list[tuple[str, dict[str, Any]]] = []
 
     def resolve_mandate_binding(self, **kwargs: Any) -> DpmCoreMandateBindingResponse:
@@ -110,6 +112,10 @@ class FakeCoreResolver:
         self.calls.append(("benchmark_assignment", kwargs))
         if self.optional_unavailable:
             raise DpmCoreResolverUnavailableError("DPM_CORE_BENCHMARK_ASSIGNMENT_UNAVAILABLE")
+        if self.benchmark_inactive:
+            return DpmCoreBenchmarkAssignmentResponse.model_validate(
+                _benchmark_assignment_payload(assignment_status="retired")
+            )
         return DpmCoreBenchmarkAssignmentResponse.model_validate(_benchmark_assignment_payload())
 
 
@@ -155,8 +161,8 @@ def _mandate_binding_payload(*, binding_version: int = 3) -> dict[str, Any]:
     }
 
 
-def _benchmark_assignment_payload() -> dict[str, Any]:
-    return {
+def _benchmark_assignment_payload(**overrides: Any) -> dict[str, Any]:
+    payload = {
         "product_name": "BenchmarkAssignment",
         "product_version": "v1",
         "portfolio_id": PORTFOLIO_ID,
@@ -173,6 +179,8 @@ def _benchmark_assignment_payload() -> dict[str, Any]:
         "data_quality_status": "COMPLETE",
         "latest_evidence_timestamp": "2026-05-03T01:00:00Z",
     }
+    payload.update(overrides)
+    return payload
 
 
 def _model_targets_payload() -> dict[str, Any]:
@@ -452,6 +460,28 @@ def test_refresh_from_core_degrades_optional_profile_gaps_without_fabricating_he
         reason["reason_code"] == "DPM_SOURCE_STALE"
         for reason in body["health_snapshot"]["top_reasons"]
     )
+
+
+def test_refresh_from_core_rejects_inactive_benchmark_assignment_without_local_methodology() -> (
+    None
+):
+    repository = InMemoryDpmMandateRepository()
+    resolver = FakeCoreResolver(benchmark_inactive=True)
+
+    with _client(repository, resolver) as client:
+        response = client.post(
+            f"/api/v1/mandates/{MANDATE_ID}/refresh-from-core",
+            json={"portfolio_id": PORTFOLIO_ID, "as_of_date": "2026-05-03"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["mandate"]["benchmark_id"] is None
+    assert "BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED" in body["field_gap_codes"]
+    assert body["health_snapshot"]["source_readiness_state"] == "DEGRADED"
+    assert "BenchmarkAssignment" not in {
+        lineage["product_name"] for lineage in body["mandate"]["source_lineage"]
+    }
 
 
 def test_refresh_from_core_preserves_gap_when_optional_profile_is_incomplete() -> None:

--- a/tests/unit/dpm/core/test_mandate_health.py
+++ b/tests/unit/dpm/core/test_mandate_health.py
@@ -504,6 +504,7 @@ def test_compile_mandate_twin_preserves_explicit_gap_codes_for_missing_profile_f
     assert twin.review_policy.review_frequency == "QUARTERLY"
     assert "MANDATE_OBJECTIVE_PROFILE_NOT_YET_SOURCED" in twin.field_gap_codes
     assert "MANDATE_REVIEW_SCHEDULE_NOT_YET_SOURCED" in twin.field_gap_codes
+    assert "BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED" in twin.field_gap_codes
 
 
 def test_compile_mandate_twin_preserves_client_profile_cashflow_and_sustainability_lineage() -> (

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -443,6 +443,10 @@ RFC36-WTBD-005 is now done for the current Lotus-owned source-depth wave because
 PR #378 approves bounded `lotus-manage` consumption of `BenchmarkAssignment:v1`, `lotus-platform`
 PR #342 mirrors the approval into catalog truth, and Manage declares the dependency for
 mandate-health benchmark identity lineage without claiming benchmark analytics or execution.
+Manage now preserves only active `BenchmarkAssignment:v1` source assignments; unavailable,
+incomplete, degraded, missing, or non-active assignments leave benchmark identity unset, emit
+`BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED`, and degrade mandate-health source readiness without local
+benchmark methodology or stale benchmark promotion.
 Broader strategic source-product depth remains RFC37-WTBD-004. `lotus-performance` PR #168 and
 PR #170 now support the closed RFC42-WTBD-006 Lotus-owned source-methodology supportability claim:
 they add source-owned MWR source-preconverted FX evidence and single-currency no-conversion posture


### PR DESCRIPTION
## Summary
- harden mandate refresh so `BenchmarkAssignment:v1` is preserved only when the Core source assignment is active
- emit `BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED` and degrade mandate-health source readiness for missing, unavailable, incomplete, degraded, or non-active benchmark assignment evidence
- update RFC, field-map, domain-product README, and wiki source without closing RFC37-WTBD-004 or claiming benchmark analytics/execution support

## Validation
- `python -m pytest tests/unit/dpm/core/test_mandate_health.py tests/unit/dpm/api/test_mandates_api.py -q` -> 50 passed
- `python -m pytest tests/unit/test_domain_data_product_contracts.py tests/unit/test_documentation_current_state.py -q` -> 29 passed
- `python -m pytest tests/unit/dpm/core/test_mandate_health.py tests/unit/dpm/api/test_mandates_api.py tests/unit/test_domain_data_product_contracts.py tests/unit/test_documentation_current_state.py -q` -> 79 passed
- `make lint` -> passed
- `make typecheck` -> passed
- `make no-alias-gate` -> passed
- `make domain-product-validate` -> passed
- `make test-unit` -> 1488 passed, 4 warnings
- `make test-integration` -> 168 passed
- `make test-e2e` -> 28 passed
- `make openapi-gate` -> passed
- `make api-vocabulary-gate` -> passed, no drift
- `python ../lotus-platform/automation/validate_engineering_context_system.py` -> passed
- `python ../lotus-platform/automation/validate_lotus_skill_alignment.py` -> passed
- `git diff --check` -> passed

## Governance
- Phase 0: clean mainline baseline, no open PRs, no unmerged remote branches before implementation
- Stranded truth: reran `git fetch origin --prune` and `git branch -r --no-merged origin/main`; no unmerged durable-truth branches
- Wiki: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reports expected drift on `Supported-Features.md` until this PR merges and wiki publication runs
- Tiering: Domain API docs/source-consumer hardening; local Feature Lane and PR Merge Gate equivalents are green. GitHub Feature Lane and PR Merge Gate are required before merge.