### PR TITLE
Extract source product authority context updates

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -6788,3 +6788,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   source-family attachment decisions only where the extracted boundary remains directly testable.
 - Wiki decision: no wiki source change required; this is internal source-product context
   modularity cleanup with no route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-266: Source-product authority update extraction
+
+- Date: 2026-06-01
+- Scope:
+  `src/api/services/construction_source_product_context.py`,
+  `src/api/services/construction_service.py`, and
+  `tests/unit/dpm/construction/test_source_product_context.py`.
+- Finding: construction orchestration still contained the full source-product authority-context
+  update matrix for transaction cost, liquidity, currency-overlay, execution acknowledgement,
+  client restrictions, and sustainability preferences. The mapping was pure source-boundary
+  assembly with existing-context preservation rules, not method orchestration.
+- Action: added `source_product_authority_context_updates` to compute source-derived authority
+  context updates in the helper module. Reduced `_authority_context_with_source_products` to a
+  null-source guard, helper call, and model-copy application. Added direct tests proving all source
+  families are lifted and caller-supplied existing contexts are not overwritten.
+- Status: hardened
+- Evidence: focused source-product context, construction enrichment, and construction API
+  regressions (`tests/unit/dpm/construction/test_source_product_context.py`,
+  `tests/unit/dpm/construction/test_enrichment.py`, and
+  `tests/unit/dpm/api/test_construction_api.py`) passed with 66 tests. Focused Ruff checks,
+  focused mypy over source-product context and construction service, OpenAPI quality, API
+  vocabulary validation, service leakage scan, and `git diff --check` passed.
+- Follow-up: continue reviewing `construction_service.py` for pass-through supportability wrappers
+  that can move to domain-specific helper modules without weakening method-level readability.
+- Wiki decision: no wiki source change required; this is internal source-product context
+  modularity cleanup with no route, payload, supported-feature, or operator-contract change.

