### PR TITLE
Extract construction source product contexts

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -6703,3 +6703,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   requirements, and planned withdrawals.
 - Wiki decision: no wiki source change required; this is internal source-product context
   modularity cleanup with no route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-263: Client income-needs source context extraction
+
+- Date: 2026-06-01
+- Scope:
+  `src/api/services/construction_source_product_context.py`,
+  `src/api/services/construction_service.py`, and
+  `tests/unit/dpm/construction/test_source_product_context.py`.
+- Finding: lotus-core `ClientIncomeNeedsSchedule:v1` mapping into Manage's liquidity context
+  still lived inside construction orchestration. The mapping preserves client income-needs lineage,
+  schedule count, represented currencies, priority posture, and supportability state for
+  liquidity-aware construction without turning Manage into a financial-planning source owner.
+- Action: extracted client income-needs mapping into
+  `client_income_needs_schedule_context`. Added direct tests that preserve source lineage,
+  currency aggregation, highest-priority selection, incomplete-source fail-closed posture, and
+  reason-code evidence.
+- Status: hardened
+- Evidence: focused source-product context, construction enrichment, and construction API
+  regressions (`tests/unit/dpm/construction/test_source_product_context.py`,
+  `tests/unit/dpm/construction/test_enrichment.py`, and
+  `tests/unit/dpm/api/test_construction_api.py`) passed with 58 tests, focused Ruff checks, and
+  focused mypy over source-product context and construction service passed.
+- Follow-up: extract remaining liquidity source products for reserve requirements and planned
+  withdrawals.
+- Wiki decision: no wiki source change required; this is internal source-product context
+  modularity cleanup with no route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -6677,3 +6677,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   restriction, and sustainability source products.
 - Wiki decision: no wiki source change required; this is internal source-product context
   modularity cleanup with no route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-262: Liquidity cashflow source context extraction
+
+- Date: 2026-06-01
+- Scope:
+  `src/api/services/construction_source_product_context.py`,
+  `src/api/services/construction_service.py`, and
+  `tests/unit/dpm/construction/test_source_product_context.py`.
+- Finding: lotus-core `PortfolioCashflowProjection:v1` mapping into Manage's liquidity context
+  still lived inside construction orchestration. The mapping preserves source lineage, projection
+  window, projected-cashflow inclusion, currency, amount, and data-quality posture for
+  liquidity-aware construction alternatives.
+- Action: extracted cashflow projection mapping into
+  `liquidity_cashflow_projection_context`. Added direct tests that preserve source lineage,
+  degraded data-quality posture, money currency/amount, projected inclusion, and reason-code
+  evidence.
+- Status: hardened
+- Evidence: focused source-product context, construction enrichment, and construction API
+  regressions (`tests/unit/dpm/construction/test_source_product_context.py`,
+  `tests/unit/dpm/construction/test_enrichment.py`, and
+  `tests/unit/dpm/api/test_construction_api.py`) passed with 57 tests, focused Ruff checks, and
+  focused mypy over source-product context and construction service passed.
+- Follow-up: extract remaining liquidity source products for client income needs, reserve
+  requirements, and planned withdrawals.
+- Wiki decision: no wiki source change required; this is internal source-product context
+  modularity cleanup with no route, payload, supported-feature, or operator-contract change.

