### PR TITLE
Extract liquidity source-family context assembly

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -6758,3 +6758,33 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   attachment orchestration only when it can be done without hiding method-specific behavior.
 - Wiki decision: no wiki source change required; this is internal source-product context
   modularity cleanup with no route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-265: Liquidity source-family context assembly extraction
+
+- Date: 2026-06-01
+- Scope:
+  `src/api/services/construction_source_product_context.py`,
+  `src/api/services/construction_service.py`,
+  `tests/unit/dpm/construction/test_source_product_context.py`, and
+  `tests/unit/dpm/construction/test_enrichment.py`.
+- Finding: after individual liquidity source-product mappings were extracted, the construction
+  service still assembled the composite liquidity authority context and policy reason codes
+  inline. The service also kept thin pass-through wrappers for external treasury and execution
+  acknowledgement source-context helpers. This left pure source-boundary assembly mixed with
+  construction orchestration.
+- Action: added `source_liquidity_context` to assemble the liquidity source family from
+  cashflow projection, client income-needs, liquidity reserve, and planned-withdrawal source
+  products. Updated construction orchestration to attach the returned liquidity context when
+  present and removed thin pass-through wrapper functions. Added direct helper tests for complete
+  liquidity source-family assembly and absent-source behavior.
+- Status: hardened
+- Evidence: focused source-product context, construction enrichment, and construction API
+  regressions (`tests/unit/dpm/construction/test_source_product_context.py`,
+  `tests/unit/dpm/construction/test_enrichment.py`, and
+  `tests/unit/dpm/api/test_construction_api.py`) passed with 64 tests. Focused Ruff checks,
+  focused mypy over source-product context and construction service, OpenAPI quality, API
+  vocabulary validation, service leakage scan, and `git diff --check` passed.
+- Follow-up: continue shrinking `construction_service.py` by extracting the remaining
+  source-family attachment decisions only where the extracted boundary remains directly testable.
+- Wiki decision: no wiki source change required; this is internal source-product context
+  modularity cleanup with no route, payload, supported-feature, or operator-contract change.

--- a/src/api/services/construction_service.py
+++ b/src/api/services/construction_service.py
@@ -36,13 +36,10 @@ from src.api.services.construction_solver_supportability import (
 )
 from src.api.services.construction_source_analytics_posture import source_analytics_posture
 from src.api.services.construction_source_product_context import (
-    client_income_needs_schedule_context,
     client_restriction_profile_context,
     external_order_execution_acknowledgement_context,
     external_treasury_currency_overlay_context,
-    liquidity_cashflow_projection_context,
-    liquidity_reserve_requirement_context,
-    planned_withdrawal_schedule_context,
+    source_liquidity_context,
     sustainability_preference_profile_context,
     transaction_cost_context_from_curve,
 )
