### PR TITLE
Prune construction supportability wrappers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -6815,3 +6815,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   that can move to domain-specific helper modules without weakening method-level readability.
 - Wiki decision: no wiki source change required; this is internal source-product context
   modularity cleanup with no route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-267: Construction supportability wrapper pruning
+
+- Date: 2026-06-01
+- Scope: `src/api/services/construction_service.py` and
+  `docs/architecture/CODEBASE-REVIEW-LEDGER.md`.
+- Finding: construction orchestration retained thin pass-through wrappers for method-specific
+  status, enrichment reason-code attachment, source analytics posture, and an unused construction
+  options wrapper. These wrappers added private indirection without preserving domain ownership or
+  isolating behavior.
+- Action: removed the unused options wrapper and replaced private pass-through calls with direct
+  calls to the established domain helper modules. Kept the remaining wrappers where existing
+  tests still document supportability behavior through the current service boundary.
+- Status: hardened
+- Evidence: focused construction enrichment and construction API regressions
+  (`tests/unit/dpm/construction/test_enrichment.py` and
+  `tests/unit/dpm/api/test_construction_api.py`) passed with 50 tests. Focused Ruff checks,
+  focused mypy over construction service, OpenAPI quality, API vocabulary validation, service
+  leakage scan, and `git diff --check` passed.
+- Follow-up: continue moving supportability tests toward their owning helper modules so additional
+  pass-through wrappers can be removed without reducing behavioral coverage.
+- Wiki decision: no wiki source change required; this is internal orchestration cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/src/api/services/construction_service.py
+++ b/src/api/services/construction_service.py
@@ -22,7 +22,6 @@ from src.api.services.construction_method_supportability import (
     regime_stress_status,
 )
 from src.api.services.construction_method_execution import (
-    options_for_construction_method,
     run_construction_method,
 )
 from src.api.services.construction_method_authority import authority_context_for_method
@@ -94,7 +93,7 @@ from src.core.construction.vocabulary import (
 from src.core.dpm_source_context import (
     DpmResolvedSourceContext,
 )
-from src.core.models import EngineOptions, RebalanceResult
+from src.core.models import RebalanceResult
 from src.core.models import Money, SecurityTradeIntent, ShelfEntry
 from src.core.rebalance_runs.service import DpmRunSupportService
 from src.api.request_models import RebalanceRequest
@@ -284,14 +283,6 @@ def _run_method(
     )
 
 
-def _options_for_method(
-    *,
-    options: EngineOptions,
-    method: ConstructionMethod,
-) -> EngineOptions:
-    return options_for_construction_method(options=options, method=method)
-
-
 def _apply_supportability(
     *,
     request: RebalanceRequest,
@@ -339,7 +330,7 @@ def _apply_supportability(
         [
             alternative.method_status,
             plan.method_status,
-            _method_specific_status(
+            method_specific_status(
                 request=request,
                 method=method,
                 result=result,
@@ -378,34 +369,17 @@ def _apply_supportability(
             "diagnostics": {
                 **alternative.diagnostics,
                 "method_plan": plan.model_dump(mode="json"),
-                "enrichment_summary": _with_method_reason_codes(
+                "enrichment_summary": with_method_reason_codes(
                     enrichment=enrichment,
                     reason_codes=method_reason_codes,
                 ).model_dump(mode="json"),
                 "authority_context": authority_context.model_dump(mode="json", exclude_none=True),
-                "source_analytics_posture": _source_analytics_posture(
+                "source_analytics_posture": source_analytics_posture(
                     method=method,
                     authority_context=authority_context,
                 ),
             },
         }
-    )
-
-
-def _method_specific_status(
-    *,
-    request: RebalanceRequest,
-    method: ConstructionMethod,
-    result: RebalanceResult,
-    enrichment: ConstructionEnrichmentSummary,
-    authority_context: ConstructionAuthorityContext,
-) -> ConstructionMethodStatus:
-    return method_specific_status(
-        request=request,
-        method=method,
-        result=result,
-        enrichment=enrichment,
-        authority_context=authority_context,
     )
 
 
@@ -423,14 +397,6 @@ def _method_specific_reason_codes(
         result=result,
         authority_context=authority_context,
     )
-
-
-def _source_analytics_posture(
-    *,
-    method: ConstructionMethod,
-    authority_context: ConstructionAuthorityContext,
-) -> dict[str, object]:
-    return source_analytics_posture(method=method, authority_context=authority_context)
 
 
 def _authority_context_for_method(
@@ -612,14 +578,6 @@ def _sustainability_classification_review_required(
     context: AuthoritativeSustainabilityPreferenceContext,
 ) -> bool:
     return sustainability_classification_review_required(context=context)
-
-
-def _with_method_reason_codes(
-    *,
-    enrichment: ConstructionEnrichmentSummary,
-    reason_codes: list[str],
-) -> ConstructionEnrichmentSummary:
-    return with_method_reason_codes(enrichment=enrichment, reason_codes=reason_codes)
 
 
 def _solver_method_status(*, result: RebalanceResult) -> ConstructionMethodStatus:


### PR DESCRIPTION
## Summary
- Remove unused construction options wrapper from `construction_service.py`.
- Replace private pass-through supportability calls with direct calls to their owning helper modules.
- Record ledger entry `BACKEND-REVIEW-20260601-267` with the no-wiki-change decision.

## Evidence
- `python -m ruff check src/api/services/construction_service.py`
- `python -m ruff format --check src/api/services/construction_service.py`
- `python -m mypy --config-file mypy.ini src/api/services/construction_service.py`
- `python -m pytest tests/unit/dpm/construction/test_enrichment.py tests/unit/dpm/api/test_construction_api.py` (`50 passed`)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP" src/api/services -g "*.py"` (no matches)
- `make check` (`1666 passed`)

## Governance
- Stranded truth reconciliation: `git fetch origin --prune`; `git branch -r --no-merged origin/main` returned no branches.
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`; no wiki publication required.
- No platform e2e required: this is a pure service orchestration cleanup with no route, payload, OpenAPI, runtime, or supported-feature contract change.