--- a/src/api/services/construction_service.py
+++ b/src/api/services/construction_service.py
@@ -36,6 +36,7 @@ from src.api.services.construction_solver_supportability import (
 )
 from src.api.services.construction_source_analytics_posture import source_analytics_posture
 from src.api.services.construction_source_product_context import (
+    client_income_needs_schedule_context,
     external_order_execution_acknowledgement_context,
     external_treasury_currency_overlay_context,
     liquidity_cashflow_projection_context,
@@ -71,7 +72,6 @@ from src.core.construction.alternative_engine import (
 from src.core.construction.enrichment import summarize_enrichment_posture
 from src.core.construction.method_registry import resolve_method_plan
 from src.core.construction.models import (
-    AuthoritativeClientIncomeNeedsSchedule,
     AuthoritativeClientRestrictionContext,
     AuthoritativeClientRestrictionRule,
     AuthoritativeCurrencyOverlayContext,
@@ -523,28 +523,7 @@ def _authority_context_with_source_products(
         if cashflow_projection is not None:
             cashflow_context = liquidity_cashflow_projection_context(cashflow_projection)
         if income_needs is not None:
-            payload = income_needs.model_dump(mode="json", exclude_none=True)
-            source_hash = hash_canonical_payload(payload)
-            income_context = AuthoritativeClientIncomeNeedsSchedule(
-                source_product_name=income_needs.product_name,
-                source_product_version=income_needs.product_version,
-                source_system="lotus-core",
-                source_id=income_needs.source_batch_fingerprint
-                or income_needs.lineage.get("source_batch_fingerprint")
-                or source_hash,
-                content_hash=source_hash,
-                schedule_count=income_needs.supportability.schedule_count,
-                currencies=sorted({entry.currency for entry in income_needs.schedules}),
-                highest_priority=(
-                    min(entry.priority for entry in income_needs.schedules)
-                    if income_needs.schedules
-                    else None
-                ),
-                supportability_status=_source_status_to_method_status(
-                    income_needs.supportability.state
-                ),
-                reason_codes=[income_needs.supportability.reason, "CORE_INCOME_NEEDS_PRESENT"],
-            )
+            income_context = client_income_needs_schedule_context(income_needs)
             source_reason_codes.append("CLIENT_INCOME_NEEDS_SOURCE_PRESENT")
         if reserve_requirement is not None:
             payload = reserve_requirement.model_dump(mode="json", exclude_none=True)

--- a/src/api/services/construction_service.py
+++ b/src/api/services/construction_service.py
@@ -38,6 +38,7 @@ from src.api.services.construction_source_analytics_posture import source_analyt
 from src.api.services.construction_source_product_context import (
     external_order_execution_acknowledgement_context,
     external_treasury_currency_overlay_context,
+    liquidity_cashflow_projection_context,
     source_status_to_method_status,
     transaction_cost_context_from_curve,
 )
@@ -75,7 +76,6 @@ from src.core.construction.models import (
     AuthoritativeClientRestrictionRule,
     AuthoritativeCurrencyOverlayContext,
     AuthoritativeExecutionAcknowledgementContext,
-    AuthoritativeLiquidityCashflowProjection,
     AuthoritativeLiquidityContext,
     AuthoritativeLiquidityReserveRequirement,
     AuthoritativePlannedWithdrawalSchedule,
@@ -521,31 +521,7 @@ def _authority_context_with_source_products(
         ):
             source_reason_codes.append("CORE_LIQUIDITY_SOURCE_CONTEXT_PRESENT")
         if cashflow_projection is not None:
-            payload = cashflow_projection.model_dump(mode="json", exclude_none=True)
-            source_hash = hash_canonical_payload(payload)
-            status = (
-                cashflow_projection.data_quality_status
-                if cashflow_projection.data_quality_status in {"READY", "DEGRADED", "INCOMPLETE"}
-                else "READY"
-            )
-            cashflow_context = AuthoritativeLiquidityCashflowProjection(
-                source_product_name=cashflow_projection.product_name,
-                source_product_version=cashflow_projection.product_version,
-                source_system="lotus-core",
-                total_net_cashflow=Money(
-                    amount=cashflow_projection.total_net_cashflow,
-                    currency=cashflow_projection.portfolio_currency,
-                ),
-                projection_start=cashflow_projection.range_start_date,
-                projection_end=cashflow_projection.range_end_date,
-                include_projected=cashflow_projection.include_projected,
-                latest_evidence_timestamp=cashflow_projection.latest_evidence_timestamp,
-                source_batch_fingerprint=cashflow_projection.source_batch_fingerprint
-                or cashflow_projection.lineage.get("source_batch_fingerprint")
-                or source_hash,
-                data_quality_status=_source_status_to_method_status(status),
-                reason_codes=["CORE_CASHFLOW_PROJECTION_READY"],
-            )
+            cashflow_context = liquidity_cashflow_projection_context(cashflow_projection)
         if income_needs is not None:
             payload = income_needs.model_dump(mode="json", exclude_none=True)
             source_hash = hash_canonical_payload(payload)

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 
 from src.core.common.canonical import hash_canonical_payload
 from src.core.construction.models import (
+    AuthoritativeClientIncomeNeedsSchedule,
     AuthoritativeCurrencyOverlayContext,
     AuthoritativeExecutionAcknowledgementContext,
     AuthoritativeLiquidityCashflowProjection,
@@ -10,6 +11,7 @@ from src.core.construction.models import (
 )
 from src.core.construction.vocabulary import ConstructionMethodStatus
 from src.core.dpm_source_context import (
+    DpmCoreClientIncomeNeedsScheduleResponse,
     DpmCoreExternalCurrencyExposureResponse,
     DpmCoreExternalEligibleHedgeInstrumentResponse,
     DpmCoreExternalFXForwardCurveResponse,
@@ -20,6 +22,31 @@ from src.core.dpm_source_context import (
     DpmCoreTransactionCostCurveResponse,
 )
 from src.core.models import Money
+
+
+def client_income_needs_schedule_context(
+    income_needs: DpmCoreClientIncomeNeedsScheduleResponse,
+) -> AuthoritativeClientIncomeNeedsSchedule:
+    payload = income_needs.model_dump(mode="json", exclude_none=True)
+    source_hash = hash_canonical_payload(payload)
+    return AuthoritativeClientIncomeNeedsSchedule(
+        source_product_name=income_needs.product_name,
+        source_product_version=income_needs.product_version,
+        source_system="lotus-core",
+        source_id=income_needs.source_batch_fingerprint
+        or income_needs.lineage.get("source_batch_fingerprint")
+        or source_hash,
+        content_hash=source_hash,
+        schedule_count=income_needs.supportability.schedule_count,
+        currencies=sorted({entry.currency for entry in income_needs.schedules}),
+        highest_priority=(
+            min(entry.priority for entry in income_needs.schedules)
+            if income_needs.schedules
+            else None
+        ),
+        supportability_status=source_status_to_method_status(income_needs.supportability.state),
+        reason_codes=[income_needs.supportability.reason, "CORE_INCOME_NEEDS_PRESENT"],
+    )
 
 
 def liquidity_cashflow_projection_context(
@@ -404,6 +431,7 @@ def source_status_to_method_status(status: str) -> ConstructionMethodStatus:
 __all__ = [
     "external_order_execution_acknowledgement_context",
     "external_treasury_currency_overlay_context",
+    "client_income_needs_schedule_context",
     "liquidity_cashflow_projection_context",
     "source_status_to_method_status",
     "transaction_cost_context_from_curve",

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -4,6 +4,7 @@ from src.core.common.canonical import hash_canonical_payload
 from src.core.construction.models import (
     AuthoritativeCurrencyOverlayContext,
     AuthoritativeExecutionAcknowledgementContext,
+    AuthoritativeLiquidityCashflowProjection,
     AuthoritativeTransactionCostContext,
     AuthoritativeTransactionCostPoint,
 )
@@ -15,8 +16,40 @@ from src.core.dpm_source_context import (
     DpmCoreExternalHedgeExecutionReadinessResponse,
     DpmCoreExternalHedgePolicyResponse,
     DpmCoreExternalOrderExecutionAcknowledgementResponse,
+    DpmCorePortfolioCashflowProjectionResponse,
     DpmCoreTransactionCostCurveResponse,
 )
+from src.core.models import Money
+
+
+def liquidity_cashflow_projection_context(
+    cashflow_projection: DpmCorePortfolioCashflowProjectionResponse,
+) -> AuthoritativeLiquidityCashflowProjection:
+    payload = cashflow_projection.model_dump(mode="json", exclude_none=True)
+    source_hash = hash_canonical_payload(payload)
+    status = (
+        cashflow_projection.data_quality_status
+        if cashflow_projection.data_quality_status in {"READY", "DEGRADED", "INCOMPLETE"}
+        else "READY"
+    )
+    return AuthoritativeLiquidityCashflowProjection(
+        source_product_name=cashflow_projection.product_name,
+        source_product_version=cashflow_projection.product_version,
+        source_system="lotus-core",
+        total_net_cashflow=Money(
+            amount=cashflow_projection.total_net_cashflow,
+            currency=cashflow_projection.portfolio_currency,
+        ),
+        projection_start=cashflow_projection.range_start_date,
+        projection_end=cashflow_projection.range_end_date,
+        include_projected=cashflow_projection.include_projected,
+        latest_evidence_timestamp=cashflow_projection.latest_evidence_timestamp,
+        source_batch_fingerprint=cashflow_projection.source_batch_fingerprint
+        or cashflow_projection.lineage.get("source_batch_fingerprint")
+        or source_hash,
+        data_quality_status=source_status_to_method_status(status),
+        reason_codes=["CORE_CASHFLOW_PROJECTION_READY"],
+    )
 
 
 def transaction_cost_context_from_curve(
@@ -371,6 +404,7 @@ def source_status_to_method_status(status: str) -> ConstructionMethodStatus:
 __all__ = [
     "external_order_execution_acknowledgement_context",
     "external_treasury_currency_overlay_context",
+    "liquidity_cashflow_projection_context",
     "source_status_to_method_status",
     "transaction_cost_context_from_curve",
 ]

--- a/tests/unit/dpm/construction/test_source_product_context.py
+++ b/tests/unit/dpm/construction/test_source_product_context.py
@@ -2,6 +2,7 @@ from datetime import date
 from decimal import Decimal
 
 from src.api.services.construction_source_product_context import (
+    client_income_needs_schedule_context,
     external_order_execution_acknowledgement_context,
     external_treasury_currency_overlay_context,
     liquidity_cashflow_projection_context,
@@ -10,6 +11,9 @@ from src.api.services.construction_source_product_context import (
 )
 from src.core.construction.vocabulary import ConstructionMethodStatus
 from src.core.dpm_source_context import (
+    DpmCoreClientIncomeNeedsScheduleEntry,
+    DpmCoreClientIncomeNeedsScheduleResponse,
+    DpmCoreClientIncomeNeedsScheduleSupportability,
     DpmCoreExternalOrderExecutionAcknowledgementResponse,
     DpmCoreExternalOrderExecutionAcknowledgementSupportability,
     DpmCoreExternalHedgeExecutionReadinessResponse,
@@ -125,6 +129,62 @@ def _cashflow_projection() -> DpmCorePortfolioCashflowProjectionResponse:
         source_batch_fingerprint=None,
         lineage={"source_batch_fingerprint": "cashflow-lineage"},
     )
+
+
+def _income_needs_schedule() -> DpmCoreClientIncomeNeedsScheduleResponse:
+    return DpmCoreClientIncomeNeedsScheduleResponse(
+        product_name="ClientIncomeNeedsSchedule",
+        product_version="v1",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        client_id="client-1",
+        mandate_id="mandate-1",
+        as_of_date=date(2026, 6, 1),
+        schedules=[
+            DpmCoreClientIncomeNeedsScheduleEntry(
+                schedule_id="income-1",
+                need_type="RETIREMENT_INCOME",
+                need_status="ACTIVE",
+                amount=Decimal("5000"),
+                currency="SGD",
+                frequency="MONTHLY",
+                start_date=date(2026, 6, 1),
+                priority=2,
+            ),
+            DpmCoreClientIncomeNeedsScheduleEntry(
+                schedule_id="income-2",
+                need_type="SCHOOL_FEES",
+                need_status="ACTIVE",
+                amount=Decimal("12000"),
+                currency="USD",
+                frequency="QUARTERLY",
+                start_date=date(2026, 7, 1),
+                priority=1,
+            ),
+        ],
+        supportability=DpmCoreClientIncomeNeedsScheduleSupportability(
+            state="INCOMPLETE",
+            reason="CLIENT_INCOME_NEEDS_PARTIAL",
+            schedule_count=2,
+            missing_data_families=["income_needs_review"],
+        ),
+        lineage={"source_batch_fingerprint": "income-lineage"},
+    )
+
+
+def test_client_income_needs_context_preserves_priority_currency_and_status() -> None:
+    context = client_income_needs_schedule_context(_income_needs_schedule())
+
+    assert context.source_system == "lotus-core"
+    assert context.source_product_name == "ClientIncomeNeedsSchedule"
+    assert context.source_id == "income-lineage"
+    assert context.schedule_count == 2
+    assert context.currencies == ["SGD", "USD"]
+    assert context.highest_priority == 1
+    assert context.supportability_status == ConstructionMethodStatus.BLOCKED
+    assert context.reason_codes == [
+        "CLIENT_INCOME_NEEDS_PARTIAL",
+        "CORE_INCOME_NEEDS_PRESENT",
+    ]
 
 
 def test_liquidity_cashflow_projection_context_preserves_source_lineage_and_status() -> None:

--- a/tests/unit/dpm/construction/test_source_product_context.py
+++ b/tests/unit/dpm/construction/test_source_product_context.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from src.api.services.construction_source_product_context import (
     external_order_execution_acknowledgement_context,
     external_treasury_currency_overlay_context,
+    liquidity_cashflow_projection_context,
     source_status_to_method_status,
     transaction_cost_context_from_curve,
 )
@@ -14,6 +15,7 @@ from src.core.dpm_source_context import (
     DpmCoreExternalHedgeExecutionReadinessResponse,
     DpmCoreExternalHedgeExecutionReadinessSupportability,
     DpmCoreIntegrationWindow,
+    DpmCorePortfolioCashflowProjectionResponse,
     DpmCoreTransactionCostCurvePageMetadata,
     DpmCoreTransactionCostCurvePoint,
     DpmCoreTransactionCostCurveResponse,
@@ -104,6 +106,38 @@ def _transaction_cost_curve() -> DpmCoreTransactionCostCurveResponse:
         ),
         lineage={"source_batch_fingerprint": "curve-lineage"},
     )
+
+
+def _cashflow_projection() -> DpmCorePortfolioCashflowProjectionResponse:
+    return DpmCorePortfolioCashflowProjectionResponse(
+        product_name="PortfolioCashflowProjection",
+        product_version="v1",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        as_of_date=date(2026, 6, 1),
+        range_start_date=date(2026, 6, 1),
+        range_end_date=date(2026, 6, 30),
+        include_projected=True,
+        portfolio_currency="USD",
+        points=[],
+        total_net_cashflow=Decimal("1250.50"),
+        projection_days=30,
+        data_quality_status="DEGRADED",
+        source_batch_fingerprint=None,
+        lineage={"source_batch_fingerprint": "cashflow-lineage"},
+    )
+
+
+def test_liquidity_cashflow_projection_context_preserves_source_lineage_and_status() -> None:
+    context = liquidity_cashflow_projection_context(_cashflow_projection())
+
+    assert context.source_system == "lotus-core"
+    assert context.source_product_name == "PortfolioCashflowProjection"
+    assert context.source_batch_fingerprint == "cashflow-lineage"
+    assert context.total_net_cashflow.amount == Decimal("1250.50")
+    assert context.total_net_cashflow.currency == "USD"
+    assert context.include_projected is True
+    assert context.data_quality_status == ConstructionMethodStatus.DEGRADED
+    assert context.reason_codes == ["CORE_CASHFLOW_PROJECTION_READY"]
 
 
 def test_transaction_cost_context_preserves_core_curve_lineage_and_bounds_samples() -> None:


### PR DESCRIPTION
## Summary
- Extracted liquidity cashflow source-product context mapping from construction orchestration into `construction_source_product_context`.
- Extracted client income-needs source-product context mapping into the same helper boundary.
- Added focused direct unit coverage and ledger entries for both small commits while preserving construction service behavior.

## Validation
- `make check` passed locally: ruff, ruff format check, monetary float guard, no-alias guard, mypy, OpenAPI quality gate, API vocabulary inventory, domain data product contract validation, trust telemetry contract validation, observability contract validation, and `1658 passed` unit tests.
- `git diff --check origin/main...HEAD` passed.
- Service-layer router/HTTP leakage scan returned no matches: `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP" src/api/services -g "*.py"`.

## Governance
- Stranded truth reconciliation: `git branch -r --no-merged origin/main` shows only `origin/feat/manage-hardening-wave-3`, the current PR branch.
- Wiki source check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`; no wiki source or publication change is required for this code-only refactoring slice.
- Merge strategy: normal merge commit, no squash.