### PR TITLE
Extract construction source-product context mappings

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -6729,3 +6729,32 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   withdrawals.
 - Wiki decision: no wiki source change required; this is internal source-product context
   modularity cleanup with no route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-264: Remaining source-product context extraction
+
+- Date: 2026-06-01
+- Scope:
+  `src/api/services/construction_source_product_context.py`,
+  `src/api/services/construction_service.py`, and
+  `tests/unit/dpm/construction/test_source_product_context.py`.
+- Finding: liquidity reserve requirements, planned withdrawal schedules, client restriction
+  profiles, and sustainability preference profiles still mapped lotus-core source products inside
+  construction orchestration. These mappings preserve lineage, content hashes, supportability
+  states, represented currencies, horizons, restriction rules, and sustainability preferences, but
+  they are pure source-boundary assembly rather than orchestration.
+- Action: extracted the four remaining source-product mappings into
+  `construction_source_product_context.py`, keeping `_authority_context_with_source_products`
+  responsible only for deciding when to attach source-derived contexts. Added direct helper tests
+  for reserve requirement, planned withdrawal, client restriction, and sustainability preference
+  source evidence.
+- Status: hardened
+- Evidence: focused source-product context, construction enrichment, and construction API
+  regressions (`tests/unit/dpm/construction/test_source_product_context.py`,
+  `tests/unit/dpm/construction/test_enrichment.py`, and
+  `tests/unit/dpm/api/test_construction_api.py`) passed with 62 tests. Focused Ruff checks,
+  focused mypy over source-product context and construction service, OpenAPI quality, API
+  vocabulary validation, service leakage scan, and `git diff --check` passed.
+- Follow-up: continue shrinking `construction_service.py` by extracting larger source-family
+  attachment orchestration only when it can be done without hiding method-specific behavior.
+- Wiki decision: no wiki source change required; this is internal source-product context
+  modularity cleanup with no route, payload, supported-feature, or operator-contract change.