@@ -77,7 +74,6 @@ from src.core.construction.models import (
     AuthoritativeClientRestrictionContext,
     AuthoritativeClientRestrictionRule,
     AuthoritativeCurrencyOverlayContext,
-    AuthoritativeExecutionAcknowledgementContext,
     AuthoritativeLiquidityContext,
     AuthoritativeRegimeStressContext,
     AuthoritativeSustainabilityPreference,
@@ -101,12 +97,6 @@ from src.core.construction.vocabulary import (
     FIRST_WAVE_CONSTRUCTION_METHODS,
 )
 from src.core.dpm_source_context import (
-    DpmCoreExternalCurrencyExposureResponse,
-    DpmCoreExternalEligibleHedgeInstrumentResponse,
-    DpmCoreExternalFXForwardCurveResponse,
-    DpmCoreExternalHedgeExecutionReadinessResponse,
-    DpmCoreExternalHedgePolicyResponse,
-    DpmCoreExternalOrderExecutionAcknowledgementResponse,
     DpmResolvedSourceContext,
 )
 from src.core.models import EngineOptions, RebalanceResult
@@ -468,29 +458,6 @@ def _authority_context_for_method(
     )
 
 
-def _external_treasury_currency_overlay_context(
-    *,
-    hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
-    currency_exposure: DpmCoreExternalCurrencyExposureResponse | None,
-    hedge_policy: DpmCoreExternalHedgePolicyResponse | None,
-    eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None,
-    fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None,
-) -> AuthoritativeCurrencyOverlayContext | None:
-    return external_treasury_currency_overlay_context(
-        hedge_readiness=hedge_readiness,
-        currency_exposure=currency_exposure,
-        hedge_policy=hedge_policy,
-        eligible_hedge_instruments=eligible_hedge_instruments,
-        fx_forward_curve=fx_forward_curve,
-    )
-
-
-def _external_order_execution_acknowledgement_context(
-    acknowledgement: DpmCoreExternalOrderExecutionAcknowledgementResponse | None,
-) -> AuthoritativeExecutionAcknowledgementContext | None:
-    return external_order_execution_acknowledgement_context(acknowledgement)
-
-
 def _authority_context_with_source_products(
     *,
     authority_context: ConstructionAuthorityContext,
@@ -504,51 +471,18 @@ def _authority_context_with_source_products(
         if curve is not None:
             context_updates["transaction_cost_context"] = transaction_cost_context_from_curve(curve)
     if authority_context.liquidity_context is None:
-        cashflow_projection = source_context.context.portfolio_cashflow_projection
-        income_needs = getattr(source_context.context, "client_income_needs_schedule", None)
-        reserve_requirement = getattr(source_context.context, "liquidity_reserve_requirement", None)
-        planned_withdrawals = getattr(source_context.context, "planned_withdrawal_schedule", None)
-        source_reason_codes = ["LIQUIDITY_POLICY_DERIVED_FROM_MANAGE_SETTLEMENT_RULES"]
-        cashflow_context = None
-        income_context = None
-        reserve_context = None
-        withdrawal_context = None
-        if (
-            cashflow_projection is not None
-            or income_needs is not None
-            or reserve_requirement is not None
-            or planned_withdrawals is not None
-        ):
-            source_reason_codes.append("CORE_LIQUIDITY_SOURCE_CONTEXT_PRESENT")
-        if cashflow_projection is not None:
-            cashflow_context = liquidity_cashflow_projection_context(cashflow_projection)
-        if income_needs is not None:
-            income_context = client_income_needs_schedule_context(income_needs)
-            source_reason_codes.append("CLIENT_INCOME_NEEDS_SOURCE_PRESENT")
-        if reserve_requirement is not None:
-            reserve_context = liquidity_reserve_requirement_context(reserve_requirement)
-            source_reason_codes.append("LIQUIDITY_RESERVE_SOURCE_PRESENT")
-        if planned_withdrawals is not None:
-            withdrawal_context = planned_withdrawal_schedule_context(planned_withdrawals)
-            source_reason_codes.append("PLANNED_WITHDRAWAL_SOURCE_PRESENT")
-        if (
-            cashflow_projection is not None
-            or income_needs is not None
-            or reserve_requirement is not None
-            or planned_withdrawals is not None
-        ):
-            context_updates["liquidity_context"] = AuthoritativeLiquidityContext(
-                supportability_status=ConstructionMethodStatus.READY,
-                source_system="lotus-manage-settlement-engine",
-                policy_id="manage-liquidity-policy.v1",
-                minimum_cash_weight=Decimal("0.02"),
-                allowed_liquidity_tiers=["L1", "L2", "L3"],
-                cashflow_projection=cashflow_context,
-                client_income_needs_schedule=income_context,
-                liquidity_reserve_requirement=reserve_context,
-                planned_withdrawal_schedule=withdrawal_context,
-                reason_codes=source_reason_codes,
-            )
+        liquidity_context = source_liquidity_context(
+            cashflow_projection=source_context.context.portfolio_cashflow_projection,
+            income_needs=getattr(source_context.context, "client_income_needs_schedule", None),
+            reserve_requirement=getattr(
+                source_context.context, "liquidity_reserve_requirement", None
+            ),
+            planned_withdrawals=getattr(
+                source_context.context, "planned_withdrawal_schedule", None
+            ),
+        )
+        if liquidity_context is not None:
+            context_updates["liquidity_context"] = liquidity_context
     if authority_context.currency_overlay_context is None:
         hedge_readiness = getattr(
             source_context.context,
@@ -575,7 +509,7 @@ def _authority_context_with_source_products(
             "external_fx_forward_curve",
             None,
         )
-        currency_context = _external_treasury_currency_overlay_context(
+        currency_context = external_treasury_currency_overlay_context(
             hedge_readiness=hedge_readiness,
             currency_exposure=currency_exposure,
             hedge_policy=hedge_policy,
@@ -590,7 +524,7 @@ def _authority_context_with_source_products(
             "external_order_execution_acknowledgement",
             None,
         )
-        acknowledgement_context = _external_order_execution_acknowledgement_context(acknowledgement)
+        acknowledgement_context = external_order_execution_acknowledgement_context(acknowledgement)
         if acknowledgement_context is not None:
             context_updates["execution_acknowledgement_context"] = acknowledgement_context
     if authority_context.client_restriction_context is None:

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -8,6 +8,7 @@ from src.core.construction.models import (
     AuthoritativeCurrencyOverlayContext,
     AuthoritativeExecutionAcknowledgementContext,
     AuthoritativeLiquidityCashflowProjection,
+    AuthoritativeLiquidityContext,
     AuthoritativeLiquidityReserveRequirement,
     AuthoritativePlannedWithdrawalSchedule,
     AuthoritativeSustainabilityPreference,
@@ -142,6 +143,64 @@ def planned_withdrawal_schedule_context(
             planned_withdrawals.supportability.reason,
             "CORE_PLANNED_WITHDRAWALS_PRESENT",
         ],
+    )
+
+
+def source_liquidity_context(
+    *,
+    cashflow_projection: DpmCorePortfolioCashflowProjectionResponse | None,
+    income_needs: DpmCoreClientIncomeNeedsScheduleResponse | None,
+    reserve_requirement: DpmCoreLiquidityReserveRequirementResponse | None,
+    planned_withdrawals: DpmCorePlannedWithdrawalScheduleResponse | None,
+) -> AuthoritativeLiquidityContext | None:
+    if (
+        cashflow_projection is None
+        and income_needs is None
+        and reserve_requirement is None
+        and planned_withdrawals is None
+    ):
+        return None
+
+    source_reason_codes = [
+        "LIQUIDITY_POLICY_DERIVED_FROM_MANAGE_SETTLEMENT_RULES",
+        "CORE_LIQUIDITY_SOURCE_CONTEXT_PRESENT",
+    ]
+    cashflow_context = (
+        liquidity_cashflow_projection_context(cashflow_projection)
+        if cashflow_projection is not None
+        else None
+    )
+    income_context = (
+        client_income_needs_schedule_context(income_needs) if income_needs is not None else None
+    )
+    reserve_context = (
+        liquidity_reserve_requirement_context(reserve_requirement)
+        if reserve_requirement is not None
+        else None
+    )
+    withdrawal_context = (
+        planned_withdrawal_schedule_context(planned_withdrawals)
+        if planned_withdrawals is not None
+        else None
+    )
+    if income_context is not None:
+        source_reason_codes.append("CLIENT_INCOME_NEEDS_SOURCE_PRESENT")
+    if reserve_context is not None:
+        source_reason_codes.append("LIQUIDITY_RESERVE_SOURCE_PRESENT")
+    if withdrawal_context is not None:
+        source_reason_codes.append("PLANNED_WITHDRAWAL_SOURCE_PRESENT")
+
+    return AuthoritativeLiquidityContext(
+        supportability_status=ConstructionMethodStatus.READY,
+        source_system="lotus-manage-settlement-engine",
+        policy_id="manage-liquidity-policy.v1",
+        minimum_cash_weight=Decimal("0.02"),
+        allowed_liquidity_tiers=["L1", "L2", "L3"],
+        cashflow_projection=cashflow_context,
+        client_income_needs_schedule=income_context,
+        liquidity_reserve_requirement=reserve_context,
+        planned_withdrawal_schedule=withdrawal_context,
+        reason_codes=source_reason_codes,
     )
 
 
@@ -565,6 +624,7 @@ __all__ = [
     "liquidity_reserve_requirement_context",
     "planned_withdrawal_schedule_context",
     "source_status_to_method_status",
+    "source_liquidity_context",
     "sustainability_preference_profile_context",
     "transaction_cost_context_from_curve",
 ]

--- a/tests/unit/dpm/construction/test_enrichment.py
+++ b/tests/unit/dpm/construction/test_enrichment.py
@@ -6,7 +6,10 @@ import pytest
 from src.api.request_models import RebalanceRequest
 from src.api.routers.construction_http import construction_http_exception
 import src.api.services.construction_service as construction_service
-from src.api.services.construction_source_product_context import source_status_to_method_status
+from src.api.services.construction_source_product_context import (
+    external_treasury_currency_overlay_context,
+    source_status_to_method_status,
+)
 from src.core.construction import (
     AuthoritativeClientRestrictionContext,
     AuthoritativeClientRestrictionRule,
@@ -979,21 +982,21 @@ def test_source_context_lifts_external_hedge_readiness_as_fail_closed_currency_c
     )
     assert currency_context.external_fx_forward_curve_point_count == 0
 
-    exposure_only = construction_service._external_treasury_currency_overlay_context(
+    exposure_only = external_treasury_currency_overlay_context(
         hedge_readiness=None,
         currency_exposure=exposure,
         hedge_policy=None,
         eligible_hedge_instruments=None,
         fx_forward_curve=None,
     )
-    hedge_policy_only = construction_service._external_treasury_currency_overlay_context(
+    hedge_policy_only = external_treasury_currency_overlay_context(
         hedge_readiness=None,
         currency_exposure=None,
         hedge_policy=hedge_policy,
         eligible_hedge_instruments=None,
         fx_forward_curve=None,
     )
-    eligible_instruments_only = construction_service._external_treasury_currency_overlay_context(
+    eligible_instruments_only = external_treasury_currency_overlay_context(
         hedge_readiness=None,
         currency_exposure=None,
         hedge_policy=None,

--- a/tests/unit/dpm/construction/test_source_product_context.py
+++ b/tests/unit/dpm/construction/test_source_product_context.py
@@ -9,6 +9,7 @@ from src.api.services.construction_source_product_context import (
     liquidity_cashflow_projection_context,
     liquidity_reserve_requirement_context,
     planned_withdrawal_schedule_context,
+    source_liquidity_context,
     source_status_to_method_status,
     sustainability_preference_profile_context,
     transaction_cost_context_from_curve,
@@ -393,6 +394,49 @@ def test_liquidity_cashflow_projection_context_preserves_source_lineage_and_stat
     assert context.include_projected is True
     assert context.data_quality_status == ConstructionMethodStatus.DEGRADED
     assert context.reason_codes == ["CORE_CASHFLOW_PROJECTION_READY"]
+
+
+def test_source_liquidity_context_preserves_source_family_policy_and_children() -> None:
+    context = source_liquidity_context(
+        cashflow_projection=_cashflow_projection(),
+        income_needs=_income_needs_schedule(),
+        reserve_requirement=_liquidity_reserve_requirement(),
+        planned_withdrawals=_planned_withdrawal_schedule(),
+    )
+
+    assert context is not None
+    assert context.supportability_status == ConstructionMethodStatus.READY
+    assert context.source_system == "lotus-manage-settlement-engine"
+    assert context.policy_id == "manage-liquidity-policy.v1"
+    assert context.minimum_cash_weight == Decimal("0.02")
+    assert context.allowed_liquidity_tiers == ["L1", "L2", "L3"]
+    assert context.cashflow_projection is not None
+    assert context.cashflow_projection.source_batch_fingerprint == "cashflow-lineage"
+    assert context.client_income_needs_schedule is not None
+    assert context.client_income_needs_schedule.source_id == "income-lineage"
+    assert context.liquidity_reserve_requirement is not None
+    assert context.liquidity_reserve_requirement.source_id == "reserve-lineage"
+    assert context.planned_withdrawal_schedule is not None
+    assert context.planned_withdrawal_schedule.source_id == "withdrawal-lineage"
+    assert context.reason_codes == [
+        "LIQUIDITY_POLICY_DERIVED_FROM_MANAGE_SETTLEMENT_RULES",
+        "CORE_LIQUIDITY_SOURCE_CONTEXT_PRESENT",
+        "CLIENT_INCOME_NEEDS_SOURCE_PRESENT",
+        "LIQUIDITY_RESERVE_SOURCE_PRESENT",
+        "PLANNED_WITHDRAWAL_SOURCE_PRESENT",
+    ]
+
+
+def test_source_liquidity_context_absent_without_source_family() -> None:
+    assert (
+        source_liquidity_context(
+            cashflow_projection=None,
+            income_needs=None,
+            reserve_requirement=None,
+            planned_withdrawals=None,
+        )
+        is None
+    )
 
 
 def test_client_restriction_profile_context_preserves_rules_and_lineage() -> None:


### PR DESCRIPTION
## Summary
- Extract composite liquidity source-family authority-context assembly into `source_liquidity_context`.
- Keep `construction_service.py` responsible for conditional source-context attachment while removing pure source-family mapping and thin pass-through wrappers.
- Add direct helper tests for full liquidity source-family assembly and absent-source behavior.
- Record codebase review ledger entry `BACKEND-REVIEW-20260601-265`.

## Evidence
- `python -m ruff check src/api/services/construction_source_product_context.py src/api/services/construction_service.py tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py`
- `python -m ruff format --check src/api/services/construction_source_product_context.py src/api/services/construction_service.py tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py`
- `python -m mypy --config-file mypy.ini src/api/services/construction_source_product_context.py src/api/services/construction_service.py`
- `python -m pytest tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py tests/unit/dpm/api/test_construction_api.py` (`64 passed`)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP" src/api/services -g "*.py"` (no matches)
- `make check` (`1664 passed`)

## Governance
- Stranded truth: `git fetch origin --prune` and `git branch -r --no-merged origin/main` returned no unmerged remote feature branches.
- Wiki drift: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`; no wiki publication required.
- Tiering: Feature Lane and PR Merge Gate are required GitHub proof for this backend modularity slice; no platform end-to-end proof required because routes, payloads, runtime behavior, and supported features did not change.