--- a/src/api/services/construction_service.py
+++ b/src/api/services/construction_service.py
@@ -36,12 +36,7 @@ from src.api.services.construction_solver_supportability import (
 )
 from src.api.services.construction_source_analytics_posture import source_analytics_posture
 from src.api.services.construction_source_product_context import (
-    client_restriction_profile_context,
-    external_order_execution_acknowledgement_context,
-    external_treasury_currency_overlay_context,
-    source_liquidity_context,
-    sustainability_preference_profile_context,
-    transaction_cost_context_from_curve,
+    source_product_authority_context_updates,
 )
 from src.api.services.construction_esg_supportability import (
     client_restriction_reason_codes,
@@ -465,80 +460,10 @@ def _authority_context_with_source_products(
 ) -> ConstructionAuthorityContext:
     if source_context is None:
         return authority_context
-    context_updates: dict[str, object] = {}
-    if authority_context.transaction_cost_context is None:
-        curve = source_context.context.transaction_cost_curve
-        if curve is not None:
-            context_updates["transaction_cost_context"] = transaction_cost_context_from_curve(curve)
-    if authority_context.liquidity_context is None:
-        liquidity_context = source_liquidity_context(
-            cashflow_projection=source_context.context.portfolio_cashflow_projection,
-            income_needs=getattr(source_context.context, "client_income_needs_schedule", None),
-            reserve_requirement=getattr(
-                source_context.context, "liquidity_reserve_requirement", None
-            ),
-            planned_withdrawals=getattr(
-                source_context.context, "planned_withdrawal_schedule", None
-            ),
-        )
-        if liquidity_context is not None:
-            context_updates["liquidity_context"] = liquidity_context
-    if authority_context.currency_overlay_context is None:
-        hedge_readiness = getattr(
-            source_context.context,
-            "external_hedge_execution_readiness",
-            None,
-        )
-        currency_exposure = getattr(
-            source_context.context,
-            "external_currency_exposure",
-            None,
-        )
-        hedge_policy = getattr(
-            source_context.context,
-            "external_hedge_policy",
-            None,
-        )
-        eligible_hedge_instruments = getattr(
-            source_context.context,
-            "external_eligible_hedge_instruments",
-            None,
-        )
-        fx_forward_curve = getattr(
-            source_context.context,
-            "external_fx_forward_curve",
-            None,
-        )
-        currency_context = external_treasury_currency_overlay_context(
-            hedge_readiness=hedge_readiness,
-            currency_exposure=currency_exposure,
-            hedge_policy=hedge_policy,
-            eligible_hedge_instruments=eligible_hedge_instruments,
-            fx_forward_curve=fx_forward_curve,
-        )
-        if currency_context is not None:
-            context_updates["currency_overlay_context"] = currency_context
-    if authority_context.execution_acknowledgement_context is None:
-        acknowledgement = getattr(
-            source_context.context,
-            "external_order_execution_acknowledgement",
-            None,
-        )
-        acknowledgement_context = external_order_execution_acknowledgement_context(acknowledgement)
-        if acknowledgement_context is not None:
-            context_updates["execution_acknowledgement_context"] = acknowledgement_context
-    if authority_context.client_restriction_context is None:
-        restriction_profile = source_context.context.client_restriction_profile
-        if restriction_profile is not None:
-            context_updates["client_restriction_context"] = client_restriction_profile_context(
-                restriction_profile
-            )
-    if authority_context.sustainability_preference_context is None:
-        sustainability_profile = source_context.context.sustainability_preference_profile
-        if sustainability_profile is not None:
-            context_updates["sustainability_preference_context"] = (
-                sustainability_preference_profile_context(sustainability_profile)
-            )
+    context_updates = source_product_authority_context_updates(
+        source_context=source_context.context,
+        authority_context=authority_context,
+    )
     if not context_updates:
         return authority_context
     return authority_context.model_copy(update=context_updates)

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -15,6 +15,7 @@ from src.core.construction.models import (
     AuthoritativeSustainabilityPreferenceContext,
     AuthoritativeTransactionCostContext,
     AuthoritativeTransactionCostPoint,
+    ConstructionAuthorityContext,
 )
 from src.core.construction.vocabulary import ConstructionMethodStatus
 from src.core.dpm_source_context import (
@@ -26,6 +27,7 @@ from src.core.dpm_source_context import (
     DpmCoreExternalHedgeExecutionReadinessResponse,
     DpmCoreExternalHedgePolicyResponse,
     DpmCoreExternalOrderExecutionAcknowledgementResponse,
+    DpmCoreExecutionContext,
     DpmCoreLiquidityReserveRequirementResponse,
     DpmCorePlannedWithdrawalScheduleResponse,
     DpmCorePortfolioCashflowProjectionResponse,
@@ -607,6 +609,58 @@ def external_order_execution_acknowledgement_context(
     )
 
 
+def source_product_authority_context_updates(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> dict[str, object]:
+    context_updates: dict[str, object] = {}
+    if authority_context.transaction_cost_context is None:
+        curve = getattr(source_context, "transaction_cost_curve", None)
+        if curve is not None:
+            context_updates["transaction_cost_context"] = transaction_cost_context_from_curve(curve)
+    if authority_context.liquidity_context is None:
+        liquidity_context = source_liquidity_context(
+            cashflow_projection=getattr(source_context, "portfolio_cashflow_projection", None),
+            income_needs=getattr(source_context, "client_income_needs_schedule", None),
+            reserve_requirement=getattr(source_context, "liquidity_reserve_requirement", None),
+            planned_withdrawals=getattr(source_context, "planned_withdrawal_schedule", None),
+        )
+        if liquidity_context is not None:
+            context_updates["liquidity_context"] = liquidity_context
+    if authority_context.currency_overlay_context is None:
+        currency_context = external_treasury_currency_overlay_context(
+            hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
+            currency_exposure=getattr(source_context, "external_currency_exposure", None),
+            hedge_policy=getattr(source_context, "external_hedge_policy", None),
+            eligible_hedge_instruments=getattr(
+                source_context, "external_eligible_hedge_instruments", None
+            ),
+            fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
+        )
+        if currency_context is not None:
+            context_updates["currency_overlay_context"] = currency_context
+    if authority_context.execution_acknowledgement_context is None:
+        acknowledgement_context = external_order_execution_acknowledgement_context(
+            getattr(source_context, "external_order_execution_acknowledgement", None)
+        )
+        if acknowledgement_context is not None:
+            context_updates["execution_acknowledgement_context"] = acknowledgement_context
+    if authority_context.client_restriction_context is None:
+        restriction_profile = getattr(source_context, "client_restriction_profile", None)
+        if restriction_profile is not None:
+            context_updates["client_restriction_context"] = client_restriction_profile_context(
+                restriction_profile
+            )
+    if authority_context.sustainability_preference_context is None:
+        sustainability_profile = getattr(source_context, "sustainability_preference_profile", None)
+        if sustainability_profile is not None:
+            context_updates["sustainability_preference_context"] = (
+                sustainability_preference_profile_context(sustainability_profile)
+            )
+    return context_updates
+
+
 def source_status_to_method_status(status: str) -> ConstructionMethodStatus:
     if status == "READY":
         return ConstructionMethodStatus.READY
@@ -625,6 +679,7 @@ __all__ = [
     "planned_withdrawal_schedule_context",
     "source_status_to_method_status",
     "source_liquidity_context",
+    "source_product_authority_context_updates",
     "sustainability_preference_profile_context",
     "transaction_cost_context_from_curve",
 ]

--- a/tests/unit/dpm/construction/test_source_product_context.py
+++ b/tests/unit/dpm/construction/test_source_product_context.py
@@ -10,10 +10,12 @@ from src.api.services.construction_source_product_context import (
     liquidity_reserve_requirement_context,
     planned_withdrawal_schedule_context,
     source_liquidity_context,
+    source_product_authority_context_updates,
     source_status_to_method_status,
     sustainability_preference_profile_context,
     transaction_cost_context_from_curve,
 )
+from src.core.construction.models import ConstructionAuthorityContext
 from src.core.construction.vocabulary import ConstructionMethodStatus
 from src.core.dpm_source_context import (
     DpmCoreClientIncomeNeedsScheduleEntry,
@@ -26,6 +28,7 @@ from src.core.dpm_source_context import (
     DpmCoreExternalOrderExecutionAcknowledgementSupportability,
     DpmCoreExternalHedgeExecutionReadinessResponse,
     DpmCoreExternalHedgeExecutionReadinessSupportability,
+    DpmCoreExecutionContext,
     DpmCoreIntegrationWindow,
     DpmCoreLiquidityReserveRequirementEntry,
     DpmCoreLiquidityReserveRequirementResponse,
@@ -335,6 +338,26 @@ def _sustainability_preference_profile() -> DpmCoreSustainabilityPreferenceProfi
     )
 
 
+def _source_execution_context(**overrides: object) -> DpmCoreExecutionContext:
+    source_products = {
+        "transaction_cost_curve": None,
+        "portfolio_cashflow_projection": None,
+        "client_income_needs_schedule": None,
+        "liquidity_reserve_requirement": None,
+        "planned_withdrawal_schedule": None,
+        "external_hedge_execution_readiness": None,
+        "external_currency_exposure": None,
+        "external_hedge_policy": None,
+        "external_eligible_hedge_instruments": None,
+        "external_fx_forward_curve": None,
+        "external_order_execution_acknowledgement": None,
+        "client_restriction_profile": None,
+        "sustainability_preference_profile": None,
+    }
+    source_products.update(overrides)
+    return DpmCoreExecutionContext.model_construct(**source_products)
+
+
 def test_client_income_needs_context_preserves_priority_currency_and_status() -> None:
     context = client_income_needs_schedule_context(_income_needs_schedule())
 
@@ -437,6 +460,63 @@ def test_source_liquidity_context_absent_without_source_family() -> None:
         )
         is None
     )
+
+
+def test_source_product_authority_context_updates_lifts_all_source_families() -> None:
+    updates = source_product_authority_context_updates(
+        source_context=_source_execution_context(
+            transaction_cost_curve=_transaction_cost_curve(),
+            portfolio_cashflow_projection=_cashflow_projection(),
+            client_income_needs_schedule=_income_needs_schedule(),
+            liquidity_reserve_requirement=_liquidity_reserve_requirement(),
+            planned_withdrawal_schedule=_planned_withdrawal_schedule(),
+            external_hedge_execution_readiness=_hedge_readiness_response(),
+            external_order_execution_acknowledgement=_acknowledgement_response(),
+            client_restriction_profile=_client_restriction_profile(),
+            sustainability_preference_profile=_sustainability_preference_profile(),
+        ),
+        authority_context=ConstructionAuthorityContext(),
+    )
+
+    assert sorted(updates) == [
+        "client_restriction_context",
+        "currency_overlay_context",
+        "execution_acknowledgement_context",
+        "liquidity_context",
+        "sustainability_preference_context",
+        "transaction_cost_context",
+    ]
+    assert updates["transaction_cost_context"].source_id == "curve-lineage"
+    assert updates["liquidity_context"].planned_withdrawal_schedule is not None
+    assert updates["currency_overlay_context"].source_id == "core-hedge-readiness"
+    assert updates["execution_acknowledgement_context"].source_id == "core-ack-fingerprint"
+    assert updates["client_restriction_context"].source_id == "restriction-lineage"
+    assert updates["sustainability_preference_context"].source_id == "sustainability-lineage"
+
+
+def test_source_product_authority_context_updates_preserves_existing_contexts() -> None:
+    existing_liquidity_context = source_liquidity_context(
+        cashflow_projection=_cashflow_projection(),
+        income_needs=None,
+        reserve_requirement=None,
+        planned_withdrawals=None,
+    )
+    assert existing_liquidity_context is not None
+    updates = source_product_authority_context_updates(
+        source_context=_source_execution_context(
+            transaction_cost_curve=_transaction_cost_curve(),
+            portfolio_cashflow_projection=_cashflow_projection(),
+            external_order_execution_acknowledgement=_acknowledgement_response(),
+        ),
+        authority_context=ConstructionAuthorityContext(
+            transaction_cost_context=transaction_cost_context_from_curve(_transaction_cost_curve()),
+            liquidity_context=existing_liquidity_context,
+        ),
+    )
+
+    assert "transaction_cost_context" not in updates
+    assert "liquidity_context" not in updates
+    assert sorted(updates) == ["execution_acknowledgement_context"]
 
 
 def test_client_restriction_profile_context_preserves_rules_and_lineage() -> None:


### PR DESCRIPTION
## Summary
- Extract source-derived authority-context update assembly into `construction_source_product_context`.
- Reduce `_authority_context_with_source_products` to orchestration: null-source guard, helper call, and model-copy application.
- Add direct helper tests proving all source families are lifted and existing authority contexts are preserved.
- Record ledger entry `BACKEND-REVIEW-20260601-266`.

## Evidence
- `python -m ruff check src/api/services/construction_source_product_context.py src/api/services/construction_service.py tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py`
- `python -m ruff format --check src/api/services/construction_source_product_context.py src/api/services/construction_service.py tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py`
- `python -m mypy --config-file mypy.ini src/api/services/construction_source_product_context.py src/api/services/construction_service.py`
- `python -m pytest tests/unit/dpm/construction/test_source_product_context.py tests/unit/dpm/construction/test_enrichment.py tests/unit/dpm/api/test_construction_api.py` (`66 passed`)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP" src/api/services -g "*.py"` (no matches)
- `make check` (`1666 passed`)

## Governance
- Stranded truth reconciliation: `git fetch origin --prune`; `git branch -r --no-merged origin/main` returned no branches.
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`; no wiki publication required.
- No platform e2e required: this is a pure service/helper extraction with no route, payload, OpenAPI, runtime, or supported-feature contract change.