--- a/src/api/services/construction_service.py
+++ b/src/api/services/construction_service.py
@@ -37,10 +37,13 @@ from src.api.services.construction_solver_supportability import (
 from src.api.services.construction_source_analytics_posture import source_analytics_posture
 from src.api.services.construction_source_product_context import (
     client_income_needs_schedule_context,
+    client_restriction_profile_context,
     external_order_execution_acknowledgement_context,
     external_treasury_currency_overlay_context,
     liquidity_cashflow_projection_context,
-    source_status_to_method_status,
+    liquidity_reserve_requirement_context,
+    planned_withdrawal_schedule_context,
+    sustainability_preference_profile_context,
     transaction_cost_context_from_curve,
 )
 from src.api.services.construction_esg_supportability import (
@@ -63,7 +66,6 @@ from src.api.services.construction_transaction_cost_supportability import (
     with_observed_transaction_cost_estimate,
 )
 from src.core.common.capabilities import has_solver_dependencies
-from src.core.common.canonical import hash_canonical_payload
 from src.core.construction.alternative_engine import (
     build_alternative_set,
     build_do_nothing_baseline,
@@ -77,8 +79,6 @@ from src.core.construction.models import (
     AuthoritativeCurrencyOverlayContext,
     AuthoritativeExecutionAcknowledgementContext,
     AuthoritativeLiquidityContext,
-    AuthoritativeLiquidityReserveRequirement,
-    AuthoritativePlannedWithdrawalSchedule,
     AuthoritativeRegimeStressContext,
     AuthoritativeSustainabilityPreference,
     AuthoritativeSustainabilityPreferenceContext,
@@ -526,54 +526,10 @@ def _authority_context_with_source_products(
             income_context = client_income_needs_schedule_context(income_needs)
             source_reason_codes.append("CLIENT_INCOME_NEEDS_SOURCE_PRESENT")
         if reserve_requirement is not None:
-            payload = reserve_requirement.model_dump(mode="json", exclude_none=True)
-            source_hash = hash_canonical_payload(payload)
-            reserve_context = AuthoritativeLiquidityReserveRequirement(
-                source_product_name=reserve_requirement.product_name,
-                source_product_version=reserve_requirement.product_version,
-                source_system="lotus-core",
-                source_id=reserve_requirement.source_batch_fingerprint
-                or reserve_requirement.lineage.get("source_batch_fingerprint")
-                or source_hash,
-                content_hash=source_hash,
-                requirement_count=reserve_requirement.supportability.requirement_count,
-                currencies=sorted({entry.currency for entry in reserve_requirement.requirements}),
-                maximum_horizon_days=(
-                    max(entry.horizon_days for entry in reserve_requirement.requirements)
-                    if reserve_requirement.requirements
-                    else None
-                ),
-                supportability_status=_source_status_to_method_status(
-                    reserve_requirement.supportability.state
-                ),
-                reason_codes=[
-                    reserve_requirement.supportability.reason,
-                    "CORE_LIQUIDITY_RESERVE_PRESENT",
-                ],
-            )
+            reserve_context = liquidity_reserve_requirement_context(reserve_requirement)
             source_reason_codes.append("LIQUIDITY_RESERVE_SOURCE_PRESENT")
         if planned_withdrawals is not None:
-            payload = planned_withdrawals.model_dump(mode="json", exclude_none=True)
-            source_hash = hash_canonical_payload(payload)
-            withdrawal_context = AuthoritativePlannedWithdrawalSchedule(
-                source_product_name=planned_withdrawals.product_name,
-                source_product_version=planned_withdrawals.product_version,
-                source_system="lotus-core",
-                source_id=planned_withdrawals.source_batch_fingerprint
-                or planned_withdrawals.lineage.get("source_batch_fingerprint")
-                or source_hash,
-                content_hash=source_hash,
-                withdrawal_count=planned_withdrawals.supportability.withdrawal_count,
-                currencies=sorted({entry.currency for entry in planned_withdrawals.withdrawals}),
-                horizon_days=planned_withdrawals.horizon_days,
-                supportability_status=_source_status_to_method_status(
-                    planned_withdrawals.supportability.state
-                ),
-                reason_codes=[
-                    planned_withdrawals.supportability.reason,
-                    "CORE_PLANNED_WITHDRAWALS_PRESENT",
-                ],
-            )
+            withdrawal_context = planned_withdrawal_schedule_context(planned_withdrawals)
             source_reason_codes.append("PLANNED_WITHDRAWAL_SOURCE_PRESENT")
         if (
             cashflow_projection is not None
@@ -640,72 +596,18 @@ def _authority_context_with_source_products(
     if authority_context.client_restriction_context is None:
         restriction_profile = source_context.context.client_restriction_profile
         if restriction_profile is not None:
-            payload = restriction_profile.model_dump(mode="json", exclude_none=True)
-            source_hash = hash_canonical_payload(payload)
-            context_updates["client_restriction_context"] = AuthoritativeClientRestrictionContext(
-                supportability_status=_source_status_to_method_status(
-                    restriction_profile.supportability.state
-                ),
-                source_system="lotus-core",
-                source_product_name=restriction_profile.product_name,
-                source_product_version=restriction_profile.product_version,
-                source_id=restriction_profile.source_batch_fingerprint
-                or restriction_profile.lineage.get("source_batch_fingerprint")
-                or source_hash,
-                content_hash=source_hash,
-                portfolio_id=restriction_profile.portfolio_id,
-                client_id=restriction_profile.client_id,
-                mandate_id=restriction_profile.mandate_id,
-                as_of_date=restriction_profile.as_of_date,
-                restriction_count=restriction_profile.supportability.restriction_count,
-                missing_data_families=restriction_profile.supportability.missing_data_families,
-                restrictions=[
-                    AuthoritativeClientRestrictionRule.model_validate(
-                        rule.model_dump(mode="python")
-                    )
-                    for rule in restriction_profile.restrictions
-                ],
-                reason_codes=[restriction_profile.supportability.reason],
+            context_updates["client_restriction_context"] = client_restriction_profile_context(
+                restriction_profile
             )
     if authority_context.sustainability_preference_context is None:
         sustainability_profile = source_context.context.sustainability_preference_profile
         if sustainability_profile is not None:
-            payload = sustainability_profile.model_dump(mode="json", exclude_none=True)
-            source_hash = hash_canonical_payload(payload)
             context_updates["sustainability_preference_context"] = (
-                AuthoritativeSustainabilityPreferenceContext(
-                    supportability_status=_source_status_to_method_status(
-                        sustainability_profile.supportability.state
-                    ),
-                    source_system="lotus-core",
-                    source_product_name=sustainability_profile.product_name,
-                    source_product_version=sustainability_profile.product_version,
-                    source_id=sustainability_profile.source_batch_fingerprint
-                    or sustainability_profile.lineage.get("source_batch_fingerprint")
-                    or source_hash,
-                    content_hash=source_hash,
-                    portfolio_id=sustainability_profile.portfolio_id,
-                    client_id=sustainability_profile.client_id,
-                    mandate_id=sustainability_profile.mandate_id,
-                    as_of_date=sustainability_profile.as_of_date,
-                    preference_count=sustainability_profile.supportability.preference_count,
-                    missing_data_families=sustainability_profile.supportability.missing_data_families,
-                    preferences=[
-                        AuthoritativeSustainabilityPreference.model_validate(
-                            preference.model_dump(mode="python")
-                        )
-                        for preference in sustainability_profile.preferences
-                    ],
-                    reason_codes=[sustainability_profile.supportability.reason],
-                )
+                sustainability_preference_profile_context(sustainability_profile)
             )
     if not context_updates:
         return authority_context
     return authority_context.model_copy(update=context_updates)
-
-
-def _source_status_to_method_status(status: str) -> ConstructionMethodStatus:
-    return source_status_to_method_status(status)
 
 
 def _with_observed_transaction_cost_estimate(

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -2,23 +2,33 @@ from decimal import Decimal
 
 from src.core.common.canonical import hash_canonical_payload
 from src.core.construction.models import (
+    AuthoritativeClientRestrictionContext,
+    AuthoritativeClientRestrictionRule,
     AuthoritativeClientIncomeNeedsSchedule,
     AuthoritativeCurrencyOverlayContext,
     AuthoritativeExecutionAcknowledgementContext,
     AuthoritativeLiquidityCashflowProjection,
+    AuthoritativeLiquidityReserveRequirement,
+    AuthoritativePlannedWithdrawalSchedule,
+    AuthoritativeSustainabilityPreference,
+    AuthoritativeSustainabilityPreferenceContext,
     AuthoritativeTransactionCostContext,
     AuthoritativeTransactionCostPoint,
 )
 from src.core.construction.vocabulary import ConstructionMethodStatus
 from src.core.dpm_source_context import (
     DpmCoreClientIncomeNeedsScheduleResponse,
+    DpmCoreClientRestrictionProfileResponse,
     DpmCoreExternalCurrencyExposureResponse,
     DpmCoreExternalEligibleHedgeInstrumentResponse,
     DpmCoreExternalFXForwardCurveResponse,
     DpmCoreExternalHedgeExecutionReadinessResponse,
     DpmCoreExternalHedgePolicyResponse,
     DpmCoreExternalOrderExecutionAcknowledgementResponse,
+    DpmCoreLiquidityReserveRequirementResponse,
+    DpmCorePlannedWithdrawalScheduleResponse,
     DpmCorePortfolioCashflowProjectionResponse,
+    DpmCoreSustainabilityPreferenceProfileResponse,
     DpmCoreTransactionCostCurveResponse,
 )
 from src.core.models import Money
@@ -76,6 +86,62 @@ def liquidity_cashflow_projection_context(
         or source_hash,
         data_quality_status=source_status_to_method_status(status),
         reason_codes=["CORE_CASHFLOW_PROJECTION_READY"],
+    )
+
+
+def liquidity_reserve_requirement_context(
+    reserve_requirement: DpmCoreLiquidityReserveRequirementResponse,
+) -> AuthoritativeLiquidityReserveRequirement:
+    payload = reserve_requirement.model_dump(mode="json", exclude_none=True)
+    source_hash = hash_canonical_payload(payload)
+    return AuthoritativeLiquidityReserveRequirement(
+        source_product_name=reserve_requirement.product_name,
+        source_product_version=reserve_requirement.product_version,
+        source_system="lotus-core",
+        source_id=reserve_requirement.source_batch_fingerprint
+        or reserve_requirement.lineage.get("source_batch_fingerprint")
+        or source_hash,
+        content_hash=source_hash,
+        requirement_count=reserve_requirement.supportability.requirement_count,
+        currencies=sorted({entry.currency for entry in reserve_requirement.requirements}),
+        maximum_horizon_days=(
+            max(entry.horizon_days for entry in reserve_requirement.requirements)
+            if reserve_requirement.requirements
+            else None
+        ),
+        supportability_status=source_status_to_method_status(
+            reserve_requirement.supportability.state
+        ),
+        reason_codes=[
+            reserve_requirement.supportability.reason,
+            "CORE_LIQUIDITY_RESERVE_PRESENT",
+        ],
+    )
+
+
+def planned_withdrawal_schedule_context(
+    planned_withdrawals: DpmCorePlannedWithdrawalScheduleResponse,
+) -> AuthoritativePlannedWithdrawalSchedule:
+    payload = planned_withdrawals.model_dump(mode="json", exclude_none=True)
+    source_hash = hash_canonical_payload(payload)
+    return AuthoritativePlannedWithdrawalSchedule(
+        source_product_name=planned_withdrawals.product_name,
+        source_product_version=planned_withdrawals.product_version,
+        source_system="lotus-core",
+        source_id=planned_withdrawals.source_batch_fingerprint
+        or planned_withdrawals.lineage.get("source_batch_fingerprint")
+        or source_hash,
+        content_hash=source_hash,
+        withdrawal_count=planned_withdrawals.supportability.withdrawal_count,
+        currencies=sorted({entry.currency for entry in planned_withdrawals.withdrawals}),
+        horizon_days=planned_withdrawals.horizon_days,
+        supportability_status=source_status_to_method_status(
+            planned_withdrawals.supportability.state
+        ),
+        reason_codes=[
+            planned_withdrawals.supportability.reason,
+            "CORE_PLANNED_WITHDRAWALS_PRESENT",
+        ],
     )
 
 
@@ -391,6 +457,68 @@ def external_treasury_currency_overlay_context(
     )
 
 
+def client_restriction_profile_context(
+    restriction_profile: DpmCoreClientRestrictionProfileResponse,
+) -> AuthoritativeClientRestrictionContext:
+    payload = restriction_profile.model_dump(mode="json", exclude_none=True)
+    source_hash = hash_canonical_payload(payload)
+    return AuthoritativeClientRestrictionContext(
+        supportability_status=source_status_to_method_status(
+            restriction_profile.supportability.state
+        ),
+        source_system="lotus-core",
+        source_product_name=restriction_profile.product_name,
+        source_product_version=restriction_profile.product_version,
+        source_id=restriction_profile.source_batch_fingerprint
+        or restriction_profile.lineage.get("source_batch_fingerprint")
+        or source_hash,
+        content_hash=source_hash,
+        portfolio_id=restriction_profile.portfolio_id,
+        client_id=restriction_profile.client_id,
+        mandate_id=restriction_profile.mandate_id,
+        as_of_date=restriction_profile.as_of_date,
+        restriction_count=restriction_profile.supportability.restriction_count,
+        missing_data_families=restriction_profile.supportability.missing_data_families,
+        restrictions=[
+            AuthoritativeClientRestrictionRule.model_validate(rule.model_dump(mode="python"))
+            for rule in restriction_profile.restrictions
+        ],
+        reason_codes=[restriction_profile.supportability.reason],
+    )
+
+
+def sustainability_preference_profile_context(
+    sustainability_profile: DpmCoreSustainabilityPreferenceProfileResponse,
+) -> AuthoritativeSustainabilityPreferenceContext:
+    payload = sustainability_profile.model_dump(mode="json", exclude_none=True)
+    source_hash = hash_canonical_payload(payload)
+    return AuthoritativeSustainabilityPreferenceContext(
+        supportability_status=source_status_to_method_status(
+            sustainability_profile.supportability.state
+        ),
+        source_system="lotus-core",
+        source_product_name=sustainability_profile.product_name,
+        source_product_version=sustainability_profile.product_version,
+        source_id=sustainability_profile.source_batch_fingerprint
+        or sustainability_profile.lineage.get("source_batch_fingerprint")
+        or source_hash,
+        content_hash=source_hash,
+        portfolio_id=sustainability_profile.portfolio_id,
+        client_id=sustainability_profile.client_id,
+        mandate_id=sustainability_profile.mandate_id,
+        as_of_date=sustainability_profile.as_of_date,
+        preference_count=sustainability_profile.supportability.preference_count,
+        missing_data_families=sustainability_profile.supportability.missing_data_families,
+        preferences=[
+            AuthoritativeSustainabilityPreference.model_validate(
+                preference.model_dump(mode="python")
+            )
+            for preference in sustainability_profile.preferences
+        ],
+        reason_codes=[sustainability_profile.supportability.reason],
+    )
+
+
 def external_order_execution_acknowledgement_context(
     acknowledgement: DpmCoreExternalOrderExecutionAcknowledgementResponse | None,
 ) -> AuthoritativeExecutionAcknowledgementContext | None:
@@ -429,10 +557,14 @@ def source_status_to_method_status(status: str) -> ConstructionMethodStatus:
 
 
 __all__ = [
+    "client_restriction_profile_context",
     "external_order_execution_acknowledgement_context",
     "external_treasury_currency_overlay_context",
     "client_income_needs_schedule_context",
     "liquidity_cashflow_projection_context",
+    "liquidity_reserve_requirement_context",
+    "planned_withdrawal_schedule_context",
     "source_status_to_method_status",
+    "sustainability_preference_profile_context",
     "transaction_cost_context_from_curve",
 ]

--- a/tests/unit/dpm/construction/test_enrichment.py
+++ b/tests/unit/dpm/construction/test_enrichment.py
@@ -6,6 +6,7 @@ import pytest
 from src.api.request_models import RebalanceRequest
 from src.api.routers.construction_http import construction_http_exception
 import src.api.services.construction_service as construction_service
+from src.api.services.construction_source_product_context import source_status_to_method_status
 from src.core.construction import (
     AuthoritativeClientRestrictionContext,
     AuthoritativeClientRestrictionRule,
@@ -648,10 +649,7 @@ def test_source_context_lifts_client_restriction_and_sustainability_profiles() -
         == ConstructionMethodStatus.READY
     )
     assert context.sustainability_preference_context.content_hash
-    assert (
-        construction_service._source_status_to_method_status("INCOMPLETE")
-        == ConstructionMethodStatus.BLOCKED
-    )
+    assert source_status_to_method_status("INCOMPLETE") == ConstructionMethodStatus.BLOCKED
 
 
 def test_source_context_lifts_income_reserve_and_withdrawal_sources() -> None:

--- a/tests/unit/dpm/construction/test_source_product_context.py
+++ b/tests/unit/dpm/construction/test_source_product_context.py
@@ -3,10 +3,14 @@ from decimal import Decimal
 
 from src.api.services.construction_source_product_context import (
     client_income_needs_schedule_context,
+    client_restriction_profile_context,
     external_order_execution_acknowledgement_context,
     external_treasury_currency_overlay_context,
     liquidity_cashflow_projection_context,
+    liquidity_reserve_requirement_context,
+    planned_withdrawal_schedule_context,
     source_status_to_method_status,
+    sustainability_preference_profile_context,
     transaction_cost_context_from_curve,
 )
 from src.core.construction.vocabulary import ConstructionMethodStatus
@@ -14,12 +18,24 @@ from src.core.dpm_source_context import (
     DpmCoreClientIncomeNeedsScheduleEntry,
     DpmCoreClientIncomeNeedsScheduleResponse,
     DpmCoreClientIncomeNeedsScheduleSupportability,
+    DpmCoreClientRestrictionEntry,
+    DpmCoreClientRestrictionProfileResponse,
+    DpmCoreClientRestrictionSupportability,
     DpmCoreExternalOrderExecutionAcknowledgementResponse,
     DpmCoreExternalOrderExecutionAcknowledgementSupportability,
     DpmCoreExternalHedgeExecutionReadinessResponse,
     DpmCoreExternalHedgeExecutionReadinessSupportability,
     DpmCoreIntegrationWindow,
+    DpmCoreLiquidityReserveRequirementEntry,
+    DpmCoreLiquidityReserveRequirementResponse,
+    DpmCoreLiquidityReserveRequirementSupportability,
+    DpmCorePlannedWithdrawalScheduleEntry,
+    DpmCorePlannedWithdrawalScheduleResponse,
+    DpmCorePlannedWithdrawalScheduleSupportability,
     DpmCorePortfolioCashflowProjectionResponse,
+    DpmCoreSustainabilityPreferenceEntry,
+    DpmCoreSustainabilityPreferenceProfileResponse,
+    DpmCoreSustainabilityPreferenceSupportability,
     DpmCoreTransactionCostCurvePageMetadata,
     DpmCoreTransactionCostCurvePoint,
     DpmCoreTransactionCostCurveResponse,
@@ -171,6 +187,153 @@ def _income_needs_schedule() -> DpmCoreClientIncomeNeedsScheduleResponse:
     )
 
 
+def _liquidity_reserve_requirement() -> DpmCoreLiquidityReserveRequirementResponse:
+    return DpmCoreLiquidityReserveRequirementResponse(
+        product_name="LiquidityReserveRequirement",
+        product_version="v1",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        client_id="client-1",
+        mandate_id="mandate-1",
+        as_of_date=date(2026, 6, 1),
+        requirements=[
+            DpmCoreLiquidityReserveRequirementEntry(
+                reserve_requirement_id="reserve-1",
+                reserve_type="OPERATING_CASH",
+                reserve_status="ACTIVE",
+                required_amount=Decimal("7500"),
+                currency="USD",
+                horizon_days=30,
+                priority=1,
+                policy_source="BANK_POLICY",
+                effective_from=date(2026, 6, 1),
+                requirement_version=1,
+            ),
+            DpmCoreLiquidityReserveRequirementEntry(
+                reserve_requirement_id="reserve-2",
+                reserve_type="CLIENT_BUFFER",
+                reserve_status="ACTIVE",
+                required_amount=Decimal("10000"),
+                currency="SGD",
+                horizon_days=90,
+                priority=2,
+                policy_source="CLIENT_POLICY",
+                effective_from=date(2026, 6, 1),
+                requirement_version=1,
+            ),
+        ],
+        supportability=DpmCoreLiquidityReserveRequirementSupportability(
+            state="READY",
+            reason="LIQUIDITY_RESERVE_READY",
+            requirement_count=2,
+        ),
+        lineage={"source_batch_fingerprint": "reserve-lineage"},
+    )
+
+
+def _planned_withdrawal_schedule() -> DpmCorePlannedWithdrawalScheduleResponse:
+    return DpmCorePlannedWithdrawalScheduleResponse(
+        product_name="PlannedWithdrawalSchedule",
+        product_version="v1",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        client_id="client-1",
+        mandate_id="mandate-1",
+        as_of_date=date(2026, 6, 1),
+        horizon_days=120,
+        withdrawals=[
+            DpmCorePlannedWithdrawalScheduleEntry(
+                withdrawal_schedule_id="withdrawal-1",
+                withdrawal_type="TUITION",
+                withdrawal_status="ACTIVE",
+                amount=Decimal("12000"),
+                currency="USD",
+                scheduled_date=date(2026, 7, 15),
+                recurrence_frequency="ONE_TIME",
+            ),
+            DpmCorePlannedWithdrawalScheduleEntry(
+                withdrawal_schedule_id="withdrawal-2",
+                withdrawal_type="LIFESTYLE",
+                withdrawal_status="ACTIVE",
+                amount=Decimal("5000"),
+                currency="SGD",
+                scheduled_date=date(2026, 8, 1),
+                recurrence_frequency="MONTHLY",
+            ),
+        ],
+        supportability=DpmCorePlannedWithdrawalScheduleSupportability(
+            state="INCOMPLETE",
+            reason="PLANNED_WITHDRAWALS_PARTIAL",
+            withdrawal_count=2,
+            missing_data_families=["external_planning_review"],
+        ),
+        lineage={"source_batch_fingerprint": "withdrawal-lineage"},
+    )
+
+
+def _client_restriction_profile() -> DpmCoreClientRestrictionProfileResponse:
+    return DpmCoreClientRestrictionProfileResponse(
+        product_name="ClientRestrictionProfile",
+        product_version="v1",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        client_id="client-1",
+        mandate_id="mandate-1",
+        as_of_date=date(2026, 6, 1),
+        restrictions=[
+            DpmCoreClientRestrictionEntry(
+                restriction_scope="INSTRUMENT",
+                restriction_code="NO_SINGLE_STOCK_A",
+                restriction_status="ACTIVE",
+                restriction_source="CLIENT_MANDATE",
+                applies_to_buy=True,
+                applies_to_sell=False,
+                instrument_ids=["EQ_A"],
+                effective_from=date(2026, 1, 1),
+                restriction_version=3,
+                source_record_id="restriction-record-1",
+            )
+        ],
+        supportability=DpmCoreClientRestrictionSupportability(
+            state="READY",
+            reason="CLIENT_RESTRICTIONS_READY",
+            restriction_count=1,
+            missing_data_families=[],
+        ),
+        lineage={"source_batch_fingerprint": "restriction-lineage"},
+    )
+
+
+def _sustainability_preference_profile() -> DpmCoreSustainabilityPreferenceProfileResponse:
+    return DpmCoreSustainabilityPreferenceProfileResponse(
+        product_name="SustainabilityPreferenceProfile",
+        product_version="v1",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        client_id="client-1",
+        mandate_id="mandate-1",
+        as_of_date=date(2026, 6, 1),
+        preferences=[
+            DpmCoreSustainabilityPreferenceEntry(
+                preference_framework="SFDR",
+                preference_code="MIN_ARTICLE_8",
+                preference_status="ACTIVE",
+                preference_source="CLIENT_MANDATE",
+                minimum_allocation=Decimal("0.40"),
+                applies_to_asset_classes=["EQUITY"],
+                exclusion_codes=["THERMAL_COAL"],
+                positive_tilt_codes=["LOW_CARBON"],
+                effective_from=date(2026, 1, 1),
+                preference_version=2,
+                source_record_id="preference-record-1",
+            )
+        ],
+        supportability=DpmCoreSustainabilityPreferenceSupportability(
+            state="INCOMPLETE",
+            reason="SUSTAINABILITY_PREFERENCES_PARTIAL",
+            preference_count=1,
+            missing_data_families=["classification_review"],
+        ),
+        lineage={"source_batch_fingerprint": "sustainability-lineage"},
+    )
+
+
 def test_client_income_needs_context_preserves_priority_currency_and_status() -> None:
     context = client_income_needs_schedule_context(_income_needs_schedule())
 
@@ -187,6 +350,38 @@ def test_client_income_needs_context_preserves_priority_currency_and_status() ->
     ]
 
 
+def test_liquidity_reserve_requirement_context_preserves_horizon_currency_and_status() -> None:
+    context = liquidity_reserve_requirement_context(_liquidity_reserve_requirement())
+
+    assert context.source_system == "lotus-core"
+    assert context.source_product_name == "LiquidityReserveRequirement"
+    assert context.source_id == "reserve-lineage"
+    assert context.requirement_count == 2
+    assert context.currencies == ["SGD", "USD"]
+    assert context.maximum_horizon_days == 90
+    assert context.supportability_status == ConstructionMethodStatus.READY
+    assert context.reason_codes == [
+        "LIQUIDITY_RESERVE_READY",
+        "CORE_LIQUIDITY_RESERVE_PRESENT",
+    ]
+
+
+def test_planned_withdrawal_context_preserves_horizon_currency_and_status() -> None:
+    context = planned_withdrawal_schedule_context(_planned_withdrawal_schedule())
+
+    assert context.source_system == "lotus-core"
+    assert context.source_product_name == "PlannedWithdrawalSchedule"
+    assert context.source_id == "withdrawal-lineage"
+    assert context.withdrawal_count == 2
+    assert context.currencies == ["SGD", "USD"]
+    assert context.horizon_days == 120
+    assert context.supportability_status == ConstructionMethodStatus.BLOCKED
+    assert context.reason_codes == [
+        "PLANNED_WITHDRAWALS_PARTIAL",
+        "CORE_PLANNED_WITHDRAWALS_PRESENT",
+    ]
+
+
 def test_liquidity_cashflow_projection_context_preserves_source_lineage_and_status() -> None:
     context = liquidity_cashflow_projection_context(_cashflow_projection())
 
@@ -198,6 +393,39 @@ def test_liquidity_cashflow_projection_context_preserves_source_lineage_and_stat
     assert context.include_projected is True
     assert context.data_quality_status == ConstructionMethodStatus.DEGRADED
     assert context.reason_codes == ["CORE_CASHFLOW_PROJECTION_READY"]
+
+
+def test_client_restriction_profile_context_preserves_rules_and_lineage() -> None:
+    context = client_restriction_profile_context(_client_restriction_profile())
+
+    assert context.supportability_status == ConstructionMethodStatus.READY
+    assert context.source_system == "lotus-core"
+    assert context.source_product_name == "ClientRestrictionProfile"
+    assert context.source_id == "restriction-lineage"
+    assert context.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert context.client_id == "client-1"
+    assert context.restriction_count == 1
+    assert context.reason_codes == ["CLIENT_RESTRICTIONS_READY"]
+    assert len(context.restrictions) == 1
+    assert context.restrictions[0].restriction_code == "NO_SINGLE_STOCK_A"
+    assert context.restrictions[0].instrument_ids == ["EQ_A"]
+    assert context.restrictions[0].source_record_id == "restriction-record-1"
+
+
+def test_sustainability_preference_context_preserves_preferences_and_status() -> None:
+    context = sustainability_preference_profile_context(_sustainability_preference_profile())
+
+    assert context.supportability_status == ConstructionMethodStatus.BLOCKED
+    assert context.source_system == "lotus-core"
+    assert context.source_product_name == "SustainabilityPreferenceProfile"
+    assert context.source_id == "sustainability-lineage"
+    assert context.preference_count == 1
+    assert context.missing_data_families == ["classification_review"]
+    assert context.reason_codes == ["SUSTAINABILITY_PREFERENCES_PARTIAL"]
+    assert len(context.preferences) == 1
+    assert context.preferences[0].preference_code == "MIN_ARTICLE_8"
+    assert context.preferences[0].minimum_allocation == Decimal("0.40")
+    assert context.preferences[0].positive_tilt_codes == ["LOW_CARBON"]
 
 
 def test_transaction_cost_context_preserves_core_curve_lineage_and_bounds_samples() -> None:


### PR DESCRIPTION
## Summary
- Extract liquidity reserve requirement, planned withdrawal schedule, client restriction profile, and sustainability preference profile mappings from `construction_service.py` into `construction_source_product_context.py`.
- Keep construction service orchestration responsible for conditional source-context attachment only.
- Add direct helper coverage for the extracted source-product mappings and update the codebase review ledger with `BACKEND-REVIEW-20260601-264`.

## Evidence
- `python -m ruff check src/api/services/construction_source_product_context.py src/api/services/construction_service.py tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py`
- `python -m ruff format --check src/api/services/construction_source_product_context.py src/api/services/construction_service.py tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py`
- `python -m mypy --config-file mypy.ini src/api/services/construction_source_product_context.py src/api/services/construction_service.py`
- `python -m pytest tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py tests/unit/dpm/api/test_construction_api.py` (`62 passed`)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP" src/api/services -g "*.py"` (no matches)
- `make check` (`1662 passed`)

## Governance
- Stranded truth: `git fetch origin --prune` and `git branch -r --no-merged origin/main` returned no unmerged remote feature branches.
- Wiki drift: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`; no wiki publication required.
- Tiering: Feature Lane and PR Merge Gate are required GitHub proof for this backend modularity slice; no platform end-to-end proof required because routes, payloads, runtime behavior, and supported features did not change.