### PR TITLE
Continue manage backend hardening

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9014,3 +9014,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   compatibility gaps.
 - Wiki decision: no wiki source change required; this is an internal compatibility fix with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-370: Mandate service error extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_errors.py`,
+  `tests/unit/dpm/mandates/test_mandate_errors.py`, selected mandate API regressions, and this
+  ledger.
+- Finding: `mandate_service.py` still defined reusable mandate service exception carrier classes
+  directly, keeping shared service error vocabulary embedded in a large orchestration module.
+- Action: extracted mandate lookup, diff, source-availability, health, and monitoring-run error
+  types into a focused service error module, preserved the existing `mandate_service` import surface
+  for routers and tests, and added direct tests for compatibility aliases, exception families, and
+  export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_errors.py`; direct mandate error tests and selected
+  mandate API regressions passed with 26 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue shrinking `mandate_service.py` by moving pure diff, command-center, and
+  source-resolution support helpers into directly tested modules while preserving route-facing
+  service compatibility.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9985,3 +9985,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   assembly that can be separated without moving repository lookup ownership out of the service.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-410: Proof-pack handoff-ref lookup extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/proof_pack_service.py`,
+  `src/api/services/proof_pack_handoff_refs.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_handoff_refs.py`, selected proof-pack regressions,
+  and this ledger.
+- Finding: proof-pack report-input and AI-evidence ref accessors repeated the hydrated-ref,
+  append-only stored-ref, and missing-generated-ref decision path inside the service, making the
+  supportability fallback harder to test directly.
+- Action: extracted the common handoff-ref resolution decision into the handoff-ref helper,
+  preserving service-specific generated-ref exceptions while adding direct tests for hydrated-ref
+  preference, latest stored-ref fallback, and missing-ref return behavior.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `proof_pack_handoff_refs.py`; direct proof-pack
+  handoff-ref tests and selected proof-pack service regressions passed with 19 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing proof-pack generation flow for builder-input assembly that can be
+  separated without moving source lookup or exception ownership out of the service.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9911,3 +9911,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   support where it produces directly testable source-boundary behavior.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-407: Outcome review report-input context extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/outcome_review_service.py`,
+  `src/api/services/outcome_review_report_inputs.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_report_inputs.py`, selected outcome/proof-pack
+  regressions, and this ledger.
+- Finding: outcome review report-input and AI-evidence input accessors duplicated
+  portfolio-memory context assembly inside the service, keeping downstream handoff context
+  construction embedded in lookup orchestration.
+- Action: extracted outcome report/AI evidence input builders and portfolio-memory context
+  assembly into a focused helper module, preserving service ownership of review lookup while adding
+  direct tests for missing repository gating, portfolio id propagation, report input context
+  passing, AI evidence context passing, export surface, and service alias compatibility.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `outcome_review_service.py` and `outcome_review_report_inputs.py`; direct outcome
+  report-input tests and selected outcome/proof-pack regressions passed with 113 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing proof-pack report/AI input helpers for the same handoff-context
+  duplication pattern.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9374,3 +9374,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   or moving to the next largest service hotspot once wave orchestration is sufficiently lean.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-385: Wave created-id helper extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_creation.py`,
+  `tests/unit/dpm/waves/test_wave_creation.py`, selected wave API regressions, and this ledger.
+- Finding: `wave_service.py` still generated durable wave identifiers directly with `uuid`, while
+  the rest of the create-wave request hashing and preview-promotion mechanics already lived in
+  `wave_creation.py`.
+- Action: moved created-wave id generation into `create_created_wave_id`, removed the direct `uuid`
+  dependency from `wave_service.py`, and added a deterministic direct test for the governed
+  `dwv_` identifier prefix and 12-character entropy slice.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_creation.py`; direct wave creation tests and selected wave
+  API regressions passed with 136 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting persisted transition update support
+  or move to the next largest service hotspot once wave orchestration is sufficiently lean.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10130,3 +10130,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   can be isolated without hiding lookup or run lifecycle ownership.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-416: Mandate monitoring aggregation extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`,
+  `src/api/services/mandate_monitoring_run.py`,
+  `tests/unit/dpm/mandates/test_mandate_monitoring_run.py`, selected mandate regressions, and this
+  ledger.
+- Finding: mandate monitoring orchestration still owned mutable health-distribution,
+  source-readiness, and exception-count aggregation inside the service loop, mixing run accounting
+  with mandate lookup, health calculation, and persistence flow.
+- Action: introduced a monitoring-run accumulator in the monitoring helper, kept repository lookup
+  and run lifecycle orchestration in the service, and added direct tests proving repeated mandate
+  results update health distribution, source-readiness summary, and exception count consistently.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_monitoring_run.py`; direct mandate monitoring
+  helper tests and selected mandate API regressions passed with 31 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing mandate service read-model and command-center assembly boundaries
+  for directly testable extraction opportunities.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9887,3 +9887,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   testable supportability and operation-lifecycle boundaries.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-406: Outcome review dimension-input extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/outcome_review_service.py`,
+  `src/api/services/outcome_review_dimensions.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_dimensions.py`, selected outcome review/API
+  regressions, and this ledger.
+- Finding: outcome review preview and refresh flows still depended on a private service function
+  for expected-versus-realized dimension input assembly and missing-evidence validation, leaving a
+  domain validation boundary embedded inside orchestration.
+- Action: extracted dimension configuration, validation error, and dimension input assembly into a
+  focused helper module with direct tests for configured dimension projection, missing expected
+  evidence, missing realized evidence, helper export surface, and service import compatibility.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `outcome_review_service.py` and `outcome_review_dimensions.py`; direct outcome
+  dimension tests and selected outcome/proof-pack regressions passed with 107 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue extracting outcome review report/AI input context assembly or creation
+  support where it produces directly testable source-boundary behavior.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9861,3 +9861,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   similarly testable context assembly or supportability-boundary extraction.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-405: Rebalance async submission-context extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/rebalance_simulation_service.py`,
+  `src/api/services/rebalance_async_submission_context.py`,
+  `tests/unit/api/test_rebalance_async_submission_context.py`, selected rebalance API/runtime
+  regressions, and this ledger.
+- Finding: `submit_and_optionally_execute_async_analysis` still mixed async support-service
+  resolution, supportability-store unavailable mapping, analyze-async policy resolution,
+  execution-mode resolution, and request-json assembly inside the public orchestration function.
+- Action: extracted async submission-context assembly into a focused helper that returns the
+  support service, persisted request payload, execution mode, and policy resolution metadata while
+  preserving service-level support-service factory injection for test and runtime override
+  compatibility.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `rebalance_simulation_service.py`,
+  `rebalance_async_submission_context.py`, and the related rebalance execution-context helpers;
+  direct async submission-context tests and selected rebalance API/runtime regressions passed with
+  144 tests; OpenAPI quality gate passed; API vocabulary inventory validate-only gate passed; `git
+  diff --check` passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing rebalance manual execution and async runner seams for directly
+  testable supportability and operation-lifecycle boundaries.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9212,3 +9212,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   they can be made directly testable without hiding orchestration.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-378: Mandate health-result helper extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_health_result.py`,
+  `tests/unit/dpm/mandates/test_mandate_health_result.py`, selected mandate API regressions, and
+  this ledger.
+- Finding: mandate refresh and recalculation paths both performed the same health snapshot
+  calculation followed by monitoring-exception derivation from the mandate twin source lineage.
+- Action: extracted the repeated health-calculation result assembly into a focused helper returning
+  a typed `DpmMandateHealthCalculationResult`, kept persistence and mismatch validation in
+  `mandate_service.py`, preserved the service compatibility alias, and added direct tests for
+  snapshot/exception projection, service import compatibility, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_health_result.py`; direct health-result helper tests
+  and selected mandate API regressions passed with 26 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue extracting small repository lookup wrappers or move to another service hotspot
+  once the remaining `mandate_service.py` orchestration is sufficiently lean.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9715,3 +9715,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   directly testable boundary; otherwise move to the next service hotspot.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-399: Wave report-input assembly extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_report_input.py`,
+  `tests/unit/dpm/waves/test_wave_report_input.py`, selected wave report/API regressions, and this
+  ledger.
+- Finding: `get_report_input` still assembled supportability, proof-pack posture, portfolio-memory
+  context, and external-execution boundary error mapping inside the public service function instead
+  of keeping the service focused on lookup and orchestration.
+- Action: extracted report-input assembly into a focused helper that builds supportability and
+  proof-pack posture, resolves optional portfolio-memory report context, maps core boundary
+  failures to the existing bounded service error, and leaves `wave_service.py` responsible only for
+  wave lookup and delegation.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_report_input.py`; direct report-input tests and selected
+  wave report/API regressions passed with 145 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` only where remaining workflow functions still mix
+  orchestration with directly testable domain assembly; otherwise shift to the next service hotspot.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9328,3 +9328,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   or construction-selection orchestration helpers where they stay domain-specific and testable.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-383: Wave selection metadata extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_workflow_metadata.py`,
+  `tests/unit/dpm/waves/test_wave_workflow_metadata.py`, selected wave API regressions, and this
+  ledger.
+- Finding: item-selection still built its audit event metadata inline while other wave workflow
+  event metadata had already moved into a directly tested helper module.
+- Action: added `selection_event_metadata` to the wave workflow metadata helper, replaced the inline
+  selection metadata dictionary in `wave_service.py`, preserved the private service alias, and
+  expanded direct metadata tests to cover selected alternative, alternative set, proof-pack id, and
+  proof-pack state evidence.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_workflow_metadata.py`; direct workflow metadata tests and
+  selected wave API regressions passed with 139 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting persisted transition update support
+  or construction-selection orchestration helpers where the service can remain workflow-oriented.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9663,3 +9663,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   remaining workflow support that can be directly tested.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-397: Wave cancel-transition extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_cancel_transition.py`,
+  `tests/unit/dpm/waves/test_wave_cancel_transition.py`, selected wave workflow/API regressions, and
+  this ledger.
+- Finding: `cancel_wave` still embedded item cancellation, no-external-execution diagnostics,
+  aggregate refresh, cancel event assembly, and invalid transition mapping inside the public
+  workflow orchestration function.
+- Action: extracted cancel transition assembly into a focused helper that returns the cancelled wave
+  or maps invalid domain transitions to the existing bounded validation error, preserved the private
+  workflow metadata alias expected by existing tests, and added direct tests for cancellation
+  metadata, handoff-ready item preservation, invalid transition mapping, aggregate refresh, and
+  export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_cancel_transition.py`; direct cancel-transition tests and
+  selected wave workflow/API regressions passed with 122 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` around remaining orchestration support or move to
+  the next service hotspot once workflow transition assembly is sufficiently lean.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9235,3 +9235,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   once the remaining `mandate_service.py` orchestration is sufficiently lean.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-379: Wave item collection update extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_item_collection.py`,
+  `tests/unit/dpm/waves/test_wave_item_collection.py`, selected wave API regressions, and this
+  ledger.
+- Finding: `wave_service.py` repeated the same item-list replacement plus aggregate-metric
+  recalculation block across selection, approval, staging, handoff, and cancellation workflows.
+- Action: extracted `wave_with_items_and_aggregate` into a focused wave helper module, replaced the
+  repeated model-copy blocks in `wave_service.py`, preserved a private service alias for
+  compatibility, and added direct tests for metric recomputation, handoff-ref extra updates, alias
+  preservation, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_item_collection.py`; direct wave item collection tests and
+  selected wave API regressions passed with 136 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting wave state guard/idempotent replay
+  checks or workflow persistence patterns where behavior can be directly tested.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9739,3 +9739,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   orchestration with directly testable domain assembly; otherwise shift to the next service hotspot.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-400: Mandate monitoring run item calculation extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`,
+  `src/api/services/mandate_monitoring_run.py`,
+  `tests/unit/dpm/mandates/test_mandate_monitoring_run.py`, selected mandate monitoring
+  regressions, and this ledger.
+- Finding: `run_mandate_monitoring_once` still mixed repository writes with per-mandate health
+  recalculation, exception derivation, requested as-of-date projection, and monitoring-run id
+  attachment inside the service loop.
+- Action: extracted per-mandate monitoring calculation into a focused result helper that returns
+  the health snapshot and run-scoped exceptions, preserving service ownership of repository reads,
+  writes, run summary distribution, and monitoring-run persistence.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_monitoring_run.py`; direct monitoring-run helper
+  tests and selected mandate API regressions passed with 33 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue shrinking `mandate_service.py` where source resolution, persistence, or
+  command-center orchestration can be separated without hiding repository ownership.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9062,3 +9062,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   repository orchestration in `mandate_service.py`.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-372: Mandate diff projection extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_diff.py`,
+  `tests/unit/dpm/mandates/test_mandate_diff.py`, selected mandate API regressions, and this
+  ledger.
+- Finding: `mandate_service.py` still owned mandate diff DTOs, recursive payload comparison, and
+  materiality classification even though the service method only needs to orchestrate repository
+  version selection.
+- Action: extracted the mandate diff DTO and pure diff projection helpers into a focused module,
+  kept repository version selection in `mandate_service.py`, preserved the existing service import
+  and private-helper compatibility surface, and added direct helper tests for recursive comparison,
+  lineage-ignore behavior, deterministic sorting, materiality classification, diff projection, and
+  export aliases.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_diff.py`; direct mandate diff helper tests and
+  selected mandate API regressions passed with 29 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue extracting optional mandate source-resolution helpers while keeping
+  core-resolver orchestration in `mandate_service.py`.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9837,3 +9837,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   where extracted helpers improve auditability without hiding runtime gates.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-404: Rebalance batch execution-context extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/rebalance_simulation_service.py`,
+  `src/api/services/rebalance_batch_execution_context.py`,
+  `tests/unit/api/test_rebalance_batch_execution_context.py`, selected rebalance API/runtime
+  regressions, and this ledger.
+- Finding: `execute_batch_analysis` still assembled generated batch id, analyze policy-pack
+  context, and policy-resolution observability fields inline before delegating to batch scenario
+  execution.
+- Action: extracted batch execution-context assembly into a focused helper that returns the batch
+  id, selected policy definition, and policy resolution metadata, keeping batch analysis focused on
+  logging and execution delegation.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `rebalance_simulation_service.py` and `rebalance_batch_execution_context.py`; direct
+  batch execution-context tests and selected rebalance API/runtime regressions passed with 140
+  tests; OpenAPI quality gate passed; API vocabulary inventory validate-only gate passed; `git diff
+  --check` passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing rebalance async submission and manual execution paths for
+  similarly testable context assembly or supportability-boundary extraction.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10154,3 +10154,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   for directly testable extraction opportunities.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-417: Mandate command-center run selection extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`,
+  `src/api/services/mandate_command_center.py`,
+  `tests/unit/dpm/mandates/test_mandate_command_center.py`, selected mandate regressions, and this
+  ledger.
+- Finding: command-center summary orchestration still embedded latest monitoring-run selection in
+  the service, while the command-center helper already owned filter semantics and summary
+  projection.
+- Action: extracted latest command-center run selection into the command-center helper, kept
+  repository reads and active-exception lookup in the service, and added direct tests for first
+  matching run selection, missing-match behavior, export surface, and service compatibility alias.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_command_center.py`; direct mandate command-center
+  helper tests and selected mandate API regressions passed with 32 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing command-center service orchestration for active-exception query
+  and summary-input boundaries that can be clarified without hiding repository ownership.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10032,3 +10032,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   can be tested directly without moving repository idempotency ownership.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-412: Outcome review creation assembly extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/outcome_review_service.py`,
+  `src/api/services/outcome_review_creation.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_creation.py`, selected outcome-review regressions,
+  and this ledger.
+- Finding: outcome review creation orchestration still assembled the full persisted review object
+  directly after idempotency validation, mixing repository control flow with pure review/event
+  payload assembly already partially owned by `outcome_review_creation.py`.
+- Action: extracted persisted outcome-review assembly into the creation helper, kept idempotency,
+  clock/id generation, and persistence in the service, and added direct tests for source lineage,
+  identity, event, hash, actor, correlation, and idempotency propagation.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `outcome_review_service.py` and `outcome_review_creation.py`; direct outcome review
+  creation tests and selected outcome/API regressions passed with 41 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing outcome refresh and proof-pack generation for pure event/input
+  assembly that can move out of orchestration services with direct tests.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9763,3 +9763,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   command-center orchestration can be separated without hiding repository ownership.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-401: Mandate refresh assembly extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_refresh.py`,
+  `tests/unit/dpm/mandates/test_mandate_refresh.py`, selected mandate refresh/API regressions, and
+  this ledger.
+- Finding: `refresh_mandate_from_core` still mixed core source resolution, model-target fallback,
+  optional source assembly, market-data coverage resolution, twin compilation, health input
+  assembly, source error mapping, health calculation, and repository persistence in a single
+  service function.
+- Action: extracted source-backed refresh result assembly into a focused helper that resolves core
+  inputs, maps core source errors to bounded mandate service errors, builds the digital twin and
+  health result, and returns a refresh result for the service to persist.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_refresh.py`; direct mandate-refresh tests and
+  selected mandate API regressions passed with 32 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing mandate service persistence/orchestration seams where helper
+  extraction produces directly testable private-banking source-boundary behavior.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10056,3 +10056,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   assembly that can move out of orchestration services with direct tests.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-413: Outcome review refresh assembly extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/outcome_review_service.py`,
+  `src/api/services/outcome_review_refresh.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_refresh.py`, selected outcome-review regressions,
+  and this ledger.
+- Finding: outcome review source-refresh orchestration still performed dimension comparison and
+  refreshed-event assembly inline, mixing repository lookup/append control flow with pure refresh
+  payload assembly.
+- Action: extracted source-refresh comparison and event assembly into the refresh helper, kept
+  review lookup, clock/suffix generation, and append persistence in the service, and added direct
+  tests that prove snapshot comparison output drives refreshed-event state, reason codes, and
+  source lineage.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `outcome_review_service.py` and `outcome_review_refresh.py`; direct outcome review
+  refresh tests and selected outcome/API regressions passed with 42 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing proof-pack generation and rebalance orchestration for pure
+  builder-input assembly that can move behind direct helper tests.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9787,3 +9787,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   extraction produces directly testable private-banking source-boundary behavior.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-402: Mandate diff version resolution extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_diff.py`,
+  `tests/unit/dpm/mandates/test_mandate_diff.py`, selected mandate API regressions, and this
+  ledger.
+- Finding: `diff_mandate_versions` still embedded requested version-pair validation, latest-two
+  fallback selection, unknown-version error mapping, and diff construction inside the service
+  function even though this is mandate-diff domain behavior.
+- Action: moved version resolution into `build_mandate_diff_for_versions`, preserving repository
+  lookup and missing-mandate handling in the service while adding direct tests for explicit version
+  pairs, default latest-two comparison, incomplete version pairs, unknown versions, helper export,
+  and service alias compatibility.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_diff.py`; direct mandate-diff tests and selected
+  mandate API regressions passed with 33 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue moving domain-specific selection and validation rules out of
+  `mandate_service.py` while keeping repository access and API-facing orchestration there.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9588,3 +9588,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   duplicated orchestration support or directly testable boundary behavior.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-394: Wave approval-transition extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_approval_transition.py`,
+  `tests/unit/dpm/waves/test_wave_approval_transition.py`, selected wave workflow/API
+  regressions, and this ledger.
+- Finding: `approve_wave` still embedded item approval mapping, eligible-item validation,
+  aggregate refresh, target-state selection, and approval event assembly inside the public workflow
+  orchestration function.
+- Action: extracted approval transition assembly into a focused helper that returns the approved
+  wave or raises the existing bounded validation error, preserved the private workflow metadata
+  alias expected by existing tests, and added direct tests for full approval, approval with
+  exceptions, no eligible items, approval metadata, aggregate refresh, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_approval_transition.py`; direct approval-transition tests
+  and selected wave workflow/API regressions passed with 122 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting stage, handoff, or cancel transition
+  assembly using the same directly tested pattern.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9305,3 +9305,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   persisted transition update support where it improves readability without hiding domain behavior.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-382: Wave workflow metadata extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_workflow_metadata.py`,
+  `tests/unit/dpm/waves/test_wave_workflow_metadata.py`, selected wave API regressions, and this
+  ledger.
+- Finding: approval, staging, handoff, and cancellation workflows still built audit/event metadata
+  inline, duplicating optional-comment handling and no-external-execution boundary fields.
+- Action: extracted workflow event metadata builders into a focused helper module, replaced inline
+  metadata dictionaries in `wave_service.py`, preserved private service aliases, and added direct
+  tests for approval exception counts, stage comments, handoff no-external-execution evidence,
+  cancellation no-external-execution evidence, alias preservation, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_workflow_metadata.py`; direct workflow metadata tests and
+  selected wave API regressions passed with 138 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting persisted transition update support
+  or construction-selection orchestration helpers where they stay domain-specific and testable.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9351,3 +9351,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   or construction-selection orchestration helpers where the service can remain workflow-oriented.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-384: Wave construction-selection adapter extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_construction_selection.py`,
+  `tests/unit/dpm/waves/test_wave_construction_selection.py`, selected wave API regressions, and
+  this ledger.
+- Finding: `wave_service.py` still imported `construction_service` directly to select a construction
+  alternative and translate construction lookup failures into bounded wave errors.
+- Action: extracted the construction selection call and wave-specific error mapping into a focused
+  adapter module, removed the direct construction-service import from `wave_service.py`, preserved a
+  private service alias for compatibility, and added direct tests for delegation arguments, bounded
+  lookup-error mapping, alias preservation, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_construction_selection.py`; direct wave construction
+  selection tests and selected wave API regressions passed with 136 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting persisted transition update support
+  or moving to the next largest service hotspot once wave orchestration is sufficiently lean.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9936,3 +9936,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   duplication pattern.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-408: Proof-pack report-input context extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/proof_pack_service.py`,
+  `src/api/services/proof_pack_report_inputs.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_report_inputs.py`, selected proof-pack/API
+  regressions, and this ledger.
+- Finding: proof-pack report-input and AI-evidence input accessors duplicated portfolio-memory
+  context assembly inside the service, mirroring the outcome-review handoff-context duplication and
+  leaving downstream handoff context construction embedded in lookup orchestration.
+- Action: extracted proof-pack report/AI evidence input builders and portfolio-memory context
+  assembly into a focused helper module, preserving service ownership of proof-pack lookup while
+  adding direct tests for missing repository gating, portfolio id propagation, report input context
+  passing, AI evidence context passing, export surface, and service alias compatibility.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `proof_pack_report_inputs.py`; direct proof-pack
+  report-input tests and selected proof-pack/outcome regressions passed with 119 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing proof-pack generation flows for source/replay assembly that can be
+  directly tested without hiding persistence ownership.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9087,3 +9087,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   core-resolver orchestration in `mandate_service.py`.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-373: Mandate optional-source readiness extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_optional_sources.py`,
+  `tests/unit/dpm/mandates/test_mandate_optional_sources.py`, selected mandate API regressions, and
+  this ledger.
+- Finding: `mandate_service.py` still owned reusable optional core-source resolver and readiness
+  screening logic for missing resolver methods, resolver errors, supportability states, data-quality
+  statuses, and benchmark-assignment lifecycle status.
+- Action: extracted optional source resolution and readiness helpers into a focused service helper
+  module, kept refresh orchestration and hard failure handling in `mandate_service.py`, preserved
+  existing private service helper aliases for compatibility, and added direct tests for resolver
+  dispatch, absent optional methods, resolver error family mapping, ready/degraded/stale source
+  screening, benchmark assignment status screening, alias preservation, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_optional_sources.py`; direct optional-source helper
+  tests and selected mandate API regressions passed with 33 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue shrinking mandate refresh orchestration by grouping source-family resolution
+  calls without moving router or HTTP concerns into services.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9281,3 +9281,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   or selection workflow support where behavior can be directly covered.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-381: Wave selection guard extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_selection_guard.py`,
+  `tests/unit/dpm/waves/test_wave_selection_guard.py`, selected wave API regressions, and this
+  ledger.
+- Finding: `select_wave_item_alternative` still embedded wave-item lookup and alternative-set
+  availability validation inside the larger selection orchestration flow.
+- Action: extracted selectable wave-item validation into a focused helper that returns the governed
+  wave item or raises the existing bounded lookup/validation errors, kept construction selection and
+  proof-pack orchestration in `wave_service.py`, preserved a private service alias, and added direct
+  tests for successful lookup, missing items, missing alternatives, alias preservation, and export
+  surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_selection_guard.py`; direct wave selection guard tests and
+  selected wave API regressions passed with 137 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting workflow event metadata builders or
+  persisted transition update support where it improves readability without hiding domain behavior.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9445,3 +9445,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   proof-pack persistence/idempotency replay support where direct coverage remains clear.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-388: Proof pack mandate-evidence extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/proof_pack_service.py`,
+  `src/api/services/proof_pack_mandate_evidence.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_mandate_evidence.py`, selected proof-pack service
+  regressions, and this ledger.
+- Finding: proof-pack generation still resolved mandate twin and health evidence inline, mixing
+  portfolio-ownership validation and evidence-gap construction into the orchestration service.
+- Action: extracted mandate evidence resolution into a focused helper that returns the optional
+  twin, optional health snapshot, and bounded evidence gap codes; updated run-based and
+  selected-alternative proof-pack paths to consume the helper result directly.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `proof_pack_mandate_evidence.py`; direct mandate-evidence
+  tests and selected proof-pack service regressions passed with 16 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `proof_pack_service.py` by extracting proof-pack idempotency replay
+  or portfolio-memory handoff context support where behavior remains directly testable.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9515,3 +9515,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   assembly, content-hash support, or transition support only where direct tests can pin behavior.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-391: Outcome review creation-support extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/outcome_review_service.py`,
+  `src/api/services/outcome_review_creation.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_creation.py`, selected outcome-review API
+  regressions, and this ledger.
+- Finding: outcome-review creation still embedded canonical content hashing and created-event
+  type/source-lineage assembly inside the orchestration service.
+- Action: extracted review content-hash generation, bounded created-event type mapping, and created
+  event assembly into a focused helper while keeping idempotency, review construction, and
+  persistence in `outcome_review_service.py`; added direct tests for state-to-event mapping,
+  expected/realized source-lineage projection, stable hashing, and hash drift when source evidence
+  changes.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `outcome_review_service.py` and `outcome_review_creation.py`; direct creation-support
+  tests and selected outcome-review API regressions passed with 8 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reducing service hotspots by extracting dimension-input validation or
+  refresh-event support where tests can pin validation and event semantics directly.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9112,3 +9112,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   calls without moving router or HTTP concerns into services.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-374: Mandate optional-source bundle extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_optional_sources.py`,
+  `tests/unit/dpm/mandates/test_mandate_optional_sources.py`, selected mandate API regressions, and
+  this ledger.
+- Finding: even after the readiness helpers were extracted, `refresh_mandate_from_core` still
+  contained a long repeated sequence for resolving each optional source family and assembling the
+  unavailable-source list, making the service harder to scan as orchestration.
+- Action: added a typed `DpmMandateOptionalSources` bundle and moved source-family resolution
+  assembly into `resolve_mandate_optional_sources`; the service now obtains the bundle and passes it
+  into mandate twin and health-input builders while preserving private helper compatibility aliases.
+  Direct tests now verify bundle typing, source-family request parameters, degraded-family
+  filtering, and alias/export surfaces.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_optional_sources.py`; direct optional-source helper
+  tests and selected mandate API regressions passed with 34 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `mandate_service.py` by extracting monitoring-run assembly and
+  portfolio-manager book membership helpers where they remain pure service support logic.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9163,3 +9163,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   support logic.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-376: Mandate PM-book membership helper extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_pm_book.py`,
+  `tests/unit/dpm/mandates/test_mandate_pm_book.py`, selected monitoring API regressions, and this
+  ledger.
+- Finding: `mandate_service.py` still owned portfolio-manager book membership mandate-id resolution
+  even though the logic is reusable support code for resolving source-owned PM book membership
+  products into locally persisted mandate snapshots.
+- Action: extracted PM-book membership mandate-id resolution into a focused service helper module,
+  preserved the existing `mandate_service.mandate_ids_from_pm_book_membership` router import
+  surface, and added direct tests for successful member resolution, missing mandate snapshots,
+  empty membership payloads, service import compatibility, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_pm_book.py`; direct PM-book helper tests and selected
+  monitoring API regressions passed with 15 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue extracting command-center summary assembly and health recalculation support
+  where repository orchestration can remain in `mandate_service.py`.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9396,3 +9396,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   or move to the next largest service hotspot once wave orchestration is sufficiently lean.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-386: Proof pack handoff-ref helper extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/proof_pack_service.py`,
+  `src/api/services/proof_pack_handoff_refs.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_handoff_refs.py`, selected proof-pack service
+  regressions, and this ledger.
+- Finding: `proof_pack_service.py` still embedded append-only handoff reference lookup, hydration,
+  and idempotent append mechanics inside the public proof-pack orchestration service.
+- Action: extracted handoff reference support into a focused helper module, kept public proof-pack
+  not-generated error translation in `proof_pack_service.py`, and added direct tests for latest
+  append-only reference selection, immutable hydration overlay, idempotent handoff reference
+  generation, and stored-ref to evidence-ref identity preservation.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `proof_pack_handoff_refs.py`; direct handoff-ref tests and
+  selected proof-pack service regressions passed with 16 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `proof_pack_service.py` by extracting selected-alternative source
+  resolution or mandate-evidence resolution where the service can remain orchestration-focused.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9187,3 +9187,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   where repository orchestration can remain in `mandate_service.py`.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-377: Mandate command-center summary extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_command_center.py`,
+  `tests/unit/dpm/mandates/test_mandate_command_center.py`, selected monitoring API regressions,
+  and this ledger.
+- Finding: `get_command_center_summary` still mixed repository reads with DTO projection,
+  health-state filtering, partial-readiness reason assembly, supportability classification, and
+  attention/recommended-action aggregation.
+- Action: moved command-center summary projection into `build_command_center_summary` in the
+  existing command-center helper module, kept repository reads and monitoring-run selection in
+  `mandate_service.py`, preserved private compatibility aliases, and added direct tests for
+  populated and empty summary projection, selected health-state filtering, source-run provenance,
+  partial reasons, limit handling, supportability, aliases, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_command_center.py`; direct command-center helper
+  tests and selected monitoring API regressions passed with 18 tests; OpenAPI quality gate passed;
+  API vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage
+  scan found no router/HTTP imports in service modules.
+- Follow-up: continue extracting health recalculation support and repository lookup wrappers where
+  they can be made directly testable without hiding orchestration.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9638,3 +9638,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   assembly using the same directly tested pattern.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-396: Wave handoff-transition extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_handoff_transition.py`,
+  `tests/unit/dpm/waves/test_wave_handoff_transition.py`, selected wave workflow/API regressions,
+  and this ledger.
+- Finding: `handoff_wave` still embedded handoff item transition mapping, operations handoff-ref
+  construction, no-external-execution boundary evidence, aggregate refresh, and handoff event
+  assembly inside the public workflow orchestration function.
+- Action: extracted handoff transition assembly into a focused helper that returns the
+  handoff-ready wave or raises the existing bounded validation error, preserved the private
+  workflow metadata alias expected by existing tests, and added direct tests for handoff ref
+  creation, partial handoff, no eligible items, no external execution claim, handoff metadata,
+  aggregate refresh, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_handoff_transition.py`; direct handoff-transition tests
+  and selected wave workflow/API regressions passed with 122 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting cancel transition assembly or other
+  remaining workflow support that can be directly tested.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9811,3 +9811,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `mandate_service.py` while keeping repository access and API-facing orchestration there.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-403: Rebalance simulation execution-context extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/rebalance_simulation_service.py`,
+  `src/api/services/rebalance_simulation_execution_context.py`,
+  `tests/unit/api/test_rebalance_simulation_execution_context.py`, selected rebalance API/runtime
+  regressions, and this ledger.
+- Finding: `simulate_rebalance` still assembled request hash, resolved correlation id, policy-pack
+  context, policy-pack replay flag, and policy-resolution observability fields inline before
+  delegating to sync execution.
+- Action: extracted simulation execution-context assembly into a focused helper that returns the
+  request hash, resolved correlation id, selected policy definition, replay flag, and policy
+  resolution metadata, keeping `simulate_rebalance` focused on logging and sync execution
+  delegation.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `rebalance_simulation_service.py` and
+  `rebalance_simulation_execution_context.py`; direct execution-context tests and selected
+  rebalance API/runtime regressions passed with 140 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing rebalance orchestration around async submission and batch execution
+  where extracted helpers improve auditability without hiding runtime gates.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9490,3 +9490,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   support logic with direct tests; keep proof-pack generation orchestration in the service.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-390: Outcome review source-search extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/outcome_review_service.py`,
+  `src/api/services/outcome_review_search.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_search.py`, selected outcome-review API
+  regressions, and this ledger.
+- Finding: outcome-review source-lineage search normalization, filtering, facet counting, bounded
+  scan behavior, and pagination were embedded in `outcome_review_service.py`, making source-boundary
+  search behavior harder to test directly.
+- Action: extracted source-lineage search into a focused helper returning a typed search page,
+  preserved the public service tuple contract for existing routers, and added direct tests for
+  blank-filter normalization, conjunctive source-owner/source-type matching, sorted facet counts,
+  pagination, bounded source-scan behavior, and current latest-first repository ordering.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `outcome_review_service.py` and `outcome_review_search.py`; direct outcome-review
+  search tests and selected API regressions passed with 9 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing outcome-review or wave service hotspots by extracting creation event
+  assembly, content-hash support, or transition support only where direct tests can pin behavior.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9688,3 +9688,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   the next service hotspot once workflow transition assembly is sufficiently lean.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-398: Wave item-selection transition extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_item_selection_transition.py`,
+  `tests/unit/dpm/waves/test_wave_item_selection_transition.py`, selected wave workflow/API
+  regressions, and this ledger.
+- Finding: `select_wave_item_alternative` still embedded selected-item mutation, proof-pack state
+  projection, aggregate refresh, and item-selection audit event assembly inside the public workflow
+  orchestration function after performing lookup, state guarding, construction selection, and
+  persistence.
+- Action: extracted item-selection transition assembly into a focused helper while keeping lookup,
+  state guards, construction repository selection, and persistence in the service; preserved the
+  private workflow metadata alias expected by existing tests; and added direct tests for selected
+  item replacement, retained-item preservation, aggregate refresh, degraded proof-pack metadata,
+  generated proof-pack metadata, selection event evidence, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_item_selection_transition.py`; direct item-selection
+  transition tests and selected wave workflow/API regressions passed with 147 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` only where remaining orchestration support has a
+  directly testable boundary; otherwise move to the next service hotspot.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9564,3 +9564,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   move only after preserving router-owned validation-error imports cleanly.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-393: Rebalance operation identity extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/rebalance_simulation_service.py`,
+  `src/api/services/rebalance_operation_identity.py`,
+  `tests/unit/api/test_rebalance_operation_identity.py`, selected runtime/service edge regressions,
+  and this ledger.
+- Finding: rebalance simulation orchestration directly formatted generated correlation ids and
+  batch analysis ids with inline UUID slicing, leaving identifier conventions untested outside
+  broad endpoint flows.
+- Action: extracted generated operation identity helpers for rebalance correlation ids and batch
+  analysis ids, preserved caller-supplied correlation ids, removed the direct UUID dependency from
+  the orchestration service, and added direct deterministic tests for each identifier convention.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `rebalance_simulation_service.py` and `rebalance_operation_identity.py`; direct
+  identity tests and selected runtime/service edge regressions passed with 33 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reducing rebalance or wave service hotspots where extraction removes
+  duplicated orchestration support or directly testable boundary behavior.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9961,3 +9961,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   directly tested without hiding persistence ownership.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-409: Proof-pack persistence retention extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/proof_pack_service.py`,
+  `src/api/services/proof_pack_persistence.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_persistence.py`, selected proof-pack regressions,
+  and this ledger.
+- Finding: proof-pack generation orchestration still owned the append-only persistence retention
+  calculation directly, leaving the seven-year evidence-retention policy hidden in the service
+  rather than in a small supportability helper with direct tests.
+- Action: extracted proof-pack persistence and retention-expiry calculation into a focused helper,
+  kept proof-pack generation orchestration in the service, and added direct tests for deterministic
+  seven-year retention expiry and the helper export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `proof_pack_persistence.py`; direct proof-pack
+  persistence tests and selected proof-pack service/repository regressions passed with 19 tests;
+  OpenAPI quality gate passed; API vocabulary inventory validate-only gate passed; `git diff
+  --check` passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing proof-pack generation flow for source-resolution and builder-input
+  assembly that can be separated without moving repository lookup ownership out of the service.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9137,3 +9137,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   portfolio-manager book membership helpers where they remain pure service support logic.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-375: Mandate monitoring-run support extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_monitoring_run.py`,
+  `tests/unit/dpm/mandates/test_mandate_monitoring_run.py`, selected monitoring API regressions,
+  and this ledger.
+- Finding: `run_mandate_monitoring_once` still mixed repository orchestration with reusable
+  monitoring-run support logic for run-id generation, distribution counting, exception run-id
+  attachment, and terminal run projection.
+- Action: extracted the pure monitoring-run support functions into a focused service helper module,
+  kept mandate lookup, health recalculation, persistence, and error propagation in
+  `mandate_service.py`, preserved private service helper aliases for compatibility, and added
+  direct tests for deterministic run ids, distribution counts, immutable exception run-id
+  attachment, terminal run projection, aliases, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_monitoring_run.py`; direct monitoring-run helper
+  tests and selected monitoring API regressions passed with 16 tests; OpenAPI quality gate passed;
+  API vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage
+  scan found no router/HTTP imports in service modules.
+- Follow-up: continue shrinking `mandate_service.py` by extracting portfolio-manager book
+  membership mandate-id resolution and monitoring command-center assembly where they remain pure
+  support logic.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9613,3 +9613,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   assembly using the same directly tested pattern.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-395: Wave stage-transition extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_stage_transition.py`,
+  `tests/unit/dpm/waves/test_wave_stage_transition.py`, selected wave workflow/API regressions, and
+  this ledger.
+- Finding: `stage_wave` still embedded item staging, no-external-execution diagnostics, eligible
+  item validation, aggregate refresh, and stage event assembly inside the public workflow
+  orchestration function.
+- Action: extracted stage transition assembly into a focused helper that returns the staged wave or
+  raises the existing bounded validation error, preserved the private workflow metadata alias
+  expected by existing tests, and added direct tests for staging approved items, preserving
+  unapproved exception items, no eligible items, stage metadata, aggregate refresh, and export
+  surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_stage_transition.py`; direct stage-transition tests and
+  selected wave workflow/API regressions passed with 122 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting handoff or cancel transition
+  assembly using the same directly tested pattern.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9420,3 +9420,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   resolution or mandate-evidence resolution where the service can remain orchestration-focused.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-387: Proof pack selected-source extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/proof_pack_service.py`,
+  `src/api/services/proof_pack_selected_source.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_selected_source.py`, selected proof-pack service
+  regressions, and this ledger.
+- Finding: selected-alternative proof-pack generation still performed source lookup, selected
+  alternative validation, optional selection lookup, and linked-run degradation inline in the public
+  service function.
+- Action: extracted selected-alternative source resolution into a focused helper that returns the
+  alternative set, persisted selection, optional linked run, and workflow decisions while preserving
+  existing missing-source validation and missing-run degradation behavior; updated service
+  regressions to import the source validation error from the core proof-pack owner.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `proof_pack_selected_source.py`; direct selected-source
+  tests and selected proof-pack service regressions passed with 16 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reducing `proof_pack_service.py` by extracting mandate evidence resolution or
+  proof-pack persistence/idempotency replay support where direct coverage remains clear.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9038,3 +9038,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   service compatibility.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-371: Mandate command-center projection extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `src/api/services/mandate_command_center.py`,
+  `tests/unit/dpm/mandates/test_mandate_command_center.py`, selected mandate API regressions, and
+  this ledger.
+- Finding: `mandate_service.py` still owned pure command-center projection helpers for
+  supportability-state classification, monitoring-run filter matching, attention-bucket rollups,
+  recommended-action rollups, and severity ordering.
+- Action: extracted the command-center helper cluster into a focused module, preserved existing
+  private service aliases for compatibility, removed now-unused enum imports from the service, and
+  added direct tests for source-readiness supportability mapping, bounded filter matching, bucket
+  sorting and reason ranking, recommended-action ordering, alias preservation, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_command_center.py`; direct command-center helper
+  tests and selected mandate API regressions passed with 29 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue extracting pure mandate diff and source-resolution helpers while keeping
+  repository orchestration in `mandate_service.py`.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9540,3 +9540,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   refresh-event support where tests can pin validation and event semantics directly.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-392: Outcome review refresh-event extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/outcome_review_service.py`,
+  `src/api/services/outcome_review_refresh.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_refresh.py`, selected outcome-review API
+  regressions, and this ledger.
+- Finding: source-refresh event identity, bounded event type, state/reason projection, and
+  expected-plus-realized source lineage assembly were embedded in the refresh orchestration path.
+- Action: extracted source-refresh event assembly into a focused helper while preserving lookup,
+  comparison, persistence append, and return orchestration in `outcome_review_service.py`; added a
+  direct deterministic test for event identity, timestamp, actor, state, reason codes, and source
+  lineage projection.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `outcome_review_service.py` and `outcome_review_refresh.py`; direct refresh-event tests
+  and selected outcome-review API regressions passed with 6 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reducing service hotspots; evaluate whether dimension-input validation should
+  move only after preserving router-owned validation-error imports cleanly.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10105,3 +10105,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   seams that can be clarified without hiding ownership or idempotency behavior.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-415: Mandate health persistence extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`,
+  `src/api/services/mandate_health_persistence.py`,
+  `tests/unit/dpm/mandates/test_mandate_health_persistence.py`, selected mandate regressions, and
+  this ledger.
+- Finding: mandate refresh, recalculation, and monitoring flows repeated health-snapshot and
+  monitoring-exception persistence loops in the orchestration service, making evidence persistence
+  behavior harder to test directly.
+- Action: extracted mandate health evidence persistence into a focused helper, kept source
+  resolution, health calculation, monitoring-run aggregation, and repository lookup ownership in
+  the service, and added direct tests for twin-backed and health-only persistence paths plus the
+  service compatibility alias.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py` and `mandate_health_persistence.py`; direct mandate health
+  persistence tests and selected mandate refresh/API regressions passed with 36 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing mandate monitoring orchestration for aggregation boundaries that
+  can be isolated without hiding lookup or run lifecycle ownership.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10009,3 +10009,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   separated without moving source lookup or exception ownership out of the service.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-411: Outcome review persistence retention extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/outcome_review_service.py`,
+  `src/api/services/outcome_review_persistence.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_persistence.py`, selected outcome-review
+  regressions, and this ledger.
+- Finding: outcome review creation orchestration still owned the seven-year evidence-retention
+  calculation directly, duplicating the persistence-policy pattern found in proof-pack generation.
+- Action: extracted outcome-review persistence and retention-expiry calculation into a focused
+  helper, kept review creation orchestration in the service, and added direct tests for
+  deterministic seven-year retention expiry and the helper export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `outcome_review_service.py` and `outcome_review_persistence.py`; direct outcome
+  review persistence tests and selected outcome/API regressions passed with 40 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing outcome-review creation for event/content assembly boundaries that
+  can be tested directly without moving repository idempotency ownership.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10081,3 +10081,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   builder-input assembly that can move behind direct helper tests.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-414: Proof-pack generation assembly extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/proof_pack_service.py`,
+  `src/api/services/proof_pack_generation.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_generation.py`, selected proof-pack regressions,
+  and this ledger.
+- Finding: proof-pack generation orchestration still mapped resolved run, selected-alternative,
+  mandate-evidence, workflow-decision, and regime-stress inputs directly into core proof-pack
+  builders, mixing source lookup/replay/persistence control flow with pure builder-input assembly.
+- Action: extracted run and selected-alternative proof-pack assembly into a focused helper, kept
+  replay, source lookup, mandate evidence lookup, and persistence in the service, and added direct
+  tests for resolved source/evidence propagation into the core builders.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `proof_pack_generation.py`; direct proof-pack generation
+  tests and selected proof-pack service/builder regressions passed with 43 tests; OpenAPI quality
+  gate passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed;
+  service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing generation services for remaining source lookup and persistence
+  seams that can be clarified without hiding ownership or idempotency behavior.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9258,3 +9258,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   checks or workflow persistence patterns where behavior can be directly tested.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-380: Wave state guard extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `src/api/services/wave_state_guard.py`,
+  `tests/unit/dpm/waves/test_wave_state_guard.py`, selected wave API regressions, and this ledger.
+- Finding: `wave_service.py` repeated idempotent replay checks and invalid-state validation error
+  construction across source-check, simulation, selection, approval, staging, handoff, and
+  cancellation workflows.
+- Action: extracted wave state replay and allowed-state guard helpers into a focused module,
+  replaced inline workflow guard checks in `wave_service.py`, preserved private service aliases, and
+  added direct tests for replay-state matching, allowed-state acceptance, governed error code/message
+  construction, alias preservation, and export surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_state_guard.py`; direct wave state guard tests and selected
+  wave API regressions passed with 137 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules.
+- Follow-up: continue reducing `wave_service.py` by extracting persisted transition update helpers
+  or selection workflow support where behavior can be directly covered.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -9468,3 +9468,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   or portfolio-memory handoff context support where behavior remains directly testable.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-389: Proof pack replay lookup extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/proof_pack_service.py`, `src/api/services/proof_pack_replay.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_replay.py`, selected proof-pack service regressions,
+  and this ledger.
+- Finding: run-based and selected-alternative proof-pack generation duplicated replay lookup logic
+  for idempotency-key matches and immutable source-identity matches.
+- Action: extracted replay lookup into a focused helper that preserves idempotency precedence before
+  falling back to proof-pack source identity; updated both generation paths to use the helper and
+  added direct tests for idempotency replay, source-identity fallback, and no-match behavior.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `proof_pack_replay.py`; direct replay tests and selected
+  proof-pack service regressions passed with 15 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules.
+- Follow-up: continue reducing proof-pack and other service hotspots by extracting only reusable
+  support logic with direct tests; keep proof-pack generation orchestration in the service.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/src/api/services/mandate_command_center.py
+++ b/src/api/services/mandate_command_center.py
@@ -54,6 +54,30 @@ def run_matches_command_center_filters(
     )
 
 
+def latest_command_center_run(
+    runs: list[DpmMonitoringRun],
+    *,
+    tenant_id: str | None,
+    portfolio_manager_id: str | None,
+    book_id: str | None,
+    as_of_date: date | None,
+) -> DpmMonitoringRun | None:
+    return next(
+        (
+            run
+            for run in runs
+            if run_matches_command_center_filters(
+                run,
+                tenant_id=tenant_id,
+                portfolio_manager_id=portfolio_manager_id,
+                book_id=book_id,
+                as_of_date=as_of_date,
+            )
+        ),
+        None,
+    )
+
+
 def build_command_center_summary(
     *,
     tenant_id: str | None,
@@ -193,6 +217,7 @@ __all__ = [
     "attention_buckets",
     "build_command_center_summary",
     "command_center_supportability_state",
+    "latest_command_center_run",
     "recommended_actions",
     "run_matches_command_center_filters",
     "severity_rank",

--- a/src/api/services/mandate_command_center.py
+++ b/src/api/services/mandate_command_center.py
@@ -1,12 +1,15 @@
-from datetime import date
+from datetime import date, datetime
 from typing import Literal
 
 from src.core.mandates import (
     DpmCommandCenterAttentionBucket,
     DpmCommandCenterRecommendedAction,
+    DpmCommandCenterSummary,
+    DpmCommandCenterSupportability,
     DpmMonitoringException,
     DpmMonitoringRun,
     MandateHealthDimension,
+    MandateHealthState,
     MandateRecommendedAction,
     MonitoringSeverity,
 )
@@ -48,6 +51,68 @@ def run_matches_command_center_filters(
     }
     return all(
         value is None or run.filters.get(key) == value for key, value in expected_filters.items()
+    )
+
+
+def build_command_center_summary(
+    *,
+    tenant_id: str | None,
+    portfolio_manager_id: str | None,
+    book_id: str | None,
+    as_of_date: date | None,
+    health_state: str | None,
+    latest_run: DpmMonitoringRun | None,
+    active_exceptions: list[DpmMonitoringException],
+    limit: int,
+    generated_at: datetime,
+) -> DpmCommandCenterSummary:
+    health_distribution = dict(latest_run.health_distribution) if latest_run else {}
+    if health_state is not None:
+        health_distribution = {health_state: health_distribution.get(health_state, 0)}
+
+    partial_reasons: list[str] = []
+    if latest_run is None:
+        partial_reasons.append("NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS")
+    if portfolio_manager_id is None and book_id is None:
+        partial_reasons.append("PM_BOOK_DISCOVERY_NOT_YET_SOURCED")
+    if len(active_exceptions) >= limit:
+        partial_reasons.append("ATTENTION_QUEUE_LIMIT_REACHED")
+
+    completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"] = "COMPLETE"
+    if latest_run is None:
+        completeness = "EMPTY"
+    elif partial_reasons:
+        completeness = "PARTIAL"
+    supportability_state, supportability_reason = command_center_supportability_state(
+        latest_run=latest_run,
+        completeness=completeness,
+        partial_reasons=partial_reasons,
+    )
+
+    return DpmCommandCenterSummary(
+        tenant_id=tenant_id,
+        portfolio_manager_id=portfolio_manager_id,
+        book_id=book_id,
+        as_of_date=as_of_date or (latest_run.as_of_date if latest_run else None),
+        selected_health_state=MandateHealthState(health_state)
+        if health_state is not None
+        else None,
+        evaluated_mandates=latest_run.total_mandates if latest_run else 0,
+        monitored_mandate_ids=list(latest_run.mandate_ids) if latest_run else [],
+        health_distribution=health_distribution,
+        source_readiness_summary=dict(latest_run.source_readiness_summary) if latest_run else {},
+        active_exception_count=len(active_exceptions),
+        attention_buckets=attention_buckets(active_exceptions),
+        recommended_actions=recommended_actions(active_exceptions),
+        latest_monitoring_run=latest_run,
+        supportability=DpmCommandCenterSupportability(
+            state=supportability_state,
+            data_completeness_state=completeness,
+            reason=supportability_reason,
+            generated_at=generated_at,
+            source_run_id=latest_run.monitoring_run_id if latest_run else None,
+            partial_readiness_reasons=partial_reasons,
+        ),
     )
 
 
@@ -126,6 +191,7 @@ def severity_rank(severity: str) -> int:
 
 __all__ = [
     "attention_buckets",
+    "build_command_center_summary",
     "command_center_supportability_state",
     "recommended_actions",
     "run_matches_command_center_filters",

--- a/src/api/services/mandate_command_center.py
+++ b/src/api/services/mandate_command_center.py
@@ -1,0 +1,133 @@
+from datetime import date
+from typing import Literal
+
+from src.core.mandates import (
+    DpmCommandCenterAttentionBucket,
+    DpmCommandCenterRecommendedAction,
+    DpmMonitoringException,
+    DpmMonitoringRun,
+    MandateHealthDimension,
+    MandateRecommendedAction,
+    MonitoringSeverity,
+)
+
+
+def command_center_supportability_state(
+    *,
+    latest_run: DpmMonitoringRun | None,
+    completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"],
+    partial_reasons: list[str],
+) -> tuple[Literal["READY", "PARTIAL", "EMPTY", "DEGRADED", "BLOCKED"], str]:
+    if latest_run is None or completeness == "EMPTY":
+        return "EMPTY", "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
+
+    source_states = {state.upper() for state in latest_run.source_readiness_summary}
+    if source_states.intersection({"INCOMPLETE", "UNAVAILABLE", "BLOCKED"}):
+        return "BLOCKED", "COMMAND_CENTER_SOURCE_READINESS_BLOCKED"
+    if source_states.intersection({"DEGRADED", "STALE"}):
+        return "DEGRADED", "COMMAND_CENTER_SOURCE_READINESS_DEGRADED"
+    if completeness == "PARTIAL" or partial_reasons:
+        return "PARTIAL", partial_reasons[0] if partial_reasons else "COMMAND_CENTER_PARTIAL"
+    return "READY", "COMMAND_CENTER_READY"
+
+
+def run_matches_command_center_filters(
+    run: DpmMonitoringRun,
+    *,
+    tenant_id: str | None,
+    portfolio_manager_id: str | None,
+    book_id: str | None,
+    as_of_date: date | None,
+) -> bool:
+    if as_of_date is not None and run.as_of_date != as_of_date:
+        return False
+    expected_filters = {
+        "tenant_id": tenant_id,
+        "portfolio_manager_id": portfolio_manager_id,
+        "book_id": book_id,
+    }
+    return all(
+        value is None or run.filters.get(key) == value for key, value in expected_filters.items()
+    )
+
+
+def attention_buckets(
+    exceptions: list[DpmMonitoringException],
+) -> list[DpmCommandCenterAttentionBucket]:
+    bucket_counts: dict[tuple[str, str, str], int] = {}
+    bucket_reason_counts: dict[tuple[str, str, str], dict[str, int]] = {}
+    for exception in exceptions:
+        key = (
+            exception.dimension.value,
+            exception.severity.value,
+            exception.recommended_action.value,
+        )
+        bucket_counts[key] = bucket_counts.get(key, 0) + 1
+        reason_counts = bucket_reason_counts.setdefault(key, {})
+        reason_counts[exception.reason_code] = reason_counts.get(exception.reason_code, 0) + 1
+
+    return [
+        DpmCommandCenterAttentionBucket(
+            dimension=MandateHealthDimension(dimension),
+            severity=MonitoringSeverity(severity),
+            recommended_action=MandateRecommendedAction(recommended_action),
+            exception_count=exception_count,
+            top_reason_codes=[
+                reason_code
+                for reason_code, _ in sorted(
+                    bucket_reason_counts[(dimension, severity, recommended_action)].items(),
+                    key=lambda item: (-item[1], item[0]),
+                )[:3]
+            ],
+        )
+        for (dimension, severity, recommended_action), exception_count in sorted(
+            bucket_counts.items(),
+            key=lambda item: (
+                -severity_rank(item[0][1]),
+                -item[1],
+                item[0][0],
+            ),
+        )
+    ]
+
+
+def recommended_actions(
+    exceptions: list[DpmMonitoringException],
+) -> list[DpmCommandCenterRecommendedAction]:
+    action_counts: dict[str, int] = {}
+    action_highest_severity: dict[str, str] = {}
+    for exception in exceptions:
+        action = exception.recommended_action.value
+        action_counts[action] = action_counts.get(action, 0) + 1
+        current_highest = action_highest_severity.setdefault(action, exception.severity.value)
+        if severity_rank(exception.severity.value) > severity_rank(current_highest):
+            action_highest_severity[action] = exception.severity.value
+
+    return [
+        DpmCommandCenterRecommendedAction(
+            recommended_action=MandateRecommendedAction(action),
+            exception_count=exception_count,
+            highest_severity=MonitoringSeverity(action_highest_severity[action]),
+        )
+        for action, exception_count in sorted(
+            action_counts.items(),
+            key=lambda item: (
+                -severity_rank(action_highest_severity[item[0]]),
+                -item[1],
+                item[0],
+            ),
+        )
+    ]
+
+
+def severity_rank(severity: str) -> int:
+    return {"CRITICAL": 3, "WARNING": 2, "INFO": 1}.get(severity, 0)
+
+
+__all__ = [
+    "attention_buckets",
+    "command_center_supportability_state",
+    "recommended_actions",
+    "run_matches_command_center_filters",
+    "severity_rank",
+]

--- a/src/api/services/mandate_diff.py
+++ b/src/api/services/mandate_diff.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from src.api.services.mandate_errors import DpmMandateDiffUnavailableError
 from src.core.mandates import DpmMandateDigitalTwin
 
 
@@ -82,6 +83,33 @@ def build_mandate_diff(
     )
 
 
+def build_mandate_diff_for_versions(
+    *,
+    mandate_id: str,
+    versions: list[DpmMandateDigitalTwin],
+    from_version: str | None,
+    to_version: str | None,
+) -> DpmMandateDiff:
+    by_version = {version.mandate_version: version for version in versions}
+    if from_version is not None or to_version is not None:
+        if from_version is None or to_version is None:
+            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
+        if from_version not in by_version or to_version not in by_version:
+            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_VERSION_NOT_FOUND")
+        previous = by_version[from_version]
+        current = by_version[to_version]
+    else:
+        if len(versions) < 2:
+            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
+        current, previous = versions[0], versions[1]
+
+    return build_mandate_diff(
+        mandate_id=mandate_id,
+        previous=previous,
+        current=current,
+    )
+
+
 def iter_changed_fields(
     previous: dict[str, Any],
     current: dict[str, Any],
@@ -123,6 +151,7 @@ __all__ = [
     "DpmMandateDiff",
     "DpmMandateFieldChange",
     "build_mandate_diff",
+    "build_mandate_diff_for_versions",
     "diff_payloads",
     "iter_changed_fields",
     "materiality_for_field",

--- a/src/api/services/mandate_diff.py
+++ b/src/api/services/mandate_diff.py
@@ -1,0 +1,129 @@
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from src.core.mandates import DpmMandateDigitalTwin
+
+
+class DpmMandateFieldChange(BaseModel):
+    field_path: str = Field(
+        description="Dot-separated mandate digital-twin field path that changed.",
+        examples=["constraints.turnover_budget"],
+    )
+    previous_value: Any = Field(
+        description="Value from the older mandate version.",
+        examples=["0.1000000000"],
+    )
+    current_value: Any = Field(
+        description="Value from the newer mandate version.",
+        examples=["0.1500000000"],
+    )
+    materiality: str = Field(
+        description="Business materiality of the field change for DPM oversight.",
+        examples=["HIGH"],
+    )
+
+
+class DpmMandateDiff(BaseModel):
+    mandate_id: str = Field(
+        description="Discretionary mandate identifier whose versions were compared.",
+        examples=["MANDATE_PB_SG_GLOBAL_BAL_001"],
+    )
+    compared_at: datetime = Field(
+        description="UTC timestamp when lotus-manage generated the diff.",
+        examples=["2026-05-03T08:30:00Z"],
+    )
+    from_version: str = Field(
+        description="Older mandate version used as the comparison baseline.",
+        examples=["2"],
+    )
+    to_version: str = Field(
+        description="Newer mandate version used as the comparison target.",
+        examples=["3"],
+    )
+    changed_fields: list[DpmMandateFieldChange] = Field(
+        description="Changed mandate fields, ordered by field path for deterministic review.",
+    )
+
+
+def diff_payloads(
+    previous: dict[str, Any],
+    current: dict[str, Any],
+) -> list[DpmMandateFieldChange]:
+    changes: list[DpmMandateFieldChange] = []
+    for field_path, previous_value, current_value in iter_changed_fields(previous, current):
+        changes.append(
+            DpmMandateFieldChange(
+                field_path=field_path,
+                previous_value=previous_value,
+                current_value=current_value,
+                materiality=materiality_for_field(field_path),
+            )
+        )
+    return sorted(changes, key=lambda change: change.field_path)
+
+
+def build_mandate_diff(
+    *,
+    mandate_id: str,
+    previous: DpmMandateDigitalTwin,
+    current: DpmMandateDigitalTwin,
+) -> DpmMandateDiff:
+    return DpmMandateDiff(
+        mandate_id=mandate_id,
+        compared_at=datetime.now(timezone.utc),
+        from_version=previous.mandate_version,
+        to_version=current.mandate_version,
+        changed_fields=diff_payloads(
+            previous.model_dump(mode="json"),
+            current.model_dump(mode="json"),
+        ),
+    )
+
+
+def iter_changed_fields(
+    previous: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    prefix: str = "",
+) -> list[tuple[str, Any, Any]]:
+    ignored = {"source_lineage"}
+    changes: list[tuple[str, Any, Any]] = []
+    keys = sorted((set(previous) | set(current)) - ignored)
+    for key in keys:
+        field_path = f"{prefix}.{key}" if prefix else key
+        previous_value = previous.get(key)
+        current_value = current.get(key)
+        if isinstance(previous_value, dict) and isinstance(current_value, dict):
+            changes.extend(iter_changed_fields(previous_value, current_value, prefix=field_path))
+            continue
+        if previous_value != current_value:
+            changes.append((field_path, previous_value, current_value))
+    return changes
+
+
+def materiality_for_field(field_path: str) -> str:
+    high_prefixes = (
+        "constraints.",
+        "risk_profile",
+        "investment_objective",
+        "model_portfolio_id",
+        "model_portfolio_version",
+        "time_horizon",
+    )
+    if field_path.startswith(high_prefixes):
+        return "HIGH"
+    if field_path in {"mandate_version", "as_of_date", "field_gap_codes"}:
+        return "MEDIUM"
+    return "LOW"
+
+
+__all__ = [
+    "DpmMandateDiff",
+    "DpmMandateFieldChange",
+    "build_mandate_diff",
+    "diff_payloads",
+    "iter_changed_fields",
+    "materiality_for_field",
+]

--- a/src/api/services/mandate_errors.py
+++ b/src/api/services/mandate_errors.py
@@ -1,0 +1,32 @@
+class DpmMandateNotFoundError(LookupError):
+    pass
+
+
+class DpmMandateDiffUnavailableError(LookupError):
+    pass
+
+
+class DpmMandateSourceUnavailableError(RuntimeError):
+    pass
+
+
+class DpmMandateSourceIncompleteError(RuntimeError):
+    pass
+
+
+class DpmMandateHealthNotFoundError(LookupError):
+    pass
+
+
+class DpmMonitoringRunNotFoundError(LookupError):
+    pass
+
+
+__all__ = [
+    "DpmMandateDiffUnavailableError",
+    "DpmMandateHealthNotFoundError",
+    "DpmMandateNotFoundError",
+    "DpmMandateSourceIncompleteError",
+    "DpmMandateSourceUnavailableError",
+    "DpmMonitoringRunNotFoundError",
+]

--- a/src/api/services/mandate_health_persistence.py
+++ b/src/api/services/mandate_health_persistence.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.mandates import (
+    DpmMandateDigitalTwin,
+    DpmMandateHealthSnapshot,
+    DpmMonitoringException,
+)
+
+
+def persist_mandate_health_evidence(
+    *,
+    repository: DpmMandateRepository,
+    health_snapshot: DpmMandateHealthSnapshot,
+    monitoring_exceptions: list[DpmMonitoringException],
+    twin: DpmMandateDigitalTwin | None = None,
+) -> None:
+    if twin is not None:
+        repository.save_mandate_snapshot(twin)
+    repository.save_health_snapshot(health_snapshot)
+    for exception in monitoring_exceptions:
+        repository.save_monitoring_exception(exception)
+
+
+__all__ = ["persist_mandate_health_evidence"]

--- a/src/api/services/mandate_health_result.py
+++ b/src/api/services/mandate_health_result.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.core.mandates import (
+    DpmMandateHealthInput,
+    DpmMandateHealthSnapshot,
+    DpmMonitoringException,
+    calculate_mandate_health,
+    monitoring_exceptions_from_health,
+)
+
+
+@dataclass(frozen=True)
+class DpmMandateHealthCalculationResult:
+    snapshot: DpmMandateHealthSnapshot
+    monitoring_exceptions: list[DpmMonitoringException]
+
+
+def calculate_mandate_health_result(
+    health_input: DpmMandateHealthInput,
+) -> DpmMandateHealthCalculationResult:
+    snapshot = calculate_mandate_health(health_input)
+    return DpmMandateHealthCalculationResult(
+        snapshot=snapshot,
+        monitoring_exceptions=monitoring_exceptions_from_health(
+            snapshot,
+            source_lineage=health_input.twin.source_lineage,
+        ),
+    )
+
+
+__all__ = [
+    "DpmMandateHealthCalculationResult",
+    "calculate_mandate_health_result",
+]

--- a/src/api/services/mandate_monitoring_run.py
+++ b/src/api/services/mandate_monitoring_run.py
@@ -20,6 +20,28 @@ class DpmMonitoringRunMandateResult:
     monitoring_exceptions: list[DpmMonitoringException]
 
 
+@dataclass
+class DpmMonitoringRunAccumulator:
+    health_distribution: dict[str, int]
+    source_readiness_summary: dict[str, int]
+    exception_count: int = 0
+
+    @classmethod
+    def empty(cls) -> "DpmMonitoringRunAccumulator":
+        return cls(health_distribution={}, source_readiness_summary={})
+
+    def record(self, result: DpmMonitoringRunMandateResult) -> None:
+        increment_distribution(
+            self.health_distribution,
+            result.health_snapshot.health_state.value,
+        )
+        increment_distribution(
+            self.source_readiness_summary,
+            result.health_snapshot.source_readiness_state,
+        )
+        self.exception_count += len(result.monitoring_exceptions)
+
+
 def monitoring_run_id_for(requested_at: datetime) -> str:
     return f"dmr_{requested_at.strftime('%Y%m%d_%H%M%S_%f')}"
 
@@ -92,6 +114,7 @@ def build_monitoring_run(
 
 
 __all__ = [
+    "DpmMonitoringRunAccumulator",
     "DpmMonitoringRunMandateResult",
     "build_monitoring_run",
     "calculate_monitoring_run_mandate_result",

--- a/src/api/services/mandate_monitoring_run.py
+++ b/src/api/services/mandate_monitoring_run.py
@@ -1,8 +1,23 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import date, datetime
 
-from src.core.mandates import DpmMonitoringException, DpmMonitoringRun
+from src.core.mandates import (
+    DpmMandateDigitalTwin,
+    DpmMandateHealthInput,
+    DpmMandateHealthSnapshot,
+    DpmMonitoringException,
+    DpmMonitoringRun,
+    calculate_mandate_health,
+    monitoring_exceptions_from_health,
+)
+
+
+@dataclass(frozen=True)
+class DpmMonitoringRunMandateResult:
+    health_snapshot: DpmMandateHealthSnapshot
+    monitoring_exceptions: list[DpmMonitoringException]
 
 
 def monitoring_run_id_for(requested_at: datetime) -> str:
@@ -25,6 +40,28 @@ def exceptions_for_monitoring_run(
         exception.model_copy(update={"monitoring_run_id": monitoring_run_id})
         for exception in exceptions
     ]
+
+
+def calculate_monitoring_run_mandate_result(
+    *,
+    twin: DpmMandateDigitalTwin,
+    as_of_date: date,
+    monitoring_run_id: str,
+) -> DpmMonitoringRunMandateResult:
+    snapshot = calculate_mandate_health(
+        DpmMandateHealthInput(twin=twin.model_copy(update={"as_of_date": as_of_date}))
+    )
+    exceptions = monitoring_exceptions_from_health(
+        snapshot,
+        source_lineage=twin.source_lineage,
+    )
+    return DpmMonitoringRunMandateResult(
+        health_snapshot=snapshot,
+        monitoring_exceptions=exceptions_for_monitoring_run(
+            exceptions,
+            monitoring_run_id=monitoring_run_id,
+        ),
+    )
 
 
 def build_monitoring_run(
@@ -55,7 +92,9 @@ def build_monitoring_run(
 
 
 __all__ = [
+    "DpmMonitoringRunMandateResult",
     "build_monitoring_run",
+    "calculate_monitoring_run_mandate_result",
     "exceptions_for_monitoring_run",
     "increment_distribution",
     "monitoring_run_id_for",

--- a/src/api/services/mandate_monitoring_run.py
+++ b/src/api/services/mandate_monitoring_run.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from src.core.mandates import DpmMonitoringException, DpmMonitoringRun
+
+
+def monitoring_run_id_for(requested_at: datetime) -> str:
+    return f"dmr_{requested_at.strftime('%Y%m%d_%H%M%S_%f')}"
+
+
+def increment_distribution(
+    distribution: dict[str, int],
+    key: str,
+) -> None:
+    distribution[key] = distribution.get(key, 0) + 1
+
+
+def exceptions_for_monitoring_run(
+    exceptions: list[DpmMonitoringException],
+    *,
+    monitoring_run_id: str,
+) -> list[DpmMonitoringException]:
+    return [
+        exception.model_copy(update={"monitoring_run_id": monitoring_run_id})
+        for exception in exceptions
+    ]
+
+
+def build_monitoring_run(
+    *,
+    monitoring_run_id: str,
+    as_of_date: date,
+    requested_at: datetime,
+    completed_at: datetime,
+    mandate_ids: list[str],
+    filters: dict[str, str],
+    health_distribution: dict[str, int],
+    exception_count: int,
+    source_readiness_summary: dict[str, int],
+) -> DpmMonitoringRun:
+    return DpmMonitoringRun(
+        monitoring_run_id=monitoring_run_id,
+        as_of_date=as_of_date,
+        requested_at=requested_at,
+        completed_at=completed_at,
+        status="SUCCEEDED",
+        mandate_ids=mandate_ids,
+        filters=filters,
+        total_mandates=len(mandate_ids),
+        health_distribution=health_distribution,
+        exception_count=exception_count,
+        source_readiness_summary=source_readiness_summary,
+    )
+
+
+__all__ = [
+    "build_monitoring_run",
+    "exceptions_for_monitoring_run",
+    "increment_distribution",
+    "monitoring_run_id_for",
+]

--- a/src/api/services/mandate_optional_sources.py
+++ b/src/api/services/mandate_optional_sources.py
@@ -1,9 +1,31 @@
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Optional, cast
 
-from src.core.dpm_source_context import DpmCoreBenchmarkAssignmentResponse
+from src.core.dpm_source_context import (
+    DpmCoreBenchmarkAssignmentResponse,
+    DpmCoreClientIncomeNeedsScheduleResponse,
+    DpmCoreClientRestrictionProfileResponse,
+    DpmCoreLiquidityReserveRequirementResponse,
+    DpmCorePlannedWithdrawalScheduleResponse,
+    DpmCorePortfolioCashflowProjectionResponse,
+    DpmCoreSustainabilityPreferenceProfileResponse,
+)
 from src.infrastructure.core_sourcing import DpmCoreResolverClient, DpmCoreResolverError
+
+
+@dataclass(frozen=True)
+class DpmMandateOptionalSources:
+    client_restriction_profile: DpmCoreClientRestrictionProfileResponse | None
+    sustainability_preference_profile: DpmCoreSustainabilityPreferenceProfileResponse | None
+    portfolio_cashflow_projection: DpmCorePortfolioCashflowProjectionResponse | None
+    client_income_needs_schedule: DpmCoreClientIncomeNeedsScheduleResponse | None
+    liquidity_reserve_requirement: DpmCoreLiquidityReserveRequirementResponse | None
+    planned_withdrawal_schedule: DpmCorePlannedWithdrawalScheduleResponse | None
+    benchmark_assignment: DpmCoreBenchmarkAssignmentResponse | None
+    unavailable_source_families: list[str]
 
 
 def try_resolve_optional_source(
@@ -43,6 +65,179 @@ def ready_optional_source(
     return source, unavailable_family
 
 
+def resolve_mandate_optional_sources(
+    *,
+    resolver: DpmCoreResolverClient,
+    portfolio_id: str,
+    mandate_id: str,
+    as_of_date: date,
+    tenant_id: Optional[str],
+    reference_currency: Optional[str],
+    correlation_id: Optional[str],
+) -> DpmMandateOptionalSources:
+    client_restriction_profile, unavailable_client_restrictions = try_resolve_optional_source(
+        resolver=resolver,
+        method_name="resolve_client_restriction_profile",
+        family_name="CLIENT_RESTRICTION_PROFILE",
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        tenant_id=tenant_id,
+        mandate_id=mandate_id,
+        include_inactive_restrictions=False,
+        correlation_id=correlation_id,
+    )
+    client_restriction_profile, unavailable_client_restrictions = ready_optional_source(
+        source=client_restriction_profile,
+        unavailable_family=unavailable_client_restrictions,
+        family_name="CLIENT_RESTRICTION_PROFILE",
+    )
+    (
+        sustainability_preference_profile,
+        unavailable_sustainability_preferences,
+    ) = try_resolve_optional_source(
+        resolver=resolver,
+        method_name="resolve_sustainability_preference_profile",
+        family_name="SUSTAINABILITY_PREFERENCE_PROFILE",
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        tenant_id=tenant_id,
+        mandate_id=mandate_id,
+        include_inactive_preferences=False,
+        correlation_id=correlation_id,
+    )
+    (
+        sustainability_preference_profile,
+        unavailable_sustainability_preferences,
+    ) = ready_optional_source(
+        source=sustainability_preference_profile,
+        unavailable_family=unavailable_sustainability_preferences,
+        family_name="SUSTAINABILITY_PREFERENCE_PROFILE",
+    )
+    portfolio_cashflow_projection, unavailable_cashflow_projection = try_resolve_optional_source(
+        resolver=resolver,
+        method_name="resolve_portfolio_cashflow_projection",
+        family_name="PORTFOLIO_CASHFLOW_PROJECTION",
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        horizon_days=90,
+        include_projected=True,
+        correlation_id=correlation_id,
+    )
+    portfolio_cashflow_projection, unavailable_cashflow_projection = ready_optional_source(
+        source=portfolio_cashflow_projection,
+        unavailable_family=unavailable_cashflow_projection,
+        family_name="PORTFOLIO_CASHFLOW_PROJECTION",
+    )
+    client_income_needs_schedule, unavailable_income_needs = try_resolve_optional_source(
+        resolver=resolver,
+        method_name="resolve_client_income_needs_schedule",
+        family_name="CLIENT_INCOME_NEEDS_SCHEDULE",
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        tenant_id=tenant_id,
+        mandate_id=mandate_id,
+        include_inactive_schedules=False,
+        correlation_id=correlation_id,
+    )
+    client_income_needs_schedule, unavailable_income_needs = ready_optional_source(
+        source=client_income_needs_schedule,
+        unavailable_family=unavailable_income_needs,
+        family_name="CLIENT_INCOME_NEEDS_SCHEDULE",
+    )
+    liquidity_reserve_requirement, unavailable_liquidity_reserve = try_resolve_optional_source(
+        resolver=resolver,
+        method_name="resolve_liquidity_reserve_requirement",
+        family_name="LIQUIDITY_RESERVE_REQUIREMENT",
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        tenant_id=tenant_id,
+        mandate_id=mandate_id,
+        include_inactive_requirements=False,
+        correlation_id=correlation_id,
+    )
+    liquidity_reserve_requirement, unavailable_liquidity_reserve = ready_optional_source(
+        source=liquidity_reserve_requirement,
+        unavailable_family=unavailable_liquidity_reserve,
+        family_name="LIQUIDITY_RESERVE_REQUIREMENT",
+    )
+    planned_withdrawal_schedule, unavailable_planned_withdrawal = try_resolve_optional_source(
+        resolver=resolver,
+        method_name="resolve_planned_withdrawal_schedule",
+        family_name="PLANNED_WITHDRAWAL_SCHEDULE",
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        tenant_id=tenant_id,
+        mandate_id=mandate_id,
+        horizon_days=365,
+        include_inactive_withdrawals=False,
+        correlation_id=correlation_id,
+    )
+    planned_withdrawal_schedule, unavailable_planned_withdrawal = ready_optional_source(
+        source=planned_withdrawal_schedule,
+        unavailable_family=unavailable_planned_withdrawal,
+        family_name="PLANNED_WITHDRAWAL_SCHEDULE",
+    )
+    benchmark_assignment, unavailable_benchmark_assignment = try_resolve_optional_source(
+        resolver=resolver,
+        method_name="resolve_benchmark_assignment",
+        family_name="BENCHMARK_ASSIGNMENT",
+        portfolio_id=portfolio_id,
+        as_of_date=as_of_date,
+        reporting_currency=reference_currency,
+        correlation_id=correlation_id,
+    )
+    benchmark_assignment, unavailable_benchmark_assignment = ready_optional_source(
+        source=benchmark_assignment,
+        unavailable_family=unavailable_benchmark_assignment,
+        family_name="BENCHMARK_ASSIGNMENT",
+    )
+    benchmark_assignment, unavailable_benchmark_assignment = ready_benchmark_assignment_source(
+        source=cast(DpmCoreBenchmarkAssignmentResponse | None, benchmark_assignment),
+        unavailable_family=unavailable_benchmark_assignment,
+    )
+    unavailable_source_families = [
+        family
+        for family in (
+            unavailable_client_restrictions,
+            unavailable_sustainability_preferences,
+            unavailable_cashflow_projection,
+            unavailable_income_needs,
+            unavailable_liquidity_reserve,
+            unavailable_planned_withdrawal,
+            unavailable_benchmark_assignment,
+        )
+        if family is not None
+    ]
+    return DpmMandateOptionalSources(
+        client_restriction_profile=cast(
+            DpmCoreClientRestrictionProfileResponse | None,
+            client_restriction_profile,
+        ),
+        sustainability_preference_profile=cast(
+            DpmCoreSustainabilityPreferenceProfileResponse | None,
+            sustainability_preference_profile,
+        ),
+        portfolio_cashflow_projection=cast(
+            DpmCorePortfolioCashflowProjectionResponse | None,
+            portfolio_cashflow_projection,
+        ),
+        client_income_needs_schedule=cast(
+            DpmCoreClientIncomeNeedsScheduleResponse | None,
+            client_income_needs_schedule,
+        ),
+        liquidity_reserve_requirement=cast(
+            DpmCoreLiquidityReserveRequirementResponse | None,
+            liquidity_reserve_requirement,
+        ),
+        planned_withdrawal_schedule=cast(
+            DpmCorePlannedWithdrawalScheduleResponse | None,
+            planned_withdrawal_schedule,
+        ),
+        benchmark_assignment=benchmark_assignment,
+        unavailable_source_families=unavailable_source_families,
+    )
+
+
 def ready_benchmark_assignment_source(
     *,
     source: DpmCoreBenchmarkAssignmentResponse | None,
@@ -56,7 +251,9 @@ def ready_benchmark_assignment_source(
 
 
 __all__ = [
+    "DpmMandateOptionalSources",
     "ready_benchmark_assignment_source",
     "ready_optional_source",
+    "resolve_mandate_optional_sources",
     "try_resolve_optional_source",
 ]

--- a/src/api/services/mandate_optional_sources.py
+++ b/src/api/services/mandate_optional_sources.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.core.dpm_source_context import DpmCoreBenchmarkAssignmentResponse
+from src.infrastructure.core_sourcing import DpmCoreResolverClient, DpmCoreResolverError
+
+
+def try_resolve_optional_source(
+    *,
+    resolver: DpmCoreResolverClient,
+    method_name: str,
+    family_name: str,
+    **kwargs: Any,
+) -> tuple[Any | None, str | None]:
+    method = getattr(resolver, method_name, None)
+    if method is None:
+        return None, None
+    try:
+        return method(**kwargs), None
+    except DpmCoreResolverError:
+        return None, family_name
+
+
+def ready_optional_source(
+    *,
+    source: Any | None,
+    unavailable_family: str | None,
+    family_name: str,
+) -> tuple[Any | None, str | None]:
+    if source is None:
+        return None, unavailable_family
+    supportability = getattr(source, "supportability", None)
+    if supportability is not None and getattr(supportability, "state", None) != "READY":
+        return None, family_name
+    data_quality_status = getattr(source, "data_quality_status", None)
+    if data_quality_status is not None and str(data_quality_status).upper() not in {
+        "READY",
+        "COMPLETE",
+        "ACCEPTED",
+    }:
+        return None, family_name
+    return source, unavailable_family
+
+
+def ready_benchmark_assignment_source(
+    *,
+    source: DpmCoreBenchmarkAssignmentResponse | None,
+    unavailable_family: str | None,
+) -> tuple[DpmCoreBenchmarkAssignmentResponse | None, str | None]:
+    if source is None:
+        return None, unavailable_family
+    if source.assignment_status.upper() != "ACTIVE":
+        return None, "BENCHMARK_ASSIGNMENT"
+    return source, unavailable_family
+
+
+__all__ = [
+    "ready_benchmark_assignment_source",
+    "ready_optional_source",
+    "try_resolve_optional_source",
+]

--- a/src/api/services/mandate_pm_book.py
+++ b/src/api/services/mandate_pm_book.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from src.api.services.mandate_errors import DpmMandateSourceIncompleteError
+from src.core.dpm_source_context import DpmCorePortfolioManagerBookMembershipResponse
+from src.core.mandate_repository import DpmMandateRepository
+
+
+def mandate_ids_from_pm_book_membership(
+    *,
+    repository: DpmMandateRepository,
+    membership: DpmCorePortfolioManagerBookMembershipResponse,
+) -> list[str]:
+    mandate_ids: list[str] = []
+    missing_portfolio_ids: list[str] = []
+    for member in membership.members:
+        twin = repository.get_latest_mandate_by_portfolio(portfolio_id=member.portfolio_id)
+        if twin is None:
+            missing_portfolio_ids.append(member.portfolio_id)
+            continue
+        mandate_ids.append(twin.mandate_id)
+
+    if missing_portfolio_ids:
+        raise DpmMandateSourceIncompleteError("DPM_PM_BOOK_MANDATE_SNAPSHOT_MISSING")
+    if not mandate_ids:
+        raise DpmMandateSourceIncompleteError("DPM_PM_BOOK_MANDATE_SNAPSHOT_EMPTY")
+    return mandate_ids
+
+
+__all__ = ["mandate_ids_from_pm_book_membership"]

--- a/src/api/services/mandate_refresh.py
+++ b/src/api/services/mandate_refresh.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Optional
+
+from src.api.services.mandate_errors import (
+    DpmMandateSourceIncompleteError,
+    DpmMandateSourceUnavailableError,
+)
+from src.api.services.mandate_health_result import (
+    DpmMandateHealthCalculationResult,
+    calculate_mandate_health_result,
+)
+from src.api.services.mandate_optional_sources import resolve_mandate_optional_sources
+from src.core.mandates import (
+    DpmMandateDigitalTwin,
+    DpmMandateHealthSnapshot,
+    DpmMonitoringException,
+    build_health_input_from_core_sources,
+    compile_mandate_digital_twin_from_core,
+)
+from src.infrastructure.core_sourcing import (
+    DpmCoreResolverClient,
+    DpmCoreResolverError,
+    DpmCoreResolverUnavailableError,
+)
+
+
+@dataclass(frozen=True)
+class DpmMandateRefreshResult:
+    twin: DpmMandateDigitalTwin
+    health_snapshot: DpmMandateHealthSnapshot
+    monitoring_exceptions: list[DpmMonitoringException]
+
+
+def build_mandate_refresh_result_from_core(
+    *,
+    core_resolver: DpmCoreResolverClient,
+    portfolio_id: str,
+    mandate_id: str,
+    as_of_date: date,
+    tenant_id: Optional[str],
+    booking_center_code: Optional[str],
+    model_portfolio_id: Optional[str],
+    reference_currency: Optional[str],
+    include_market_data_coverage: bool,
+    correlation_id: Optional[str],
+) -> DpmMandateRefreshResult:
+    try:
+        mandate = core_resolver.resolve_mandate_binding(
+            portfolio_id=portfolio_id,
+            as_of_date=as_of_date,
+            tenant_id=tenant_id,
+            mandate_id=mandate_id,
+            booking_center_code=booking_center_code,
+            include_policy_pack=True,
+            correlation_id=correlation_id,
+        )
+        resolved_model_portfolio_id = model_portfolio_id or mandate.model_portfolio_id
+        model_targets = core_resolver.resolve_model_portfolio_targets(
+            model_portfolio_id=resolved_model_portfolio_id,
+            as_of_date=as_of_date,
+            tenant_id=tenant_id,
+            correlation_id=correlation_id,
+        )
+        market_data_coverage = None
+        if include_market_data_coverage:
+            market_data_coverage = core_resolver.resolve_market_data_coverage(
+                instrument_ids=[target.instrument_id for target in model_targets.targets],
+                currency_pairs=[],
+                as_of_date=as_of_date,
+                valuation_currency=model_targets.base_currency,
+                tenant_id=tenant_id,
+                correlation_id=correlation_id,
+            )
+    except DpmCoreResolverUnavailableError as exc:
+        raise DpmMandateSourceUnavailableError("DPM_MANDATE_SOURCE_UNAVAILABLE") from exc
+    except DpmCoreResolverError as exc:
+        raise DpmMandateSourceIncompleteError("DPM_MANDATE_SOURCE_INCOMPLETE") from exc
+
+    optional_sources = resolve_mandate_optional_sources(
+        resolver=core_resolver,
+        portfolio_id=portfolio_id,
+        mandate_id=mandate_id,
+        as_of_date=as_of_date,
+        tenant_id=tenant_id,
+        reference_currency=reference_currency,
+        correlation_id=correlation_id,
+    )
+    twin = compile_mandate_digital_twin_from_core(
+        mandate=mandate,
+        model_targets=model_targets,
+        as_of_date=as_of_date,
+        reference_currency=reference_currency,
+        client_restriction_profile=optional_sources.client_restriction_profile,
+        sustainability_preference_profile=optional_sources.sustainability_preference_profile,
+        portfolio_cashflow_projection=optional_sources.portfolio_cashflow_projection,
+        client_income_needs_schedule=optional_sources.client_income_needs_schedule,
+        liquidity_reserve_requirement=optional_sources.liquidity_reserve_requirement,
+        planned_withdrawal_schedule=optional_sources.planned_withdrawal_schedule,
+        benchmark_assignment=optional_sources.benchmark_assignment,
+    )
+    health_result = _health_result_for_refresh(
+        twin=twin,
+        model_targets=model_targets,
+        market_data_coverage=market_data_coverage,
+        optional_sources=optional_sources,
+    )
+    return DpmMandateRefreshResult(
+        twin=twin,
+        health_snapshot=health_result.snapshot,
+        monitoring_exceptions=health_result.monitoring_exceptions,
+    )
+
+
+def _health_result_for_refresh(
+    *,
+    twin: DpmMandateDigitalTwin,
+    model_targets: Any,
+    market_data_coverage: Any | None,
+    optional_sources: Any,
+) -> DpmMandateHealthCalculationResult:
+    health_input = build_health_input_from_core_sources(
+        twin=twin,
+        model_targets=model_targets,
+        market_data_coverage=market_data_coverage,
+        client_restriction_profile=optional_sources.client_restriction_profile,
+        sustainability_preference_profile=optional_sources.sustainability_preference_profile,
+        portfolio_cashflow_projection=optional_sources.portfolio_cashflow_projection,
+        unavailable_source_families=optional_sources.unavailable_source_families,
+    )
+    return calculate_mandate_health_result(health_input)
+
+
+__all__ = ["DpmMandateRefreshResult", "build_mandate_refresh_result_from_core"]

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -34,6 +34,7 @@ from src.api.services.mandate_health_result import (
 )
 from src.api.services.mandate_health_persistence import persist_mandate_health_evidence
 from src.api.services.mandate_monitoring_run import (
+    DpmMonitoringRunAccumulator as DpmMonitoringRunAccumulator,
     DpmMonitoringRunMandateResult as DpmMonitoringRunMandateResult,
     build_monitoring_run,
     calculate_monitoring_run_mandate_result,
@@ -81,6 +82,7 @@ _ready_benchmark_assignment_source = ready_benchmark_assignment_source
 _resolve_mandate_optional_sources = resolve_mandate_optional_sources
 _calculate_mandate_health_result = calculate_mandate_health_result
 _persist_mandate_health_evidence = persist_mandate_health_evidence
+_monitoring_run_accumulator = DpmMonitoringRunAccumulator
 _monitoring_run_id_for = monitoring_run_id_for
 _increment_distribution = increment_distribution
 _exceptions_for_monitoring_run = exceptions_for_monitoring_run
@@ -197,9 +199,7 @@ def run_mandate_monitoring_once(
 ) -> DpmMonitoringRun:
     requested_at = datetime.now(timezone.utc)
     monitoring_run_id = _monitoring_run_id_for(requested_at)
-    health_distribution: dict[str, int] = {}
-    source_readiness_summary: dict[str, int] = {}
-    exception_count = 0
+    accumulator = _monitoring_run_accumulator.empty()
 
     for mandate_id in mandate_ids:
         twin = get_latest_mandate(repository=repository, mandate_id=mandate_id)
@@ -214,9 +214,7 @@ def run_mandate_monitoring_once(
             health_snapshot=snapshot,
             monitoring_exceptions=mandate_result.monitoring_exceptions,
         )
-        _increment_distribution(health_distribution, snapshot.health_state.value)
-        _increment_distribution(source_readiness_summary, snapshot.source_readiness_state)
-        exception_count += len(mandate_result.monitoring_exceptions)
+        accumulator.record(mandate_result)
 
     run = _build_monitoring_run(
         monitoring_run_id=monitoring_run_id,
@@ -225,9 +223,9 @@ def run_mandate_monitoring_once(
         completed_at=datetime.now(timezone.utc),
         mandate_ids=mandate_ids,
         filters=filters,
-        health_distribution=health_distribution,
-        exception_count=exception_count,
-        source_readiness_summary=source_readiness_summary,
+        health_distribution=accumulator.health_distribution,
+        exception_count=accumulator.exception_count,
+        source_readiness_summary=accumulator.source_readiness_summary,
     )
     repository.save_monitoring_run(run)
     return run

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from typing import Any, Literal, Optional
+from typing import Literal, Optional
 
 from src.api.services.mandate_command_center import (
     attention_buckets as _attention_buckets,
@@ -27,6 +27,11 @@ from src.api.services.mandate_diff import (
     iter_changed_fields,
     materiality_for_field,
 )
+from src.api.services.mandate_optional_sources import (
+    ready_benchmark_assignment_source,
+    ready_optional_source,
+    try_resolve_optional_source,
+)
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import (
     DpmCommandCenterSummary,
@@ -48,7 +53,6 @@ from src.infrastructure.core_sourcing import (
     DpmCoreResolverUnavailableError,
 )
 from src.core.dpm_source_context import (
-    DpmCoreBenchmarkAssignmentResponse,
     DpmCorePortfolioManagerBookMembershipResponse,
 )
 
@@ -56,6 +60,9 @@ _severity_rank = severity_rank
 _diff_payloads = diff_payloads
 _iter_changed_fields = iter_changed_fields
 _materiality_for_field = materiality_for_field
+_try_resolve_optional_source = try_resolve_optional_source
+_ready_optional_source = ready_optional_source
+_ready_benchmark_assignment_source = ready_benchmark_assignment_source
 
 
 @dataclass(frozen=True)
@@ -282,55 +289,6 @@ def refresh_mandate_from_core(
         health_snapshot=health_snapshot,
         monitoring_exceptions=monitoring_exceptions,
     )
-
-
-def _try_resolve_optional_source(
-    *,
-    resolver: DpmCoreResolverClient,
-    method_name: str,
-    family_name: str,
-    **kwargs: Any,
-) -> tuple[Any | None, str | None]:
-    method = getattr(resolver, method_name, None)
-    if method is None:
-        return None, None
-    try:
-        return method(**kwargs), None
-    except DpmCoreResolverError:
-        return None, family_name
-
-
-def _ready_optional_source(
-    *,
-    source: Any | None,
-    unavailable_family: str | None,
-    family_name: str,
-) -> tuple[Any | None, str | None]:
-    if source is None:
-        return None, unavailable_family
-    supportability = getattr(source, "supportability", None)
-    if supportability is not None and getattr(supportability, "state", None) != "READY":
-        return None, family_name
-    data_quality_status = getattr(source, "data_quality_status", None)
-    if data_quality_status is not None and str(data_quality_status).upper() not in {
-        "READY",
-        "COMPLETE",
-        "ACCEPTED",
-    }:
-        return None, family_name
-    return source, unavailable_family
-
-
-def _ready_benchmark_assignment_source(
-    *,
-    source: DpmCoreBenchmarkAssignmentResponse | None,
-    unavailable_family: str | None,
-) -> tuple[DpmCoreBenchmarkAssignmentResponse | None, str | None]:
-    if source is None:
-        return None, unavailable_family
-    if source.assignment_status.upper() != "ACTIVE":
-        return None, "BENCHMARK_ASSIGNMENT"
-    return source, unavailable_family
 
 
 def get_latest_mandate_by_portfolio(

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field
-
 from src.api.services.mandate_command_center import (
     attention_buckets as _attention_buckets,
     command_center_supportability_state as _command_center_supportability_state,
@@ -20,6 +18,14 @@ from src.api.services.mandate_errors import (
     DpmMandateSourceIncompleteError as DpmMandateSourceIncompleteError,
     DpmMandateSourceUnavailableError as DpmMandateSourceUnavailableError,
     DpmMonitoringRunNotFoundError as DpmMonitoringRunNotFoundError,
+)
+from src.api.services.mandate_diff import (
+    DpmMandateDiff as DpmMandateDiff,
+    DpmMandateFieldChange as DpmMandateFieldChange,
+    build_mandate_diff as _build_mandate_diff,
+    diff_payloads,
+    iter_changed_fields,
+    materiality_for_field,
 )
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import (
@@ -47,47 +53,9 @@ from src.core.dpm_source_context import (
 )
 
 _severity_rank = severity_rank
-
-
-class DpmMandateFieldChange(BaseModel):
-    field_path: str = Field(
-        description="Dot-separated mandate digital-twin field path that changed.",
-        examples=["constraints.turnover_budget"],
-    )
-    previous_value: Any = Field(
-        description="Value from the older mandate version.",
-        examples=["0.1000000000"],
-    )
-    current_value: Any = Field(
-        description="Value from the newer mandate version.",
-        examples=["0.1500000000"],
-    )
-    materiality: str = Field(
-        description="Business materiality of the field change for DPM oversight.",
-        examples=["HIGH"],
-    )
-
-
-class DpmMandateDiff(BaseModel):
-    mandate_id: str = Field(
-        description="Discretionary mandate identifier whose versions were compared.",
-        examples=["MANDATE_PB_SG_GLOBAL_BAL_001"],
-    )
-    compared_at: datetime = Field(
-        description="UTC timestamp when lotus-manage generated the diff.",
-        examples=["2026-05-03T08:30:00Z"],
-    )
-    from_version: str = Field(
-        description="Older mandate version used as the comparison baseline.",
-        examples=["2"],
-    )
-    to_version: str = Field(
-        description="Newer mandate version used as the comparison target.",
-        examples=["3"],
-    )
-    changed_fields: list[DpmMandateFieldChange] = Field(
-        description="Changed mandate fields, ordered by field path for deterministic review.",
-    )
+_diff_payloads = diff_payloads
+_iter_changed_fields = iter_changed_fields
+_materiality_for_field = materiality_for_field
 
 
 @dataclass(frozen=True)
@@ -665,66 +633,8 @@ def diff_mandate_versions(
             raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
         current, previous = versions[0], versions[1]
 
-    return DpmMandateDiff(
+    return _build_mandate_diff(
         mandate_id=mandate_id,
-        compared_at=datetime.now(timezone.utc),
-        from_version=previous.mandate_version,
-        to_version=current.mandate_version,
-        changed_fields=_diff_payloads(
-            previous.model_dump(mode="json"),
-            current.model_dump(mode="json"),
-        ),
+        previous=previous,
+        current=current,
     )
-
-
-def _diff_payloads(
-    previous: dict[str, Any], current: dict[str, Any]
-) -> list[DpmMandateFieldChange]:
-    changes: list[DpmMandateFieldChange] = []
-    for field_path, previous_value, current_value in _iter_changed_fields(previous, current):
-        changes.append(
-            DpmMandateFieldChange(
-                field_path=field_path,
-                previous_value=previous_value,
-                current_value=current_value,
-                materiality=_materiality_for_field(field_path),
-            )
-        )
-    return sorted(changes, key=lambda change: change.field_path)
-
-
-def _iter_changed_fields(
-    previous: dict[str, Any],
-    current: dict[str, Any],
-    *,
-    prefix: str = "",
-) -> list[tuple[str, Any, Any]]:
-    ignored = {"source_lineage"}
-    changes: list[tuple[str, Any, Any]] = []
-    keys = sorted((set(previous) | set(current)) - ignored)
-    for key in keys:
-        field_path = f"{prefix}.{key}" if prefix else key
-        previous_value = previous.get(key)
-        current_value = current.get(key)
-        if isinstance(previous_value, dict) and isinstance(current_value, dict):
-            changes.extend(_iter_changed_fields(previous_value, current_value, prefix=field_path))
-            continue
-        if previous_value != current_value:
-            changes.append((field_path, previous_value, current_value))
-    return changes
-
-
-def _materiality_for_field(field_path: str) -> str:
-    high_prefixes = (
-        "constraints.",
-        "risk_profile",
-        "investment_objective",
-        "model_portfolio_id",
-        "model_portfolio_version",
-        "time_horizon",
-    )
-    if field_path.startswith(high_prefixes):
-        return "HIGH"
-    if field_path in {"mandate_version", "as_of_date", "field_gap_codes"}:
-        return "MEDIUM"
-    return "LOW"

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -33,7 +33,9 @@ from src.api.services.mandate_health_result import (
     calculate_mandate_health_result,
 )
 from src.api.services.mandate_monitoring_run import (
+    DpmMonitoringRunMandateResult as DpmMonitoringRunMandateResult,
     build_monitoring_run,
+    calculate_monitoring_run_mandate_result,
     exceptions_for_monitoring_run,
     increment_distribution,
     monitoring_run_id_for,
@@ -56,9 +58,7 @@ from src.core.mandates import (
     DpmMonitoringException,
     DpmMonitoringRun,
     build_health_input_from_core_sources,
-    calculate_mandate_health,
     compile_mandate_digital_twin_from_core,
-    monitoring_exceptions_from_health,
 )
 from src.infrastructure.core_sourcing import (
     DpmCoreResolverClient,
@@ -82,6 +82,7 @@ _calculate_mandate_health_result = calculate_mandate_health_result
 _monitoring_run_id_for = monitoring_run_id_for
 _increment_distribution = increment_distribution
 _exceptions_for_monitoring_run = exceptions_for_monitoring_run
+_calculate_monitoring_run_mandate_result = calculate_monitoring_run_mandate_result
 _build_monitoring_run = build_monitoring_run
 
 
@@ -258,22 +259,17 @@ def run_mandate_monitoring_once(
 
     for mandate_id in mandate_ids:
         twin = get_latest_mandate(repository=repository, mandate_id=mandate_id)
-        health_input = DpmMandateHealthInput(
-            twin=twin.model_copy(update={"as_of_date": as_of_date})
+        mandate_result = _calculate_monitoring_run_mandate_result(
+            twin=twin,
+            as_of_date=as_of_date,
+            monitoring_run_id=monitoring_run_id,
         )
-        snapshot = calculate_mandate_health(health_input)
+        snapshot = mandate_result.health_snapshot
         repository.save_health_snapshot(snapshot)
         _increment_distribution(health_distribution, snapshot.health_state.value)
         _increment_distribution(source_readiness_summary, snapshot.source_readiness_state)
-        exceptions = monitoring_exceptions_from_health(
-            snapshot,
-            source_lineage=twin.source_lineage,
-        )
-        exception_count += len(exceptions)
-        for exception in _exceptions_for_monitoring_run(
-            exceptions,
-            monitoring_run_id=monitoring_run_id,
-        ):
+        exception_count += len(mandate_result.monitoring_exceptions)
+        for exception in mandate_result.monitoring_exceptions:
             repository.save_monitoring_exception(exception)
 
     run = _build_monitoring_run(

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import Optional
 
@@ -49,6 +48,10 @@ from src.api.services.mandate_optional_sources import (
 from src.api.services.mandate_pm_book import (
     mandate_ids_from_pm_book_membership as mandate_ids_from_pm_book_membership,
 )
+from src.api.services.mandate_refresh import (
+    DpmMandateRefreshResult as DpmMandateRefreshResult,
+    build_mandate_refresh_result_from_core,
+)
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import (
     DpmCommandCenterSummary,
@@ -57,14 +60,8 @@ from src.core.mandates import (
     DpmMandateHealthSnapshot,
     DpmMonitoringException,
     DpmMonitoringRun,
-    build_health_input_from_core_sources,
-    compile_mandate_digital_twin_from_core,
 )
-from src.infrastructure.core_sourcing import (
-    DpmCoreResolverClient,
-    DpmCoreResolverError,
-    DpmCoreResolverUnavailableError,
-)
+from src.infrastructure.core_sourcing import DpmCoreResolverClient
 
 _severity_rank = severity_rank
 _attention_buckets = attention_buckets
@@ -84,13 +81,7 @@ _increment_distribution = increment_distribution
 _exceptions_for_monitoring_run = exceptions_for_monitoring_run
 _calculate_monitoring_run_mandate_result = calculate_monitoring_run_mandate_result
 _build_monitoring_run = build_monitoring_run
-
-
-@dataclass(frozen=True)
-class DpmMandateRefreshResult:
-    twin: DpmMandateDigitalTwin
-    health_snapshot: DpmMandateHealthSnapshot
-    monitoring_exceptions: list[DpmMonitoringException]
+_build_mandate_refresh_result_from_core = build_mandate_refresh_result_from_core
 
 
 def refresh_mandate_from_core(
@@ -107,81 +98,25 @@ def refresh_mandate_from_core(
     include_market_data_coverage: bool,
     correlation_id: Optional[str],
 ) -> DpmMandateRefreshResult:
-    try:
-        mandate = core_resolver.resolve_mandate_binding(
-            portfolio_id=portfolio_id,
-            as_of_date=as_of_date,
-            tenant_id=tenant_id,
-            mandate_id=mandate_id,
-            booking_center_code=booking_center_code,
-            include_policy_pack=True,
-            correlation_id=correlation_id,
-        )
-        resolved_model_portfolio_id = model_portfolio_id or mandate.model_portfolio_id
-        model_targets = core_resolver.resolve_model_portfolio_targets(
-            model_portfolio_id=resolved_model_portfolio_id,
-            as_of_date=as_of_date,
-            tenant_id=tenant_id,
-            correlation_id=correlation_id,
-        )
-        market_data_coverage = None
-        if include_market_data_coverage:
-            market_data_coverage = core_resolver.resolve_market_data_coverage(
-                instrument_ids=[target.instrument_id for target in model_targets.targets],
-                currency_pairs=[],
-                as_of_date=as_of_date,
-                valuation_currency=model_targets.base_currency,
-                tenant_id=tenant_id,
-                correlation_id=correlation_id,
-            )
-    except DpmCoreResolverUnavailableError as exc:
-        raise DpmMandateSourceUnavailableError("DPM_MANDATE_SOURCE_UNAVAILABLE") from exc
-    except DpmCoreResolverError as exc:
-        raise DpmMandateSourceIncompleteError("DPM_MANDATE_SOURCE_INCOMPLETE") from exc
-    optional_sources = _resolve_mandate_optional_sources(
-        resolver=core_resolver,
+    refresh_result = _build_mandate_refresh_result_from_core(
+        core_resolver=core_resolver,
         portfolio_id=portfolio_id,
         mandate_id=mandate_id,
         as_of_date=as_of_date,
         tenant_id=tenant_id,
+        booking_center_code=booking_center_code,
+        model_portfolio_id=model_portfolio_id,
         reference_currency=reference_currency,
+        include_market_data_coverage=include_market_data_coverage,
         correlation_id=correlation_id,
     )
 
-    twin = compile_mandate_digital_twin_from_core(
-        mandate=mandate,
-        model_targets=model_targets,
-        as_of_date=as_of_date,
-        reference_currency=reference_currency,
-        client_restriction_profile=optional_sources.client_restriction_profile,
-        sustainability_preference_profile=optional_sources.sustainability_preference_profile,
-        portfolio_cashflow_projection=optional_sources.portfolio_cashflow_projection,
-        client_income_needs_schedule=optional_sources.client_income_needs_schedule,
-        liquidity_reserve_requirement=optional_sources.liquidity_reserve_requirement,
-        planned_withdrawal_schedule=optional_sources.planned_withdrawal_schedule,
-        benchmark_assignment=optional_sources.benchmark_assignment,
-    )
-    health_input = build_health_input_from_core_sources(
-        twin=twin,
-        model_targets=model_targets,
-        market_data_coverage=market_data_coverage,
-        client_restriction_profile=optional_sources.client_restriction_profile,
-        sustainability_preference_profile=optional_sources.sustainability_preference_profile,
-        portfolio_cashflow_projection=optional_sources.portfolio_cashflow_projection,
-        unavailable_source_families=optional_sources.unavailable_source_families,
-    )
-    health_result = _calculate_mandate_health_result(health_input)
-
-    repository.save_mandate_snapshot(twin)
-    repository.save_health_snapshot(health_result.snapshot)
-    for exception in health_result.monitoring_exceptions:
+    repository.save_mandate_snapshot(refresh_result.twin)
+    repository.save_health_snapshot(refresh_result.health_snapshot)
+    for exception in refresh_result.monitoring_exceptions:
         repository.save_monitoring_exception(exception)
 
-    return DpmMandateRefreshResult(
-        twin=twin,
-        health_snapshot=health_result.snapshot,
-        monitoring_exceptions=health_result.monitoring_exceptions,
-    )
+    return refresh_result
 
 
 def get_latest_mandate_by_portfolio(

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -6,6 +6,14 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from src.api.services.mandate_errors import (
+    DpmMandateDiffUnavailableError as DpmMandateDiffUnavailableError,
+    DpmMandateHealthNotFoundError as DpmMandateHealthNotFoundError,
+    DpmMandateNotFoundError as DpmMandateNotFoundError,
+    DpmMandateSourceIncompleteError as DpmMandateSourceIncompleteError,
+    DpmMandateSourceUnavailableError as DpmMandateSourceUnavailableError,
+    DpmMonitoringRunNotFoundError as DpmMonitoringRunNotFoundError,
+)
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import (
     DpmCommandCenterAttentionBucket,
@@ -35,30 +43,6 @@ from src.core.dpm_source_context import (
     DpmCoreBenchmarkAssignmentResponse,
     DpmCorePortfolioManagerBookMembershipResponse,
 )
-
-
-class DpmMandateNotFoundError(LookupError):
-    pass
-
-
-class DpmMandateDiffUnavailableError(LookupError):
-    pass
-
-
-class DpmMandateSourceUnavailableError(RuntimeError):
-    pass
-
-
-class DpmMandateSourceIncompleteError(RuntimeError):
-    pass
-
-
-class DpmMandateHealthNotFoundError(LookupError):
-    pass
-
-
-class DpmMonitoringRunNotFoundError(LookupError):
-    pass
 
 
 class DpmMandateFieldChange(BaseModel):

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -7,8 +7,9 @@ from src.api.services.mandate_command_center import (
     attention_buckets,
     build_command_center_summary,
     command_center_supportability_state,
+    latest_command_center_run,
     recommended_actions,
-    run_matches_command_center_filters as _run_matches_command_center_filters,
+    run_matches_command_center_filters,
     severity_rank,
 )
 from src.api.services.mandate_errors import (
@@ -69,7 +70,9 @@ from src.infrastructure.core_sourcing import DpmCoreResolverClient
 _severity_rank = severity_rank
 _attention_buckets = attention_buckets
 _build_command_center_summary = build_command_center_summary
+_latest_command_center_run = latest_command_center_run
 _command_center_supportability_state = command_center_supportability_state
+_run_matches_command_center_filters = run_matches_command_center_filters
 _recommended_actions = recommended_actions
 _build_mandate_diff = build_mandate_diff
 _diff_payloads = diff_payloads
@@ -298,18 +301,13 @@ def get_command_center_summary(
     limit: int,
 ) -> DpmCommandCenterSummary:
     runs, _ = repository.list_monitoring_runs(status=None, limit=200, cursor=None)
-    matching_runs = [
-        run
-        for run in runs
-        if _run_matches_command_center_filters(
-            run,
-            tenant_id=tenant_id,
-            portfolio_manager_id=portfolio_manager_id,
-            book_id=book_id,
-            as_of_date=as_of_date,
-        )
-    ]
-    latest_run = matching_runs[0] if matching_runs else None
+    latest_run = _latest_command_center_run(
+        runs,
+        tenant_id=tenant_id,
+        portfolio_manager_id=portfolio_manager_id,
+        book_id=book_id,
+        as_of_date=as_of_date,
+    )
     active_exceptions, _ = repository.list_monitoring_exceptions(
         monitoring_run_id=latest_run.monitoring_run_id if latest_run else None,
         mandate_id=None,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -6,6 +6,13 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from src.api.services.mandate_command_center import (
+    attention_buckets as _attention_buckets,
+    command_center_supportability_state as _command_center_supportability_state,
+    recommended_actions as _recommended_actions,
+    run_matches_command_center_filters as _run_matches_command_center_filters,
+    severity_rank,
+)
 from src.api.services.mandate_errors import (
     DpmMandateDiffUnavailableError as DpmMandateDiffUnavailableError,
     DpmMandateHealthNotFoundError as DpmMandateHealthNotFoundError,
@@ -16,8 +23,6 @@ from src.api.services.mandate_errors import (
 )
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import (
-    DpmCommandCenterAttentionBucket,
-    DpmCommandCenterRecommendedAction,
     DpmCommandCenterSummary,
     DpmCommandCenterSupportability,
     DpmMandateDigitalTwin,
@@ -25,10 +30,7 @@ from src.core.mandates import (
     DpmMandateHealthSnapshot,
     DpmMonitoringException,
     DpmMonitoringRun,
-    MandateHealthDimension,
     MandateHealthState,
-    MandateRecommendedAction,
-    MonitoringSeverity,
     build_health_input_from_core_sources,
     calculate_mandate_health,
     compile_mandate_digital_twin_from_core,
@@ -43,6 +45,8 @@ from src.core.dpm_source_context import (
     DpmCoreBenchmarkAssignmentResponse,
     DpmCorePortfolioManagerBookMembershipResponse,
 )
+
+_severity_rank = severity_rank
 
 
 class DpmMandateFieldChange(BaseModel):
@@ -635,118 +639,6 @@ def get_command_center_summary(
             partial_readiness_reasons=partial_reasons,
         ),
     )
-
-
-def _command_center_supportability_state(
-    *,
-    latest_run: Optional[DpmMonitoringRun],
-    completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"],
-    partial_reasons: list[str],
-) -> tuple[Literal["READY", "PARTIAL", "EMPTY", "DEGRADED", "BLOCKED"], str]:
-    if latest_run is None or completeness == "EMPTY":
-        return "EMPTY", "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
-
-    source_states = {state.upper() for state in latest_run.source_readiness_summary}
-    if source_states.intersection({"INCOMPLETE", "UNAVAILABLE", "BLOCKED"}):
-        return "BLOCKED", "COMMAND_CENTER_SOURCE_READINESS_BLOCKED"
-    if source_states.intersection({"DEGRADED", "STALE"}):
-        return "DEGRADED", "COMMAND_CENTER_SOURCE_READINESS_DEGRADED"
-    if completeness == "PARTIAL" or partial_reasons:
-        return "PARTIAL", partial_reasons[0] if partial_reasons else "COMMAND_CENTER_PARTIAL"
-    return "READY", "COMMAND_CENTER_READY"
-
-
-def _run_matches_command_center_filters(
-    run: DpmMonitoringRun,
-    *,
-    tenant_id: Optional[str],
-    portfolio_manager_id: Optional[str],
-    book_id: Optional[str],
-    as_of_date: Optional[date],
-) -> bool:
-    if as_of_date is not None and run.as_of_date != as_of_date:
-        return False
-    expected_filters = {
-        "tenant_id": tenant_id,
-        "portfolio_manager_id": portfolio_manager_id,
-        "book_id": book_id,
-    }
-    return all(
-        value is None or run.filters.get(key) == value for key, value in expected_filters.items()
-    )
-
-
-def _attention_buckets(
-    exceptions: list[DpmMonitoringException],
-) -> list[DpmCommandCenterAttentionBucket]:
-    bucket_counts: dict[tuple[str, str, str], int] = {}
-    bucket_reason_counts: dict[tuple[str, str, str], dict[str, int]] = {}
-    for exception in exceptions:
-        key = (
-            exception.dimension.value,
-            exception.severity.value,
-            exception.recommended_action.value,
-        )
-        bucket_counts[key] = bucket_counts.get(key, 0) + 1
-        reason_counts = bucket_reason_counts.setdefault(key, {})
-        reason_counts[exception.reason_code] = reason_counts.get(exception.reason_code, 0) + 1
-
-    return [
-        DpmCommandCenterAttentionBucket(
-            dimension=MandateHealthDimension(dimension),
-            severity=MonitoringSeverity(severity),
-            recommended_action=MandateRecommendedAction(recommended_action),
-            exception_count=exception_count,
-            top_reason_codes=[
-                reason_code
-                for reason_code, _ in sorted(
-                    bucket_reason_counts[(dimension, severity, recommended_action)].items(),
-                    key=lambda item: (-item[1], item[0]),
-                )[:3]
-            ],
-        )
-        for (dimension, severity, recommended_action), exception_count in sorted(
-            bucket_counts.items(),
-            key=lambda item: (
-                -_severity_rank(item[0][1]),
-                -item[1],
-                item[0][0],
-            ),
-        )
-    ]
-
-
-def _recommended_actions(
-    exceptions: list[DpmMonitoringException],
-) -> list[DpmCommandCenterRecommendedAction]:
-    action_counts: dict[str, int] = {}
-    action_highest_severity: dict[str, str] = {}
-    for exception in exceptions:
-        action = exception.recommended_action.value
-        action_counts[action] = action_counts.get(action, 0) + 1
-        current_highest = action_highest_severity.setdefault(action, exception.severity.value)
-        if _severity_rank(exception.severity.value) > _severity_rank(current_highest):
-            action_highest_severity[action] = exception.severity.value
-
-    return [
-        DpmCommandCenterRecommendedAction(
-            recommended_action=MandateRecommendedAction(action),
-            exception_count=exception_count,
-            highest_severity=MonitoringSeverity(action_highest_severity[action]),
-        )
-        for action, exception_count in sorted(
-            action_counts.items(),
-            key=lambda item: (
-                -_severity_rank(action_highest_severity[item[0]]),
-                -item[1],
-                item[0],
-            ),
-        )
-    ]
-
-
-def _severity_rank(severity: str) -> int:
-    return {"CRITICAL": 3, "WARNING": 2, "INFO": 1}.get(severity, 0)
 
 
 def diff_mandate_versions(

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -39,6 +39,9 @@ from src.api.services.mandate_optional_sources import (
     resolve_mandate_optional_sources,
     try_resolve_optional_source,
 )
+from src.api.services.mandate_pm_book import (
+    mandate_ids_from_pm_book_membership as mandate_ids_from_pm_book_membership,
+)
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import (
     DpmCommandCenterSummary,
@@ -58,9 +61,6 @@ from src.infrastructure.core_sourcing import (
     DpmCoreResolverClient,
     DpmCoreResolverError,
     DpmCoreResolverUnavailableError,
-)
-from src.core.dpm_source_context import (
-    DpmCorePortfolioManagerBookMembershipResponse,
 )
 
 _severity_rank = severity_rank
@@ -289,27 +289,6 @@ def run_mandate_monitoring_once(
     )
     repository.save_monitoring_run(run)
     return run
-
-
-def mandate_ids_from_pm_book_membership(
-    *,
-    repository: DpmMandateRepository,
-    membership: DpmCorePortfolioManagerBookMembershipResponse,
-) -> list[str]:
-    mandate_ids: list[str] = []
-    missing_portfolio_ids: list[str] = []
-    for member in membership.members:
-        twin = repository.get_latest_mandate_by_portfolio(portfolio_id=member.portfolio_id)
-        if twin is None:
-            missing_portfolio_ids.append(member.portfolio_id)
-            continue
-        mandate_ids.append(twin.mandate_id)
-
-    if missing_portfolio_ids:
-        raise DpmMandateSourceIncompleteError("DPM_PM_BOOK_MANDATE_SNAPSHOT_MISSING")
-    if not mandate_ids:
-        raise DpmMandateSourceIncompleteError("DPM_PM_BOOK_MANDATE_SNAPSHOT_EMPTY")
-    return mandate_ids
 
 
 def get_monitoring_run(

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -22,7 +22,8 @@ from src.api.services.mandate_errors import (
 from src.api.services.mandate_diff import (
     DpmMandateDiff as DpmMandateDiff,
     DpmMandateFieldChange as DpmMandateFieldChange,
-    build_mandate_diff as _build_mandate_diff,
+    build_mandate_diff,
+    build_mandate_diff_for_versions,
     diff_payloads,
     iter_changed_fields,
     materiality_for_field,
@@ -68,9 +69,11 @@ _attention_buckets = attention_buckets
 _build_command_center_summary = build_command_center_summary
 _command_center_supportability_state = command_center_supportability_state
 _recommended_actions = recommended_actions
+_build_mandate_diff = build_mandate_diff
 _diff_payloads = diff_payloads
 _iter_changed_fields = iter_changed_fields
 _materiality_for_field = materiality_for_field
+_build_mandate_diff_for_versions = build_mandate_diff_for_versions
 _try_resolve_optional_source = try_resolve_optional_source
 _ready_optional_source = ready_optional_source
 _ready_benchmark_assignment_source = ready_benchmark_assignment_source
@@ -334,21 +337,9 @@ def diff_mandate_versions(
     if not versions:
         raise DpmMandateNotFoundError("DPM_MANDATE_NOT_FOUND")
 
-    by_version = {version.mandate_version: version for version in versions}
-    if from_version is not None or to_version is not None:
-        if from_version is None or to_version is None:
-            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
-        if from_version not in by_version or to_version not in by_version:
-            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_VERSION_NOT_FOUND")
-        previous = by_version[from_version]
-        current = by_version[to_version]
-    else:
-        if len(versions) < 2:
-            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
-        current, previous = versions[0], versions[1]
-
-    return _build_mandate_diff(
+    return _build_mandate_diff_for_versions(
         mandate_id=mandate_id,
-        previous=previous,
-        current=current,
+        versions=versions,
+        from_version=from_version,
+        to_version=to_version,
     )

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
-from typing import Literal, Optional
+from typing import Optional
 
 from src.api.services.mandate_command_center import (
-    attention_buckets as _attention_buckets,
-    command_center_supportability_state as _command_center_supportability_state,
-    recommended_actions as _recommended_actions,
+    attention_buckets,
+    build_command_center_summary,
+    command_center_supportability_state,
+    recommended_actions,
     run_matches_command_center_filters as _run_matches_command_center_filters,
     severity_rank,
 )
@@ -45,13 +46,11 @@ from src.api.services.mandate_pm_book import (
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import (
     DpmCommandCenterSummary,
-    DpmCommandCenterSupportability,
     DpmMandateDigitalTwin,
     DpmMandateHealthInput,
     DpmMandateHealthSnapshot,
     DpmMonitoringException,
     DpmMonitoringRun,
-    MandateHealthState,
     build_health_input_from_core_sources,
     calculate_mandate_health,
     compile_mandate_digital_twin_from_core,
@@ -64,6 +63,10 @@ from src.infrastructure.core_sourcing import (
 )
 
 _severity_rank = severity_rank
+_attention_buckets = attention_buckets
+_build_command_center_summary = build_command_center_summary
+_command_center_supportability_state = command_center_supportability_state
+_recommended_actions = recommended_actions
 _diff_payloads = diff_payloads
 _iter_changed_fields = iter_changed_fields
 _materiality_for_field = materiality_for_field
@@ -379,53 +382,16 @@ def get_command_center_summary(
         cursor=None,
     )
 
-    health_distribution = dict(latest_run.health_distribution) if latest_run else {}
-    if health_state is not None:
-        health_distribution = {health_state: health_distribution.get(health_state, 0)}
-
-    partial_reasons: list[str] = []
-    if latest_run is None:
-        partial_reasons.append("NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS")
-    if portfolio_manager_id is None and book_id is None:
-        partial_reasons.append("PM_BOOK_DISCOVERY_NOT_YET_SOURCED")
-    if len(active_exceptions) >= limit:
-        partial_reasons.append("ATTENTION_QUEUE_LIMIT_REACHED")
-
-    completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"] = "COMPLETE"
-    if latest_run is None:
-        completeness = "EMPTY"
-    elif partial_reasons:
-        completeness = "PARTIAL"
-    supportability_state, supportability_reason = _command_center_supportability_state(
-        latest_run=latest_run,
-        completeness=completeness,
-        partial_reasons=partial_reasons,
-    )
-
-    return DpmCommandCenterSummary(
+    return _build_command_center_summary(
         tenant_id=tenant_id,
         portfolio_manager_id=portfolio_manager_id,
         book_id=book_id,
-        as_of_date=as_of_date or (latest_run.as_of_date if latest_run else None),
-        selected_health_state=MandateHealthState(health_state)
-        if health_state is not None
-        else None,
-        evaluated_mandates=latest_run.total_mandates if latest_run else 0,
-        monitored_mandate_ids=list(latest_run.mandate_ids) if latest_run else [],
-        health_distribution=health_distribution,
-        source_readiness_summary=dict(latest_run.source_readiness_summary) if latest_run else {},
-        active_exception_count=len(active_exceptions),
-        attention_buckets=_attention_buckets(active_exceptions),
-        recommended_actions=_recommended_actions(active_exceptions),
-        latest_monitoring_run=latest_run,
-        supportability=DpmCommandCenterSupportability(
-            state=supportability_state,
-            data_completeness_state=completeness,
-            reason=supportability_reason,
-            generated_at=datetime.now(timezone.utc),
-            source_run_id=latest_run.monitoring_run_id if latest_run else None,
-            partial_readiness_reasons=partial_reasons,
-        ),
+        as_of_date=as_of_date,
+        health_state=health_state,
+        latest_run=latest_run,
+        active_exceptions=active_exceptions,
+        limit=limit,
+        generated_at=datetime.now(timezone.utc),
     )
 
 

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -28,6 +28,10 @@ from src.api.services.mandate_diff import (
     iter_changed_fields,
     materiality_for_field,
 )
+from src.api.services.mandate_health_result import (
+    DpmMandateHealthCalculationResult as DpmMandateHealthCalculationResult,
+    calculate_mandate_health_result,
+)
 from src.api.services.mandate_monitoring_run import (
     build_monitoring_run,
     exceptions_for_monitoring_run,
@@ -74,6 +78,7 @@ _try_resolve_optional_source = try_resolve_optional_source
 _ready_optional_source = ready_optional_source
 _ready_benchmark_assignment_source = ready_benchmark_assignment_source
 _resolve_mandate_optional_sources = resolve_mandate_optional_sources
+_calculate_mandate_health_result = calculate_mandate_health_result
 _monitoring_run_id_for = monitoring_run_id_for
 _increment_distribution = increment_distribution
 _exceptions_for_monitoring_run = exceptions_for_monitoring_run
@@ -164,21 +169,17 @@ def refresh_mandate_from_core(
         portfolio_cashflow_projection=optional_sources.portfolio_cashflow_projection,
         unavailable_source_families=optional_sources.unavailable_source_families,
     )
-    health_snapshot = calculate_mandate_health(health_input)
-    monitoring_exceptions = monitoring_exceptions_from_health(
-        health_snapshot,
-        source_lineage=twin.source_lineage,
-    )
+    health_result = _calculate_mandate_health_result(health_input)
 
     repository.save_mandate_snapshot(twin)
-    repository.save_health_snapshot(health_snapshot)
-    for exception in monitoring_exceptions:
+    repository.save_health_snapshot(health_result.snapshot)
+    for exception in health_result.monitoring_exceptions:
         repository.save_monitoring_exception(exception)
 
     return DpmMandateRefreshResult(
         twin=twin,
-        health_snapshot=health_snapshot,
-        monitoring_exceptions=monitoring_exceptions,
+        health_snapshot=health_result.snapshot,
+        monitoring_exceptions=health_result.monitoring_exceptions,
     )
 
 
@@ -234,16 +235,12 @@ def recalculate_mandate_health(
 ) -> DpmMandateHealthSnapshot:
     if health_input.twin.mandate_id != mandate_id:
         raise DpmMandateSourceIncompleteError("DPM_MANDATE_HEALTH_INPUT_MISMATCH")
-    snapshot = calculate_mandate_health(health_input)
-    exceptions = monitoring_exceptions_from_health(
-        snapshot,
-        source_lineage=health_input.twin.source_lineage,
-    )
+    health_result = _calculate_mandate_health_result(health_input)
     repository.save_mandate_snapshot(health_input.twin)
-    repository.save_health_snapshot(snapshot)
-    for exception in exceptions:
+    repository.save_health_snapshot(health_result.snapshot)
+    for exception in health_result.monitoring_exceptions:
         repository.save_monitoring_exception(exception)
-    return snapshot
+    return health_result.snapshot
 
 
 def run_mandate_monitoring_once(

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -27,6 +27,12 @@ from src.api.services.mandate_diff import (
     iter_changed_fields,
     materiality_for_field,
 )
+from src.api.services.mandate_monitoring_run import (
+    build_monitoring_run,
+    exceptions_for_monitoring_run,
+    increment_distribution,
+    monitoring_run_id_for,
+)
 from src.api.services.mandate_optional_sources import (
     ready_benchmark_assignment_source,
     ready_optional_source,
@@ -65,6 +71,10 @@ _try_resolve_optional_source = try_resolve_optional_source
 _ready_optional_source = ready_optional_source
 _ready_benchmark_assignment_source = ready_benchmark_assignment_source
 _resolve_mandate_optional_sources = resolve_mandate_optional_sources
+_monitoring_run_id_for = monitoring_run_id_for
+_increment_distribution = increment_distribution
+_exceptions_for_monitoring_run = exceptions_for_monitoring_run
+_build_monitoring_run = build_monitoring_run
 
 
 @dataclass(frozen=True)
@@ -241,7 +251,7 @@ def run_mandate_monitoring_once(
     filters: dict[str, str],
 ) -> DpmMonitoringRun:
     requested_at = datetime.now(timezone.utc)
-    monitoring_run_id = f"dmr_{requested_at.strftime('%Y%m%d_%H%M%S_%f')}"
+    monitoring_run_id = _monitoring_run_id_for(requested_at)
     health_distribution: dict[str, int] = {}
     source_readiness_summary: dict[str, int] = {}
     exception_count = 0
@@ -253,31 +263,26 @@ def run_mandate_monitoring_once(
         )
         snapshot = calculate_mandate_health(health_input)
         repository.save_health_snapshot(snapshot)
-        health_distribution[snapshot.health_state.value] = (
-            health_distribution.get(snapshot.health_state.value, 0) + 1
-        )
-        source_readiness_summary[snapshot.source_readiness_state] = (
-            source_readiness_summary.get(snapshot.source_readiness_state, 0) + 1
-        )
+        _increment_distribution(health_distribution, snapshot.health_state.value)
+        _increment_distribution(source_readiness_summary, snapshot.source_readiness_state)
         exceptions = monitoring_exceptions_from_health(
             snapshot,
             source_lineage=twin.source_lineage,
         )
         exception_count += len(exceptions)
-        for exception in exceptions:
-            repository.save_monitoring_exception(
-                exception.model_copy(update={"monitoring_run_id": monitoring_run_id})
-            )
+        for exception in _exceptions_for_monitoring_run(
+            exceptions,
+            monitoring_run_id=monitoring_run_id,
+        ):
+            repository.save_monitoring_exception(exception)
 
-    run = DpmMonitoringRun(
+    run = _build_monitoring_run(
         monitoring_run_id=monitoring_run_id,
         as_of_date=as_of_date,
         requested_at=requested_at,
         completed_at=datetime.now(timezone.utc),
-        status="SUCCEEDED",
         mandate_ids=mandate_ids,
         filters=filters,
-        total_mandates=len(mandate_ids),
         health_distribution=health_distribution,
         exception_count=exception_count,
         source_readiness_summary=source_readiness_summary,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -32,6 +32,7 @@ from src.api.services.mandate_health_result import (
     DpmMandateHealthCalculationResult as DpmMandateHealthCalculationResult,
     calculate_mandate_health_result,
 )
+from src.api.services.mandate_health_persistence import persist_mandate_health_evidence
 from src.api.services.mandate_monitoring_run import (
     DpmMonitoringRunMandateResult as DpmMonitoringRunMandateResult,
     build_monitoring_run,
@@ -79,6 +80,7 @@ _ready_optional_source = ready_optional_source
 _ready_benchmark_assignment_source = ready_benchmark_assignment_source
 _resolve_mandate_optional_sources = resolve_mandate_optional_sources
 _calculate_mandate_health_result = calculate_mandate_health_result
+_persist_mandate_health_evidence = persist_mandate_health_evidence
 _monitoring_run_id_for = monitoring_run_id_for
 _increment_distribution = increment_distribution
 _exceptions_for_monitoring_run = exceptions_for_monitoring_run
@@ -114,10 +116,12 @@ def refresh_mandate_from_core(
         correlation_id=correlation_id,
     )
 
-    repository.save_mandate_snapshot(refresh_result.twin)
-    repository.save_health_snapshot(refresh_result.health_snapshot)
-    for exception in refresh_result.monitoring_exceptions:
-        repository.save_monitoring_exception(exception)
+    _persist_mandate_health_evidence(
+        repository=repository,
+        twin=refresh_result.twin,
+        health_snapshot=refresh_result.health_snapshot,
+        monitoring_exceptions=refresh_result.monitoring_exceptions,
+    )
 
     return refresh_result
 
@@ -175,10 +179,12 @@ def recalculate_mandate_health(
     if health_input.twin.mandate_id != mandate_id:
         raise DpmMandateSourceIncompleteError("DPM_MANDATE_HEALTH_INPUT_MISMATCH")
     health_result = _calculate_mandate_health_result(health_input)
-    repository.save_mandate_snapshot(health_input.twin)
-    repository.save_health_snapshot(health_result.snapshot)
-    for exception in health_result.monitoring_exceptions:
-        repository.save_monitoring_exception(exception)
+    _persist_mandate_health_evidence(
+        repository=repository,
+        twin=health_input.twin,
+        health_snapshot=health_result.snapshot,
+        monitoring_exceptions=health_result.monitoring_exceptions,
+    )
     return health_result.snapshot
 
 
@@ -203,12 +209,14 @@ def run_mandate_monitoring_once(
             monitoring_run_id=monitoring_run_id,
         )
         snapshot = mandate_result.health_snapshot
-        repository.save_health_snapshot(snapshot)
+        _persist_mandate_health_evidence(
+            repository=repository,
+            health_snapshot=snapshot,
+            monitoring_exceptions=mandate_result.monitoring_exceptions,
+        )
         _increment_distribution(health_distribution, snapshot.health_state.value)
         _increment_distribution(source_readiness_summary, snapshot.source_readiness_state)
         exception_count += len(mandate_result.monitoring_exceptions)
-        for exception in mandate_result.monitoring_exceptions:
-            repository.save_monitoring_exception(exception)
 
     run = _build_monitoring_run(
         monitoring_run_id=monitoring_run_id,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -30,6 +30,7 @@ from src.api.services.mandate_diff import (
 from src.api.services.mandate_optional_sources import (
     ready_benchmark_assignment_source,
     ready_optional_source,
+    resolve_mandate_optional_sources,
     try_resolve_optional_source,
 )
 from src.core.mandate_repository import DpmMandateRepository
@@ -63,6 +64,7 @@ _materiality_for_field = materiality_for_field
 _try_resolve_optional_source = try_resolve_optional_source
 _ready_optional_source = ready_optional_source
 _ready_benchmark_assignment_source = ready_benchmark_assignment_source
+_resolve_mandate_optional_sources = resolve_mandate_optional_sources
 
 
 @dataclass(frozen=True)
@@ -117,161 +119,37 @@ def refresh_mandate_from_core(
         raise DpmMandateSourceUnavailableError("DPM_MANDATE_SOURCE_UNAVAILABLE") from exc
     except DpmCoreResolverError as exc:
         raise DpmMandateSourceIncompleteError("DPM_MANDATE_SOURCE_INCOMPLETE") from exc
-    client_restriction_profile, unavailable_client_restrictions = _try_resolve_optional_source(
+    optional_sources = _resolve_mandate_optional_sources(
         resolver=core_resolver,
-        method_name="resolve_client_restriction_profile",
-        family_name="CLIENT_RESTRICTION_PROFILE",
         portfolio_id=portfolio_id,
+        mandate_id=mandate_id,
         as_of_date=as_of_date,
         tenant_id=tenant_id,
-        mandate_id=mandate_id,
-        include_inactive_restrictions=False,
+        reference_currency=reference_currency,
         correlation_id=correlation_id,
     )
-    client_restriction_profile, unavailable_client_restrictions = _ready_optional_source(
-        source=client_restriction_profile,
-        unavailable_family=unavailable_client_restrictions,
-        family_name="CLIENT_RESTRICTION_PROFILE",
-    )
-    (
-        sustainability_preference_profile,
-        unavailable_sustainability_preferences,
-    ) = _try_resolve_optional_source(
-        resolver=core_resolver,
-        method_name="resolve_sustainability_preference_profile",
-        family_name="SUSTAINABILITY_PREFERENCE_PROFILE",
-        portfolio_id=portfolio_id,
-        as_of_date=as_of_date,
-        tenant_id=tenant_id,
-        mandate_id=mandate_id,
-        include_inactive_preferences=False,
-        correlation_id=correlation_id,
-    )
-    (
-        sustainability_preference_profile,
-        unavailable_sustainability_preferences,
-    ) = _ready_optional_source(
-        source=sustainability_preference_profile,
-        unavailable_family=unavailable_sustainability_preferences,
-        family_name="SUSTAINABILITY_PREFERENCE_PROFILE",
-    )
-    portfolio_cashflow_projection, unavailable_cashflow_projection = _try_resolve_optional_source(
-        resolver=core_resolver,
-        method_name="resolve_portfolio_cashflow_projection",
-        family_name="PORTFOLIO_CASHFLOW_PROJECTION",
-        portfolio_id=portfolio_id,
-        as_of_date=as_of_date,
-        horizon_days=90,
-        include_projected=True,
-        correlation_id=correlation_id,
-    )
-    portfolio_cashflow_projection, unavailable_cashflow_projection = _ready_optional_source(
-        source=portfolio_cashflow_projection,
-        unavailable_family=unavailable_cashflow_projection,
-        family_name="PORTFOLIO_CASHFLOW_PROJECTION",
-    )
-    client_income_needs_schedule, unavailable_income_needs = _try_resolve_optional_source(
-        resolver=core_resolver,
-        method_name="resolve_client_income_needs_schedule",
-        family_name="CLIENT_INCOME_NEEDS_SCHEDULE",
-        portfolio_id=portfolio_id,
-        as_of_date=as_of_date,
-        tenant_id=tenant_id,
-        mandate_id=mandate_id,
-        include_inactive_schedules=False,
-        correlation_id=correlation_id,
-    )
-    client_income_needs_schedule, unavailable_income_needs = _ready_optional_source(
-        source=client_income_needs_schedule,
-        unavailable_family=unavailable_income_needs,
-        family_name="CLIENT_INCOME_NEEDS_SCHEDULE",
-    )
-    liquidity_reserve_requirement, unavailable_liquidity_reserve = _try_resolve_optional_source(
-        resolver=core_resolver,
-        method_name="resolve_liquidity_reserve_requirement",
-        family_name="LIQUIDITY_RESERVE_REQUIREMENT",
-        portfolio_id=portfolio_id,
-        as_of_date=as_of_date,
-        tenant_id=tenant_id,
-        mandate_id=mandate_id,
-        include_inactive_requirements=False,
-        correlation_id=correlation_id,
-    )
-    liquidity_reserve_requirement, unavailable_liquidity_reserve = _ready_optional_source(
-        source=liquidity_reserve_requirement,
-        unavailable_family=unavailable_liquidity_reserve,
-        family_name="LIQUIDITY_RESERVE_REQUIREMENT",
-    )
-    planned_withdrawal_schedule, unavailable_planned_withdrawal = _try_resolve_optional_source(
-        resolver=core_resolver,
-        method_name="resolve_planned_withdrawal_schedule",
-        family_name="PLANNED_WITHDRAWAL_SCHEDULE",
-        portfolio_id=portfolio_id,
-        as_of_date=as_of_date,
-        tenant_id=tenant_id,
-        mandate_id=mandate_id,
-        horizon_days=365,
-        include_inactive_withdrawals=False,
-        correlation_id=correlation_id,
-    )
-    planned_withdrawal_schedule, unavailable_planned_withdrawal = _ready_optional_source(
-        source=planned_withdrawal_schedule,
-        unavailable_family=unavailable_planned_withdrawal,
-        family_name="PLANNED_WITHDRAWAL_SCHEDULE",
-    )
-    benchmark_assignment, unavailable_benchmark_assignment = _try_resolve_optional_source(
-        resolver=core_resolver,
-        method_name="resolve_benchmark_assignment",
-        family_name="BENCHMARK_ASSIGNMENT",
-        portfolio_id=portfolio_id,
-        as_of_date=as_of_date,
-        reporting_currency=reference_currency,
-        correlation_id=correlation_id,
-    )
-    benchmark_assignment, unavailable_benchmark_assignment = _ready_optional_source(
-        source=benchmark_assignment,
-        unavailable_family=unavailable_benchmark_assignment,
-        family_name="BENCHMARK_ASSIGNMENT",
-    )
-    benchmark_assignment, unavailable_benchmark_assignment = _ready_benchmark_assignment_source(
-        source=benchmark_assignment,
-        unavailable_family=unavailable_benchmark_assignment,
-    )
-    unavailable_source_families = [
-        family
-        for family in (
-            unavailable_client_restrictions,
-            unavailable_sustainability_preferences,
-            unavailable_cashflow_projection,
-            unavailable_income_needs,
-            unavailable_liquidity_reserve,
-            unavailable_planned_withdrawal,
-            unavailable_benchmark_assignment,
-        )
-        if family is not None
-    ]
 
     twin = compile_mandate_digital_twin_from_core(
         mandate=mandate,
         model_targets=model_targets,
         as_of_date=as_of_date,
         reference_currency=reference_currency,
-        client_restriction_profile=client_restriction_profile,
-        sustainability_preference_profile=sustainability_preference_profile,
-        portfolio_cashflow_projection=portfolio_cashflow_projection,
-        client_income_needs_schedule=client_income_needs_schedule,
-        liquidity_reserve_requirement=liquidity_reserve_requirement,
-        planned_withdrawal_schedule=planned_withdrawal_schedule,
-        benchmark_assignment=benchmark_assignment,
+        client_restriction_profile=optional_sources.client_restriction_profile,
+        sustainability_preference_profile=optional_sources.sustainability_preference_profile,
+        portfolio_cashflow_projection=optional_sources.portfolio_cashflow_projection,
+        client_income_needs_schedule=optional_sources.client_income_needs_schedule,
+        liquidity_reserve_requirement=optional_sources.liquidity_reserve_requirement,
+        planned_withdrawal_schedule=optional_sources.planned_withdrawal_schedule,
+        benchmark_assignment=optional_sources.benchmark_assignment,
     )
     health_input = build_health_input_from_core_sources(
         twin=twin,
         model_targets=model_targets,
         market_data_coverage=market_data_coverage,
-        client_restriction_profile=client_restriction_profile,
-        sustainability_preference_profile=sustainability_preference_profile,
-        portfolio_cashflow_projection=portfolio_cashflow_projection,
-        unavailable_source_families=unavailable_source_families,
+        client_restriction_profile=optional_sources.client_restriction_profile,
+        sustainability_preference_profile=optional_sources.sustainability_preference_profile,
+        portfolio_cashflow_projection=optional_sources.portfolio_cashflow_projection,
+        unavailable_source_families=optional_sources.unavailable_source_families,
     )
     health_snapshot = calculate_mandate_health(health_input)
     monitoring_exceptions = monitoring_exceptions_from_health(

--- a/src/api/services/outcome_review_creation.py
+++ b/src/api/services/outcome_review_creation.py
@@ -8,6 +8,7 @@ from src.core.outcomes import (
     DpmExpectedOutcomeSnapshot,
     DpmOutcomeEvent,
     DpmOutcomeReviewComparison,
+    DpmPostTradeOutcomeReview,
     DpmRealizedOutcomeSnapshot,
     OutcomeEventType,
 )
@@ -48,6 +49,57 @@ def build_created_outcome_event(
         state=comparison.state,
         reason_codes=comparison.supportability.reason_codes,
         source_refs=[*expected_snapshot.source_lineage, *realized_snapshot.source_lineage],
+    )
+
+
+def build_created_outcome_review(
+    *,
+    outcome_review_id: str,
+    comparison: DpmOutcomeReviewComparison,
+    expected_snapshot: DpmExpectedOutcomeSnapshot,
+    realized_snapshot: DpmRealizedOutcomeSnapshot,
+    actor_id: str,
+    correlation_id: str,
+    idempotency_key: str,
+    content_hash: str,
+    created_at: datetime,
+) -> DpmPostTradeOutcomeReview:
+    event = build_created_outcome_event(
+        outcome_review_id=outcome_review_id,
+        comparison=comparison,
+        expected_snapshot=expected_snapshot,
+        realized_snapshot=realized_snapshot,
+        actor_id=actor_id,
+        created_at=created_at,
+    )
+    return DpmPostTradeOutcomeReview(
+        outcome_review_id=outcome_review_id,
+        state=comparison.state,
+        portfolio_id=expected_snapshot.portfolio_id,
+        mandate_id=expected_snapshot.mandate_id,
+        rebalance_run_id=expected_snapshot.rebalance_run_id,
+        alternative_set_id=expected_snapshot.alternative_set_id,
+        selected_alternative_id=expected_snapshot.selected_alternative_id,
+        proof_pack_id=expected_snapshot.proof_pack_id,
+        wave_id=expected_snapshot.wave_id,
+        wave_item_id=expected_snapshot.wave_item_id,
+        operations_handoff_ref_id=expected_snapshot.operations_handoff_ref_id,
+        review_window=realized_snapshot.review_window,
+        expected_snapshot=expected_snapshot,
+        realized_snapshot=realized_snapshot,
+        dimension_results=comparison.dimension_results,
+        overall_outcome=comparison.overall_outcome,
+        variance_summary=comparison.variance_summary,
+        supportability=comparison.supportability,
+        source_lineage=[*expected_snapshot.source_lineage, *realized_snapshot.source_lineage],
+        source_hashes={**expected_snapshot.source_hashes, **realized_snapshot.source_hashes},
+        section_hashes=expected_snapshot.section_hashes,
+        events=[event],
+        content_hash=content_hash,
+        created_at=created_at,
+        created_by=actor_id,
+        correlation_id=correlation_id,
+        idempotency_key=idempotency_key,
     )
 
 

--- a/src/api/services/outcome_review_creation.py
+++ b/src/api/services/outcome_review_creation.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+
+from src.core.outcomes import (
+    DpmExpectedOutcomeSnapshot,
+    DpmOutcomeEvent,
+    DpmOutcomeReviewComparison,
+    DpmRealizedOutcomeSnapshot,
+    OutcomeEventType,
+)
+
+
+def build_review_content_hash(
+    *,
+    expected_snapshot: DpmExpectedOutcomeSnapshot,
+    realized_snapshot: DpmRealizedOutcomeSnapshot,
+    comparison: DpmOutcomeReviewComparison,
+) -> str:
+    return _content_hash(
+        {
+            "expected_snapshot": expected_snapshot.model_dump(mode="json"),
+            "realized_snapshot": realized_snapshot.model_dump(mode="json"),
+            "dimension_results": [
+                result.model_dump(mode="json") for result in comparison.dimension_results
+            ],
+        }
+    )
+
+
+def build_created_outcome_event(
+    *,
+    outcome_review_id: str,
+    comparison: DpmOutcomeReviewComparison,
+    expected_snapshot: DpmExpectedOutcomeSnapshot,
+    realized_snapshot: DpmRealizedOutcomeSnapshot,
+    actor_id: str,
+    created_at: datetime,
+) -> DpmOutcomeEvent:
+    return DpmOutcomeEvent(
+        event_id=f"{outcome_review_id}_created",
+        event_type=created_event_type(comparison.state),
+        event_time=created_at.isoformat(),
+        actor=actor_id,
+        outcome_review_id=outcome_review_id,
+        state=comparison.state,
+        reason_codes=comparison.supportability.reason_codes,
+        source_refs=[*expected_snapshot.source_lineage, *realized_snapshot.source_lineage],
+    )
+
+
+def created_event_type(state: str) -> OutcomeEventType:
+    if state == "BLOCKED":
+        return "OUTCOME_REVIEW_BLOCKED"
+    if state == "DEGRADED":
+        return "OUTCOME_REVIEW_DEGRADED"
+    if state == "READY":
+        return "OUTCOME_REVIEW_READY"
+    return "OUTCOME_REVIEW_CREATED"
+
+
+def _content_hash(payload: dict[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/src/api/services/outcome_review_dimensions.py
+++ b/src/api/services/outcome_review_dimensions.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from src.core.outcomes import (
+    DpmExpectedOutcomeSnapshot,
+    DpmOutcomeDimensionInput,
+    DpmOutcomeTolerance,
+    DpmRealizedOutcomeSnapshot,
+    OutcomeComparisonDirection,
+    OutcomeDimension,
+)
+
+
+class DpmOutcomeReviewValidationError(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class DpmOutcomeDimensionConfig:
+    dimension: OutcomeDimension
+    tolerance: DpmOutcomeTolerance
+    materiality: Decimal
+    direction: OutcomeComparisonDirection
+
+
+def dimension_inputs_for_review(
+    *,
+    expected_snapshot: DpmExpectedOutcomeSnapshot,
+    realized_snapshot: DpmRealizedOutcomeSnapshot,
+    dimension_configs: list[DpmOutcomeDimensionConfig],
+) -> list[DpmOutcomeDimensionInput]:
+    inputs: list[DpmOutcomeDimensionInput] = []
+    for config in dimension_configs:
+        expected = expected_snapshot.expected_values.get(config.dimension)
+        realized = realized_snapshot.realized_values.get(config.dimension)
+        if expected is None or realized is None:
+            raise DpmOutcomeReviewValidationError(
+                f"DPM_OUTCOME_DIMENSION_EVIDENCE_MISSING:{config.dimension}"
+            )
+        inputs.append(
+            DpmOutcomeDimensionInput(
+                dimension=config.dimension,
+                expected=expected,
+                realized=realized,
+                tolerance=config.tolerance,
+                materiality=config.materiality,
+                direction=config.direction,
+            )
+        )
+    return inputs
+
+
+__all__ = [
+    "DpmOutcomeDimensionConfig",
+    "DpmOutcomeReviewValidationError",
+    "dimension_inputs_for_review",
+]

--- a/src/api/services/outcome_review_persistence.py
+++ b/src/api/services/outcome_review_persistence.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.core.outcomes import DpmPostTradeOutcomeReview
+from src.core.outcomes.repository import DpmOutcomeReviewRepository
+
+OUTCOME_REVIEW_RETENTION_DAYS = 365 * 7
+
+
+def persist_outcome_review(
+    *,
+    repository: DpmOutcomeReviewRepository,
+    review: DpmPostTradeOutcomeReview,
+    persisted_at: datetime | None = None,
+) -> None:
+    retention_base = persisted_at or datetime.now(timezone.utc)
+    repository.save_outcome_review(
+        review=review,
+        retention_expires_at=retention_base + timedelta(days=OUTCOME_REVIEW_RETENTION_DAYS),
+    )
+
+
+__all__ = ["OUTCOME_REVIEW_RETENTION_DAYS", "persist_outcome_review"]

--- a/src/api/services/outcome_review_refresh.py
+++ b/src/api/services/outcome_review_refresh.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from src.core.outcomes import (
+    DpmExpectedOutcomeSnapshot,
+    DpmOutcomeEvent,
+    DpmOutcomeReviewComparison,
+    DpmRealizedOutcomeSnapshot,
+)
+
+
+def build_source_refreshed_event(
+    *,
+    outcome_review_id: str,
+    expected_snapshot: DpmExpectedOutcomeSnapshot,
+    realized_snapshot: DpmRealizedOutcomeSnapshot,
+    comparison: DpmOutcomeReviewComparison,
+    actor_id: str,
+    refreshed_at: datetime,
+    event_id_suffix: str,
+) -> DpmOutcomeEvent:
+    return DpmOutcomeEvent(
+        event_id=f"{outcome_review_id}_source_refreshed_{event_id_suffix}",
+        event_type="OUTCOME_REVIEW_SOURCE_REFRESHED",
+        event_time=refreshed_at.isoformat(),
+        actor=actor_id,
+        outcome_review_id=outcome_review_id,
+        state=comparison.state,
+        reason_codes=comparison.supportability.reason_codes,
+        source_refs=[*expected_snapshot.source_lineage, *realized_snapshot.source_lineage],
+    )

--- a/src/api/services/outcome_review_refresh.py
+++ b/src/api/services/outcome_review_refresh.py
@@ -6,8 +6,42 @@ from src.core.outcomes import (
     DpmExpectedOutcomeSnapshot,
     DpmOutcomeEvent,
     DpmOutcomeReviewComparison,
+    DpmPostTradeOutcomeReview,
     DpmRealizedOutcomeSnapshot,
+    compare_outcome_dimensions,
 )
+from src.api.services.outcome_review_dimensions import (
+    DpmOutcomeDimensionConfig,
+    dimension_inputs_for_review,
+)
+
+
+def build_source_refresh_result(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    realized_snapshot: DpmRealizedOutcomeSnapshot,
+    dimension_configs: list[DpmOutcomeDimensionConfig],
+    actor_id: str,
+    refreshed_at: datetime,
+    event_id_suffix: str,
+) -> tuple[DpmOutcomeEvent, DpmOutcomeReviewComparison]:
+    comparison = compare_outcome_dimensions(
+        dimension_inputs_for_review(
+            expected_snapshot=review.expected_snapshot,
+            realized_snapshot=realized_snapshot,
+            dimension_configs=dimension_configs,
+        )
+    )
+    event = build_source_refreshed_event(
+        outcome_review_id=review.outcome_review_id,
+        expected_snapshot=review.expected_snapshot,
+        realized_snapshot=realized_snapshot,
+        comparison=comparison,
+        actor_id=actor_id,
+        refreshed_at=refreshed_at,
+        event_id_suffix=event_id_suffix,
+    )
+    return event, comparison
 
 
 def build_source_refreshed_event(

--- a/src/api/services/outcome_review_report_inputs.py
+++ b/src/api/services/outcome_review_report_inputs.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from src.api.services.portfolio_memory_context_service import (
+    build_report_portfolio_memory_context,
+)
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.outcomes import (
+    DpmOutcomeAiEvidenceInput,
+    DpmOutcomeReportInput,
+    DpmPostTradeOutcomeReview,
+    build_ai_evidence_input,
+    build_report_input,
+)
+from src.core.outcomes.repository import DpmOutcomeReviewRepository
+from src.core.portfolio_memory.handoffs import DpmPortfolioMemoryReportContext
+from src.core.proof_packs.repository import DpmProofPackRepository
+from src.core.waves.repository import DpmWaveRepository
+
+
+def build_outcome_report_input(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    proof_pack_repository: DpmProofPackRepository | None,
+    wave_repository: DpmWaveRepository | None,
+    outcome_review_repository: DpmOutcomeReviewRepository,
+    mandate_repository: DpmMandateRepository | None,
+) -> DpmOutcomeReportInput:
+    return build_report_input(
+        review,
+        portfolio_memory_context=portfolio_memory_context_for_report(
+            review=review,
+            proof_pack_repository=proof_pack_repository,
+            wave_repository=wave_repository,
+            outcome_review_repository=outcome_review_repository,
+            mandate_repository=mandate_repository,
+        ),
+    )
+
+
+def build_outcome_ai_evidence_input(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    proof_pack_repository: DpmProofPackRepository | None,
+    wave_repository: DpmWaveRepository | None,
+    outcome_review_repository: DpmOutcomeReviewRepository,
+    mandate_repository: DpmMandateRepository | None,
+) -> DpmOutcomeAiEvidenceInput:
+    return build_ai_evidence_input(
+        review,
+        portfolio_memory_context=portfolio_memory_context_for_report(
+            review=review,
+            proof_pack_repository=proof_pack_repository,
+            wave_repository=wave_repository,
+            outcome_review_repository=outcome_review_repository,
+            mandate_repository=mandate_repository,
+        ),
+    )
+
+
+def portfolio_memory_context_for_report(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    proof_pack_repository: DpmProofPackRepository | None,
+    wave_repository: DpmWaveRepository | None,
+    outcome_review_repository: DpmOutcomeReviewRepository,
+    mandate_repository: DpmMandateRepository | None,
+) -> DpmPortfolioMemoryReportContext | None:
+    if proof_pack_repository is None or wave_repository is None:
+        return None
+    return build_report_portfolio_memory_context(
+        portfolio_id=review.portfolio_id,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_review_repository,
+        mandate_repository=mandate_repository,
+    )
+
+
+__all__ = [
+    "build_outcome_ai_evidence_input",
+    "build_outcome_report_input",
+    "portfolio_memory_context_for_report",
+]

--- a/src/api/services/outcome_review_search.py
+++ b/src/api/services/outcome_review_search.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.core.outcomes import DpmPostTradeOutcomeReview
+from src.core.outcomes.repository import DpmOutcomeReviewRepository
+
+
+@dataclass(frozen=True)
+class OutcomeReviewSearchPage:
+    items: list[DpmPostTradeOutcomeReview]
+    total: int
+    source_owner_counts: dict[str, int]
+    source_type_counts: dict[str, int]
+    normalized_source_system: str | None
+    normalized_source_type: str | None
+
+
+def search_outcome_review_page(
+    *,
+    repository: DpmOutcomeReviewRepository,
+    portfolio_id: str | None = None,
+    mandate_id: str | None = None,
+    wave_id: str | None = None,
+    rebalance_run_id: str | None = None,
+    state: str | None = None,
+    source_system: str | None = None,
+    source_type: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    source_scan_limit: int = 500,
+) -> OutcomeReviewSearchPage:
+    normalized_source_system = normalize_outcome_review_search_filter(source_system)
+    normalized_source_type = normalize_outcome_review_search_filter(source_type)
+    candidate_reviews = repository.list_outcome_reviews(
+        portfolio_id=portfolio_id,
+        mandate_id=mandate_id,
+        wave_id=wave_id,
+        rebalance_run_id=rebalance_run_id,
+        state=state,
+        limit=source_scan_limit,
+        offset=0,
+    )
+    matching_reviews = [
+        review
+        for review in candidate_reviews
+        if review_matches_source_lineage_filters(
+            review=review,
+            source_system=normalized_source_system,
+            source_type=normalized_source_type,
+        )
+    ]
+    source_owner_counts: dict[str, int] = {}
+    source_type_counts: dict[str, int] = {}
+    for review in matching_reviews:
+        for represented_source_system in review_source_systems(review):
+            source_owner_counts[represented_source_system] = (
+                source_owner_counts.get(represented_source_system, 0) + 1
+            )
+        for represented_source_type in review_source_types(review):
+            source_type_counts[represented_source_type] = (
+                source_type_counts.get(represented_source_type, 0) + 1
+            )
+    return OutcomeReviewSearchPage(
+        items=matching_reviews[offset : offset + limit],
+        total=len(matching_reviews),
+        source_owner_counts=dict(sorted(source_owner_counts.items())),
+        source_type_counts=dict(sorted(source_type_counts.items())),
+        normalized_source_system=normalized_source_system,
+        normalized_source_type=normalized_source_type,
+    )
+
+
+def normalize_outcome_review_search_filter(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def review_matches_source_lineage_filters(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    source_system: str | None,
+    source_type: str | None,
+) -> bool:
+    if source_system is not None and source_system not in review_source_systems(review):
+        return False
+    if source_type is not None and source_type not in review_source_types(review):
+        return False
+    return True
+
+
+def review_source_systems(review: DpmPostTradeOutcomeReview) -> set[str]:
+    return {ref.source_system for ref in review.source_lineage if ref.source_system}
+
+
+def review_source_types(review: DpmPostTradeOutcomeReview) -> set[str]:
+    return {ref.source_type for ref in review.source_lineage if ref.source_type}

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -25,6 +25,7 @@ from src.api.services.outcome_review_creation import (
     build_created_outcome_event,
     build_review_content_hash,
 )
+from src.api.services.outcome_review_refresh import build_source_refreshed_event
 from src.api.services.portfolio_memory_context_service import (
     build_report_portfolio_memory_context,
 )
@@ -206,15 +207,14 @@ def refresh_outcome_review_sources(
         realized_snapshot=realized_snapshot,
         dimension_configs=dimension_configs,
     )
-    event = DpmOutcomeEvent(
-        event_id=f"{outcome_review_id}_source_refreshed_{uuid4().hex[:8]}",
-        event_type="OUTCOME_REVIEW_SOURCE_REFRESHED",
-        event_time=datetime.now(timezone.utc).isoformat(),
-        actor=actor_id,
+    event = build_source_refreshed_event(
         outcome_review_id=outcome_review_id,
-        state=comparison.state,
-        reason_codes=comparison.supportability.reason_codes,
-        source_refs=[*review.expected_snapshot.source_lineage, *realized_snapshot.source_lineage],
+        expected_snapshot=review.expected_snapshot,
+        realized_snapshot=realized_snapshot,
+        comparison=comparison,
+        actor_id=actor_id,
+        refreshed_at=datetime.now(timezone.utc),
+        event_id_suffix=uuid4().hex[:8],
     )
     repository.append_event(event=event)
     return event, comparison

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -17,7 +17,7 @@ from src.api.services.outcome_review_creation import (
     build_created_outcome_review,
     build_review_content_hash,
 )
-from src.api.services.outcome_review_refresh import build_source_refreshed_event
+from src.api.services.outcome_review_refresh import build_source_refresh_result
 from src.api.services.outcome_review_dimensions import (
     DpmOutcomeDimensionConfig as DpmOutcomeDimensionConfig,
     DpmOutcomeReviewValidationError as DpmOutcomeReviewValidationError,
@@ -170,16 +170,10 @@ def refresh_outcome_review_sources(
     repository: DpmOutcomeReviewRepository,
 ) -> tuple[DpmOutcomeEvent, DpmOutcomeReviewComparison]:
     review = get_outcome_review(outcome_review_id=outcome_review_id, repository=repository)
-    comparison = preview_outcome_review(
-        expected_snapshot=review.expected_snapshot,
+    event, comparison = build_source_refresh_result(
+        review=review,
         realized_snapshot=realized_snapshot,
         dimension_configs=dimension_configs,
-    )
-    event = build_source_refreshed_event(
-        outcome_review_id=outcome_review_id,
-        expected_snapshot=review.expected_snapshot,
-        realized_snapshot=realized_snapshot,
-        comparison=comparison,
         actor_id=actor_id,
         refreshed_at=datetime.now(timezone.utc),
         event_id_suffix=uuid4().hex[:8],

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -11,8 +11,6 @@ from src.core.outcomes import (
     DpmOutcomeReportInput,
     DpmPostTradeOutcomeReview,
     DpmRealizedOutcomeSnapshot,
-    build_ai_evidence_input,
-    build_report_input,
     compare_outcome_dimensions,
 )
 from src.api.services.outcome_review_creation import (
@@ -25,15 +23,16 @@ from src.api.services.outcome_review_dimensions import (
     DpmOutcomeReviewValidationError as DpmOutcomeReviewValidationError,
     dimension_inputs_for_review,
 )
-from src.api.services.portfolio_memory_context_service import (
-    build_report_portfolio_memory_context,
+from src.api.services.outcome_review_report_inputs import (
+    build_outcome_ai_evidence_input,
+    build_outcome_report_input,
+    portfolio_memory_context_for_report,
 )
 from src.api.services.outcome_review_search import (
     normalize_outcome_review_search_filter as _normalize_outcome_review_search_filter,
     search_outcome_review_page,
 )
 from src.core.mandate_repository import DpmMandateRepository
-from src.core.portfolio_memory.handoffs import DpmPortfolioMemoryReportContext
 from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.waves.repository import DpmWaveRepository
 from src.core.outcomes.repository import DpmOutcomeReviewConflictError, DpmOutcomeReviewRepository
@@ -46,6 +45,7 @@ class DpmOutcomeReviewNotFoundError(Exception):
 
 
 _dimension_inputs = dimension_inputs_for_review
+_portfolio_memory_context_for_report = portfolio_memory_context_for_report
 
 
 def preview_outcome_review(
@@ -231,15 +231,12 @@ def get_report_input(
     mandate_repository: DpmMandateRepository | None = None,
 ) -> DpmOutcomeReportInput:
     review = get_outcome_review(outcome_review_id=outcome_review_id, repository=repository)
-    return build_report_input(
-        review,
-        portfolio_memory_context=_portfolio_memory_context_for_report(
-            review=review,
-            proof_pack_repository=proof_pack_repository,
-            wave_repository=wave_repository,
-            outcome_review_repository=repository,
-            mandate_repository=mandate_repository,
-        ),
+    return build_outcome_report_input(
+        review=review,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=repository,
+        mandate_repository=mandate_repository,
     )
 
 
@@ -252,32 +249,10 @@ def get_ai_evidence_input(
     mandate_repository: DpmMandateRepository | None = None,
 ) -> DpmOutcomeAiEvidenceInput:
     review = get_outcome_review(outcome_review_id=outcome_review_id, repository=repository)
-    return build_ai_evidence_input(
-        review,
-        portfolio_memory_context=_portfolio_memory_context_for_report(
-            review=review,
-            proof_pack_repository=proof_pack_repository,
-            wave_repository=wave_repository,
-            outcome_review_repository=repository,
-            mandate_repository=mandate_repository,
-        ),
-    )
-
-
-def _portfolio_memory_context_for_report(
-    *,
-    review: DpmPostTradeOutcomeReview,
-    proof_pack_repository: DpmProofPackRepository | None,
-    wave_repository: DpmWaveRepository | None,
-    outcome_review_repository: DpmOutcomeReviewRepository,
-    mandate_repository: DpmMandateRepository | None,
-) -> DpmPortfolioMemoryReportContext | None:
-    if proof_pack_repository is None or wave_repository is None:
-        return None
-    return build_report_portfolio_memory_context(
-        portfolio_id=review.portfolio_id,
+    return build_outcome_ai_evidence_input(
+        review=review,
         proof_pack_repository=proof_pack_repository,
         wave_repository=wave_repository,
-        outcome_review_repository=outcome_review_repository,
+        outcome_review_repository=repository,
         mandate_repository=mandate_repository,
     )

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -27,6 +27,10 @@ from src.core.outcomes import (
 from src.api.services.portfolio_memory_context_service import (
     build_report_portfolio_memory_context,
 )
+from src.api.services.outcome_review_search import (
+    normalize_outcome_review_search_filter as _normalize_outcome_review_search_filter,
+    search_outcome_review_page,
+)
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.portfolio_memory.handoffs import DpmPortfolioMemoryReportContext
 from src.core.proof_packs.repository import DpmProofPackRepository
@@ -166,45 +170,26 @@ def search_outcome_reviews(
 ]:
     """Search persisted outcome reviews without querying source-owner systems."""
 
-    normalized_source_system = normalize_outcome_review_search_filter(source_system)
-    normalized_source_type = normalize_outcome_review_search_filter(source_type)
-    candidate_reviews = repository.list_outcome_reviews(
+    page = search_outcome_review_page(
+        repository=repository,
         portfolio_id=portfolio_id,
         mandate_id=mandate_id,
         wave_id=wave_id,
         rebalance_run_id=rebalance_run_id,
         state=state,
-        limit=source_scan_limit,
-        offset=0,
+        source_system=source_system,
+        source_type=source_type,
+        limit=limit,
+        offset=offset,
+        source_scan_limit=source_scan_limit,
     )
-    matching_reviews = [
-        review
-        for review in candidate_reviews
-        if _review_matches_source_lineage_filters(
-            review=review,
-            source_system=normalized_source_system,
-            source_type=normalized_source_type,
-        )
-    ]
-    source_owner_counts: dict[str, int] = {}
-    source_type_counts: dict[str, int] = {}
-    for review in matching_reviews:
-        for represented_source_system in _review_source_systems(review):
-            source_owner_counts[represented_source_system] = (
-                source_owner_counts.get(represented_source_system, 0) + 1
-            )
-        for represented_source_type in _review_source_types(review):
-            source_type_counts[represented_source_type] = (
-                source_type_counts.get(represented_source_type, 0) + 1
-            )
-    page = matching_reviews[offset : offset + limit]
     return (
-        page,
-        len(matching_reviews),
-        dict(sorted(source_owner_counts.items())),
-        dict(sorted(source_type_counts.items())),
-        normalized_source_system,
-        normalized_source_type,
+        page.items,
+        page.total,
+        page.source_owner_counts,
+        page.source_type_counts,
+        page.normalized_source_system,
+        page.normalized_source_type,
     )
 
 
@@ -237,31 +222,7 @@ def refresh_outcome_review_sources(
 
 
 def normalize_outcome_review_search_filter(value: str | None) -> str | None:
-    if value is None:
-        return None
-    normalized = value.strip()
-    return normalized or None
-
-
-def _review_matches_source_lineage_filters(
-    *,
-    review: DpmPostTradeOutcomeReview,
-    source_system: str | None,
-    source_type: str | None,
-) -> bool:
-    if source_system is not None and source_system not in _review_source_systems(review):
-        return False
-    if source_type is not None and source_type not in _review_source_types(review):
-        return False
-    return True
-
-
-def _review_source_systems(review: DpmPostTradeOutcomeReview) -> set[str]:
-    return {ref.source_system for ref in review.source_lineage if ref.source_system}
-
-
-def _review_source_types(review: DpmPostTradeOutcomeReview) -> set[str]:
-    return {ref.source_type for ref in review.source_lineage if ref.source_type}
+    return _normalize_outcome_review_search_filter(value)
 
 
 def get_report_input(

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
@@ -19,10 +17,13 @@ from src.core.outcomes import (
     DpmRealizedOutcomeSnapshot,
     OutcomeComparisonDirection,
     OutcomeDimension,
-    OutcomeEventType,
     build_ai_evidence_input,
     build_report_input,
     compare_outcome_dimensions,
+)
+from src.api.services.outcome_review_creation import (
+    build_created_outcome_event,
+    build_review_content_hash,
 )
 from src.api.services.portfolio_memory_context_service import (
     build_report_portfolio_memory_context,
@@ -78,7 +79,7 @@ def create_outcome_review(
         realized_snapshot=realized_snapshot,
         dimension_configs=dimension_configs,
     )
-    content_hash = _review_content_hash(
+    content_hash = build_review_content_hash(
         expected_snapshot=expected_snapshot,
         realized_snapshot=realized_snapshot,
         comparison=comparison,
@@ -90,15 +91,13 @@ def create_outcome_review(
         return existing
     created_at = datetime.now(timezone.utc)
     outcome_review_id = f"dor_{uuid4().hex[:16]}"
-    event = DpmOutcomeEvent(
-        event_id=f"{outcome_review_id}_created",
-        event_type=_created_event_type(comparison.state),
-        event_time=created_at.isoformat(),
-        actor=actor_id,
+    event = build_created_outcome_event(
         outcome_review_id=outcome_review_id,
-        state=comparison.state,
-        reason_codes=comparison.supportability.reason_codes,
-        source_refs=[*expected_snapshot.source_lineage, *realized_snapshot.source_lineage],
+        comparison=comparison,
+        expected_snapshot=expected_snapshot,
+        realized_snapshot=realized_snapshot,
+        actor_id=actor_id,
+        created_at=created_at,
     )
     review = DpmPostTradeOutcomeReview(
         outcome_review_id=outcome_review_id,
@@ -319,35 +318,3 @@ def _dimension_inputs(
             )
         )
     return inputs
-
-
-def _created_event_type(state: str) -> OutcomeEventType:
-    if state == "BLOCKED":
-        return "OUTCOME_REVIEW_BLOCKED"
-    if state == "DEGRADED":
-        return "OUTCOME_REVIEW_DEGRADED"
-    if state == "READY":
-        return "OUTCOME_REVIEW_READY"
-    return "OUTCOME_REVIEW_CREATED"
-
-
-def _content_hash(payload: dict[str, object]) -> str:
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
-    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-
-
-def _review_content_hash(
-    *,
-    expected_snapshot: DpmExpectedOutcomeSnapshot,
-    realized_snapshot: DpmRealizedOutcomeSnapshot,
-    comparison: DpmOutcomeReviewComparison,
-) -> str:
-    return _content_hash(
-        {
-            "expected_snapshot": expected_snapshot.model_dump(mode="json"),
-            "realized_snapshot": realized_snapshot.model_dump(mode="json"),
-            "dimension_results": [
-                result.model_dump(mode="json") for result in comparison.dimension_results
-            ],
-        }
-    )

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -14,7 +14,7 @@ from src.core.outcomes import (
     compare_outcome_dimensions,
 )
 from src.api.services.outcome_review_creation import (
-    build_created_outcome_event,
+    build_created_outcome_review,
     build_review_content_hash,
 )
 from src.api.services.outcome_review_refresh import build_source_refreshed_event
@@ -89,42 +89,16 @@ def create_outcome_review(
         return existing
     created_at = datetime.now(timezone.utc)
     outcome_review_id = f"dor_{uuid4().hex[:16]}"
-    event = build_created_outcome_event(
+    review = build_created_outcome_review(
         outcome_review_id=outcome_review_id,
         comparison=comparison,
         expected_snapshot=expected_snapshot,
         realized_snapshot=realized_snapshot,
         actor_id=actor_id,
-        created_at=created_at,
-    )
-    review = DpmPostTradeOutcomeReview(
-        outcome_review_id=outcome_review_id,
-        state=comparison.state,
-        portfolio_id=expected_snapshot.portfolio_id,
-        mandate_id=expected_snapshot.mandate_id,
-        rebalance_run_id=expected_snapshot.rebalance_run_id,
-        alternative_set_id=expected_snapshot.alternative_set_id,
-        selected_alternative_id=expected_snapshot.selected_alternative_id,
-        proof_pack_id=expected_snapshot.proof_pack_id,
-        wave_id=expected_snapshot.wave_id,
-        wave_item_id=expected_snapshot.wave_item_id,
-        operations_handoff_ref_id=expected_snapshot.operations_handoff_ref_id,
-        review_window=realized_snapshot.review_window,
-        expected_snapshot=expected_snapshot,
-        realized_snapshot=realized_snapshot,
-        dimension_results=comparison.dimension_results,
-        overall_outcome=comparison.overall_outcome,
-        variance_summary=comparison.variance_summary,
-        supportability=comparison.supportability,
-        source_lineage=[*expected_snapshot.source_lineage, *realized_snapshot.source_lineage],
-        source_hashes={**expected_snapshot.source_hashes, **realized_snapshot.source_hashes},
-        section_hashes=expected_snapshot.section_hashes,
-        events=[event],
-        content_hash=content_hash,
-        created_at=created_at,
-        created_by=actor_id,
         correlation_id=correlation_id,
         idempotency_key=idempotency_key,
+        content_hash=content_hash,
+        created_at=created_at,
     )
     persist_outcome_review(repository=repository, review=review, persisted_at=created_at)
     return review

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
 from uuid import uuid4
 
 from src.core.outcomes import (
     DpmExpectedOutcomeSnapshot,
-    DpmOutcomeDimensionInput,
     DpmOutcomeEvent,
     DpmOutcomeAiEvidenceInput,
     DpmOutcomeReviewComparison,
     DpmOutcomeReportInput,
-    DpmOutcomeTolerance,
     DpmPostTradeOutcomeReview,
     DpmRealizedOutcomeSnapshot,
-    OutcomeComparisonDirection,
-    OutcomeDimension,
     build_ai_evidence_input,
     build_report_input,
     compare_outcome_dimensions,
@@ -26,6 +20,11 @@ from src.api.services.outcome_review_creation import (
     build_review_content_hash,
 )
 from src.api.services.outcome_review_refresh import build_source_refreshed_event
+from src.api.services.outcome_review_dimensions import (
+    DpmOutcomeDimensionConfig as DpmOutcomeDimensionConfig,
+    DpmOutcomeReviewValidationError as DpmOutcomeReviewValidationError,
+    dimension_inputs_for_review,
+)
 from src.api.services.portfolio_memory_context_service import (
     build_report_portfolio_memory_context,
 )
@@ -42,12 +41,11 @@ from src.core.outcomes.repository import DpmOutcomeReviewConflictError, DpmOutco
 OUTCOME_REVIEW_RETENTION_DAYS = 365 * 7
 
 
-class DpmOutcomeReviewValidationError(Exception):
-    pass
-
-
 class DpmOutcomeReviewNotFoundError(Exception):
     pass
+
+
+_dimension_inputs = dimension_inputs_for_review
 
 
 def preview_outcome_review(
@@ -57,7 +55,7 @@ def preview_outcome_review(
     dimension_configs: list[DpmOutcomeDimensionConfig],
 ) -> DpmOutcomeReviewComparison:
     return compare_outcome_dimensions(
-        _dimension_inputs(
+        dimension_inputs_for_review(
             expected_snapshot=expected_snapshot,
             realized_snapshot=realized_snapshot,
             dimension_configs=dimension_configs,
@@ -283,38 +281,3 @@ def _portfolio_memory_context_for_report(
         outcome_review_repository=outcome_review_repository,
         mandate_repository=mandate_repository,
     )
-
-
-@dataclass(frozen=True)
-class DpmOutcomeDimensionConfig:
-    dimension: OutcomeDimension
-    tolerance: DpmOutcomeTolerance
-    materiality: Decimal
-    direction: OutcomeComparisonDirection
-
-
-def _dimension_inputs(
-    *,
-    expected_snapshot: DpmExpectedOutcomeSnapshot,
-    realized_snapshot: DpmRealizedOutcomeSnapshot,
-    dimension_configs: list[DpmOutcomeDimensionConfig],
-) -> list[DpmOutcomeDimensionInput]:
-    inputs: list[DpmOutcomeDimensionInput] = []
-    for config in dimension_configs:
-        expected = expected_snapshot.expected_values.get(config.dimension)
-        realized = realized_snapshot.realized_values.get(config.dimension)
-        if expected is None or realized is None:
-            raise DpmOutcomeReviewValidationError(
-                f"DPM_OUTCOME_DIMENSION_EVIDENCE_MISSING:{config.dimension}"
-            )
-        inputs.append(
-            DpmOutcomeDimensionInput(
-                dimension=config.dimension,
-                expected=expected,
-                realized=realized,
-                tolerance=config.tolerance,
-                materiality=config.materiality,
-                direction=config.direction,
-            )
-        )
-    return inputs

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from uuid import uuid4
 
 from src.core.outcomes import (
@@ -23,6 +23,7 @@ from src.api.services.outcome_review_dimensions import (
     DpmOutcomeReviewValidationError as DpmOutcomeReviewValidationError,
     dimension_inputs_for_review,
 )
+from src.api.services.outcome_review_persistence import persist_outcome_review
 from src.api.services.outcome_review_report_inputs import (
     build_outcome_ai_evidence_input,
     build_outcome_report_input,
@@ -36,8 +37,6 @@ from src.core.mandate_repository import DpmMandateRepository
 from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.waves.repository import DpmWaveRepository
 from src.core.outcomes.repository import DpmOutcomeReviewConflictError, DpmOutcomeReviewRepository
-
-OUTCOME_REVIEW_RETENTION_DAYS = 365 * 7
 
 
 class DpmOutcomeReviewNotFoundError(Exception):
@@ -127,10 +126,7 @@ def create_outcome_review(
         correlation_id=correlation_id,
         idempotency_key=idempotency_key,
     )
-    repository.save_outcome_review(
-        review=review,
-        retention_expires_at=created_at + timedelta(days=OUTCOME_REVIEW_RETENTION_DAYS),
-    )
+    persist_outcome_review(repository=repository, review=review, persisted_at=created_at)
     return review
 
 

--- a/src/api/services/proof_pack_generation.py
+++ b/src/api/services/proof_pack_generation.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from src.api.services.proof_pack_mandate_evidence import ProofPackMandateEvidence
+from src.api.services.proof_pack_selected_source import ProofPackSelectedAlternativeSource
+from src.core.construction.models import AuthoritativeRegimeStressContext
+from src.core.proof_packs import (
+    build_proof_pack_from_run,
+    build_proof_pack_from_selected_alternative,
+)
+from src.core.proof_packs.models import DpmPreTradeProofPack
+from src.core.rebalance_runs.models import DpmRunRecord, DpmRunWorkflowDecisionRecord
+
+
+def build_run_proof_pack(
+    *,
+    run: DpmRunRecord,
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
+    actor_id: str,
+    reason: str | None,
+    correlation_id: str | None,
+    mandate_id: str | None,
+    mandate_evidence: ProofPackMandateEvidence,
+    direct_regime_stress_context: AuthoritativeRegimeStressContext | None,
+) -> DpmPreTradeProofPack:
+    return build_proof_pack_from_run(
+        run=run,
+        created_by=actor_id,
+        reason=reason,
+        correlation_id=correlation_id,
+        mandate_id=mandate_id,
+        mandate_twin=mandate_evidence.twin,
+        mandate_health=mandate_evidence.health,
+        mandate_evidence_gap_codes=mandate_evidence.gap_codes,
+        workflow_decisions=workflow_decisions,
+        direct_regime_stress_context=direct_regime_stress_context,
+    )
+
+
+def build_selected_alternative_proof_pack(
+    *,
+    selected_source: ProofPackSelectedAlternativeSource,
+    selected_alternative_id: str,
+    actor_id: str,
+    reason: str | None,
+    correlation_id: str | None,
+    mandate_id: str | None,
+    mandate_evidence: ProofPackMandateEvidence,
+    direct_regime_stress_context: AuthoritativeRegimeStressContext | None,
+) -> DpmPreTradeProofPack:
+    return build_proof_pack_from_selected_alternative(
+        alternative_set=selected_source.alternative_set,
+        selected_alternative_id=selected_alternative_id,
+        run=selected_source.run,
+        selection=selected_source.selection,
+        created_by=actor_id,
+        reason=reason,
+        correlation_id=correlation_id,
+        mandate_id=mandate_id,
+        mandate_twin=mandate_evidence.twin,
+        mandate_health=mandate_evidence.health,
+        mandate_evidence_gap_codes=mandate_evidence.gap_codes,
+        workflow_decisions=selected_source.workflow_decisions,
+        direct_regime_stress_context=direct_regime_stress_context,
+    )
+
+
+__all__ = ["build_run_proof_pack", "build_selected_alternative_proof_pack"]

--- a/src/api/services/proof_pack_handoff_refs.py
+++ b/src/api/services/proof_pack_handoff_refs.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.core.proof_packs import (
+    AI_EVIDENCE_REF_TYPE,
+    REPORT_INPUT_REF_TYPE,
+    build_ai_evidence_input,
+    build_report_input,
+)
+from src.core.proof_packs.models import (
+    DpmPreTradeProofPack,
+    DpmProofPackEvidenceRef,
+    DpmProofPackStoredRef,
+)
+from src.core.proof_packs.repository import DpmProofPackRepository
+
+
+def ensure_handoff_refs(
+    *,
+    proof_pack: DpmPreTradeProofPack,
+    proof_pack_repository: DpmProofPackRepository,
+    include_report_input: bool,
+    include_ai_evidence_input: bool,
+) -> DpmPreTradeProofPack:
+    if include_report_input:
+        report_input = build_report_input(proof_pack)
+        append_handoff_ref(
+            ref=report_input.evidence_ref,
+            proof_pack=proof_pack,
+            proof_pack_repository=proof_pack_repository,
+        )
+    if include_ai_evidence_input:
+        ai_evidence_input = build_ai_evidence_input(proof_pack)
+        append_handoff_ref(
+            ref=ai_evidence_input.evidence_ref,
+            proof_pack=proof_pack,
+            proof_pack_repository=proof_pack_repository,
+        )
+    return hydrate_handoff_refs(
+        proof_pack=proof_pack,
+        proof_pack_repository=proof_pack_repository,
+    )
+
+
+def append_handoff_ref(
+    *,
+    ref: DpmProofPackEvidenceRef,
+    proof_pack: DpmPreTradeProofPack,
+    proof_pack_repository: DpmProofPackRepository,
+) -> None:
+    existing = find_stored_ref(
+        proof_pack_id=proof_pack.proof_pack_id,
+        ref_type=ref.ref_type,
+        proof_pack_repository=proof_pack_repository,
+    )
+    if existing is not None and existing.content_hash == ref.content_hash:
+        return
+    proof_pack_repository.append_ref(
+        ref=DpmProofPackStoredRef(
+            proof_pack_id=proof_pack.proof_pack_id,
+            ref_type=ref.ref_type,
+            ref_id=ref.ref_id,
+            source_system=ref.source_system,
+            content_hash=ref.content_hash,
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+    )
+
+
+def hydrate_handoff_refs(
+    *,
+    proof_pack: DpmPreTradeProofPack,
+    proof_pack_repository: DpmProofPackRepository,
+) -> DpmPreTradeProofPack:
+    report_ref = proof_pack.report_input_ref
+    ai_ref = proof_pack.ai_evidence_ref
+    stored_report_ref = find_stored_ref(
+        proof_pack_id=proof_pack.proof_pack_id,
+        ref_type=REPORT_INPUT_REF_TYPE,
+        proof_pack_repository=proof_pack_repository,
+    )
+    stored_ai_ref = find_stored_ref(
+        proof_pack_id=proof_pack.proof_pack_id,
+        ref_type=AI_EVIDENCE_REF_TYPE,
+        proof_pack_repository=proof_pack_repository,
+    )
+    if stored_report_ref is not None:
+        report_ref = stored_ref_to_evidence_ref(stored_report_ref)
+    if stored_ai_ref is not None:
+        ai_ref = stored_ref_to_evidence_ref(stored_ai_ref)
+    if report_ref == proof_pack.report_input_ref and ai_ref == proof_pack.ai_evidence_ref:
+        return proof_pack
+    return proof_pack.model_copy(
+        update={
+            "report_input_ref": report_ref,
+            "ai_evidence_ref": ai_ref,
+        }
+    )
+
+
+def find_stored_ref(
+    *,
+    proof_pack_id: str,
+    ref_type: str,
+    proof_pack_repository: DpmProofPackRepository,
+) -> DpmProofPackStoredRef | None:
+    return next(
+        (
+            ref
+            for ref in reversed(proof_pack_repository.list_refs(proof_pack_id=proof_pack_id))
+            if ref.ref_type == ref_type
+        ),
+        None,
+    )
+
+
+def stored_ref_to_evidence_ref(ref: DpmProofPackStoredRef) -> DpmProofPackEvidenceRef:
+    return DpmProofPackEvidenceRef(
+        ref_type=ref.ref_type,
+        ref_id=ref.ref_id,
+        source_system=ref.source_system,
+        content_hash=ref.content_hash,
+    )

--- a/src/api/services/proof_pack_handoff_refs.py
+++ b/src/api/services/proof_pack_handoff_refs.py
@@ -115,6 +115,25 @@ def find_stored_ref(
     )
 
 
+def require_handoff_ref(
+    *,
+    proof_pack_id: str,
+    hydrated_ref: DpmProofPackEvidenceRef | None,
+    ref_type: str,
+    proof_pack_repository: DpmProofPackRepository,
+) -> DpmProofPackEvidenceRef | None:
+    if hydrated_ref is not None:
+        return hydrated_ref
+    stored_ref = find_stored_ref(
+        proof_pack_id=proof_pack_id,
+        ref_type=ref_type,
+        proof_pack_repository=proof_pack_repository,
+    )
+    if stored_ref is None:
+        return None
+    return stored_ref_to_evidence_ref(stored_ref)
+
+
 def stored_ref_to_evidence_ref(ref: DpmProofPackStoredRef) -> DpmProofPackEvidenceRef:
     return DpmProofPackEvidenceRef(
         ref_type=ref.ref_type,

--- a/src/api/services/proof_pack_mandate_evidence.py
+++ b/src/api/services/proof_pack_mandate_evidence.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthSnapshot
+
+
+@dataclass(frozen=True)
+class ProofPackMandateEvidence:
+    twin: DpmMandateDigitalTwin | None
+    health: DpmMandateHealthSnapshot | None
+    gap_codes: list[str]
+
+
+def resolve_mandate_evidence(
+    *,
+    mandate_id: str | None,
+    portfolio_id: str,
+    mandate_repository: DpmMandateRepository | None,
+) -> ProofPackMandateEvidence:
+    if mandate_id is None or mandate_repository is None:
+        return ProofPackMandateEvidence(twin=None, health=None, gap_codes=[])
+    twin = mandate_repository.get_latest_mandate(mandate_id=mandate_id)
+    if twin is None:
+        return ProofPackMandateEvidence(twin=None, health=None, gap_codes=[])
+    if twin.portfolio_id != portfolio_id:
+        return ProofPackMandateEvidence(
+            twin=None,
+            health=None,
+            gap_codes=["DPM_MANDATE_TWIN_PORTFOLIO_MISMATCH"],
+        )
+    return ProofPackMandateEvidence(
+        twin=twin,
+        health=mandate_repository.get_latest_health_snapshot(mandate_id=mandate_id),
+        gap_codes=[],
+    )

--- a/src/api/services/proof_pack_persistence.py
+++ b/src/api/services/proof_pack_persistence.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.core.proof_packs.models import DpmPreTradeProofPack
+from src.core.proof_packs.repository import DpmProofPackRepository
+
+PROOF_PACK_RETENTION_DAYS = 365 * 7
+
+
+def persist_proof_pack(
+    *,
+    proof_pack_repository: DpmProofPackRepository,
+    proof_pack: DpmPreTradeProofPack,
+    idempotency_key: str | None,
+    persisted_at: datetime | None = None,
+) -> None:
+    retention_base = persisted_at or datetime.now(timezone.utc)
+    proof_pack_repository.save_proof_pack(
+        proof_pack=proof_pack,
+        idempotency_key=idempotency_key,
+        retention_expires_at=retention_base + timedelta(days=PROOF_PACK_RETENTION_DAYS),
+    )
+
+
+__all__ = ["PROOF_PACK_RETENTION_DAYS", "persist_proof_pack"]

--- a/src/api/services/proof_pack_replay.py
+++ b/src/api/services/proof_pack_replay.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from src.core.proof_packs.models import DpmPreTradeProofPack
+from src.core.proof_packs.repository import DpmProofPackRepository
+
+
+def find_replayable_proof_pack(
+    *,
+    proof_pack_id: str,
+    idempotency_key: str | None,
+    proof_pack_repository: DpmProofPackRepository,
+) -> DpmPreTradeProofPack | None:
+    if idempotency_key is not None:
+        existing = proof_pack_repository.get_proof_pack_by_idempotency(
+            idempotency_key=idempotency_key
+        )
+        if existing is not None:
+            return existing
+    return proof_pack_repository.get_proof_pack(proof_pack_id=proof_pack_id)

--- a/src/api/services/proof_pack_report_inputs.py
+++ b/src/api/services/proof_pack_report_inputs.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from src.api.services.portfolio_memory_context_service import (
+    build_report_portfolio_memory_context,
+)
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.outcomes.repository import DpmOutcomeReviewRepository
+from src.core.portfolio_memory.handoffs import DpmPortfolioMemoryReportContext
+from src.core.proof_packs import build_ai_evidence_input, build_report_input
+from src.core.proof_packs.handoffs import DpmProofPackAiEvidenceInput, DpmProofPackReportInput
+from src.core.proof_packs.models import DpmPreTradeProofPack
+from src.core.proof_packs.repository import DpmProofPackRepository
+from src.core.waves.repository import DpmWaveRepository
+
+
+def build_proof_pack_report_input(
+    *,
+    proof_pack: DpmPreTradeProofPack,
+    proof_pack_repository: DpmProofPackRepository,
+    wave_repository: DpmWaveRepository | None,
+    outcome_review_repository: DpmOutcomeReviewRepository | None,
+    mandate_repository: DpmMandateRepository | None,
+) -> DpmProofPackReportInput:
+    return build_report_input(
+        proof_pack,
+        portfolio_memory_context=portfolio_memory_context_for_report(
+            portfolio_id=proof_pack.portfolio_id,
+            proof_pack_repository=proof_pack_repository,
+            wave_repository=wave_repository,
+            outcome_review_repository=outcome_review_repository,
+            mandate_repository=mandate_repository,
+        ),
+    )
+
+
+def build_proof_pack_ai_evidence_input(
+    *,
+    proof_pack: DpmPreTradeProofPack,
+    proof_pack_repository: DpmProofPackRepository,
+    wave_repository: DpmWaveRepository | None,
+    outcome_review_repository: DpmOutcomeReviewRepository | None,
+    mandate_repository: DpmMandateRepository | None,
+) -> DpmProofPackAiEvidenceInput:
+    return build_ai_evidence_input(
+        proof_pack,
+        portfolio_memory_context=portfolio_memory_context_for_report(
+            portfolio_id=proof_pack.portfolio_id,
+            proof_pack_repository=proof_pack_repository,
+            wave_repository=wave_repository,
+            outcome_review_repository=outcome_review_repository,
+            mandate_repository=mandate_repository,
+        ),
+    )
+
+
+def portfolio_memory_context_for_report(
+    *,
+    portfolio_id: str,
+    proof_pack_repository: DpmProofPackRepository,
+    wave_repository: DpmWaveRepository | None,
+    outcome_review_repository: DpmOutcomeReviewRepository | None,
+    mandate_repository: DpmMandateRepository | None,
+) -> DpmPortfolioMemoryReportContext | None:
+    if wave_repository is None or outcome_review_repository is None:
+        return None
+    return build_report_portfolio_memory_context(
+        portfolio_id=portfolio_id,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_review_repository,
+        mandate_repository=mandate_repository,
+    )
+
+
+__all__ = [
+    "build_proof_pack_ai_evidence_input",
+    "build_proof_pack_report_input",
+    "portfolio_memory_context_for_report",
+]

--- a/src/api/services/proof_pack_selected_source.py
+++ b/src/api/services/proof_pack_selected_source.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.core.construction.models import (
+    ConstructionAlternativeSelection,
+    ConstructionAlternativeSet,
+)
+from src.core.construction.repository import ConstructionRepository
+from src.core.proof_packs import ProofPackSourceValidationError
+from src.core.rebalance_runs.models import DpmRunRecord, DpmRunWorkflowDecisionRecord
+from src.core.rebalance_runs.service import DpmRunNotFoundError, DpmRunSupportService
+
+
+@dataclass(frozen=True)
+class ProofPackSelectedAlternativeSource:
+    alternative_set: ConstructionAlternativeSet
+    selection: ConstructionAlternativeSelection | None
+    run: DpmRunRecord | None
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord]
+
+
+def resolve_selected_alternative_source(
+    *,
+    alternative_set_id: str,
+    selected_alternative_id: str,
+    construction_repository: ConstructionRepository,
+    run_service: DpmRunSupportService,
+) -> ProofPackSelectedAlternativeSource:
+    alternative_set = construction_repository.get_alternative_set(
+        alternative_set_id=alternative_set_id
+    )
+    if alternative_set is None:
+        raise ProofPackSourceValidationError("DPM_ALTERNATIVE_SET_NOT_FOUND")
+    selected = next(
+        (
+            alternative
+            for alternative in alternative_set.alternatives
+            if alternative.alternative_id == selected_alternative_id
+        ),
+        None,
+    )
+    if selected is None:
+        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_NOT_FOUND")
+    run = None
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord] = []
+    if selected.rebalance_run_id is not None:
+        try:
+            run = run_service.get_run_record(rebalance_run_id=selected.rebalance_run_id)
+            workflow_decisions = run_service.list_workflow_decision_records(
+                rebalance_run_id=selected.rebalance_run_id
+            )
+        except DpmRunNotFoundError:
+            run = None
+            workflow_decisions = []
+    return ProofPackSelectedAlternativeSource(
+        alternative_set=alternative_set,
+        selection=construction_repository.get_selection(alternative_set_id=alternative_set_id),
+        run=run,
+        workflow_decisions=workflow_decisions,
+    )

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -8,7 +8,6 @@ from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthSnapshot
 from src.core.proof_packs import (
     AI_EVIDENCE_REF_TYPE,
     REPORT_INPUT_REF_TYPE,
-    ProofPackSourceValidationError,
     build_ai_evidence_input,
     build_proof_pack_from_run,
     build_proof_pack_from_selected_alternative,
@@ -27,6 +26,7 @@ from src.api.services.proof_pack_handoff_refs import (
     hydrate_handoff_refs,
     stored_ref_to_evidence_ref,
 )
+from src.api.services.proof_pack_selected_source import resolve_selected_alternative_source
 from src.core.proof_packs.models import (
     DpmPreTradeProofPack,
     DpmProofPackEvidenceRef,
@@ -129,43 +129,22 @@ def generate_proof_pack_from_selected_alternative(
     )
     if existing is not None:
         return existing
-    alternative_set = construction_repository.get_alternative_set(
-        alternative_set_id=alternative_set_id
+    selected_source = resolve_selected_alternative_source(
+        alternative_set_id=alternative_set_id,
+        selected_alternative_id=selected_alternative_id,
+        construction_repository=construction_repository,
+        run_service=run_service,
     )
-    if alternative_set is None:
-        raise ProofPackSourceValidationError("DPM_ALTERNATIVE_SET_NOT_FOUND")
-    selection = construction_repository.get_selection(alternative_set_id=alternative_set_id)
-    selected = next(
-        (
-            alternative
-            for alternative in alternative_set.alternatives
-            if alternative.alternative_id == selected_alternative_id
-        ),
-        None,
-    )
-    if selected is None:
-        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_NOT_FOUND")
-    run = None
-    workflow_decisions = []
-    if selected.rebalance_run_id is not None:
-        try:
-            run = run_service.get_run_record(rebalance_run_id=selected.rebalance_run_id)
-            workflow_decisions = run_service.list_workflow_decision_records(
-                rebalance_run_id=selected.rebalance_run_id
-            )
-        except DpmRunNotFoundError:
-            run = None
-            workflow_decisions = []
     mandate_twin, mandate_health, mandate_evidence_gap_codes = _resolve_mandate_evidence(
         mandate_id=mandate_id,
-        portfolio_id=alternative_set.portfolio_id,
+        portfolio_id=selected_source.alternative_set.portfolio_id,
         mandate_repository=mandate_repository,
     )
     proof_pack = build_proof_pack_from_selected_alternative(
-        alternative_set=alternative_set,
+        alternative_set=selected_source.alternative_set,
         selected_alternative_id=selected_alternative_id,
-        run=run,
-        selection=selection,
+        run=selected_source.run,
+        selection=selected_source.selection,
         created_by=actor_id,
         reason=reason,
         correlation_id=correlation_id,
@@ -173,7 +152,7 @@ def generate_proof_pack_from_selected_alternative(
         mandate_twin=mandate_twin,
         mandate_health=mandate_health,
         mandate_evidence_gap_codes=mandate_evidence_gap_codes,
-        workflow_decisions=workflow_decisions,
+        workflow_decisions=selected_source.workflow_decisions,
         direct_regime_stress_context=direct_regime_stress_context,
     )
     _persist(

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -7,17 +7,17 @@ from src.core.mandate_repository import DpmMandateRepository
 from src.core.proof_packs import (
     AI_EVIDENCE_REF_TYPE,
     REPORT_INPUT_REF_TYPE,
-    build_ai_evidence_input,
     build_proof_pack_from_run,
     build_proof_pack_from_selected_alternative,
-    build_report_input,
     proof_pack_id_for_rebalance_run,
     proof_pack_id_for_selected_alternative,
 )
 from src.core.construction.models import AuthoritativeRegimeStressContext
 from src.core.proof_packs.handoffs import DpmProofPackAiEvidenceInput, DpmProofPackReportInput
-from src.api.services.portfolio_memory_context_service import (
-    build_report_portfolio_memory_context,
+from src.api.services.proof_pack_report_inputs import (
+    build_proof_pack_ai_evidence_input,
+    build_proof_pack_report_input,
+    portfolio_memory_context_for_report,
 )
 from src.api.services.proof_pack_handoff_refs import (
     ensure_handoff_refs as _ensure_handoff_refs,
@@ -34,7 +34,6 @@ from src.core.proof_packs.models import (
 )
 from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
-from src.core.portfolio_memory.handoffs import DpmPortfolioMemoryReportContext
 from src.core.rebalance_runs.service import DpmRunNotFoundError, DpmRunSupportService
 from src.core.waves.repository import DpmWaveRepository
 
@@ -47,6 +46,9 @@ class DpmProofPackReportInputNotGeneratedError(Exception):
 
 class DpmProofPackAiEvidenceInputNotGeneratedError(Exception):
     pass
+
+
+_portfolio_memory_context_for_report = portfolio_memory_context_for_report
 
 
 def generate_proof_pack_from_run(
@@ -228,15 +230,12 @@ def get_report_input(
         proof_pack_id=proof_pack_id,
         proof_pack_repository=proof_pack_repository,
     )
-    return build_report_input(
-        proof_pack,
-        portfolio_memory_context=_portfolio_memory_context_for_report(
-            portfolio_id=proof_pack.portfolio_id,
-            proof_pack_repository=proof_pack_repository,
-            wave_repository=wave_repository,
-            outcome_review_repository=outcome_review_repository,
-            mandate_repository=mandate_repository,
-        ),
+    return build_proof_pack_report_input(
+        proof_pack=proof_pack,
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_review_repository,
+        mandate_repository=mandate_repository,
     )
 
 
@@ -252,30 +251,8 @@ def get_ai_evidence_input(
         proof_pack_id=proof_pack_id,
         proof_pack_repository=proof_pack_repository,
     )
-    return build_ai_evidence_input(
-        proof_pack,
-        portfolio_memory_context=_portfolio_memory_context_for_report(
-            portfolio_id=proof_pack.portfolio_id,
-            proof_pack_repository=proof_pack_repository,
-            wave_repository=wave_repository,
-            outcome_review_repository=outcome_review_repository,
-            mandate_repository=mandate_repository,
-        ),
-    )
-
-
-def _portfolio_memory_context_for_report(
-    *,
-    portfolio_id: str,
-    proof_pack_repository: DpmProofPackRepository,
-    wave_repository: DpmWaveRepository | None,
-    outcome_review_repository: DpmOutcomeReviewRepository | None,
-    mandate_repository: DpmMandateRepository | None,
-) -> DpmPortfolioMemoryReportContext | None:
-    if wave_repository is None or outcome_review_repository is None:
-        return None
-    return build_report_portfolio_memory_context(
-        portfolio_id=portfolio_id,
+    return build_proof_pack_ai_evidence_input(
+        proof_pack=proof_pack,
         proof_pack_repository=proof_pack_repository,
         wave_repository=wave_repository,
         outcome_review_repository=outcome_review_repository,

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -19,9 +19,8 @@ from src.api.services.proof_pack_report_inputs import (
 )
 from src.api.services.proof_pack_handoff_refs import (
     ensure_handoff_refs as _ensure_handoff_refs,
-    find_stored_ref,
     hydrate_handoff_refs,
-    stored_ref_to_evidence_ref,
+    require_handoff_ref,
 )
 from src.api.services.proof_pack_mandate_evidence import resolve_mandate_evidence
 from src.api.services.proof_pack_persistence import persist_proof_pack
@@ -178,18 +177,15 @@ def get_report_input_ref(
         proof_pack_id=proof_pack_id,
         proof_pack_repository=proof_pack_repository,
     )
-    if proof_pack.report_input_ref is None:
-        stored_ref = find_stored_ref(
-            proof_pack_id=proof_pack_id,
-            ref_type=REPORT_INPUT_REF_TYPE,
-            proof_pack_repository=proof_pack_repository,
-        )
-        if stored_ref is None:
-            raise DpmProofPackReportInputNotGeneratedError(
-                "DPM_PROOF_PACK_REPORT_INPUT_NOT_GENERATED"
-            )
-        return stored_ref_to_evidence_ref(stored_ref)
-    return proof_pack.report_input_ref
+    ref = require_handoff_ref(
+        proof_pack_id=proof_pack_id,
+        hydrated_ref=proof_pack.report_input_ref,
+        ref_type=REPORT_INPUT_REF_TYPE,
+        proof_pack_repository=proof_pack_repository,
+    )
+    if ref is None:
+        raise DpmProofPackReportInputNotGeneratedError("DPM_PROOF_PACK_REPORT_INPUT_NOT_GENERATED")
+    return ref
 
 
 def get_ai_evidence_ref(
@@ -201,18 +197,17 @@ def get_ai_evidence_ref(
         proof_pack_id=proof_pack_id,
         proof_pack_repository=proof_pack_repository,
     )
-    if proof_pack.ai_evidence_ref is None:
-        stored_ref = find_stored_ref(
-            proof_pack_id=proof_pack_id,
-            ref_type=AI_EVIDENCE_REF_TYPE,
-            proof_pack_repository=proof_pack_repository,
+    ref = require_handoff_ref(
+        proof_pack_id=proof_pack_id,
+        hydrated_ref=proof_pack.ai_evidence_ref,
+        ref_type=AI_EVIDENCE_REF_TYPE,
+        proof_pack_repository=proof_pack_repository,
+    )
+    if ref is None:
+        raise DpmProofPackAiEvidenceInputNotGeneratedError(
+            "DPM_PROOF_PACK_AI_EVIDENCE_INPUT_NOT_GENERATED"
         )
-        if stored_ref is None:
-            raise DpmProofPackAiEvidenceInputNotGeneratedError(
-                "DPM_PROOF_PACK_AI_EVIDENCE_INPUT_NOT_GENERATED"
-            )
-        return stored_ref_to_evidence_ref(stored_ref)
-    return proof_pack.ai_evidence_ref
+    return ref
 
 
 def get_report_input(

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-
 from src.core.construction.repository import ConstructionRepository
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.proof_packs import (
@@ -26,6 +24,7 @@ from src.api.services.proof_pack_handoff_refs import (
     stored_ref_to_evidence_ref,
 )
 from src.api.services.proof_pack_mandate_evidence import resolve_mandate_evidence
+from src.api.services.proof_pack_persistence import persist_proof_pack
 from src.api.services.proof_pack_replay import find_replayable_proof_pack
 from src.api.services.proof_pack_selected_source import resolve_selected_alternative_source
 from src.core.proof_packs.models import (
@@ -36,8 +35,6 @@ from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.core.rebalance_runs.service import DpmRunNotFoundError, DpmRunSupportService
 from src.core.waves.repository import DpmWaveRepository
-
-PROOF_PACK_RETENTION_DAYS = 365 * 7
 
 
 class DpmProofPackReportInputNotGeneratedError(Exception):
@@ -91,7 +88,7 @@ def generate_proof_pack_from_run(
         ),
         direct_regime_stress_context=direct_regime_stress_context,
     )
-    _persist(
+    persist_proof_pack(
         proof_pack_repository=proof_pack_repository,
         proof_pack=proof_pack,
         idempotency_key=idempotency_key,
@@ -150,7 +147,7 @@ def generate_proof_pack_from_selected_alternative(
         workflow_decisions=selected_source.workflow_decisions,
         direct_regime_stress_context=direct_regime_stress_context,
     )
-    _persist(
+    persist_proof_pack(
         proof_pack_repository=proof_pack_repository,
         proof_pack=proof_pack,
         idempotency_key=idempotency_key,
@@ -272,17 +269,4 @@ def ensure_handoff_refs(
         proof_pack_repository=proof_pack_repository,
         include_report_input=include_report_input,
         include_ai_evidence_input=include_ai_evidence_input,
-    )
-
-
-def _persist(
-    *,
-    proof_pack_repository: DpmProofPackRepository,
-    proof_pack: DpmPreTradeProofPack,
-    idempotency_key: str | None,
-) -> None:
-    proof_pack_repository.save_proof_pack(
-        proof_pack=proof_pack,
-        idempotency_key=idempotency_key,
-        retention_expires_at=datetime.now(timezone.utc) + timedelta(days=PROOF_PACK_RETENTION_DAYS),
     )

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -21,10 +21,15 @@ from src.core.proof_packs.handoffs import DpmProofPackAiEvidenceInput, DpmProofP
 from src.api.services.portfolio_memory_context_service import (
     build_report_portfolio_memory_context,
 )
+from src.api.services.proof_pack_handoff_refs import (
+    ensure_handoff_refs as _ensure_handoff_refs,
+    find_stored_ref,
+    hydrate_handoff_refs,
+    stored_ref_to_evidence_ref,
+)
 from src.core.proof_packs.models import (
     DpmPreTradeProofPack,
     DpmProofPackEvidenceRef,
-    DpmProofPackStoredRef,
 )
 from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
@@ -187,7 +192,7 @@ def get_proof_pack(
     proof_pack = proof_pack_repository.get_proof_pack(proof_pack_id=proof_pack_id)
     if proof_pack is None:
         raise DpmRunNotFoundError("DPM_PROOF_PACK_NOT_FOUND")
-    return _hydrate_handoff_refs(
+    return hydrate_handoff_refs(
         proof_pack=proof_pack,
         proof_pack_repository=proof_pack_repository,
     )
@@ -203,7 +208,7 @@ def get_report_input_ref(
         proof_pack_repository=proof_pack_repository,
     )
     if proof_pack.report_input_ref is None:
-        stored_ref = _find_stored_ref(
+        stored_ref = find_stored_ref(
             proof_pack_id=proof_pack_id,
             ref_type=REPORT_INPUT_REF_TYPE,
             proof_pack_repository=proof_pack_repository,
@@ -212,7 +217,7 @@ def get_report_input_ref(
             raise DpmProofPackReportInputNotGeneratedError(
                 "DPM_PROOF_PACK_REPORT_INPUT_NOT_GENERATED"
             )
-        return _stored_ref_to_evidence_ref(stored_ref)
+        return stored_ref_to_evidence_ref(stored_ref)
     return proof_pack.report_input_ref
 
 
@@ -226,7 +231,7 @@ def get_ai_evidence_ref(
         proof_pack_repository=proof_pack_repository,
     )
     if proof_pack.ai_evidence_ref is None:
-        stored_ref = _find_stored_ref(
+        stored_ref = find_stored_ref(
             proof_pack_id=proof_pack_id,
             ref_type=AI_EVIDENCE_REF_TYPE,
             proof_pack_repository=proof_pack_repository,
@@ -235,7 +240,7 @@ def get_ai_evidence_ref(
             raise DpmProofPackAiEvidenceInputNotGeneratedError(
                 "DPM_PROOF_PACK_AI_EVIDENCE_INPUT_NOT_GENERATED"
             )
-        return _stored_ref_to_evidence_ref(stored_ref)
+        return stored_ref_to_evidence_ref(stored_ref)
     return proof_pack.ai_evidence_ref
 
 
@@ -313,23 +318,11 @@ def ensure_handoff_refs(
     include_report_input: bool,
     include_ai_evidence_input: bool,
 ) -> DpmPreTradeProofPack:
-    if include_report_input:
-        report_input = build_report_input(proof_pack)
-        _append_handoff_ref(
-            ref=report_input.evidence_ref,
-            proof_pack=proof_pack,
-            proof_pack_repository=proof_pack_repository,
-        )
-    if include_ai_evidence_input:
-        ai_evidence_input = build_ai_evidence_input(proof_pack)
-        _append_handoff_ref(
-            ref=ai_evidence_input.evidence_ref,
-            proof_pack=proof_pack,
-            proof_pack_repository=proof_pack_repository,
-        )
-    return _hydrate_handoff_refs(
+    return _ensure_handoff_refs(
         proof_pack=proof_pack,
         proof_pack_repository=proof_pack_repository,
+        include_report_input=include_report_input,
+        include_ai_evidence_input=include_ai_evidence_input,
     )
 
 
@@ -360,84 +353,3 @@ def _resolve_mandate_evidence(
     if twin.portfolio_id != portfolio_id:
         return None, None, ["DPM_MANDATE_TWIN_PORTFOLIO_MISMATCH"]
     return twin, mandate_repository.get_latest_health_snapshot(mandate_id=mandate_id), []
-
-
-def _append_handoff_ref(
-    *,
-    ref: DpmProofPackEvidenceRef,
-    proof_pack: DpmPreTradeProofPack,
-    proof_pack_repository: DpmProofPackRepository,
-) -> None:
-    existing = _find_stored_ref(
-        proof_pack_id=proof_pack.proof_pack_id,
-        ref_type=ref.ref_type,
-        proof_pack_repository=proof_pack_repository,
-    )
-    if existing is not None and existing.content_hash == ref.content_hash:
-        return
-    proof_pack_repository.append_ref(
-        ref=DpmProofPackStoredRef(
-            proof_pack_id=proof_pack.proof_pack_id,
-            ref_type=ref.ref_type,
-            ref_id=ref.ref_id,
-            source_system=ref.source_system,
-            content_hash=ref.content_hash,
-            created_at=datetime.now(timezone.utc).isoformat(),
-        )
-    )
-
-
-def _hydrate_handoff_refs(
-    *,
-    proof_pack: DpmPreTradeProofPack,
-    proof_pack_repository: DpmProofPackRepository,
-) -> DpmPreTradeProofPack:
-    report_ref = proof_pack.report_input_ref
-    ai_ref = proof_pack.ai_evidence_ref
-    stored_report_ref = _find_stored_ref(
-        proof_pack_id=proof_pack.proof_pack_id,
-        ref_type=REPORT_INPUT_REF_TYPE,
-        proof_pack_repository=proof_pack_repository,
-    )
-    stored_ai_ref = _find_stored_ref(
-        proof_pack_id=proof_pack.proof_pack_id,
-        ref_type=AI_EVIDENCE_REF_TYPE,
-        proof_pack_repository=proof_pack_repository,
-    )
-    if stored_report_ref is not None:
-        report_ref = _stored_ref_to_evidence_ref(stored_report_ref)
-    if stored_ai_ref is not None:
-        ai_ref = _stored_ref_to_evidence_ref(stored_ai_ref)
-    if report_ref == proof_pack.report_input_ref and ai_ref == proof_pack.ai_evidence_ref:
-        return proof_pack
-    return proof_pack.model_copy(
-        update={
-            "report_input_ref": report_ref,
-            "ai_evidence_ref": ai_ref,
-        }
-    )
-
-
-def _find_stored_ref(
-    *,
-    proof_pack_id: str,
-    ref_type: str,
-    proof_pack_repository: DpmProofPackRepository,
-) -> DpmProofPackStoredRef | None:
-    return next(
-        (
-            ref
-            for ref in reversed(proof_pack_repository.list_refs(proof_pack_id=proof_pack_id))
-            if ref.ref_type == ref_type
-        ),
-        None,
-    )
-
-
-def _stored_ref_to_evidence_ref(ref: DpmProofPackStoredRef) -> DpmProofPackEvidenceRef:
-    return DpmProofPackEvidenceRef(
-        ref_type=ref.ref_type,
-        ref_id=ref.ref_id,
-        source_system=ref.source_system,
-        content_hash=ref.content_hash,
-    )

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta, timezone
 
 from src.core.construction.repository import ConstructionRepository
 from src.core.mandate_repository import DpmMandateRepository
-from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthSnapshot
 from src.core.proof_packs import (
     AI_EVIDENCE_REF_TYPE,
     REPORT_INPUT_REF_TYPE,
@@ -26,6 +25,7 @@ from src.api.services.proof_pack_handoff_refs import (
     hydrate_handoff_refs,
     stored_ref_to_evidence_ref,
 )
+from src.api.services.proof_pack_mandate_evidence import resolve_mandate_evidence
 from src.api.services.proof_pack_selected_source import resolve_selected_alternative_source
 from src.core.proof_packs.models import (
     DpmPreTradeProofPack,
@@ -73,7 +73,7 @@ def generate_proof_pack_from_run(
     if existing is not None:
         return existing
     run = run_service.get_run_record(rebalance_run_id=rebalance_run_id)
-    mandate_twin, mandate_health, mandate_evidence_gap_codes = _resolve_mandate_evidence(
+    mandate_evidence = resolve_mandate_evidence(
         mandate_id=mandate_id,
         portfolio_id=run.portfolio_id,
         mandate_repository=mandate_repository,
@@ -84,9 +84,9 @@ def generate_proof_pack_from_run(
         reason=reason,
         correlation_id=correlation_id,
         mandate_id=mandate_id,
-        mandate_twin=mandate_twin,
-        mandate_health=mandate_health,
-        mandate_evidence_gap_codes=mandate_evidence_gap_codes,
+        mandate_twin=mandate_evidence.twin,
+        mandate_health=mandate_evidence.health,
+        mandate_evidence_gap_codes=mandate_evidence.gap_codes,
         workflow_decisions=run_service.list_workflow_decision_records(
             rebalance_run_id=rebalance_run_id
         ),
@@ -135,7 +135,7 @@ def generate_proof_pack_from_selected_alternative(
         construction_repository=construction_repository,
         run_service=run_service,
     )
-    mandate_twin, mandate_health, mandate_evidence_gap_codes = _resolve_mandate_evidence(
+    mandate_evidence = resolve_mandate_evidence(
         mandate_id=mandate_id,
         portfolio_id=selected_source.alternative_set.portfolio_id,
         mandate_repository=mandate_repository,
@@ -149,9 +149,9 @@ def generate_proof_pack_from_selected_alternative(
         reason=reason,
         correlation_id=correlation_id,
         mandate_id=mandate_id,
-        mandate_twin=mandate_twin,
-        mandate_health=mandate_health,
-        mandate_evidence_gap_codes=mandate_evidence_gap_codes,
+        mandate_twin=mandate_evidence.twin,
+        mandate_health=mandate_evidence.health,
+        mandate_evidence_gap_codes=mandate_evidence.gap_codes,
         workflow_decisions=selected_source.workflow_decisions,
         direct_regime_stress_context=direct_regime_stress_context,
     )
@@ -316,19 +316,3 @@ def _persist(
         idempotency_key=idempotency_key,
         retention_expires_at=datetime.now(timezone.utc) + timedelta(days=PROOF_PACK_RETENTION_DAYS),
     )
-
-
-def _resolve_mandate_evidence(
-    *,
-    mandate_id: str | None,
-    portfolio_id: str,
-    mandate_repository: DpmMandateRepository | None,
-) -> tuple[DpmMandateDigitalTwin | None, DpmMandateHealthSnapshot | None, list[str]]:
-    if mandate_id is None or mandate_repository is None:
-        return None, None, []
-    twin = mandate_repository.get_latest_mandate(mandate_id=mandate_id)
-    if twin is None:
-        return None, None, []
-    if twin.portfolio_id != portfolio_id:
-        return None, None, ["DPM_MANDATE_TWIN_PORTFOLIO_MISMATCH"]
-    return twin, mandate_repository.get_latest_health_snapshot(mandate_id=mandate_id), []

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -5,8 +5,6 @@ from src.core.mandate_repository import DpmMandateRepository
 from src.core.proof_packs import (
     AI_EVIDENCE_REF_TYPE,
     REPORT_INPUT_REF_TYPE,
-    build_proof_pack_from_run,
-    build_proof_pack_from_selected_alternative,
     proof_pack_id_for_rebalance_run,
     proof_pack_id_for_selected_alternative,
 )
@@ -21,6 +19,10 @@ from src.api.services.proof_pack_handoff_refs import (
     ensure_handoff_refs as _ensure_handoff_refs,
     hydrate_handoff_refs,
     require_handoff_ref,
+)
+from src.api.services.proof_pack_generation import (
+    build_run_proof_pack,
+    build_selected_alternative_proof_pack,
 )
 from src.api.services.proof_pack_mandate_evidence import resolve_mandate_evidence
 from src.api.services.proof_pack_persistence import persist_proof_pack
@@ -73,18 +75,16 @@ def generate_proof_pack_from_run(
         portfolio_id=run.portfolio_id,
         mandate_repository=mandate_repository,
     )
-    proof_pack = build_proof_pack_from_run(
+    proof_pack = build_run_proof_pack(
         run=run,
-        created_by=actor_id,
-        reason=reason,
-        correlation_id=correlation_id,
-        mandate_id=mandate_id,
-        mandate_twin=mandate_evidence.twin,
-        mandate_health=mandate_evidence.health,
-        mandate_evidence_gap_codes=mandate_evidence.gap_codes,
         workflow_decisions=run_service.list_workflow_decision_records(
             rebalance_run_id=rebalance_run_id
         ),
+        actor_id=actor_id,
+        reason=reason,
+        correlation_id=correlation_id,
+        mandate_id=mandate_id,
+        mandate_evidence=mandate_evidence,
         direct_regime_stress_context=direct_regime_stress_context,
     )
     persist_proof_pack(
@@ -131,19 +131,14 @@ def generate_proof_pack_from_selected_alternative(
         portfolio_id=selected_source.alternative_set.portfolio_id,
         mandate_repository=mandate_repository,
     )
-    proof_pack = build_proof_pack_from_selected_alternative(
-        alternative_set=selected_source.alternative_set,
+    proof_pack = build_selected_alternative_proof_pack(
+        selected_source=selected_source,
         selected_alternative_id=selected_alternative_id,
-        run=selected_source.run,
-        selection=selected_source.selection,
-        created_by=actor_id,
+        actor_id=actor_id,
         reason=reason,
         correlation_id=correlation_id,
         mandate_id=mandate_id,
-        mandate_twin=mandate_evidence.twin,
-        mandate_health=mandate_evidence.health,
-        mandate_evidence_gap_codes=mandate_evidence.gap_codes,
-        workflow_decisions=selected_source.workflow_decisions,
+        mandate_evidence=mandate_evidence,
         direct_regime_stress_context=direct_regime_stress_context,
     )
     persist_proof_pack(

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -26,6 +26,7 @@ from src.api.services.proof_pack_handoff_refs import (
     stored_ref_to_evidence_ref,
 )
 from src.api.services.proof_pack_mandate_evidence import resolve_mandate_evidence
+from src.api.services.proof_pack_replay import find_replayable_proof_pack
 from src.api.services.proof_pack_selected_source import resolve_selected_alternative_source
 from src.core.proof_packs.models import (
     DpmPreTradeProofPack,
@@ -61,14 +62,10 @@ def generate_proof_pack_from_run(
     proof_pack_repository: DpmProofPackRepository,
     direct_regime_stress_context: AuthoritativeRegimeStressContext | None = None,
 ) -> DpmPreTradeProofPack:
-    if idempotency_key is not None:
-        existing = proof_pack_repository.get_proof_pack_by_idempotency(
-            idempotency_key=idempotency_key
-        )
-        if existing is not None:
-            return existing
-    existing = proof_pack_repository.get_proof_pack(
-        proof_pack_id=proof_pack_id_for_rebalance_run(rebalance_run_id=rebalance_run_id)
+    existing = find_replayable_proof_pack(
+        proof_pack_id=proof_pack_id_for_rebalance_run(rebalance_run_id=rebalance_run_id),
+        idempotency_key=idempotency_key,
+        proof_pack_repository=proof_pack_repository,
     )
     if existing is not None:
         return existing
@@ -115,17 +112,13 @@ def generate_proof_pack_from_selected_alternative(
     proof_pack_repository: DpmProofPackRepository,
     direct_regime_stress_context: AuthoritativeRegimeStressContext | None = None,
 ) -> DpmPreTradeProofPack:
-    if idempotency_key is not None:
-        existing = proof_pack_repository.get_proof_pack_by_idempotency(
-            idempotency_key=idempotency_key
-        )
-        if existing is not None:
-            return existing
-    existing = proof_pack_repository.get_proof_pack(
+    existing = find_replayable_proof_pack(
         proof_pack_id=proof_pack_id_for_selected_alternative(
             alternative_set_id=alternative_set_id,
             selected_alternative_id=selected_alternative_id,
-        )
+        ),
+        idempotency_key=idempotency_key,
+        proof_pack_repository=proof_pack_repository,
     )
     if existing is not None:
         return existing

--- a/src/api/services/rebalance_async_submission_context.py
+++ b/src/api/services/rebalance_async_submission_context.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Optional
+
+from src.api.services.rebalance_async_config import resolve_async_execution_mode
+from src.api.services.rebalance_async_submission_payload import build_analyze_async_request_json
+from src.api.services.rebalance_policy_pack_execution import (
+    PolicyPackCatalogLoader,
+    resolve_execution_policy_pack_context,
+)
+from src.api.services.rebalance_policy_pack_service import load_dpm_policy_pack_catalog
+from src.api.services.rebalance_run_support_service import (
+    DpmRunSupportServiceUnavailableError,
+    get_dpm_run_support_service,
+)
+from src.api.services.rebalance_simulation_errors import (
+    DpmRebalanceAsyncOperationSupportUnavailableError,
+)
+from src.core.dpm_source_context import DpmResolvedSourceContext
+from src.core.models import BatchRebalanceRequest
+from src.core.rebalance_runs import DpmRunSupportService
+
+SupportServiceFactory = Callable[[], DpmRunSupportService]
+
+
+@dataclass(frozen=True)
+class DpmAsyncSubmissionContext:
+    service: DpmRunSupportService
+    request_json: dict[str, object]
+    execution_mode: str
+    policy_resolution_enabled: bool
+    policy_resolution_source: str
+    selected_policy_pack_id: str | None
+
+
+def build_async_submission_context(
+    *,
+    request: BatchRebalanceRequest,
+    policy_pack_id: Optional[str],
+    tenant_default_policy_pack_id: Optional[str],
+    tenant_id: Optional[str],
+    source_context: Optional[DpmResolvedSourceContext],
+    support_service_factory: SupportServiceFactory = get_dpm_run_support_service,
+    catalog_loader: PolicyPackCatalogLoader = load_dpm_policy_pack_catalog,
+) -> DpmAsyncSubmissionContext:
+    try:
+        service = support_service_factory()
+    except DpmRunSupportServiceUnavailableError as exc:
+        raise DpmRebalanceAsyncOperationSupportUnavailableError(exc.detail) from exc
+    policy_context = resolve_execution_policy_pack_context(
+        request_policy_pack_id=policy_pack_id,
+        tenant_default_policy_pack_id=tenant_default_policy_pack_id,
+        tenant_id=tenant_id,
+        surface="analyze_async",
+        catalog_loader=catalog_loader,
+        load_definition=False,
+    )
+    return DpmAsyncSubmissionContext(
+        service=service,
+        request_json=build_analyze_async_request_json(
+            request=request,
+            policy_pack_id=policy_pack_id,
+            tenant_default_policy_pack_id=tenant_default_policy_pack_id,
+            tenant_id=tenant_id,
+            source_context=source_context,
+        ),
+        execution_mode=resolve_async_execution_mode(),
+        policy_resolution_enabled=policy_context.resolution.enabled,
+        policy_resolution_source=policy_context.resolution.source,
+        selected_policy_pack_id=policy_context.resolution.selected_policy_pack_id,
+    )
+
+
+__all__ = [
+    "DpmAsyncSubmissionContext",
+    "SupportServiceFactory",
+    "build_async_submission_context",
+]

--- a/src/api/services/rebalance_batch_execution_context.py
+++ b/src/api/services/rebalance_batch_execution_context.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from src.api.services.rebalance_operation_identity import create_batch_analysis_id
+from src.api.services.rebalance_policy_pack_execution import resolve_execution_policy_pack_context
+from src.api.services.rebalance_policy_pack_service import load_dpm_policy_pack_catalog
+from src.core.rebalance.policy_packs import DpmPolicyPackDefinition
+
+
+@dataclass(frozen=True)
+class DpmBatchExecutionContext:
+    batch_id: str
+    policy_pack_definition: Optional[DpmPolicyPackDefinition]
+    policy_resolution_enabled: bool
+    policy_resolution_source: str
+    selected_policy_pack_id: str | None
+
+
+def build_batch_execution_context(
+    *,
+    request_policy_pack_id: Optional[str],
+    tenant_default_policy_pack_id: Optional[str],
+    tenant_id: Optional[str],
+) -> DpmBatchExecutionContext:
+    policy_context = resolve_execution_policy_pack_context(
+        request_policy_pack_id=request_policy_pack_id,
+        tenant_default_policy_pack_id=tenant_default_policy_pack_id,
+        tenant_id=tenant_id,
+        surface="analyze",
+        catalog_loader=load_dpm_policy_pack_catalog,
+    )
+    return DpmBatchExecutionContext(
+        batch_id=create_batch_analysis_id(),
+        policy_pack_definition=policy_context.definition,
+        policy_resolution_enabled=policy_context.resolution.enabled,
+        policy_resolution_source=policy_context.resolution.source,
+        selected_policy_pack_id=policy_context.resolution.selected_policy_pack_id,
+    )
+
+
+__all__ = ["DpmBatchExecutionContext", "build_batch_execution_context"]

--- a/src/api/services/rebalance_batch_execution_context.py
+++ b/src/api/services/rebalance_batch_execution_context.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass
 from typing import Optional
 
 from src.api.services.rebalance_operation_identity import create_batch_analysis_id
-from src.api.services.rebalance_policy_pack_execution import resolve_execution_policy_pack_context
+from src.api.services.rebalance_policy_pack_execution import (
+    PolicyPackCatalogLoader,
+    resolve_execution_policy_pack_context,
+)
 from src.api.services.rebalance_policy_pack_service import load_dpm_policy_pack_catalog
 from src.core.rebalance.policy_packs import DpmPolicyPackDefinition
 
@@ -23,13 +26,14 @@ def build_batch_execution_context(
     request_policy_pack_id: Optional[str],
     tenant_default_policy_pack_id: Optional[str],
     tenant_id: Optional[str],
+    catalog_loader: PolicyPackCatalogLoader = load_dpm_policy_pack_catalog,
 ) -> DpmBatchExecutionContext:
     policy_context = resolve_execution_policy_pack_context(
         request_policy_pack_id=request_policy_pack_id,
         tenant_default_policy_pack_id=tenant_default_policy_pack_id,
         tenant_id=tenant_id,
         surface="analyze",
-        catalog_loader=load_dpm_policy_pack_catalog,
+        catalog_loader=catalog_loader,
     )
     return DpmBatchExecutionContext(
         batch_id=create_batch_analysis_id(),

--- a/src/api/services/rebalance_operation_identity.py
+++ b/src/api/services/rebalance_operation_identity.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+
+
+EntropyProvider = Callable[[], str]
+
+
+def uuid_hex_entropy() -> str:
+    return uuid.uuid4().hex
+
+
+def resolve_rebalance_correlation_id(
+    correlation_id: str | None,
+    *,
+    entropy_provider: EntropyProvider = uuid_hex_entropy,
+) -> str:
+    if correlation_id:
+        return correlation_id
+    return f"corr_{entropy_provider()[:12]}"
+
+
+def create_batch_analysis_id(
+    *,
+    entropy_provider: EntropyProvider = uuid_hex_entropy,
+) -> str:
+    return f"batch_{entropy_provider()[:8]}"

--- a/src/api/services/rebalance_simulation_execution_context.py
+++ b/src/api/services/rebalance_simulation_execution_context.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Callable
+from typing import Optional
+
+from src.api.request_models import RebalanceRequest
+from src.api.services.rebalance_async_config import env_flag
+from src.api.services.rebalance_operation_identity import resolve_rebalance_correlation_id
+from src.api.services.rebalance_policy_pack_execution import resolve_execution_policy_pack_context
+from src.api.services.rebalance_policy_pack_service import load_dpm_policy_pack_catalog
+from src.core.common.canonical import hash_canonical_payload
+from src.core.rebalance.policy_packs import (
+    DpmPolicyPackDefinition,
+    resolve_policy_pack_replay_enabled,
+)
+
+RequestHasher = Callable[[object], str]
+
+
+@dataclass(frozen=True)
+class DpmSimulationExecutionContext:
+    request_hash: str
+    correlation_id: str
+    policy_pack_definition: Optional[DpmPolicyPackDefinition]
+    replay_enabled: bool
+    policy_resolution_enabled: bool
+    policy_resolution_source: str
+    selected_policy_pack_id: str | None
+
+
+def build_simulation_execution_context(
+    *,
+    request: RebalanceRequest,
+    correlation_id: Optional[str],
+    policy_pack_id: Optional[str],
+    tenant_default_policy_pack_id: Optional[str],
+    tenant_id: Optional[str],
+    request_hasher: RequestHasher = hash_canonical_payload,
+) -> DpmSimulationExecutionContext:
+    policy_context = resolve_execution_policy_pack_context(
+        request_policy_pack_id=policy_pack_id,
+        tenant_default_policy_pack_id=tenant_default_policy_pack_id,
+        tenant_id=tenant_id,
+        surface="simulate",
+        catalog_loader=load_dpm_policy_pack_catalog,
+    )
+    return DpmSimulationExecutionContext(
+        request_hash=request_hasher(request.model_dump(mode="json")),
+        correlation_id=resolve_rebalance_correlation_id(correlation_id),
+        policy_pack_definition=policy_context.definition,
+        replay_enabled=resolve_policy_pack_replay_enabled(
+            default_replay_enabled=env_flag("DPM_IDEMPOTENCY_REPLAY_ENABLED", True),
+            policy_pack=policy_context.definition,
+        ),
+        policy_resolution_enabled=policy_context.resolution.enabled,
+        policy_resolution_source=policy_context.resolution.source,
+        selected_policy_pack_id=policy_context.resolution.selected_policy_pack_id,
+    )
+
+
+__all__ = [
+    "DpmSimulationExecutionContext",
+    "RequestHasher",
+    "build_simulation_execution_context",
+]

--- a/src/api/services/rebalance_simulation_execution_context.py
+++ b/src/api/services/rebalance_simulation_execution_context.py
@@ -7,7 +7,10 @@ from typing import Optional
 from src.api.request_models import RebalanceRequest
 from src.api.services.rebalance_async_config import env_flag
 from src.api.services.rebalance_operation_identity import resolve_rebalance_correlation_id
-from src.api.services.rebalance_policy_pack_execution import resolve_execution_policy_pack_context
+from src.api.services.rebalance_policy_pack_execution import (
+    PolicyPackCatalogLoader,
+    resolve_execution_policy_pack_context,
+)
 from src.api.services.rebalance_policy_pack_service import load_dpm_policy_pack_catalog
 from src.core.common.canonical import hash_canonical_payload
 from src.core.rebalance.policy_packs import (
@@ -37,13 +40,14 @@ def build_simulation_execution_context(
     tenant_default_policy_pack_id: Optional[str],
     tenant_id: Optional[str],
     request_hasher: RequestHasher = hash_canonical_payload,
+    catalog_loader: PolicyPackCatalogLoader = load_dpm_policy_pack_catalog,
 ) -> DpmSimulationExecutionContext:
     policy_context = resolve_execution_policy_pack_context(
         request_policy_pack_id=policy_pack_id,
         tenant_default_policy_pack_id=tenant_default_policy_pack_id,
         tenant_id=tenant_id,
         surface="simulate",
-        catalog_loader=load_dpm_policy_pack_catalog,
+        catalog_loader=catalog_loader,
     )
     return DpmSimulationExecutionContext(
         request_hash=request_hasher(request.model_dump(mode="json")),

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -28,9 +28,6 @@ from src.api.services.rebalance_simulation_errors import (
     DpmRebalanceStatefulInputDisabledError,
 )
 from src.api.services.rebalance_policy_pack_service import load_dpm_policy_pack_catalog
-from src.api.services.rebalance_policy_pack_execution import (
-    resolve_execution_policy_pack_context,
-)
 from src.api.services.rebalance_request_envelope_resolution import (
     resolve_batch_request_envelope as resolve_batch_request_envelope_from_source,
     resolve_rebalance_request_envelope as resolve_rebalance_request_envelope_from_source,
@@ -44,8 +41,11 @@ from src.api.services.rebalance_async_config import (
 from src.api.services.rebalance_async_operation_runner import (
     run_analyze_async_operation_from_store,
 )
-from src.api.services.rebalance_async_submission_payload import build_analyze_async_request_json
 from src.api.services.rebalance_async_submission import submit_analyze_async_request
+from src.api.services.rebalance_async_submission_context import (
+    DpmAsyncSubmissionContext as DpmAsyncSubmissionContext,
+    build_async_submission_context,
+)
 from src.api.services.rebalance_async_manual_execution import (
     execute_analyze_async_operation_now,
 )
@@ -56,7 +56,6 @@ from src.api.services.rebalance_batch_execution_context import (
 from src.api.services.rebalance_batch_execution import execute_batch_scenarios
 from src.api.services.rebalance_sync_execution import execute_simulation_request
 from src.api.services.rebalance_run_support_service import (
-    DpmRunSupportServiceUnavailableError,
     get_dpm_run_support_service,
     record_dpm_run_for_support,
 )
@@ -163,6 +162,7 @@ def simulate_rebalance(
         tenant_default_policy_pack_id=tenant_default_policy_pack_id,
         tenant_id=tenant_id,
         request_hasher=hash_canonical_payload,
+        catalog_loader=load_dpm_policy_pack_catalog,
     )
     current_logger.debug(
         "Resolved lotus-manage policy pack for simulate. enabled=%s source=%s policy_pack_id=%s",
@@ -204,6 +204,7 @@ def execute_batch_analysis(
         request_policy_pack_id=request_policy_pack_id,
         tenant_default_policy_pack_id=tenant_default_policy_pack_id,
         tenant_id=tenant_id,
+        catalog_loader=load_dpm_policy_pack_catalog,
     )
     current_logger.debug(
         "Resolved lotus-manage policy pack for analyze. enabled=%s source=%s policy_pack_id=%s",
@@ -257,43 +258,33 @@ def submit_and_optionally_execute_async_analysis(
     current_logger = _resolved_logger()
     if not async_operations_enabled():
         raise DpmRebalanceAsyncOperationsDisabledError("DPM_ASYNC_OPERATIONS_DISABLED")
-    try:
-        service = get_dpm_run_support_service()
-    except DpmRunSupportServiceUnavailableError as exc:
-        raise DpmRebalanceAsyncOperationSupportUnavailableError(exc.detail) from exc
-    policy_context = resolve_execution_policy_pack_context(
-        request_policy_pack_id=policy_pack_id,
+    submission_context = build_async_submission_context(
+        request=request,
+        policy_pack_id=policy_pack_id,
         tenant_default_policy_pack_id=tenant_default_policy_pack_id,
         tenant_id=tenant_id,
-        surface="analyze_async",
+        source_context=source_context,
+        support_service_factory=get_dpm_run_support_service,
         catalog_loader=load_dpm_policy_pack_catalog,
-        load_definition=False,
     )
     current_logger.debug(
         "Resolved lotus-manage policy pack for analyze async. enabled=%s source=%s policy_pack_id=%s",
-        policy_context.resolution.enabled,
-        policy_context.resolution.source,
-        policy_context.resolution.selected_policy_pack_id,
+        submission_context.policy_resolution_enabled,
+        submission_context.policy_resolution_source,
+        submission_context.selected_policy_pack_id,
     )
-    execution_mode = resolve_async_execution_mode()
     accepted = submit_analyze_async_request(
-        service=service,
+        service=submission_context.service,
         correlation_id=correlation_id,
-        request_json=build_analyze_async_request_json(
-            request=request,
-            policy_pack_id=policy_pack_id,
-            tenant_default_policy_pack_id=tenant_default_policy_pack_id,
-            tenant_id=tenant_id,
-            source_context=source_context,
-        ),
+        request_json=submission_context.request_json,
         source_context=source_context,
-        execution_mode_label=execution_mode.lower(),
+        execution_mode_label=submission_context.execution_mode.lower(),
     )
-    if execution_mode == "ACCEPT_ONLY":
+    if submission_context.execution_mode == "ACCEPT_ONLY":
         return accepted
     run_analyze_async_operation(
         operation_id=accepted.operation_id,
-        service=service,
+        service=submission_context.service,
         execution_mode="inline",
     )
     return accepted

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -32,7 +32,6 @@ from src.api.services.rebalance_policy_pack_service import (
 )
 from src.api.services.rebalance_operation_identity import (
     create_batch_analysis_id,
-    resolve_rebalance_correlation_id,
 )
 from src.api.services.rebalance_policy_pack_execution import (
     resolve_execution_policy_pack_context,
@@ -76,8 +75,9 @@ from src.core.dpm_source_context import (
     build_rebalance_request_from_core_context,
 )
 from src.core.rebalance.engine import run_simulation
-from src.core.rebalance.policy_packs import (
-    resolve_policy_pack_replay_enabled,
+from src.api.services.rebalance_simulation_execution_context import (
+    DpmSimulationExecutionContext as DpmSimulationExecutionContext,
+    build_simulation_execution_context,
 )
 from src.core.rebalance_runs import (
     DpmAsyncAcceptedResponse,
@@ -156,36 +156,29 @@ def simulate_rebalance(
     source_context: Optional[DpmResolvedSourceContext] = None,
 ) -> RebalanceResult:
     current_logger = _resolved_logger()
-    resolved_correlation_id = resolve_rebalance_correlation_id(correlation_id)
     current_logger.info("Simulating rebalance request")
-    default_replay_enabled = env_flag("DPM_IDEMPOTENCY_REPLAY_ENABLED", True)
-    request_payload = request.model_dump(mode="json")
-    request_hash = hash_canonical_payload(request_payload)
-    policy_context = resolve_execution_policy_pack_context(
-        request_policy_pack_id=policy_pack_id,
+    execution_context = build_simulation_execution_context(
+        request=request,
+        correlation_id=correlation_id,
+        policy_pack_id=policy_pack_id,
         tenant_default_policy_pack_id=tenant_default_policy_pack_id,
         tenant_id=tenant_id,
-        surface="simulate",
-        catalog_loader=load_dpm_policy_pack_catalog,
-    )
-    replay_enabled = resolve_policy_pack_replay_enabled(
-        default_replay_enabled=default_replay_enabled,
-        policy_pack=policy_context.definition,
+        request_hasher=hash_canonical_payload,
     )
     current_logger.debug(
         "Resolved lotus-manage policy pack for simulate. enabled=%s source=%s policy_pack_id=%s",
-        policy_context.resolution.enabled,
-        policy_context.resolution.source,
-        policy_context.resolution.selected_policy_pack_id,
+        execution_context.policy_resolution_enabled,
+        execution_context.policy_resolution_source,
+        execution_context.selected_policy_pack_id,
     )
 
     return execute_simulation_request(
         request=request,
         idempotency_key=idempotency_key,
-        request_hash=request_hash,
-        correlation_id=resolved_correlation_id,
-        policy_pack_definition=policy_context.definition,
-        replay_enabled=replay_enabled,
+        request_hash=execution_context.request_hash,
+        correlation_id=execution_context.correlation_id,
+        policy_pack_definition=execution_context.policy_pack_definition,
+        replay_enabled=execution_context.replay_enabled,
         source_context=source_context,
         support_service_factory=get_dpm_run_support_service,
         run_simulation_fn=resolve_callable_override("run_simulation", run_simulation),

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -27,12 +27,7 @@ from src.api.services.rebalance_simulation_errors import (
     DpmRebalanceSupportabilityStoreUnavailableError,
     DpmRebalanceStatefulInputDisabledError,
 )
-from src.api.services.rebalance_policy_pack_service import (
-    load_dpm_policy_pack_catalog,
-)
-from src.api.services.rebalance_operation_identity import (
-    create_batch_analysis_id,
-)
+from src.api.services.rebalance_policy_pack_service import load_dpm_policy_pack_catalog
 from src.api.services.rebalance_policy_pack_execution import (
     resolve_execution_policy_pack_context,
 )
@@ -53,6 +48,10 @@ from src.api.services.rebalance_async_submission_payload import build_analyze_as
 from src.api.services.rebalance_async_submission import submit_analyze_async_request
 from src.api.services.rebalance_async_manual_execution import (
     execute_analyze_async_operation_now,
+)
+from src.api.services.rebalance_batch_execution_context import (
+    DpmBatchExecutionContext as DpmBatchExecutionContext,
+    build_batch_execution_context,
 )
 from src.api.services.rebalance_batch_execution import execute_batch_scenarios
 from src.api.services.rebalance_sync_execution import execute_simulation_request
@@ -200,22 +199,24 @@ def execute_batch_analysis(
     source_context: Optional[DpmResolvedSourceContext] = None,
 ) -> BatchRebalanceResult:
     current_logger = _resolved_logger()
-    batch_id = create_batch_analysis_id()
     current_logger.info("Analyzing scenario batch")
-
-    policy_context = resolve_execution_policy_pack_context(
+    execution_context = build_batch_execution_context(
         request_policy_pack_id=request_policy_pack_id,
         tenant_default_policy_pack_id=tenant_default_policy_pack_id,
         tenant_id=tenant_id,
-        surface="analyze",
-        catalog_loader=load_dpm_policy_pack_catalog,
+    )
+    current_logger.debug(
+        "Resolved lotus-manage policy pack for analyze. enabled=%s source=%s policy_pack_id=%s",
+        execution_context.policy_resolution_enabled,
+        execution_context.policy_resolution_source,
+        execution_context.selected_policy_pack_id,
     )
 
     return execute_batch_scenarios(
         request=request,
-        batch_id=batch_id,
+        batch_id=execution_context.batch_id,
         correlation_id=correlation_id,
-        policy_definition=policy_context.definition,
+        policy_definition=execution_context.policy_pack_definition,
         source_context=source_context,
         run_simulation_fn=resolve_callable_override("run_simulation", run_simulation),
         record_for_support=resolve_callable_override(

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 from typing import Any, Optional
 
 from src.api.request_models import (
@@ -30,6 +29,10 @@ from src.api.services.rebalance_simulation_errors import (
 )
 from src.api.services.rebalance_policy_pack_service import (
     load_dpm_policy_pack_catalog,
+)
+from src.api.services.rebalance_operation_identity import (
+    create_batch_analysis_id,
+    resolve_rebalance_correlation_id,
 )
 from src.api.services.rebalance_policy_pack_execution import (
     resolve_execution_policy_pack_context,
@@ -153,7 +156,7 @@ def simulate_rebalance(
     source_context: Optional[DpmResolvedSourceContext] = None,
 ) -> RebalanceResult:
     current_logger = _resolved_logger()
-    resolved_correlation_id = correlation_id or f"corr_{uuid.uuid4().hex[:12]}"
+    resolved_correlation_id = resolve_rebalance_correlation_id(correlation_id)
     current_logger.info("Simulating rebalance request")
     default_replay_enabled = env_flag("DPM_IDEMPOTENCY_REPLAY_ENABLED", True)
     request_payload = request.model_dump(mode="json")
@@ -204,7 +207,7 @@ def execute_batch_analysis(
     source_context: Optional[DpmResolvedSourceContext] = None,
 ) -> BatchRebalanceResult:
     current_logger = _resolved_logger()
-    batch_id = f"batch_{uuid.uuid4().hex[:8]}"
+    batch_id = create_batch_analysis_id()
     current_logger.info("Analyzing scenario batch")
 
     policy_context = resolve_execution_policy_pack_context(

--- a/src/api/services/wave_approval_transition.py
+++ b/src/api/services/wave_approval_transition.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_event_evidence import build_wave_event
+from src.api.services.wave_item_collection import wave_with_items_and_aggregate
+from src.api.services.wave_item_transitions import approve_item
+from src.api.services.wave_workflow_metadata import approval_event_metadata
+from src.core.waves import DpmRebalanceWave, WaveState, apply_wave_transition
+
+
+def build_approved_wave(
+    *,
+    wave: DpmRebalanceWave,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+) -> DpmRebalanceWave:
+    approved_items = [approve_item(item, actor_id, reason_code, comment) for item in wave.items]
+    approved_count = sum(1 for item in approved_items if item.state == "APPROVED")
+    if approved_count == 0:
+        raise DpmWaveValidationError(
+            "DPM_WAVE_APPROVAL_NO_ELIGIBLE_ITEMS",
+            f"Wave {wave.wave_id} has no selected or proof-pack-ready items to approve.",
+        )
+
+    to_state: WaveState = (
+        "APPROVED" if approved_count == len(approved_items) else "APPROVED_WITH_EXCEPTIONS"
+    )
+    candidate = wave_with_items_and_aggregate(wave=wave, items=approved_items)
+    return apply_wave_transition(
+        wave=candidate,
+        to_state=to_state,
+        event=build_wave_event(
+            wave_id=wave.wave_id,
+            from_state=wave.state,
+            to_state=to_state,
+            actor_id=actor_id,
+            correlation_id=correlation_id,
+            reason_code="WAVE_APPROVED",
+            metadata=approval_event_metadata(
+                approved_item_count=approved_count,
+                total_item_count=len(approved_items),
+                reason_code=reason_code,
+                comment=comment,
+            ),
+        ),
+    )
+
+
+__all__ = ["build_approved_wave"]

--- a/src/api/services/wave_cancel_transition.py
+++ b/src/api/services/wave_cancel_transition.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_event_evidence import build_wave_event
+from src.api.services.wave_item_collection import wave_with_items_and_aggregate
+from src.api.services.wave_item_transitions import cancel_item
+from src.api.services.wave_workflow_metadata import cancel_event_metadata
+from src.core.waves import DpmRebalanceWave, DpmWaveInvalidTransitionError, apply_wave_transition
+
+
+def build_cancelled_wave(
+    *,
+    wave: DpmRebalanceWave,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+) -> DpmRebalanceWave:
+    cancelled_items = [cancel_item(item, actor_id, reason_code, comment) for item in wave.items]
+    candidate = wave_with_items_and_aggregate(wave=wave, items=cancelled_items)
+    try:
+        return apply_wave_transition(
+            wave=candidate,
+            to_state="CANCELLED",
+            event=build_wave_event(
+                wave_id=wave.wave_id,
+                from_state=wave.state,
+                to_state="CANCELLED",
+                actor_id=actor_id,
+                correlation_id=correlation_id,
+                reason_code="WAVE_CANCELLED",
+                metadata=cancel_event_metadata(
+                    cancelled_item_count=len(cancelled_items),
+                    reason_code=reason_code,
+                    comment=comment,
+                ),
+            ),
+        )
+    except DpmWaveInvalidTransitionError as exc:
+        raise DpmWaveValidationError(
+            "DPM_WAVE_CANCEL_INVALID_STATE",
+            f"Wave {wave.wave_id} cannot be cancelled from state {wave.state}.",
+        ) from exc
+
+
+__all__ = ["build_cancelled_wave"]

--- a/src/api/services/wave_construction_selection.py
+++ b/src/api/services/wave_construction_selection.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from src.api.services import construction_service
+from src.api.services.wave_errors import DpmWaveLookupError
+from src.core.construction.repository import ConstructionRepository
+
+
+def select_construction_alternative_for_wave(
+    *,
+    repository: ConstructionRepository,
+    alternative_set_id: str,
+    alternative_id: str,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+) -> None:
+    try:
+        construction_service.select_construction_alternative(
+            repository=repository,
+            alternative_set_id=alternative_set_id,
+            alternative_id=alternative_id,
+            actor_id=actor_id,
+            reason_code=reason_code,
+            comment=comment,
+            correlation_id=correlation_id,
+        )
+    except Exception as exc:
+        raise DpmWaveLookupError("DPM_CONSTRUCTION_ALTERNATIVE_NOT_FOUND", str(exc)) from exc
+
+
+__all__ = ["select_construction_alternative_for_wave"]

--- a/src/api/services/wave_creation.py
+++ b/src/api/services/wave_creation.py
@@ -1,3 +1,5 @@
+import uuid
+
 from src.api.services.wave_event_evidence import (
     build_wave_event,
     idempotency_key_hash,
@@ -25,6 +27,10 @@ def create_wave_request_hash(
             "portfolios": portfolios,
         }
     )
+
+
+def create_created_wave_id() -> str:
+    return f"dwv_{uuid.uuid4().hex[:12]}"
 
 
 def promote_preview_to_created_wave(
@@ -60,4 +66,8 @@ def promote_preview_to_created_wave(
     )
 
 
-__all__ = ["create_wave_request_hash", "promote_preview_to_created_wave"]
+__all__ = [
+    "create_created_wave_id",
+    "create_wave_request_hash",
+    "promote_preview_to_created_wave",
+]

--- a/src/api/services/wave_handoff_transition.py
+++ b/src/api/services/wave_handoff_transition.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_event_evidence import build_wave_event
+from src.api.services.wave_handoff_evidence import build_handoff_ref
+from src.api.services.wave_item_collection import wave_with_items_and_aggregate
+from src.api.services.wave_item_transitions import handoff_item
+from src.api.services.wave_workflow_metadata import handoff_event_metadata
+from src.core.waves import DpmRebalanceWave, apply_wave_transition
+
+
+def build_handoff_ready_wave(
+    *,
+    wave: DpmRebalanceWave,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+) -> DpmRebalanceWave:
+    handoff_items = [handoff_item(item, actor_id, reason_code, comment) for item in wave.items]
+    handoff_item_ids = [
+        item.wave_item_id for item in handoff_items if item.state == "HANDOFF_READY"
+    ]
+    if not handoff_item_ids:
+        raise DpmWaveValidationError(
+            "DPM_WAVE_HANDOFF_NO_ELIGIBLE_ITEMS",
+            f"Wave {wave.wave_id} has no staged items for operations handoff.",
+        )
+
+    handoff_ref = build_handoff_ref(
+        wave_id=wave.wave_id,
+        item_ids=handoff_item_ids,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        correlation_id=correlation_id,
+        comment=comment,
+    )
+    candidate = wave_with_items_and_aggregate(
+        wave=wave,
+        items=handoff_items,
+        extra_updates={"handoff_refs": [*wave.handoff_refs, handoff_ref]},
+    )
+    return apply_wave_transition(
+        wave=candidate,
+        to_state="HANDOFF_READY",
+        event=build_wave_event(
+            wave_id=wave.wave_id,
+            from_state="STAGED",
+            to_state="HANDOFF_READY",
+            actor_id=actor_id,
+            correlation_id=correlation_id,
+            reason_code="WAVE_HANDOFF_READY",
+            metadata=handoff_event_metadata(
+                handoff_ref=handoff_ref,
+                handoff_item_count=len(handoff_item_ids),
+                reason_code=reason_code,
+                comment=comment,
+            ),
+        ),
+    )
+
+
+__all__ = ["build_handoff_ready_wave"]

--- a/src/api/services/wave_item_collection.py
+++ b/src/api/services/wave_item_collection.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
+
+
+def wave_with_items_and_aggregate(
+    *,
+    wave: DpmRebalanceWave,
+    items: list[DpmRebalanceWaveItem],
+    extra_updates: dict[str, object] | None = None,
+) -> DpmRebalanceWave:
+    return wave.model_copy(
+        update={
+            "items": items,
+            "aggregate_metrics": aggregate_wave_items(items),
+            **(extra_updates or {}),
+        },
+        deep=True,
+    )
+
+
+__all__ = ["wave_with_items_and_aggregate"]

--- a/src/api/services/wave_item_selection_transition.py
+++ b/src/api/services/wave_item_selection_transition.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from src.api.services.wave_event_append import append_same_state_event
+from src.api.services.wave_event_evidence import build_wave_event
+from src.api.services.wave_item_collection import wave_with_items_and_aggregate
+from src.api.services.wave_selection_item import with_selection_and_proof_pack
+from src.api.services.wave_workflow_metadata import selection_event_metadata
+from src.core.construction.repository import ConstructionRepository
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.proof_packs.repository import DpmProofPackRepository
+from src.core.rebalance_runs.service import DpmRunSupportService
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
+
+
+def build_wave_with_selected_item_alternative(
+    *,
+    wave: DpmRebalanceWave,
+    selected_item: DpmRebalanceWaveItem,
+    alternative_id: str,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+    generate_proof_pack: bool,
+    construction_repository: ConstructionRepository,
+    proof_pack_repository: DpmProofPackRepository,
+    mandate_repository: DpmMandateRepository,
+    run_service: DpmRunSupportService,
+) -> DpmRebalanceWave:
+    assert selected_item.alternative_set_id is not None
+    updated_item = with_selection_and_proof_pack(
+        item=selected_item,
+        alternative_id=alternative_id,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+        generate_proof_pack=generate_proof_pack,
+        construction_repository=construction_repository,
+        proof_pack_repository=proof_pack_repository,
+        mandate_repository=mandate_repository,
+        run_service=run_service,
+    )
+    updated_items = [
+        updated_item if item.wave_item_id == selected_item.wave_item_id else item
+        for item in wave.items
+    ]
+    return append_same_state_event(
+        wave=wave_with_items_and_aggregate(wave=wave, items=updated_items),
+        event=build_wave_event(
+            wave_id=wave.wave_id,
+            from_state=wave.state,
+            to_state=wave.state,
+            actor_id=actor_id,
+            correlation_id=correlation_id,
+            reason_code="WAVE_ITEM_ALTERNATIVE_SELECTED",
+            event_type="ITEM_SELECTION",
+            metadata=selection_event_metadata(
+                wave_item_id=selected_item.wave_item_id,
+                alternative_set_id=selected_item.alternative_set_id,
+                selected_alternative_id=alternative_id,
+                proof_pack_id=updated_item.proof_pack_id,
+                proof_pack_state=updated_item.diagnostics.get("proof_pack_state"),
+            ),
+        ),
+    )
+
+
+__all__ = ["build_wave_with_selected_item_alternative"]

--- a/src/api/services/wave_report_input.py
+++ b/src/api/services/wave_report_input.py
@@ -1,0 +1,42 @@
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_proof_pack_posture import proof_pack_posture_for_wave
+from src.api.services.wave_report_context import portfolio_memory_context_for_report
+from src.api.services.wave_supportability_payload import wave_supportability_payload
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.outcomes.repository import DpmOutcomeReviewRepository
+from src.core.proof_packs.repository import DpmProofPackRepository
+from src.core.waves import (
+    DpmRebalanceWave,
+    DpmWaveReportInput,
+    DpmWaveReportInputBoundaryError,
+    DpmWaveRepository,
+    build_wave_report_input,
+)
+
+
+def build_report_input_for_wave(
+    *,
+    wave: DpmRebalanceWave,
+    wave_repository: DpmWaveRepository,
+    proof_pack_repository: DpmProofPackRepository | None = None,
+    outcome_review_repository: DpmOutcomeReviewRepository | None = None,
+    mandate_repository: DpmMandateRepository | None = None,
+) -> DpmWaveReportInput:
+    try:
+        return build_wave_report_input(
+            wave=wave,
+            supportability=wave_supportability_payload(wave),
+            proof_pack_posture=proof_pack_posture_for_wave(wave=wave),
+            portfolio_memory_context=portfolio_memory_context_for_report(
+                wave=wave,
+                proof_pack_repository=proof_pack_repository,
+                wave_repository=wave_repository,
+                outcome_review_repository=outcome_review_repository,
+                mandate_repository=mandate_repository,
+            ),
+        )
+    except DpmWaveReportInputBoundaryError as exc:
+        raise DpmWaveValidationError("DPM_WAVE_EXTERNAL_EXECUTION_BOUNDARY", str(exc)) from exc
+
+
+__all__ = ["build_report_input_for_wave"]

--- a/src/api/services/wave_selection_guard.py
+++ b/src/api/services/wave_selection_guard.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from src.api.services.wave_errors import DpmWaveLookupError, DpmWaveValidationError
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
+
+
+def selectable_wave_item(
+    *,
+    wave: DpmRebalanceWave,
+    wave_item_id: str,
+) -> DpmRebalanceWaveItem:
+    selected_item = next((item for item in wave.items if item.wave_item_id == wave_item_id), None)
+    if selected_item is None:
+        raise DpmWaveLookupError("DPM_WAVE_ITEM_NOT_FOUND", f"Wave item {wave_item_id} not found.")
+    if selected_item.alternative_set_id is None:
+        raise DpmWaveValidationError(
+            "DPM_WAVE_ITEM_ALTERNATIVES_MISSING",
+            f"Wave item {wave_item_id} has no generated alternatives.",
+        )
+    return selected_item
+
+
+__all__ = ["selectable_wave_item"]

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -33,7 +33,7 @@ from src.api.services.wave_persistence import (
 )
 from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_proof_pack_posture import proof_pack_posture_for_wave
-from src.api.services.wave_report_context import portfolio_memory_context_for_report
+from src.api.services.wave_report_input import build_report_input_for_wave
 from src.api.services.wave_selection_guard import selectable_wave_item as _selectable_wave_item
 from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation import build_simulated_wave
@@ -65,9 +65,7 @@ from src.core.rebalance_runs.service import DpmRunSupportService
 from src.core.waves import (
     DpmRebalanceWave,
     DpmWaveRepository,
-    DpmWaveReportInputBoundaryError,
     DpmWaveReportInput,
-    build_wave_report_input,
 )
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.infrastructure.risk_authority import LotusRiskAuthorityClient
@@ -493,20 +491,10 @@ def get_report_input(
     mandate_repository: DpmMandateRepository | None = None,
 ) -> DpmWaveReportInput:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    supportability = wave_supportability_payload(wave)
-    proof_pack_posture_payload = proof_pack_posture_for_wave(wave=wave)
-    try:
-        return build_wave_report_input(
-            wave=wave,
-            supportability=supportability,
-            proof_pack_posture=proof_pack_posture_payload,
-            portfolio_memory_context=portfolio_memory_context_for_report(
-                wave=wave,
-                proof_pack_repository=proof_pack_repository,
-                wave_repository=wave_repository,
-                outcome_review_repository=outcome_review_repository,
-                mandate_repository=mandate_repository,
-            ),
-        )
-    except DpmWaveReportInputBoundaryError as exc:
-        raise DpmWaveValidationError("DPM_WAVE_EXTERNAL_EXECUTION_BOUNDARY", str(exc)) from exc
+    return build_report_input_for_wave(
+        wave=wave,
+        wave_repository=wave_repository,
+        proof_pack_repository=proof_pack_repository,
+        outcome_review_repository=outcome_review_repository,
+        mandate_repository=mandate_repository,
+    )

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -1,9 +1,11 @@
 import uuid
 
 from src.api.request_models import RebalanceRequest
-from src.api.services import construction_service
 from src.api.services.wave_aggregate_metrics import (
     simulation_result_state,
+)
+from src.api.services.wave_construction_selection import (
+    select_construction_alternative_for_wave as _select_construction_alternative_for_wave,
 )
 from src.api.services.wave_creation import (
     create_wave_request_hash as _create_wave_request_hash,
@@ -257,18 +259,15 @@ def select_wave_item_alternative(
     )
     selected_item = _selectable_wave_item(wave=wave, wave_item_id=wave_item_id)
     assert selected_item.alternative_set_id is not None
-    try:
-        construction_service.select_construction_alternative(
-            repository=construction_repository,
-            alternative_set_id=selected_item.alternative_set_id,
-            alternative_id=alternative_id,
-            actor_id=actor_id,
-            reason_code=reason_code,
-            comment=comment,
-            correlation_id=correlation_id,
-        )
-    except Exception as exc:
-        raise DpmWaveLookupError("DPM_CONSTRUCTION_ALTERNATIVE_NOT_FOUND", str(exc)) from exc
+    _select_construction_alternative_for_wave(
+        repository=construction_repository,
+        alternative_set_id=selected_item.alternative_set_id,
+        alternative_id=alternative_id,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+    )
 
     updated_item = _with_selection_and_proof_pack(
         item=selected_item,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -12,20 +12,19 @@ from src.api.services.wave_creation import (
     create_wave_request_hash as _create_wave_request_hash,
     promote_preview_to_created_wave as _promote_preview_to_created_wave,
 )
-from src.api.services.wave_event_evidence import (
-    build_wave_event as _event,
-)
-from src.api.services.wave_event_append import append_same_state_event as _append_event
 from src.api.services.wave_errors import (
     DpmWaveLookupError as DpmWaveLookupError,
     DpmWaveValidationError as DpmWaveValidationError,
 )
 from src.api.services.wave_detail_projection import wave_detail_payload, wave_items_payload
+from src.api.services.wave_event_append import append_same_state_event
+from src.api.services.wave_event_evidence import build_wave_event
 from src.api.services.wave_handoff_transition import (
     build_handoff_ready_wave as _build_handoff_ready_wave,
 )
-from src.api.services.wave_item_collection import (
-    wave_with_items_and_aggregate as _wave_with_items_and_aggregate,
+from src.api.services.wave_item_collection import wave_with_items_and_aggregate
+from src.api.services.wave_item_selection_transition import (
+    build_wave_with_selected_item_alternative as _build_wave_with_selected_item_alternative,
 )
 from src.api.services.wave_lookup import get_wave_or_raise as _get_wave_or_raise
 from src.api.services.wave_persistence import (
@@ -35,9 +34,6 @@ from src.api.services.wave_persistence import (
 from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_proof_pack_posture import proof_pack_posture_for_wave
 from src.api.services.wave_report_context import portfolio_memory_context_for_report
-from src.api.services.wave_selection_item import (
-    with_selection_and_proof_pack as _with_selection_and_proof_pack,
-)
 from src.api.services.wave_selection_guard import selectable_wave_item as _selectable_wave_item
 from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation import build_simulated_wave
@@ -58,7 +54,7 @@ from src.api.services.wave_workflow_metadata import (
     approval_event_metadata,
     cancel_event_metadata,
     handoff_event_metadata,
-    selection_event_metadata as _selection_event_metadata,
+    selection_event_metadata,
     stage_event_metadata,
 )
 from src.core.construction.repository import ConstructionRepository
@@ -82,6 +78,10 @@ _approval_event_metadata = approval_event_metadata
 _stage_event_metadata = stage_event_metadata
 _handoff_event_metadata = handoff_event_metadata
 _cancel_event_metadata = cancel_event_metadata
+_selection_event_metadata = selection_event_metadata
+_event = build_wave_event
+_append_event = append_same_state_event
+_wave_with_items_and_aggregate = wave_with_items_and_aggregate
 
 
 def preview_wave(
@@ -268,8 +268,9 @@ def select_wave_item_alternative(
         correlation_id=correlation_id,
     )
 
-    updated_item = _with_selection_and_proof_pack(
-        item=selected_item,
+    updated = _build_wave_with_selected_item_alternative(
+        wave=wave,
+        selected_item=selected_item,
         alternative_id=alternative_id,
         actor_id=actor_id,
         reason_code=reason_code,
@@ -280,28 +281,6 @@ def select_wave_item_alternative(
         proof_pack_repository=proof_pack_repository,
         mandate_repository=mandate_repository,
         run_service=run_service,
-    )
-    updated_items = [
-        updated_item if item.wave_item_id == wave_item_id else item for item in wave.items
-    ]
-    updated = _append_event(
-        wave=_wave_with_items_and_aggregate(wave=wave, items=updated_items),
-        event=_event(
-            wave_id=wave.wave_id,
-            from_state=wave.state,
-            to_state=wave.state,
-            actor_id=actor_id,
-            correlation_id=correlation_id,
-            reason_code="WAVE_ITEM_ALTERNATIVE_SELECTED",
-            event_type="ITEM_SELECTION",
-            metadata=_selection_event_metadata(
-                wave_item_id=wave_item_id,
-                alternative_set_id=selected_item.alternative_set_id,
-                selected_alternative_id=alternative_id,
-                proof_pack_id=updated_item.proof_pack_id,
-                proof_pack_state=updated_item.diagnostics.get("proof_pack_state"),
-            ),
-        ),
     )
     _update_wave_or_raise(
         wave_repository=wave_repository,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -1,5 +1,3 @@
-import uuid
-
 from src.api.request_models import RebalanceRequest
 from src.api.services.wave_aggregate_metrics import (
     simulation_result_state,
@@ -8,6 +6,7 @@ from src.api.services.wave_construction_selection import (
     select_construction_alternative_for_wave as _select_construction_alternative_for_wave,
 )
 from src.api.services.wave_creation import (
+    create_created_wave_id as _create_created_wave_id,
     create_wave_request_hash as _create_wave_request_hash,
     promote_preview_to_created_wave as _promote_preview_to_created_wave,
 )
@@ -145,7 +144,7 @@ def create_wave(
     )
     wave = _promote_preview_to_created_wave(
         preview=preview,
-        wave_id=f"dwv_{uuid.uuid4().hex[:12]}",
+        wave_id=_create_created_wave_id(),
         actor_id=actor_id,
         correlation_id=correlation_id,
         idempotency_key=idempotency_key,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -58,6 +58,7 @@ from src.api.services.wave_workflow_metadata import (
     approval_event_metadata as _approval_event_metadata,
     cancel_event_metadata as _cancel_event_metadata,
     handoff_event_metadata as _handoff_event_metadata,
+    selection_event_metadata as _selection_event_metadata,
     stage_event_metadata as _stage_event_metadata,
 )
 from src.core.construction.repository import ConstructionRepository
@@ -295,13 +296,13 @@ def select_wave_item_alternative(
             correlation_id=correlation_id,
             reason_code="WAVE_ITEM_ALTERNATIVE_SELECTED",
             event_type="ITEM_SELECTION",
-            metadata={
-                "wave_item_id": wave_item_id,
-                "alternative_set_id": selected_item.alternative_set_id,
-                "selected_alternative_id": alternative_id,
-                "proof_pack_id": updated_item.proof_pack_id,
-                "proof_pack_state": updated_item.diagnostics.get("proof_pack_state"),
-            },
+            metadata=_selection_event_metadata(
+                wave_item_id=wave_item_id,
+                alternative_set_id=selected_item.alternative_set_id,
+                selected_alternative_id=alternative_id,
+                proof_pack_id=updated_item.proof_pack_id,
+                proof_pack_state=updated_item.diagnostics.get("proof_pack_state"),
+            ),
         ),
     )
     _update_wave_or_raise(

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -3,7 +3,6 @@ import uuid
 from src.api.request_models import RebalanceRequest
 from src.api.services import construction_service
 from src.api.services.wave_aggregate_metrics import (
-    aggregate_wave_items as _aggregate,
     simulation_result_state,
 )
 from src.api.services.wave_creation import (
@@ -25,6 +24,9 @@ from src.api.services.wave_item_transitions import (
     cancel_item as _cancel_item,
     handoff_item as _handoff_item,
     stage_item as _stage_item,
+)
+from src.api.services.wave_item_collection import (
+    wave_with_items_and_aggregate as _wave_with_items_and_aggregate,
 )
 from src.api.services.wave_lookup import get_wave_or_raise as _get_wave_or_raise
 from src.api.services.wave_persistence import (
@@ -273,13 +275,7 @@ def select_wave_item_alternative(
         updated_item if item.wave_item_id == wave_item_id else item for item in wave.items
     ]
     updated = _append_event(
-        wave=wave.model_copy(
-            update={
-                "items": updated_items,
-                "aggregate_metrics": _aggregate(updated_items),
-            },
-            deep=True,
-        ),
+        wave=_wave_with_items_and_aggregate(wave=wave, items=updated_items),
         event=_event(
             wave_id=wave.wave_id,
             from_state=wave.state,
@@ -334,13 +330,7 @@ def approve_wave(
     to_state: WaveState = (
         "APPROVED" if approved_count == len(approved_items) else "APPROVED_WITH_EXCEPTIONS"
     )
-    candidate = wave.model_copy(
-        update={
-            "items": approved_items,
-            "aggregate_metrics": _aggregate(approved_items),
-        },
-        deep=True,
-    )
+    candidate = _wave_with_items_and_aggregate(wave=wave, items=approved_items)
     approved = apply_wave_transition(
         wave=candidate,
         to_state=to_state,
@@ -393,13 +383,7 @@ def stage_wave(
             f"Wave {wave_id} has no approved items to stage.",
         )
 
-    candidate = wave.model_copy(
-        update={
-            "items": staged_items,
-            "aggregate_metrics": _aggregate(staged_items),
-        },
-        deep=True,
-    )
+    candidate = _wave_with_items_and_aggregate(wave=wave, items=staged_items)
     staged = apply_wave_transition(
         wave=candidate,
         to_state="STAGED",
@@ -461,13 +445,10 @@ def handoff_wave(
         correlation_id=correlation_id,
         comment=comment,
     )
-    candidate = wave.model_copy(
-        update={
-            "items": handoff_items,
-            "aggregate_metrics": _aggregate(handoff_items),
-            "handoff_refs": [*wave.handoff_refs, handoff_ref],
-        },
-        deep=True,
+    candidate = _wave_with_items_and_aggregate(
+        wave=wave,
+        items=handoff_items,
+        extra_updates={"handoff_refs": [*wave.handoff_refs, handoff_ref]},
     )
     handoff_ready = apply_wave_transition(
         wave=candidate,
@@ -510,13 +491,7 @@ def cancel_wave(
         return wave, True
 
     cancelled_items = [_cancel_item(item, actor_id, reason_code, comment) for item in wave.items]
-    candidate = wave.model_copy(
-        update={
-            "items": cancelled_items,
-            "aggregate_metrics": _aggregate(cancelled_items),
-        },
-        deep=True,
-    )
+    candidate = _wave_with_items_and_aggregate(wave=wave, items=cancelled_items)
     try:
         cancelled = apply_wave_transition(
             wave=candidate,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -3,6 +3,7 @@ from src.api.services.wave_aggregate_metrics import (
     simulation_result_state,
 )
 from src.api.services.wave_approval_transition import build_approved_wave as _build_approved_wave
+from src.api.services.wave_cancel_transition import build_cancelled_wave as _build_cancelled_wave
 from src.api.services.wave_construction_selection import (
     select_construction_alternative_for_wave as _select_construction_alternative_for_wave,
 )
@@ -20,9 +21,6 @@ from src.api.services.wave_errors import (
     DpmWaveValidationError as DpmWaveValidationError,
 )
 from src.api.services.wave_detail_projection import wave_detail_payload, wave_items_payload
-from src.api.services.wave_item_transitions import (
-    cancel_item as _cancel_item,
-)
 from src.api.services.wave_handoff_transition import (
     build_handoff_ready_wave as _build_handoff_ready_wave,
 )
@@ -58,7 +56,7 @@ from src.api.services.wave_supportability_payload import (
 from src.api.services.wave_trigger_validation import validate_trigger_or_raise
 from src.api.services.wave_workflow_metadata import (
     approval_event_metadata,
-    cancel_event_metadata as _cancel_event_metadata,
+    cancel_event_metadata,
     handoff_event_metadata,
     selection_event_metadata as _selection_event_metadata,
     stage_event_metadata,
@@ -70,11 +68,9 @@ from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.rebalance_runs.service import DpmRunSupportService
 from src.core.waves import (
     DpmRebalanceWave,
-    DpmWaveInvalidTransitionError,
     DpmWaveRepository,
     DpmWaveReportInputBoundaryError,
     DpmWaveReportInput,
-    apply_wave_transition,
     build_wave_report_input,
 )
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
@@ -85,6 +81,7 @@ _validate_trigger = validate_trigger_or_raise
 _approval_event_metadata = approval_event_metadata
 _stage_event_metadata = stage_event_metadata
 _handoff_event_metadata = handoff_event_metadata
+_cancel_event_metadata = cancel_event_metadata
 
 
 def preview_wave(
@@ -432,31 +429,13 @@ def cancel_wave(
     if _wave_state_is_idempotent(wave, replay_states={"CANCELLED"}):
         return wave, True
 
-    cancelled_items = [_cancel_item(item, actor_id, reason_code, comment) for item in wave.items]
-    candidate = _wave_with_items_and_aggregate(wave=wave, items=cancelled_items)
-    try:
-        cancelled = apply_wave_transition(
-            wave=candidate,
-            to_state="CANCELLED",
-            event=_event(
-                wave_id=wave.wave_id,
-                from_state=wave.state,
-                to_state="CANCELLED",
-                actor_id=actor_id,
-                correlation_id=correlation_id,
-                reason_code="WAVE_CANCELLED",
-                metadata=_cancel_event_metadata(
-                    cancelled_item_count=len(cancelled_items),
-                    reason_code=reason_code,
-                    comment=comment,
-                ),
-            ),
-        )
-    except DpmWaveInvalidTransitionError as exc:
-        raise DpmWaveValidationError(
-            "DPM_WAVE_CANCEL_INVALID_STATE",
-            f"Wave {wave_id} cannot be cancelled from state {wave.state}.",
-        ) from exc
+    cancelled = _build_cancelled_wave(
+        wave=wave,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+    )
     _update_wave_or_raise(
         wave_repository=wave_repository,
         wave=cancelled,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -20,10 +20,11 @@ from src.api.services.wave_errors import (
     DpmWaveValidationError as DpmWaveValidationError,
 )
 from src.api.services.wave_detail_projection import wave_detail_payload, wave_items_payload
-from src.api.services.wave_handoff_evidence import build_handoff_ref as _handoff_ref
 from src.api.services.wave_item_transitions import (
     cancel_item as _cancel_item,
-    handoff_item as _handoff_item,
+)
+from src.api.services.wave_handoff_transition import (
+    build_handoff_ready_wave as _build_handoff_ready_wave,
 )
 from src.api.services.wave_item_collection import (
     wave_with_items_and_aggregate as _wave_with_items_and_aggregate,
@@ -58,7 +59,7 @@ from src.api.services.wave_trigger_validation import validate_trigger_or_raise
 from src.api.services.wave_workflow_metadata import (
     approval_event_metadata,
     cancel_event_metadata as _cancel_event_metadata,
-    handoff_event_metadata as _handoff_event_metadata,
+    handoff_event_metadata,
     selection_event_metadata as _selection_event_metadata,
     stage_event_metadata,
 )
@@ -83,6 +84,7 @@ _simulation_result_state = simulation_result_state
 _validate_trigger = validate_trigger_or_raise
 _approval_event_metadata = approval_event_metadata
 _stage_event_metadata = stage_event_metadata
+_handoff_event_metadata = handoff_event_metadata
 
 
 def preview_wave(
@@ -402,46 +404,12 @@ def handoff_wave(
         action_phrase="create handoff evidence",
     )
 
-    handoff_items = [_handoff_item(item, actor_id, reason_code, comment) for item in wave.items]
-    handoff_item_ids = [
-        item.wave_item_id for item in handoff_items if item.state == "HANDOFF_READY"
-    ]
-    if not handoff_item_ids:
-        raise DpmWaveValidationError(
-            "DPM_WAVE_HANDOFF_NO_ELIGIBLE_ITEMS",
-            f"Wave {wave_id} has no staged items for operations handoff.",
-        )
-
-    handoff_ref = _handoff_ref(
-        wave_id=wave.wave_id,
-        item_ids=handoff_item_ids,
+    handoff_ready = _build_handoff_ready_wave(
+        wave=wave,
         actor_id=actor_id,
         reason_code=reason_code,
-        correlation_id=correlation_id,
         comment=comment,
-    )
-    candidate = _wave_with_items_and_aggregate(
-        wave=wave,
-        items=handoff_items,
-        extra_updates={"handoff_refs": [*wave.handoff_refs, handoff_ref]},
-    )
-    handoff_ready = apply_wave_transition(
-        wave=candidate,
-        to_state="HANDOFF_READY",
-        event=_event(
-            wave_id=wave.wave_id,
-            from_state="STAGED",
-            to_state="HANDOFF_READY",
-            actor_id=actor_id,
-            correlation_id=correlation_id,
-            reason_code="WAVE_HANDOFF_READY",
-            metadata=_handoff_event_metadata(
-                handoff_ref=handoff_ref,
-                handoff_item_count=len(handoff_item_ids),
-                reason_code=reason_code,
-                comment=comment,
-            ),
-        ),
+        correlation_id=correlation_id,
     )
     _update_wave_or_raise(
         wave_repository=wave_repository,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -39,6 +39,7 @@ from src.api.services.wave_report_context import portfolio_memory_context_for_re
 from src.api.services.wave_selection_item import (
     with_selection_and_proof_pack as _with_selection_and_proof_pack,
 )
+from src.api.services.wave_selection_guard import selectable_wave_item as _selectable_wave_item
 from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation import build_simulated_wave
 from src.api.services.wave_simulation_item import (
@@ -247,14 +248,8 @@ def select_wave_item_alternative(
         error_code="DPM_WAVE_SELECTION_INVALID_STATE",
         action_phrase="record alternative selection",
     )
-    selected_item = next((item for item in wave.items if item.wave_item_id == wave_item_id), None)
-    if selected_item is None:
-        raise DpmWaveLookupError("DPM_WAVE_ITEM_NOT_FOUND", f"Wave item {wave_item_id} not found.")
-    if selected_item.alternative_set_id is None:
-        raise DpmWaveValidationError(
-            "DPM_WAVE_ITEM_ALTERNATIVES_MISSING",
-            f"Wave item {wave_item_id} has no generated alternatives.",
-        )
+    selected_item = _selectable_wave_item(wave=wave, wave_item_id=wave_item_id)
+    assert selected_item.alternative_set_id is not None
     try:
         construction_service.select_construction_alternative(
             repository=construction_repository,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -54,6 +54,12 @@ from src.api.services.wave_supportability_payload import (
     wave_supportability_payload as _wave_supportability_payload,
 )
 from src.api.services.wave_trigger_validation import validate_trigger_or_raise
+from src.api.services.wave_workflow_metadata import (
+    approval_event_metadata as _approval_event_metadata,
+    cancel_event_metadata as _cancel_event_metadata,
+    handoff_event_metadata as _handoff_event_metadata,
+    stage_event_metadata as _stage_event_metadata,
+)
 from src.core.construction.repository import ConstructionRepository
 from src.core.construction.vocabulary import ConstructionMethod
 from src.core.mandate_repository import DpmMandateRepository
@@ -350,12 +356,12 @@ def approve_wave(
             actor_id=actor_id,
             correlation_id=correlation_id,
             reason_code="WAVE_APPROVED",
-            metadata={
-                "approved_item_count": approved_count,
-                "exception_item_count": len(approved_items) - approved_count,
-                "approval_reason_code": reason_code,
-                **({"comment": comment} if comment else {}),
-            },
+            metadata=_approval_event_metadata(
+                approved_item_count=approved_count,
+                total_item_count=len(approved_items),
+                reason_code=reason_code,
+                comment=comment,
+            ),
         ),
     )
     _update_wave_or_raise(
@@ -404,11 +410,11 @@ def stage_wave(
             actor_id=actor_id,
             correlation_id=correlation_id,
             reason_code="WAVE_STAGED",
-            metadata={
-                "staged_item_count": staged_count,
-                "stage_reason_code": reason_code,
-                **({"comment": comment} if comment else {}),
-            },
+            metadata=_stage_event_metadata(
+                staged_item_count=staged_count,
+                reason_code=reason_code,
+                comment=comment,
+            ),
         ),
     )
     _update_wave_or_raise(
@@ -471,13 +477,12 @@ def handoff_wave(
             actor_id=actor_id,
             correlation_id=correlation_id,
             reason_code="WAVE_HANDOFF_READY",
-            metadata={
-                "handoff_ref_id": handoff_ref.handoff_ref_id,
-                "handoff_item_count": len(handoff_item_ids),
-                "external_execution_claimed": False,
-                "handoff_reason_code": reason_code,
-                **({"comment": comment} if comment else {}),
-            },
+            metadata=_handoff_event_metadata(
+                handoff_ref=handoff_ref,
+                handoff_item_count=len(handoff_item_ids),
+                reason_code=reason_code,
+                comment=comment,
+            ),
         ),
     )
     _update_wave_or_raise(
@@ -514,12 +519,11 @@ def cancel_wave(
                 actor_id=actor_id,
                 correlation_id=correlation_id,
                 reason_code="WAVE_CANCELLED",
-                metadata={
-                    "cancel_reason_code": reason_code,
-                    "cancelled_item_count": len(cancelled_items),
-                    "external_execution_claimed": False,
-                    **({"comment": comment} if comment else {}),
-                },
+                metadata=_cancel_event_metadata(
+                    cancelled_item_count=len(cancelled_items),
+                    reason_code=reason_code,
+                    comment=comment,
+                ),
             ),
         )
     except DpmWaveInvalidTransitionError as exc:

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -2,6 +2,7 @@ from src.api.request_models import RebalanceRequest
 from src.api.services.wave_aggregate_metrics import (
     simulation_result_state,
 )
+from src.api.services.wave_approval_transition import build_approved_wave as _build_approved_wave
 from src.api.services.wave_construction_selection import (
     select_construction_alternative_for_wave as _select_construction_alternative_for_wave,
 )
@@ -21,7 +22,6 @@ from src.api.services.wave_errors import (
 from src.api.services.wave_detail_projection import wave_detail_payload, wave_items_payload
 from src.api.services.wave_handoff_evidence import build_handoff_ref as _handoff_ref
 from src.api.services.wave_item_transitions import (
-    approve_item as _approve_item,
     cancel_item as _cancel_item,
     handoff_item as _handoff_item,
     stage_item as _stage_item,
@@ -56,7 +56,7 @@ from src.api.services.wave_supportability_payload import (
 )
 from src.api.services.wave_trigger_validation import validate_trigger_or_raise
 from src.api.services.wave_workflow_metadata import (
-    approval_event_metadata as _approval_event_metadata,
+    approval_event_metadata,
     cancel_event_metadata as _cancel_event_metadata,
     handoff_event_metadata as _handoff_event_metadata,
     selection_event_metadata as _selection_event_metadata,
@@ -73,7 +73,6 @@ from src.core.waves import (
     DpmWaveRepository,
     DpmWaveReportInputBoundaryError,
     DpmWaveReportInput,
-    WaveState,
     apply_wave_transition,
     build_wave_report_input,
 )
@@ -82,6 +81,7 @@ from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 _simulation_result_state = simulation_result_state
 _validate_trigger = validate_trigger_or_raise
+_approval_event_metadata = approval_event_metadata
 
 
 def preview_wave(
@@ -333,35 +333,12 @@ def approve_wave(
         action_phrase="be approved",
     )
 
-    approved_items = [_approve_item(item, actor_id, reason_code, comment) for item in wave.items]
-    approved_count = sum(1 for item in approved_items if item.state == "APPROVED")
-    if approved_count == 0:
-        raise DpmWaveValidationError(
-            "DPM_WAVE_APPROVAL_NO_ELIGIBLE_ITEMS",
-            f"Wave {wave_id} has no selected or proof-pack-ready items to approve.",
-        )
-
-    to_state: WaveState = (
-        "APPROVED" if approved_count == len(approved_items) else "APPROVED_WITH_EXCEPTIONS"
-    )
-    candidate = _wave_with_items_and_aggregate(wave=wave, items=approved_items)
-    approved = apply_wave_transition(
-        wave=candidate,
-        to_state=to_state,
-        event=_event(
-            wave_id=wave.wave_id,
-            from_state=wave.state,
-            to_state=to_state,
-            actor_id=actor_id,
-            correlation_id=correlation_id,
-            reason_code="WAVE_APPROVED",
-            metadata=_approval_event_metadata(
-                approved_item_count=approved_count,
-                total_item_count=len(approved_items),
-                reason_code=reason_code,
-                comment=comment,
-            ),
-        ),
+    approved = _build_approved_wave(
+        wave=wave,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
     )
     _update_wave_or_raise(
         wave_repository=wave_repository,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -45,6 +45,10 @@ from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
 )
 from src.api.services.wave_source_check import build_source_checked_wave
+from src.api.services.wave_state_guard import (
+    require_wave_state as _require_wave_state,
+    wave_state_is_idempotent as _wave_state_is_idempotent,
+)
 from src.api.services.wave_supportability_payload import (
     wave_supportability_payload as _wave_supportability_payload,
 )
@@ -154,13 +158,14 @@ def source_check_wave(
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if wave.state == "SOURCE_CHECKED":
+    if _wave_state_is_idempotent(wave, replay_states={"SOURCE_CHECKED"}):
         return wave, True
-    if wave.state != "CREATED":
-        raise DpmWaveValidationError(
-            "DPM_WAVE_SOURCE_CHECK_INVALID_STATE",
-            f"Wave {wave_id} cannot be source-checked from state {wave.state}.",
-        )
+    _require_wave_state(
+        wave,
+        allowed_states={"CREATED"},
+        error_code="DPM_WAVE_SOURCE_CHECK_INVALID_STATE",
+        action_phrase="be source-checked",
+    )
 
     checked = build_source_checked_wave(
         wave=wave,
@@ -189,13 +194,17 @@ def simulate_wave(
     risk_authority_client: LotusRiskAuthorityClient | None = None,
 ) -> tuple[DpmRebalanceWave, bool]:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if wave.state in {"SIMULATED", "PARTIALLY_SIMULATED", "SIMULATION_FAILED"}:
+    if _wave_state_is_idempotent(
+        wave,
+        replay_states={"SIMULATED", "PARTIALLY_SIMULATED", "SIMULATION_FAILED"},
+    ):
         return wave, True
-    if wave.state != "SOURCE_CHECKED":
-        raise DpmWaveValidationError(
-            "DPM_WAVE_SIMULATION_INVALID_STATE",
-            f"Wave {wave_id} cannot be simulated from state {wave.state}.",
-        )
+    _require_wave_state(
+        wave,
+        allowed_states={"SOURCE_CHECKED"},
+        error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
+        action_phrase="be simulated",
+    )
 
     completed = build_simulated_wave(
         wave=wave,
@@ -232,11 +241,12 @@ def select_wave_item_alternative(
     wave_repository: DpmWaveRepository,
 ) -> DpmRebalanceWave:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if wave.state not in {"SIMULATED", "PARTIALLY_SIMULATED"}:
-        raise DpmWaveValidationError(
-            "DPM_WAVE_SELECTION_INVALID_STATE",
-            f"Wave {wave_id} cannot record alternative selection from state {wave.state}.",
-        )
+    _require_wave_state(
+        wave,
+        allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
+        error_code="DPM_WAVE_SELECTION_INVALID_STATE",
+        action_phrase="record alternative selection",
+    )
     selected_item = next((item for item in wave.items if item.wave_item_id == wave_item_id), None)
     if selected_item is None:
         raise DpmWaveLookupError("DPM_WAVE_ITEM_NOT_FOUND", f"Wave item {wave_item_id} not found.")
@@ -311,13 +321,17 @@ def approve_wave(
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if wave.state in {"APPROVED", "APPROVED_WITH_EXCEPTIONS"}:
+    if _wave_state_is_idempotent(
+        wave,
+        replay_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
+    ):
         return wave, True
-    if wave.state not in {"SIMULATED", "PARTIALLY_SIMULATED", "REVIEW_REQUIRED"}:
-        raise DpmWaveValidationError(
-            "DPM_WAVE_APPROVAL_INVALID_STATE",
-            f"Wave {wave_id} cannot be approved from state {wave.state}.",
-        )
+    _require_wave_state(
+        wave,
+        allowed_states={"SIMULATED", "PARTIALLY_SIMULATED", "REVIEW_REQUIRED"},
+        error_code="DPM_WAVE_APPROVAL_INVALID_STATE",
+        action_phrase="be approved",
+    )
 
     approved_items = [_approve_item(item, actor_id, reason_code, comment) for item in wave.items]
     approved_count = sum(1 for item in approved_items if item.state == "APPROVED")
@@ -367,13 +381,14 @@ def stage_wave(
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if wave.state in {"STAGED", "HANDOFF_READY"}:
+    if _wave_state_is_idempotent(wave, replay_states={"STAGED", "HANDOFF_READY"}):
         return wave, True
-    if wave.state not in {"APPROVED", "APPROVED_WITH_EXCEPTIONS"}:
-        raise DpmWaveValidationError(
-            "DPM_WAVE_STAGE_INVALID_STATE",
-            f"Wave {wave_id} cannot be staged from state {wave.state}.",
-        )
+    _require_wave_state(
+        wave,
+        allowed_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
+        error_code="DPM_WAVE_STAGE_INVALID_STATE",
+        action_phrase="be staged",
+    )
 
     staged_items = [_stage_item(item, actor_id, reason_code, comment) for item in wave.items]
     staged_count = sum(1 for item in staged_items if item.state == "STAGED")
@@ -419,13 +434,14 @@ def handoff_wave(
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if wave.state == "HANDOFF_READY":
+    if _wave_state_is_idempotent(wave, replay_states={"HANDOFF_READY"}):
         return wave, True
-    if wave.state != "STAGED":
-        raise DpmWaveValidationError(
-            "DPM_WAVE_HANDOFF_INVALID_STATE",
-            f"Wave {wave_id} cannot create handoff evidence from state {wave.state}.",
-        )
+    _require_wave_state(
+        wave,
+        allowed_states={"STAGED"},
+        error_code="DPM_WAVE_HANDOFF_INVALID_STATE",
+        action_phrase="create handoff evidence",
+    )
 
     handoff_items = [_handoff_item(item, actor_id, reason_code, comment) for item in wave.items]
     handoff_item_ids = [
@@ -487,7 +503,7 @@ def cancel_wave(
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
     wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if wave.state == "CANCELLED":
+    if _wave_state_is_idempotent(wave, replay_states={"CANCELLED"}):
         return wave, True
 
     cancelled_items = [_cancel_item(item, actor_id, reason_code, comment) for item in wave.items]

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -24,7 +24,6 @@ from src.api.services.wave_handoff_evidence import build_handoff_ref as _handoff
 from src.api.services.wave_item_transitions import (
     cancel_item as _cancel_item,
     handoff_item as _handoff_item,
-    stage_item as _stage_item,
 )
 from src.api.services.wave_item_collection import (
     wave_with_items_and_aggregate as _wave_with_items_and_aggregate,
@@ -51,6 +50,7 @@ from src.api.services.wave_state_guard import (
     require_wave_state as _require_wave_state,
     wave_state_is_idempotent as _wave_state_is_idempotent,
 )
+from src.api.services.wave_stage_transition import build_staged_wave as _build_staged_wave
 from src.api.services.wave_supportability_payload import (
     wave_supportability_payload as _wave_supportability_payload,
 )
@@ -60,7 +60,7 @@ from src.api.services.wave_workflow_metadata import (
     cancel_event_metadata as _cancel_event_metadata,
     handoff_event_metadata as _handoff_event_metadata,
     selection_event_metadata as _selection_event_metadata,
-    stage_event_metadata as _stage_event_metadata,
+    stage_event_metadata,
 )
 from src.core.construction.repository import ConstructionRepository
 from src.core.construction.vocabulary import ConstructionMethod
@@ -82,6 +82,7 @@ from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 _simulation_result_state = simulation_result_state
 _validate_trigger = validate_trigger_or_raise
 _approval_event_metadata = approval_event_metadata
+_stage_event_metadata = stage_event_metadata
 
 
 def preview_wave(
@@ -367,31 +368,12 @@ def stage_wave(
         action_phrase="be staged",
     )
 
-    staged_items = [_stage_item(item, actor_id, reason_code, comment) for item in wave.items]
-    staged_count = sum(1 for item in staged_items if item.state == "STAGED")
-    if staged_count == 0:
-        raise DpmWaveValidationError(
-            "DPM_WAVE_STAGE_NO_ELIGIBLE_ITEMS",
-            f"Wave {wave_id} has no approved items to stage.",
-        )
-
-    candidate = _wave_with_items_and_aggregate(wave=wave, items=staged_items)
-    staged = apply_wave_transition(
-        wave=candidate,
-        to_state="STAGED",
-        event=_event(
-            wave_id=wave.wave_id,
-            from_state=wave.state,
-            to_state="STAGED",
-            actor_id=actor_id,
-            correlation_id=correlation_id,
-            reason_code="WAVE_STAGED",
-            metadata=_stage_event_metadata(
-                staged_item_count=staged_count,
-                reason_code=reason_code,
-                comment=comment,
-            ),
-        ),
+    staged = _build_staged_wave(
+        wave=wave,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
     )
     _update_wave_or_raise(
         wave_repository=wave_repository,

--- a/src/api/services/wave_stage_transition.py
+++ b/src/api/services/wave_stage_transition.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_event_evidence import build_wave_event
+from src.api.services.wave_item_collection import wave_with_items_and_aggregate
+from src.api.services.wave_item_transitions import stage_item
+from src.api.services.wave_workflow_metadata import stage_event_metadata
+from src.core.waves import DpmRebalanceWave, apply_wave_transition
+
+
+def build_staged_wave(
+    *,
+    wave: DpmRebalanceWave,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+) -> DpmRebalanceWave:
+    staged_items = [stage_item(item, actor_id, reason_code, comment) for item in wave.items]
+    staged_count = sum(1 for item in staged_items if item.state == "STAGED")
+    if staged_count == 0:
+        raise DpmWaveValidationError(
+            "DPM_WAVE_STAGE_NO_ELIGIBLE_ITEMS",
+            f"Wave {wave.wave_id} has no approved items to stage.",
+        )
+
+    candidate = wave_with_items_and_aggregate(wave=wave, items=staged_items)
+    return apply_wave_transition(
+        wave=candidate,
+        to_state="STAGED",
+        event=build_wave_event(
+            wave_id=wave.wave_id,
+            from_state=wave.state,
+            to_state="STAGED",
+            actor_id=actor_id,
+            correlation_id=correlation_id,
+            reason_code="WAVE_STAGED",
+            metadata=stage_event_metadata(
+                staged_item_count=staged_count,
+                reason_code=reason_code,
+                comment=comment,
+            ),
+        ),
+    )
+
+
+__all__ = ["build_staged_wave"]

--- a/src/api/services/wave_state_guard.py
+++ b/src/api/services/wave_state_guard.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.core.waves import DpmRebalanceWave
+
+
+def wave_state_is_idempotent(
+    wave: DpmRebalanceWave,
+    *,
+    replay_states: Collection[str],
+) -> bool:
+    return wave.state in replay_states
+
+
+def require_wave_state(
+    wave: DpmRebalanceWave,
+    *,
+    allowed_states: Collection[str],
+    error_code: str,
+    action_phrase: str,
+) -> None:
+    if wave.state in allowed_states:
+        return
+    raise DpmWaveValidationError(
+        error_code,
+        f"Wave {wave.wave_id} cannot {action_phrase} from state {wave.state}.",
+    )
+
+
+__all__ = ["require_wave_state", "wave_state_is_idempotent"]

--- a/src/api/services/wave_workflow_metadata.py
+++ b/src/api/services/wave_workflow_metadata.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from src.core.waves import DpmWaveHandoffRef
+
+
+def approval_event_metadata(
+    *,
+    approved_item_count: int,
+    total_item_count: int,
+    reason_code: str,
+    comment: str | None,
+) -> dict[str, object]:
+    return _with_optional_comment(
+        {
+            "approved_item_count": approved_item_count,
+            "exception_item_count": total_item_count - approved_item_count,
+            "approval_reason_code": reason_code,
+        },
+        comment=comment,
+    )
+
+
+def stage_event_metadata(
+    *,
+    staged_item_count: int,
+    reason_code: str,
+    comment: str | None,
+) -> dict[str, object]:
+    return _with_optional_comment(
+        {
+            "staged_item_count": staged_item_count,
+            "stage_reason_code": reason_code,
+        },
+        comment=comment,
+    )
+
+
+def handoff_event_metadata(
+    *,
+    handoff_ref: DpmWaveHandoffRef,
+    handoff_item_count: int,
+    reason_code: str,
+    comment: str | None,
+) -> dict[str, object]:
+    return _with_optional_comment(
+        {
+            "handoff_ref_id": handoff_ref.handoff_ref_id,
+            "handoff_item_count": handoff_item_count,
+            "external_execution_claimed": False,
+            "handoff_reason_code": reason_code,
+        },
+        comment=comment,
+    )
+
+
+def cancel_event_metadata(
+    *,
+    cancelled_item_count: int,
+    reason_code: str,
+    comment: str | None,
+) -> dict[str, object]:
+    return _with_optional_comment(
+        {
+            "cancel_reason_code": reason_code,
+            "cancelled_item_count": cancelled_item_count,
+            "external_execution_claimed": False,
+        },
+        comment=comment,
+    )
+
+
+def _with_optional_comment(
+    metadata: dict[str, object],
+    *,
+    comment: str | None,
+) -> dict[str, object]:
+    if comment:
+        return {**metadata, "comment": comment}
+    return metadata
+
+
+__all__ = [
+    "approval_event_metadata",
+    "cancel_event_metadata",
+    "handoff_event_metadata",
+    "stage_event_metadata",
+]

--- a/src/api/services/wave_workflow_metadata.py
+++ b/src/api/services/wave_workflow_metadata.py
@@ -20,6 +20,23 @@ def approval_event_metadata(
     )
 
 
+def selection_event_metadata(
+    *,
+    wave_item_id: str,
+    alternative_set_id: str,
+    selected_alternative_id: str,
+    proof_pack_id: str | None,
+    proof_pack_state: object | None,
+) -> dict[str, object]:
+    return {
+        "wave_item_id": wave_item_id,
+        "alternative_set_id": alternative_set_id,
+        "selected_alternative_id": selected_alternative_id,
+        "proof_pack_id": proof_pack_id,
+        "proof_pack_state": proof_pack_state,
+    }
+
+
 def stage_event_metadata(
     *,
     staged_item_count: int,
@@ -83,5 +100,6 @@ __all__ = [
     "approval_event_metadata",
     "cancel_event_metadata",
     "handoff_event_metadata",
+    "selection_event_metadata",
     "stage_event_metadata",
 ]

--- a/tests/unit/api/test_rebalance_async_submission_context.py
+++ b/tests/unit/api/test_rebalance_async_submission_context.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+import pytest
+from pytest import MonkeyPatch
+
+from src.api.services import rebalance_async_submission_context as async_context
+from src.api.services import rebalance_simulation_service
+from src.api.services.rebalance_async_submission_context import (
+    DpmAsyncSubmissionContext,
+    build_async_submission_context,
+)
+from src.api.services.rebalance_run_support_service import DpmRunSupportServiceUnavailableError
+from src.api.services.rebalance_simulation_errors import (
+    DpmRebalanceAsyncOperationSupportUnavailableError,
+)
+
+
+class _BatchRequest:
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {"scenarios": {"baseline": {"options": {}}}}
+
+
+def test_build_async_submission_context_resolves_service_policy_payload_and_mode(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    service = SimpleNamespace(name="support-service")
+    captured: dict[str, object] = {}
+    source_context = SimpleNamespace(model_dump=lambda mode: {"source": mode})
+
+    def _resolve_policy(**kwargs: object) -> SimpleNamespace:
+        captured["policy"] = kwargs
+        return SimpleNamespace(
+            resolution=SimpleNamespace(
+                enabled=True,
+                source="REQUEST",
+                selected_policy_pack_id="POLICY_DPM_SG_BALANCED_V1",
+            )
+        )
+
+    monkeypatch.setattr(async_context, "resolve_execution_policy_pack_context", _resolve_policy)
+    monkeypatch.setattr(async_context, "resolve_async_execution_mode", lambda: "ACCEPT_ONLY")
+
+    context = build_async_submission_context(
+        request=_BatchRequest(),  # type: ignore[arg-type]
+        policy_pack_id="POLICY_DPM_SG_BALANCED_V1",
+        tenant_default_policy_pack_id="POLICY_TENANT_DEFAULT",
+        tenant_id="tenant_sg",
+        source_context=source_context,  # type: ignore[arg-type]
+        support_service_factory=lambda: service,  # type: ignore[return-value]
+    )
+
+    assert isinstance(context, DpmAsyncSubmissionContext)
+    assert context.service is service
+    assert context.execution_mode == "ACCEPT_ONLY"
+    assert context.policy_resolution_enabled is True
+    assert context.policy_resolution_source == "REQUEST"
+    assert context.selected_policy_pack_id == "POLICY_DPM_SG_BALANCED_V1"
+    assert context.request_json == {
+        "batch_request": {"scenarios": {"baseline": {"options": {}}}},
+        "policy_context": {
+            "request_policy_pack_id": "POLICY_DPM_SG_BALANCED_V1",
+            "tenant_default_policy_pack_id": "POLICY_TENANT_DEFAULT",
+            "tenant_id": "tenant_sg",
+        },
+        "source_context": {"source": "json"},
+    }
+    assert captured["policy"]["surface"] == "analyze_async"
+    assert captured["policy"]["load_definition"] is False
+
+
+def test_build_async_submission_context_maps_support_service_unavailable() -> None:
+    def _unavailable() -> object:
+        raise DpmRunSupportServiceUnavailableError("DPM_SUPPORTABILITY_POSTGRES_DSN_REQUIRED")
+
+    with pytest.raises(DpmRebalanceAsyncOperationSupportUnavailableError) as exc_info:
+        build_async_submission_context(
+            request=_BatchRequest(),  # type: ignore[arg-type]
+            policy_pack_id=None,
+            tenant_default_policy_pack_id=None,
+            tenant_id=None,
+            source_context=None,
+            support_service_factory=_unavailable,  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.detail == "DPM_SUPPORTABILITY_POSTGRES_DSN_REQUIRED"
+
+
+def test_rebalance_async_submission_context_exports_only_context_builder() -> None:
+    assert async_context.__all__ == [
+        "DpmAsyncSubmissionContext",
+        "SupportServiceFactory",
+        "build_async_submission_context",
+    ]
+
+
+def test_service_preserves_async_submission_context_import_surface() -> None:
+    assert rebalance_simulation_service.DpmAsyncSubmissionContext is DpmAsyncSubmissionContext

--- a/tests/unit/api/test_rebalance_batch_execution_context.py
+++ b/tests/unit/api/test_rebalance_batch_execution_context.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+from pytest import MonkeyPatch
+
+from src.api.services import rebalance_batch_execution_context as batch_context
+from src.api.services import rebalance_simulation_service
+from src.api.services.rebalance_batch_execution_context import (
+    DpmBatchExecutionContext,
+    build_batch_execution_context,
+)
+
+
+def test_build_batch_execution_context_resolves_batch_id_and_policy(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    policy_definition = SimpleNamespace(policy_pack_id="POLICY_DPM_SG_BALANCED_V1")
+
+    def _resolve_policy(**kwargs: object) -> SimpleNamespace:
+        captured["policy"] = kwargs
+        return SimpleNamespace(
+            definition=policy_definition,
+            resolution=SimpleNamespace(
+                enabled=True,
+                source="TENANT_DEFAULT",
+                selected_policy_pack_id="POLICY_DPM_SG_BALANCED_V1",
+            ),
+        )
+
+    monkeypatch.setattr(batch_context, "create_batch_analysis_id", lambda: "batch_test123")
+    monkeypatch.setattr(batch_context, "resolve_execution_policy_pack_context", _resolve_policy)
+
+    context = build_batch_execution_context(
+        request_policy_pack_id="POLICY_REQUEST",
+        tenant_default_policy_pack_id="POLICY_DPM_SG_BALANCED_V1",
+        tenant_id="tenant_sg",
+    )
+
+    assert isinstance(context, DpmBatchExecutionContext)
+    assert context.batch_id == "batch_test123"
+    assert context.policy_pack_definition is policy_definition
+    assert context.policy_resolution_enabled is True
+    assert context.policy_resolution_source == "TENANT_DEFAULT"
+    assert context.selected_policy_pack_id == "POLICY_DPM_SG_BALANCED_V1"
+    assert captured["policy"]["surface"] == "analyze"
+    assert captured["policy"]["request_policy_pack_id"] == "POLICY_REQUEST"
+
+
+def test_rebalance_batch_execution_context_exports_only_context_builder() -> None:
+    assert batch_context.__all__ == [
+        "DpmBatchExecutionContext",
+        "build_batch_execution_context",
+    ]
+
+
+def test_service_preserves_batch_execution_context_import_surface() -> None:
+    assert rebalance_simulation_service.DpmBatchExecutionContext is DpmBatchExecutionContext

--- a/tests/unit/api/test_rebalance_operation_identity.py
+++ b/tests/unit/api/test_rebalance_operation_identity.py
@@ -1,0 +1,28 @@
+from src.api.services.rebalance_operation_identity import (
+    create_batch_analysis_id,
+    resolve_rebalance_correlation_id,
+)
+
+
+def test_resolve_rebalance_correlation_id_preserves_caller_value() -> None:
+    assert (
+        resolve_rebalance_correlation_id(
+            "corr-caller",
+            entropy_provider=lambda: "unused",
+        )
+        == "corr-caller"
+    )
+
+
+def test_resolve_rebalance_correlation_id_generates_bounded_prefix() -> None:
+    assert (
+        resolve_rebalance_correlation_id(
+            None,
+            entropy_provider=lambda: "1234567890abcdef",
+        )
+        == "corr_1234567890ab"
+    )
+
+
+def test_create_batch_analysis_id_generates_bounded_prefix() -> None:
+    assert create_batch_analysis_id(entropy_provider=lambda: "abcdef123456") == "batch_abcdef12"

--- a/tests/unit/api/test_rebalance_simulation_execution_context.py
+++ b/tests/unit/api/test_rebalance_simulation_execution_context.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+from pytest import MonkeyPatch
+
+from src.api.services import rebalance_simulation_execution_context as execution_context
+from src.api.services import rebalance_simulation_service
+from src.api.services.rebalance_simulation_execution_context import (
+    DpmSimulationExecutionContext,
+    build_simulation_execution_context,
+)
+
+
+class _Request:
+    def model_dump(self, *, mode: str) -> dict[str, object]:
+        assert mode == "json"
+        return {
+            "portfolio_snapshot": {"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+            "options": {"max_turnover": "0.15"},
+        }
+
+
+def test_build_simulation_execution_context_resolves_hash_policy_and_replay(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    policy_definition = SimpleNamespace(policy_pack_id="POLICY_DPM_SG_BALANCED_V1")
+
+    def _resolve_policy(**kwargs: object) -> SimpleNamespace:
+        captured["policy"] = kwargs
+        return SimpleNamespace(
+            definition=policy_definition,
+            resolution=SimpleNamespace(
+                enabled=True,
+                source="REQUEST",
+                selected_policy_pack_id="POLICY_DPM_SG_BALANCED_V1",
+            ),
+        )
+
+    def _resolve_replay(**kwargs: object) -> bool:
+        captured["replay"] = kwargs
+        return False
+
+    monkeypatch.setattr(
+        execution_context,
+        "resolve_execution_policy_pack_context",
+        _resolve_policy,
+    )
+    monkeypatch.setattr(
+        execution_context,
+        "resolve_rebalance_correlation_id",
+        lambda correlation_id: f"resolved-{correlation_id}",
+    )
+    monkeypatch.setattr(execution_context, "env_flag", lambda *_args: True)
+    monkeypatch.setattr(execution_context, "resolve_policy_pack_replay_enabled", _resolve_replay)
+
+    context = build_simulation_execution_context(
+        request=_Request(),  # type: ignore[arg-type]
+        correlation_id="corr-001",
+        policy_pack_id="POLICY_DPM_SG_BALANCED_V1",
+        tenant_default_policy_pack_id="POLICY_TENANT_DEFAULT",
+        tenant_id="tenant_sg",
+        request_hasher=lambda payload: f"hash:{payload['portfolio_snapshot']}",
+    )
+
+    assert isinstance(context, DpmSimulationExecutionContext)
+    assert context.request_hash == "hash:{'portfolio_id': 'PB_SG_GLOBAL_BAL_001'}"
+    assert context.correlation_id == "resolved-corr-001"
+    assert context.policy_pack_definition is policy_definition
+    assert context.replay_enabled is False
+    assert context.policy_resolution_enabled is True
+    assert context.policy_resolution_source == "REQUEST"
+    assert context.selected_policy_pack_id == "POLICY_DPM_SG_BALANCED_V1"
+    assert captured["policy"]["surface"] == "simulate"
+    assert captured["policy"]["request_policy_pack_id"] == "POLICY_DPM_SG_BALANCED_V1"
+    assert captured["replay"] == {
+        "default_replay_enabled": True,
+        "policy_pack": policy_definition,
+    }
+
+
+def test_rebalance_simulation_execution_context_exports_only_context_builder() -> None:
+    assert execution_context.__all__ == [
+        "DpmSimulationExecutionContext",
+        "RequestHasher",
+        "build_simulation_execution_context",
+    ]
+
+
+def test_service_preserves_simulation_execution_context_import_surface() -> None:
+    assert (
+        rebalance_simulation_service.DpmSimulationExecutionContext is DpmSimulationExecutionContext
+    )

--- a/tests/unit/dpm/mandates/test_mandate_command_center.py
+++ b/tests/unit/dpm/mandates/test_mandate_command_center.py
@@ -5,6 +5,7 @@ from src.api.services.mandate_command_center import (
     attention_buckets,
     build_command_center_summary,
     command_center_supportability_state,
+    latest_command_center_run,
     recommended_actions,
     run_matches_command_center_filters,
     severity_rank,
@@ -121,6 +122,38 @@ def test_run_matches_command_center_filters_uses_bounded_filter_values() -> None
         portfolio_manager_id="pm_1",
         book_id=None,
         as_of_date=date(2026, 5, 4),
+    )
+
+
+def test_latest_command_center_run_returns_first_matching_run() -> None:
+    latest = _run(
+        filters={"tenant_id": "tenant_1", "portfolio_manager_id": "pm_1"},
+        as_of_date=date(2026, 5, 3),
+    )
+    older = _run(
+        filters={"tenant_id": "tenant_1", "portfolio_manager_id": "pm_1"},
+        as_of_date=date(2026, 5, 2),
+    )
+
+    assert (
+        latest_command_center_run(
+            [latest, older],
+            tenant_id="tenant_1",
+            portfolio_manager_id="pm_1",
+            book_id=None,
+            as_of_date=None,
+        )
+        is latest
+    )
+    assert (
+        latest_command_center_run(
+            [latest, older],
+            tenant_id="missing",
+            portfolio_manager_id=None,
+            book_id=None,
+            as_of_date=None,
+        )
+        is None
     )
 
 
@@ -257,6 +290,9 @@ def test_mandate_service_preserves_command_center_private_aliases() -> None:
     assert mandate_service._build_command_center_summary is (
         mandate_command_center.build_command_center_summary
     )
+    assert mandate_service._latest_command_center_run is (
+        mandate_command_center.latest_command_center_run
+    )
     assert mandate_service._command_center_supportability_state is (
         mandate_command_center.command_center_supportability_state
     )
@@ -276,6 +312,7 @@ def test_mandate_command_center_exports_only_projection_helpers() -> None:
         "attention_buckets",
         "build_command_center_summary",
         "command_center_supportability_state",
+        "latest_command_center_run",
         "recommended_actions",
         "run_matches_command_center_filters",
         "severity_rank",

--- a/tests/unit/dpm/mandates/test_mandate_command_center.py
+++ b/tests/unit/dpm/mandates/test_mandate_command_center.py
@@ -1,0 +1,213 @@
+from datetime import date, datetime, timezone
+
+from src.api.services import mandate_service
+from src.api.services.mandate_command_center import (
+    attention_buckets,
+    command_center_supportability_state,
+    recommended_actions,
+    run_matches_command_center_filters,
+    severity_rank,
+)
+from src.core.mandates import (
+    DpmMonitoringException,
+    DpmMonitoringRun,
+    MandateHealthDimension,
+    MandateRecommendedAction,
+    MonitoringSeverity,
+)
+
+
+def _run(
+    *,
+    source_readiness_summary: dict[str, int] | None = None,
+    filters: dict[str, str] | None = None,
+    as_of_date: date = date(2026, 5, 3),
+) -> DpmMonitoringRun:
+    return DpmMonitoringRun(
+        monitoring_run_id="dmr_command_center",
+        as_of_date=as_of_date,
+        requested_at=datetime(2026, 5, 3, 8, 30, tzinfo=timezone.utc),
+        completed_at=datetime(2026, 5, 3, 8, 31, tzinfo=timezone.utc),
+        status="SUCCEEDED",
+        total_mandates=2,
+        exception_count=0,
+        filters=filters or {},
+        source_readiness_summary=source_readiness_summary or {"READY": 2},
+    )
+
+
+def _exception(
+    *,
+    exception_id: str,
+    dimension: MandateHealthDimension,
+    severity: MonitoringSeverity,
+    action: MandateRecommendedAction,
+    reason_code: str,
+) -> DpmMonitoringException:
+    return DpmMonitoringException(
+        exception_id=exception_id,
+        mandate_id=f"MANDATE_{exception_id}",
+        portfolio_id=f"PB_{exception_id}",
+        detected_at=datetime(2026, 5, 3, 8, 30, tzinfo=timezone.utc),
+        as_of_date=date(2026, 5, 3),
+        dimension=dimension,
+        severity=severity,
+        reason_code=reason_code,
+        recommended_action=action,
+    )
+
+
+def test_command_center_supportability_state_maps_empty_and_source_postures() -> None:
+    assert command_center_supportability_state(
+        latest_run=None,
+        completeness="EMPTY",
+        partial_reasons=[],
+    ) == ("EMPTY", "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS")
+
+    assert command_center_supportability_state(
+        latest_run=_run(source_readiness_summary={"BLOCKED": 1}),
+        completeness="COMPLETE",
+        partial_reasons=[],
+    ) == ("BLOCKED", "COMMAND_CENTER_SOURCE_READINESS_BLOCKED")
+
+    assert command_center_supportability_state(
+        latest_run=_run(source_readiness_summary={"DEGRADED": 1}),
+        completeness="COMPLETE",
+        partial_reasons=[],
+    ) == ("DEGRADED", "COMMAND_CENTER_SOURCE_READINESS_DEGRADED")
+
+    assert command_center_supportability_state(
+        latest_run=_run(),
+        completeness="PARTIAL",
+        partial_reasons=["PM_BOOK_DISCOVERY_NOT_YET_SOURCED"],
+    ) == ("PARTIAL", "PM_BOOK_DISCOVERY_NOT_YET_SOURCED")
+
+    assert command_center_supportability_state(
+        latest_run=_run(),
+        completeness="COMPLETE",
+        partial_reasons=[],
+    ) == ("READY", "COMMAND_CENTER_READY")
+
+
+def test_run_matches_command_center_filters_uses_bounded_filter_values() -> None:
+    run = _run(
+        filters={
+            "tenant_id": "tenant_1",
+            "portfolio_manager_id": "pm_1",
+            "book_id": "book_1",
+        }
+    )
+
+    assert run_matches_command_center_filters(
+        run,
+        tenant_id="tenant_1",
+        portfolio_manager_id="pm_1",
+        book_id=None,
+        as_of_date=date(2026, 5, 3),
+    )
+    assert not run_matches_command_center_filters(
+        run,
+        tenant_id="tenant_2",
+        portfolio_manager_id=None,
+        book_id=None,
+        as_of_date=date(2026, 5, 3),
+    )
+    assert not run_matches_command_center_filters(
+        run,
+        tenant_id="tenant_1",
+        portfolio_manager_id="pm_1",
+        book_id=None,
+        as_of_date=date(2026, 5, 4),
+    )
+
+
+def test_attention_buckets_sort_by_severity_count_and_reason_frequency() -> None:
+    exceptions = [
+        _exception(
+            exception_id="1",
+            dimension=MandateHealthDimension.SOURCE_READINESS,
+            severity=MonitoringSeverity.CRITICAL,
+            action=MandateRecommendedAction.FIX_SOURCE_DATA,
+            reason_code="SOURCE_BLOCKED_B",
+        ),
+        _exception(
+            exception_id="2",
+            dimension=MandateHealthDimension.SOURCE_READINESS,
+            severity=MonitoringSeverity.CRITICAL,
+            action=MandateRecommendedAction.FIX_SOURCE_DATA,
+            reason_code="SOURCE_BLOCKED_A",
+        ),
+        _exception(
+            exception_id="3",
+            dimension=MandateHealthDimension.SOURCE_READINESS,
+            severity=MonitoringSeverity.CRITICAL,
+            action=MandateRecommendedAction.FIX_SOURCE_DATA,
+            reason_code="SOURCE_BLOCKED_A",
+        ),
+        _exception(
+            exception_id="4",
+            dimension=MandateHealthDimension.MODEL_FRESHNESS,
+            severity=MonitoringSeverity.WARNING,
+            action=MandateRecommendedAction.SIMULATE_REBALANCE,
+            reason_code="MODEL_STALE",
+        ),
+    ]
+
+    buckets = attention_buckets(exceptions)
+
+    assert buckets[0].severity == MonitoringSeverity.CRITICAL
+    assert buckets[0].exception_count == 3
+    assert buckets[0].top_reason_codes == ["SOURCE_BLOCKED_A", "SOURCE_BLOCKED_B"]
+    assert buckets[1].severity == MonitoringSeverity.WARNING
+
+
+def test_recommended_actions_sort_by_highest_severity_and_count() -> None:
+    actions = recommended_actions(
+        [
+            _exception(
+                exception_id="1",
+                dimension=MandateHealthDimension.SOURCE_READINESS,
+                severity=MonitoringSeverity.WARNING,
+                action=MandateRecommendedAction.SIMULATE_REBALANCE,
+                reason_code="MODEL_STALE",
+            ),
+            _exception(
+                exception_id="2",
+                dimension=MandateHealthDimension.WORKFLOW_READINESS,
+                severity=MonitoringSeverity.CRITICAL,
+                action=MandateRecommendedAction.REVIEW_WORKFLOW,
+                reason_code="WORKFLOW_BLOCKED",
+            ),
+        ]
+    )
+
+    assert actions[0].recommended_action == MandateRecommendedAction.REVIEW_WORKFLOW
+    assert actions[0].highest_severity == MonitoringSeverity.CRITICAL
+    assert actions[1].recommended_action == MandateRecommendedAction.SIMULATE_REBALANCE
+
+
+def test_mandate_service_preserves_command_center_private_aliases() -> None:
+    from src.api.services import mandate_command_center
+
+    assert mandate_service._command_center_supportability_state is (
+        mandate_command_center.command_center_supportability_state
+    )
+    assert mandate_service._run_matches_command_center_filters is (
+        mandate_command_center.run_matches_command_center_filters
+    )
+    assert mandate_service._attention_buckets is mandate_command_center.attention_buckets
+    assert mandate_service._recommended_actions is mandate_command_center.recommended_actions
+    assert mandate_service._severity_rank is mandate_command_center.severity_rank
+
+
+def test_mandate_command_center_exports_only_projection_helpers() -> None:
+    from src.api.services import mandate_command_center
+
+    assert severity_rank("CRITICAL") == 3
+    assert mandate_command_center.__all__ == [
+        "attention_buckets",
+        "command_center_supportability_state",
+        "recommended_actions",
+        "run_matches_command_center_filters",
+        "severity_rank",
+    ]

--- a/tests/unit/dpm/mandates/test_mandate_command_center.py
+++ b/tests/unit/dpm/mandates/test_mandate_command_center.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timezone
 from src.api.services import mandate_service
 from src.api.services.mandate_command_center import (
     attention_buckets,
+    build_command_center_summary,
     command_center_supportability_state,
     recommended_actions,
     run_matches_command_center_filters,
@@ -31,6 +32,8 @@ def _run(
         status="SUCCEEDED",
         total_mandates=2,
         exception_count=0,
+        mandate_ids=["MANDATE_1", "MANDATE_2"],
+        health_distribution={"READY": 1, "PENDING_REVIEW": 1},
         filters=filters or {},
         source_readiness_summary=source_readiness_summary or {"READY": 2},
     )
@@ -186,9 +189,74 @@ def test_recommended_actions_sort_by_highest_severity_and_count() -> None:
     assert actions[1].recommended_action == MandateRecommendedAction.SIMULATE_REBALANCE
 
 
+def test_build_command_center_summary_projects_supportability_and_attention() -> None:
+    active_exceptions = [
+        _exception(
+            exception_id="1",
+            dimension=MandateHealthDimension.SOURCE_READINESS,
+            severity=MonitoringSeverity.CRITICAL,
+            action=MandateRecommendedAction.FIX_SOURCE_DATA,
+            reason_code="SOURCE_BLOCKED",
+        )
+    ]
+
+    summary = build_command_center_summary(
+        tenant_id="default",
+        portfolio_manager_id=None,
+        book_id=None,
+        as_of_date=None,
+        health_state="PENDING_REVIEW",
+        latest_run=_run(),
+        active_exceptions=active_exceptions,
+        limit=1,
+        generated_at=datetime(2026, 5, 3, 8, 32, tzinfo=timezone.utc),
+    )
+
+    assert summary.as_of_date == date(2026, 5, 3)
+    assert summary.selected_health_state.value == "PENDING_REVIEW"
+    assert summary.evaluated_mandates == 2
+    assert summary.monitored_mandate_ids == ["MANDATE_1", "MANDATE_2"]
+    assert summary.health_distribution == {"PENDING_REVIEW": 1}
+    assert summary.active_exception_count == 1
+    assert summary.attention_buckets[0].top_reason_codes == ["SOURCE_BLOCKED"]
+    assert summary.recommended_actions[0].recommended_action == (
+        MandateRecommendedAction.FIX_SOURCE_DATA
+    )
+    assert summary.supportability.state == "PARTIAL"
+    assert summary.supportability.reason == "PM_BOOK_DISCOVERY_NOT_YET_SOURCED"
+    assert summary.supportability.source_run_id == "dmr_command_center"
+    assert summary.supportability.partial_readiness_reasons == [
+        "PM_BOOK_DISCOVERY_NOT_YET_SOURCED",
+        "ATTENTION_QUEUE_LIMIT_REACHED",
+    ]
+
+
+def test_build_command_center_summary_projects_empty_state_without_run() -> None:
+    summary = build_command_center_summary(
+        tenant_id=None,
+        portfolio_manager_id=None,
+        book_id=None,
+        as_of_date=None,
+        health_state=None,
+        latest_run=None,
+        active_exceptions=[],
+        limit=50,
+        generated_at=datetime(2026, 5, 3, 8, 32, tzinfo=timezone.utc),
+    )
+
+    assert summary.as_of_date is None
+    assert summary.evaluated_mandates == 0
+    assert summary.health_distribution == {}
+    assert summary.supportability.state == "EMPTY"
+    assert summary.supportability.reason == "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
+
+
 def test_mandate_service_preserves_command_center_private_aliases() -> None:
     from src.api.services import mandate_command_center
 
+    assert mandate_service._build_command_center_summary is (
+        mandate_command_center.build_command_center_summary
+    )
     assert mandate_service._command_center_supportability_state is (
         mandate_command_center.command_center_supportability_state
     )
@@ -206,6 +274,7 @@ def test_mandate_command_center_exports_only_projection_helpers() -> None:
     assert severity_rank("CRITICAL") == 3
     assert mandate_command_center.__all__ == [
         "attention_buckets",
+        "build_command_center_summary",
         "command_center_supportability_state",
         "recommended_actions",
         "run_matches_command_center_filters",

--- a/tests/unit/dpm/mandates/test_mandate_diff.py
+++ b/tests/unit/dpm/mandates/test_mandate_diff.py
@@ -2,10 +2,12 @@ from datetime import date
 from decimal import Decimal
 
 from src.api.services import mandate_diff, mandate_service
+from src.api.services.mandate_errors import DpmMandateDiffUnavailableError
 from src.api.services.mandate_diff import (
     DpmMandateDiff,
     DpmMandateFieldChange,
     build_mandate_diff,
+    build_mandate_diff_for_versions,
     diff_payloads,
     iter_changed_fields,
     materiality_for_field,
@@ -99,9 +101,72 @@ def test_build_mandate_diff_projects_version_comparison() -> None:
     ]
 
 
+def test_build_mandate_diff_for_versions_uses_explicit_requested_versions() -> None:
+    diff = build_mandate_diff_for_versions(
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        versions=[
+            _twin(version="3", turnover_budget=Decimal("0.15")),
+            _twin(version="2", turnover_budget=Decimal("0.10")),
+            _twin(version="1", turnover_budget=Decimal("0.08")),
+        ],
+        from_version="1",
+        to_version="3",
+    )
+
+    assert diff.from_version == "1"
+    assert diff.to_version == "3"
+    assert ("constraints.turnover_budget", "HIGH") in [
+        (change.field_path, change.materiality) for change in diff.changed_fields
+    ]
+
+
+def test_build_mandate_diff_for_versions_defaults_to_latest_two_versions() -> None:
+    diff = build_mandate_diff_for_versions(
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        versions=[
+            _twin(version="3", turnover_budget=Decimal("0.15")),
+            _twin(version="2", turnover_budget=Decimal("0.10")),
+        ],
+        from_version=None,
+        to_version=None,
+    )
+
+    assert diff.from_version == "2"
+    assert diff.to_version == "3"
+
+
+def test_build_mandate_diff_for_versions_requires_complete_version_pair() -> None:
+    try:
+        build_mandate_diff_for_versions(
+            mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+            versions=[_twin(version="3")],
+            from_version="2",
+            to_version=None,
+        )
+    except DpmMandateDiffUnavailableError as exc:
+        assert exc.args == ("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS",)
+    else:
+        raise AssertionError("Expected mandate diff version-pair validation error.")
+
+
+def test_build_mandate_diff_for_versions_rejects_unknown_requested_version() -> None:
+    try:
+        build_mandate_diff_for_versions(
+            mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+            versions=[_twin(version="3"), _twin(version="2")],
+            from_version="1",
+            to_version="3",
+        )
+    except DpmMandateDiffUnavailableError as exc:
+        assert exc.args == ("DPM_MANDATE_DIFF_VERSION_NOT_FOUND",)
+    else:
+        raise AssertionError("Expected mandate diff version-not-found validation error.")
+
+
 def test_service_preserves_existing_diff_import_surface() -> None:
     assert mandate_service.DpmMandateDiff is DpmMandateDiff
     assert mandate_service.DpmMandateFieldChange is DpmMandateFieldChange
+    assert mandate_service._build_mandate_diff_for_versions is build_mandate_diff_for_versions
     assert mandate_service._diff_payloads is diff_payloads
     assert mandate_service._iter_changed_fields is iter_changed_fields
     assert mandate_service._materiality_for_field is materiality_for_field
@@ -112,6 +177,7 @@ def test_mandate_diff_exports_public_helper_surface() -> None:
         "DpmMandateDiff",
         "DpmMandateFieldChange",
         "build_mandate_diff",
+        "build_mandate_diff_for_versions",
         "diff_payloads",
         "iter_changed_fields",
         "materiality_for_field",

--- a/tests/unit/dpm/mandates/test_mandate_diff.py
+++ b/tests/unit/dpm/mandates/test_mandate_diff.py
@@ -1,0 +1,118 @@
+from datetime import date
+from decimal import Decimal
+
+from src.api.services import mandate_diff, mandate_service
+from src.api.services.mandate_diff import (
+    DpmMandateDiff,
+    DpmMandateFieldChange,
+    build_mandate_diff,
+    diff_payloads,
+    iter_changed_fields,
+    materiality_for_field,
+)
+from src.core.mandates import DpmMandateDigitalTwin
+
+
+def _twin(
+    *,
+    version: str = "3",
+    turnover_budget: Decimal = Decimal("0.15"),
+) -> DpmMandateDigitalTwin:
+    return DpmMandateDigitalTwin.model_validate(
+        {
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_version": version,
+            "as_of_date": date(2026, 5, 3),
+            "base_currency": "SGD",
+            "reference_currency": "SGD",
+            "risk_profile": "BALANCED",
+            "investment_objective": "LONG_TERM_TOTAL_RETURN",
+            "time_horizon": "LONG_TERM",
+            "model_portfolio_id": "MODEL_PB_SG_GLOBAL_BAL_DPM",
+            "model_portfolio_version": "2026.04",
+            "constraints": {
+                "cash_band_min_weight": "0.02",
+                "cash_band_max_weight": "0.10",
+                "turnover_budget": turnover_budget,
+            },
+            "review_policy": {"review_frequency": "QUARTERLY"},
+        }
+    )
+
+
+def test_iter_changed_fields_recurses_and_ignores_source_lineage() -> None:
+    previous = {
+        "mandate_version": "2",
+        "constraints": {"turnover_budget": "0.10", "cash_band_min_weight": "0.02"},
+        "source_lineage": {"generated_at": "old"},
+    }
+    current = {
+        "mandate_version": "3",
+        "constraints": {"turnover_budget": "0.15", "cash_band_min_weight": "0.02"},
+        "source_lineage": {"generated_at": "new"},
+    }
+
+    assert iter_changed_fields(previous, current) == [
+        ("constraints.turnover_budget", "0.10", "0.15"),
+        ("mandate_version", "2", "3"),
+    ]
+
+
+def test_diff_payloads_returns_sorted_materiality_changes() -> None:
+    changes = diff_payloads(
+        {"mandate_version": "2", "constraints": {"turnover_budget": "0.10"}},
+        {
+            "mandate_version": "3",
+            "constraints": {"turnover_budget": "0.15"},
+            "display_name": "Global balanced mandate",
+        },
+    )
+
+    assert [(change.field_path, change.materiality) for change in changes] == [
+        ("constraints.turnover_budget", "HIGH"),
+        ("display_name", "LOW"),
+        ("mandate_version", "MEDIUM"),
+    ]
+
+
+def test_materiality_for_field_uses_private_banking_review_thresholds() -> None:
+    assert materiality_for_field("constraints.turnover_budget") == "HIGH"
+    assert materiality_for_field("risk_profile") == "HIGH"
+    assert materiality_for_field("as_of_date") == "MEDIUM"
+    assert materiality_for_field("display_name") == "LOW"
+
+
+def test_build_mandate_diff_projects_version_comparison() -> None:
+    diff = build_mandate_diff(
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        previous=_twin(version="2", turnover_budget=Decimal("0.10")),
+        current=_twin(version="3", turnover_budget=Decimal("0.15")),
+    )
+
+    assert diff.mandate_id == "MANDATE_PB_SG_GLOBAL_BAL_001"
+    assert diff.from_version == "2"
+    assert diff.to_version == "3"
+    assert diff.compared_at.tzinfo is not None
+    assert ("constraints.turnover_budget", "HIGH") in [
+        (change.field_path, change.materiality) for change in diff.changed_fields
+    ]
+
+
+def test_service_preserves_existing_diff_import_surface() -> None:
+    assert mandate_service.DpmMandateDiff is DpmMandateDiff
+    assert mandate_service.DpmMandateFieldChange is DpmMandateFieldChange
+    assert mandate_service._diff_payloads is diff_payloads
+    assert mandate_service._iter_changed_fields is iter_changed_fields
+    assert mandate_service._materiality_for_field is materiality_for_field
+
+
+def test_mandate_diff_exports_public_helper_surface() -> None:
+    assert set(mandate_diff.__all__) == {
+        "DpmMandateDiff",
+        "DpmMandateFieldChange",
+        "build_mandate_diff",
+        "diff_payloads",
+        "iter_changed_fields",
+        "materiality_for_field",
+    }

--- a/tests/unit/dpm/mandates/test_mandate_errors.py
+++ b/tests/unit/dpm/mandates/test_mandate_errors.py
@@ -1,0 +1,40 @@
+from src.api.services import mandate_service
+from src.api.services.mandate_errors import (
+    DpmMandateDiffUnavailableError,
+    DpmMandateHealthNotFoundError,
+    DpmMandateNotFoundError,
+    DpmMandateSourceIncompleteError,
+    DpmMandateSourceUnavailableError,
+    DpmMonitoringRunNotFoundError,
+)
+
+
+def test_mandate_service_preserves_imported_error_surface() -> None:
+    assert mandate_service.DpmMandateNotFoundError is DpmMandateNotFoundError
+    assert mandate_service.DpmMandateDiffUnavailableError is DpmMandateDiffUnavailableError
+    assert mandate_service.DpmMandateSourceUnavailableError is DpmMandateSourceUnavailableError
+    assert mandate_service.DpmMandateSourceIncompleteError is DpmMandateSourceIncompleteError
+    assert mandate_service.DpmMandateHealthNotFoundError is DpmMandateHealthNotFoundError
+    assert mandate_service.DpmMonitoringRunNotFoundError is DpmMonitoringRunNotFoundError
+
+
+def test_mandate_error_types_keep_exception_families() -> None:
+    assert issubclass(DpmMandateNotFoundError, LookupError)
+    assert issubclass(DpmMandateDiffUnavailableError, LookupError)
+    assert issubclass(DpmMandateHealthNotFoundError, LookupError)
+    assert issubclass(DpmMonitoringRunNotFoundError, LookupError)
+    assert issubclass(DpmMandateSourceUnavailableError, RuntimeError)
+    assert issubclass(DpmMandateSourceIncompleteError, RuntimeError)
+
+
+def test_mandate_errors_exports_only_error_types() -> None:
+    from src.api.services import mandate_errors
+
+    assert mandate_errors.__all__ == [
+        "DpmMandateDiffUnavailableError",
+        "DpmMandateHealthNotFoundError",
+        "DpmMandateNotFoundError",
+        "DpmMandateSourceIncompleteError",
+        "DpmMandateSourceUnavailableError",
+        "DpmMonitoringRunNotFoundError",
+    ]

--- a/tests/unit/dpm/mandates/test_mandate_health_persistence.py
+++ b/tests/unit/dpm/mandates/test_mandate_health_persistence.py
@@ -1,0 +1,62 @@
+from src.api.services import mandate_health_persistence, mandate_service
+from src.api.services.mandate_health_persistence import persist_mandate_health_evidence
+from src.core.mandates import DpmMandateHealthInput
+from tests.unit.dpm.mandates.test_mandate_health_result import _twin
+from src.api.services.mandate_health_result import calculate_mandate_health_result
+
+
+class _CapturingMandateRepository:
+    def __init__(self) -> None:
+        self.saved_twins: list[object] = []
+        self.saved_snapshots: list[object] = []
+        self.saved_exceptions: list[object] = []
+
+    def save_mandate_snapshot(self, twin: object) -> None:
+        self.saved_twins.append(twin)
+
+    def save_health_snapshot(self, snapshot: object) -> None:
+        self.saved_snapshots.append(snapshot)
+
+    def save_monitoring_exception(self, exception: object) -> None:
+        self.saved_exceptions.append(exception)
+
+
+def test_persist_mandate_health_evidence_saves_optional_twin_snapshot_and_exceptions() -> None:
+    repository = _CapturingMandateRepository()
+    twin = _twin()
+    health_result = calculate_mandate_health_result(DpmMandateHealthInput(twin=twin))
+
+    persist_mandate_health_evidence(
+        repository=repository,  # type: ignore[arg-type]
+        twin=twin,
+        health_snapshot=health_result.snapshot,
+        monitoring_exceptions=health_result.monitoring_exceptions,
+    )
+
+    assert repository.saved_twins == [twin]
+    assert repository.saved_snapshots == [health_result.snapshot]
+    assert repository.saved_exceptions == health_result.monitoring_exceptions
+
+
+def test_persist_mandate_health_evidence_supports_health_only_monitoring_results() -> None:
+    repository = _CapturingMandateRepository()
+    twin = _twin()
+    health_result = calculate_mandate_health_result(DpmMandateHealthInput(twin=twin))
+
+    persist_mandate_health_evidence(
+        repository=repository,  # type: ignore[arg-type]
+        health_snapshot=health_result.snapshot,
+        monitoring_exceptions=health_result.monitoring_exceptions,
+    )
+
+    assert repository.saved_twins == []
+    assert repository.saved_snapshots == [health_result.snapshot]
+    assert repository.saved_exceptions == health_result.monitoring_exceptions
+
+
+def test_mandate_service_preserves_health_persistence_private_alias() -> None:
+    assert mandate_service._persist_mandate_health_evidence is persist_mandate_health_evidence
+
+
+def test_mandate_health_persistence_exports_public_surface() -> None:
+    assert mandate_health_persistence.__all__ == ["persist_mandate_health_evidence"]

--- a/tests/unit/dpm/mandates/test_mandate_health_result.py
+++ b/tests/unit/dpm/mandates/test_mandate_health_result.py
@@ -1,0 +1,60 @@
+from datetime import date
+from decimal import Decimal
+
+from src.api.services import mandate_health_result, mandate_service
+from src.api.services.mandate_health_result import (
+    DpmMandateHealthCalculationResult,
+    calculate_mandate_health_result,
+)
+from src.core.mandates import (
+    DpmMandateConstraintSet,
+    DpmMandateDigitalTwin,
+    DpmMandateHealthInput,
+    DpmMandateReviewPolicy,
+)
+
+
+def _twin() -> DpmMandateDigitalTwin:
+    return DpmMandateDigitalTwin(
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        mandate_version="3",
+        as_of_date=date(2026, 5, 3),
+        base_currency="SGD",
+        reference_currency="SGD",
+        risk_profile="BALANCED",
+        investment_objective="LONG_TERM_TOTAL_RETURN",
+        time_horizon="LONG_TERM",
+        model_portfolio_id="MODEL_PB_SG_GLOBAL_BAL_DPM",
+        constraints=DpmMandateConstraintSet(
+            cash_band_min_weight=Decimal("0.02"),
+            cash_band_max_weight=Decimal("0.10"),
+            turnover_budget=Decimal("0.15"),
+        ),
+        review_policy=DpmMandateReviewPolicy(next_review_due_date=date(2026, 6, 30)),
+    )
+
+
+def test_calculate_mandate_health_result_returns_snapshot_and_exceptions() -> None:
+    result = calculate_mandate_health_result(DpmMandateHealthInput(twin=_twin()))
+
+    assert isinstance(result, DpmMandateHealthCalculationResult)
+    assert result.snapshot.mandate_id == "MANDATE_PB_SG_GLOBAL_BAL_001"
+    assert result.snapshot.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert result.snapshot.as_of_date == date(2026, 5, 3)
+    assert result.monitoring_exceptions
+    assert {exception.mandate_id for exception in result.monitoring_exceptions} == {
+        "MANDATE_PB_SG_GLOBAL_BAL_001"
+    }
+
+
+def test_service_preserves_health_result_import_surface() -> None:
+    assert mandate_service.DpmMandateHealthCalculationResult is DpmMandateHealthCalculationResult
+    assert mandate_service._calculate_mandate_health_result is calculate_mandate_health_result
+
+
+def test_health_result_helper_exports_public_surface() -> None:
+    assert mandate_health_result.__all__ == [
+        "DpmMandateHealthCalculationResult",
+        "calculate_mandate_health_result",
+    ]

--- a/tests/unit/dpm/mandates/test_mandate_monitoring_run.py
+++ b/tests/unit/dpm/mandates/test_mandate_monitoring_run.py
@@ -1,0 +1,99 @@
+from datetime import date, datetime, timezone
+
+from src.api.services import mandate_monitoring_run, mandate_service
+from src.api.services.mandate_monitoring_run import (
+    build_monitoring_run,
+    exceptions_for_monitoring_run,
+    increment_distribution,
+    monitoring_run_id_for,
+)
+from src.core.mandates import (
+    DpmMonitoringException,
+    MandateHealthDimension,
+    MandateRecommendedAction,
+    MonitoringSeverity,
+)
+
+
+def _exception() -> DpmMonitoringException:
+    return DpmMonitoringException(
+        exception_id="me_source_001",
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        detected_at=datetime(2026, 5, 3, 8, 30, tzinfo=timezone.utc),
+        as_of_date=date(2026, 5, 3),
+        dimension=MandateHealthDimension.SOURCE_READINESS,
+        severity=MonitoringSeverity.CRITICAL,
+        reason_code="SOURCE_READINESS_BLOCKED",
+        recommended_action=MandateRecommendedAction.FIX_SOURCE_DATA,
+    )
+
+
+def test_monitoring_run_id_for_uses_stable_utc_timestamp_shape() -> None:
+    assert (
+        monitoring_run_id_for(datetime(2026, 5, 3, 8, 30, 4, 123456))
+        == "dmr_20260503_083004_123456"
+    )
+
+
+def test_increment_distribution_counts_existing_and_new_keys() -> None:
+    distribution = {"READY": 1}
+
+    increment_distribution(distribution, "READY")
+    increment_distribution(distribution, "DEGRADED")
+
+    assert distribution == {"READY": 2, "DEGRADED": 1}
+
+
+def test_exceptions_for_monitoring_run_attaches_run_id_without_mutating_source() -> None:
+    source_exception = _exception()
+
+    exceptions = exceptions_for_monitoring_run(
+        [source_exception],
+        monitoring_run_id="dmr_20260503_083004_123456",
+    )
+
+    assert source_exception.monitoring_run_id is None
+    assert exceptions[0].monitoring_run_id == "dmr_20260503_083004_123456"
+    assert exceptions[0].exception_id == source_exception.exception_id
+
+
+def test_build_monitoring_run_projects_terminal_success_summary() -> None:
+    requested_at = datetime(2026, 5, 3, 8, 30, tzinfo=timezone.utc)
+    completed_at = datetime(2026, 5, 3, 8, 30, 2, tzinfo=timezone.utc)
+
+    run = build_monitoring_run(
+        monitoring_run_id="dmr_20260503_083000_000000",
+        as_of_date=date(2026, 5, 3),
+        requested_at=requested_at,
+        completed_at=completed_at,
+        mandate_ids=["MANDATE_PB_SG_GLOBAL_BAL_001"],
+        filters={"tenant_id": "default"},
+        health_distribution={"PENDING_REVIEW": 1},
+        exception_count=2,
+        source_readiness_summary={"DEGRADED": 1},
+    )
+
+    assert run.monitoring_run_id == "dmr_20260503_083000_000000"
+    assert run.status == "SUCCEEDED"
+    assert run.total_mandates == 1
+    assert run.requested_at == requested_at
+    assert run.completed_at == completed_at
+    assert run.health_distribution == {"PENDING_REVIEW": 1}
+    assert run.source_readiness_summary == {"DEGRADED": 1}
+
+
+def test_service_preserves_monitoring_run_helper_aliases() -> None:
+    assert mandate_service._monitoring_run_id_for is monitoring_run_id_for
+    assert mandate_service._increment_distribution is increment_distribution
+    assert mandate_service._exceptions_for_monitoring_run is exceptions_for_monitoring_run
+    assert mandate_service._build_monitoring_run is build_monitoring_run
+
+
+def test_monitoring_run_helper_exports_public_surface() -> None:
+    assert set(mandate_monitoring_run.__all__) == {
+        "build_monitoring_run",
+        "exceptions_for_monitoring_run",
+        "increment_distribution",
+        "monitoring_run_id_for",
+    }

--- a/tests/unit/dpm/mandates/test_mandate_monitoring_run.py
+++ b/tests/unit/dpm/mandates/test_mandate_monitoring_run.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from src.api.services import mandate_monitoring_run, mandate_service
 from src.api.services.mandate_monitoring_run import (
+    DpmMonitoringRunAccumulator,
     DpmMonitoringRunMandateResult,
     build_monitoring_run,
     calculate_monitoring_run_mandate_result,
@@ -101,6 +102,24 @@ def test_calculate_monitoring_run_mandate_result_uses_requested_as_of_date_and_r
     }
 
 
+def test_monitoring_run_accumulator_counts_health_source_and_exceptions() -> None:
+    result = calculate_monitoring_run_mandate_result(
+        twin=_twin(),
+        as_of_date=date(2026, 5, 3),
+        monitoring_run_id="dmr_20260503_083004_123456",
+    )
+    accumulator = DpmMonitoringRunAccumulator.empty()
+
+    accumulator.record(result)
+    accumulator.record(result)
+
+    assert accumulator.health_distribution == {result.health_snapshot.health_state.value: 2}
+    assert accumulator.source_readiness_summary == {
+        result.health_snapshot.source_readiness_state: 2
+    }
+    assert accumulator.exception_count == len(result.monitoring_exceptions) * 2
+
+
 def test_build_monitoring_run_projects_terminal_success_summary() -> None:
     requested_at = datetime(2026, 5, 3, 8, 30, tzinfo=timezone.utc)
     completed_at = datetime(2026, 5, 3, 8, 30, 2, tzinfo=timezone.utc)
@@ -127,6 +146,8 @@ def test_build_monitoring_run_projects_terminal_success_summary() -> None:
 
 
 def test_service_preserves_monitoring_run_helper_aliases() -> None:
+    assert mandate_service.DpmMonitoringRunAccumulator is DpmMonitoringRunAccumulator
+    assert mandate_service._monitoring_run_accumulator is DpmMonitoringRunAccumulator
     assert mandate_service.DpmMonitoringRunMandateResult is DpmMonitoringRunMandateResult
     assert mandate_service._monitoring_run_id_for is monitoring_run_id_for
     assert mandate_service._increment_distribution is increment_distribution
@@ -140,6 +161,7 @@ def test_service_preserves_monitoring_run_helper_aliases() -> None:
 
 def test_monitoring_run_helper_exports_public_surface() -> None:
     assert set(mandate_monitoring_run.__all__) == {
+        "DpmMonitoringRunAccumulator",
         "DpmMonitoringRunMandateResult",
         "build_monitoring_run",
         "calculate_monitoring_run_mandate_result",

--- a/tests/unit/dpm/mandates/test_mandate_monitoring_run.py
+++ b/tests/unit/dpm/mandates/test_mandate_monitoring_run.py
@@ -1,18 +1,45 @@
 from datetime import date, datetime, timezone
+from decimal import Decimal
 
 from src.api.services import mandate_monitoring_run, mandate_service
 from src.api.services.mandate_monitoring_run import (
+    DpmMonitoringRunMandateResult,
     build_monitoring_run,
+    calculate_monitoring_run_mandate_result,
     exceptions_for_monitoring_run,
     increment_distribution,
     monitoring_run_id_for,
 )
 from src.core.mandates import (
+    DpmMandateConstraintSet,
+    DpmMandateDigitalTwin,
+    DpmMandateReviewPolicy,
     DpmMonitoringException,
     MandateHealthDimension,
     MandateRecommendedAction,
     MonitoringSeverity,
 )
+
+
+def _twin() -> DpmMandateDigitalTwin:
+    return DpmMandateDigitalTwin(
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        mandate_version="3",
+        as_of_date=date(2026, 5, 1),
+        base_currency="SGD",
+        reference_currency="SGD",
+        risk_profile="BALANCED",
+        investment_objective="LONG_TERM_TOTAL_RETURN",
+        time_horizon="LONG_TERM",
+        model_portfolio_id="MODEL_PB_SG_GLOBAL_BAL_DPM",
+        constraints=DpmMandateConstraintSet(
+            cash_band_min_weight=Decimal("0.02"),
+            cash_band_max_weight=Decimal("0.10"),
+            turnover_budget=Decimal("0.15"),
+        ),
+        review_policy=DpmMandateReviewPolicy(next_review_due_date=date(2026, 6, 30)),
+    )
 
 
 def _exception() -> DpmMonitoringException:
@@ -58,6 +85,22 @@ def test_exceptions_for_monitoring_run_attaches_run_id_without_mutating_source()
     assert exceptions[0].exception_id == source_exception.exception_id
 
 
+def test_calculate_monitoring_run_mandate_result_uses_requested_as_of_date_and_run_id() -> None:
+    result = calculate_monitoring_run_mandate_result(
+        twin=_twin(),
+        as_of_date=date(2026, 5, 3),
+        monitoring_run_id="dmr_20260503_083004_123456",
+    )
+
+    assert isinstance(result, DpmMonitoringRunMandateResult)
+    assert result.health_snapshot.mandate_id == "MANDATE_PB_SG_GLOBAL_BAL_001"
+    assert result.health_snapshot.as_of_date == date(2026, 5, 3)
+    assert result.monitoring_exceptions
+    assert {exception.monitoring_run_id for exception in result.monitoring_exceptions} == {
+        "dmr_20260503_083004_123456"
+    }
+
+
 def test_build_monitoring_run_projects_terminal_success_summary() -> None:
     requested_at = datetime(2026, 5, 3, 8, 30, tzinfo=timezone.utc)
     completed_at = datetime(2026, 5, 3, 8, 30, 2, tzinfo=timezone.utc)
@@ -84,15 +127,22 @@ def test_build_monitoring_run_projects_terminal_success_summary() -> None:
 
 
 def test_service_preserves_monitoring_run_helper_aliases() -> None:
+    assert mandate_service.DpmMonitoringRunMandateResult is DpmMonitoringRunMandateResult
     assert mandate_service._monitoring_run_id_for is monitoring_run_id_for
     assert mandate_service._increment_distribution is increment_distribution
     assert mandate_service._exceptions_for_monitoring_run is exceptions_for_monitoring_run
+    assert (
+        mandate_service._calculate_monitoring_run_mandate_result
+        is calculate_monitoring_run_mandate_result
+    )
     assert mandate_service._build_monitoring_run is build_monitoring_run
 
 
 def test_monitoring_run_helper_exports_public_surface() -> None:
     assert set(mandate_monitoring_run.__all__) == {
+        "DpmMonitoringRunMandateResult",
         "build_monitoring_run",
+        "calculate_monitoring_run_mandate_result",
         "exceptions_for_monitoring_run",
         "increment_distribution",
         "monitoring_run_id_for",

--- a/tests/unit/dpm/mandates/test_mandate_optional_sources.py
+++ b/tests/unit/dpm/mandates/test_mandate_optional_sources.py
@@ -4,8 +4,10 @@ from typing import Any
 
 from src.api.services import mandate_optional_sources, mandate_service
 from src.api.services.mandate_optional_sources import (
+    DpmMandateOptionalSources,
     ready_benchmark_assignment_source,
     ready_optional_source,
+    resolve_mandate_optional_sources,
     try_resolve_optional_source,
 )
 from src.core.dpm_source_context import DpmCoreBenchmarkAssignmentResponse
@@ -29,6 +31,44 @@ class _Resolver:
 
     def resolve_unavailable_source(self, **kwargs: Any) -> dict[str, Any]:
         raise DpmCoreResolverError("source unavailable")
+
+
+class _BundleResolver:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def _source(self, method_name: str, kwargs: dict[str, Any]) -> _OptionalSource:
+        self.calls.append((method_name, kwargs))
+        return _OptionalSource(
+            supportability=_Supportability(state="READY"),
+            data_quality_status="COMPLETE",
+        )
+
+    def resolve_client_restriction_profile(self, **kwargs: Any) -> _OptionalSource:
+        return self._source("client_restriction_profile", kwargs)
+
+    def resolve_sustainability_preference_profile(self, **kwargs: Any) -> _OptionalSource:
+        return self._source("sustainability_preference_profile", kwargs)
+
+    def resolve_portfolio_cashflow_projection(self, **kwargs: Any) -> _OptionalSource:
+        return self._source("portfolio_cashflow_projection", kwargs)
+
+    def resolve_client_income_needs_schedule(self, **kwargs: Any) -> _OptionalSource:
+        return self._source("client_income_needs_schedule", kwargs)
+
+    def resolve_liquidity_reserve_requirement(self, **kwargs: Any) -> _OptionalSource:
+        self.calls.append(("liquidity_reserve_requirement", kwargs))
+        return _OptionalSource(
+            supportability=_Supportability(state="DEGRADED"),
+            data_quality_status="COMPLETE",
+        )
+
+    def resolve_planned_withdrawal_schedule(self, **kwargs: Any) -> _OptionalSource:
+        return self._source("planned_withdrawal_schedule", kwargs)
+
+    def resolve_benchmark_assignment(self, **kwargs: Any) -> DpmCoreBenchmarkAssignmentResponse:
+        self.calls.append(("benchmark_assignment", kwargs))
+        return _benchmark_assignment()
 
 
 def _benchmark_assignment(
@@ -156,15 +196,52 @@ def test_ready_benchmark_assignment_source_requires_active_assignment() -> None:
     assert unavailable_family == "BENCHMARK_ASSIGNMENT"
 
 
+def test_resolve_mandate_optional_sources_builds_typed_bundle_and_family_gaps() -> None:
+    resolver = _BundleResolver()
+
+    sources = resolve_mandate_optional_sources(
+        resolver=resolver,
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        as_of_date=date(2026, 5, 3),
+        tenant_id="default",
+        reference_currency="SGD",
+        correlation_id="corr_mandate_sources",
+    )
+
+    assert isinstance(sources, DpmMandateOptionalSources)
+    assert sources.client_restriction_profile is not None
+    assert sources.sustainability_preference_profile is not None
+    assert sources.portfolio_cashflow_projection is not None
+    assert sources.client_income_needs_schedule is not None
+    assert sources.liquidity_reserve_requirement is None
+    assert sources.planned_withdrawal_schedule is not None
+    assert sources.benchmark_assignment is not None
+    assert sources.unavailable_source_families == ["LIQUIDITY_RESERVE_REQUIREMENT"]
+    calls = dict(resolver.calls)
+    assert calls["client_restriction_profile"]["include_inactive_restrictions"] is False
+    assert calls["sustainability_preference_profile"]["include_inactive_preferences"] is False
+    assert calls["portfolio_cashflow_projection"]["horizon_days"] == 90
+    assert calls["portfolio_cashflow_projection"]["include_projected"] is True
+    assert calls["client_income_needs_schedule"]["include_inactive_schedules"] is False
+    assert calls["liquidity_reserve_requirement"]["include_inactive_requirements"] is False
+    assert calls["planned_withdrawal_schedule"]["horizon_days"] == 365
+    assert calls["planned_withdrawal_schedule"]["include_inactive_withdrawals"] is False
+    assert calls["benchmark_assignment"]["reporting_currency"] == "SGD"
+
+
 def test_service_preserves_optional_source_helper_aliases() -> None:
     assert mandate_service._try_resolve_optional_source is try_resolve_optional_source
     assert mandate_service._ready_optional_source is ready_optional_source
     assert mandate_service._ready_benchmark_assignment_source is ready_benchmark_assignment_source
+    assert mandate_service._resolve_mandate_optional_sources is resolve_mandate_optional_sources
 
 
 def test_optional_source_helper_exports_public_surface() -> None:
     assert set(mandate_optional_sources.__all__) == {
+        "DpmMandateOptionalSources",
         "ready_benchmark_assignment_source",
         "ready_optional_source",
+        "resolve_mandate_optional_sources",
         "try_resolve_optional_source",
     }

--- a/tests/unit/dpm/mandates/test_mandate_optional_sources.py
+++ b/tests/unit/dpm/mandates/test_mandate_optional_sources.py
@@ -1,0 +1,170 @@
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from typing import Any
+
+from src.api.services import mandate_optional_sources, mandate_service
+from src.api.services.mandate_optional_sources import (
+    ready_benchmark_assignment_source,
+    ready_optional_source,
+    try_resolve_optional_source,
+)
+from src.core.dpm_source_context import DpmCoreBenchmarkAssignmentResponse
+from src.infrastructure.core_sourcing import DpmCoreResolverError
+
+
+@dataclass(frozen=True)
+class _Supportability:
+    state: str
+
+
+@dataclass(frozen=True)
+class _OptionalSource:
+    supportability: _Supportability | None = None
+    data_quality_status: str | None = None
+
+
+class _Resolver:
+    def resolve_ready_source(self, **kwargs: Any) -> dict[str, Any]:
+        return {"kwargs": kwargs}
+
+    def resolve_unavailable_source(self, **kwargs: Any) -> dict[str, Any]:
+        raise DpmCoreResolverError("source unavailable")
+
+
+def _benchmark_assignment(
+    *,
+    assignment_status: str = "ACTIVE",
+) -> DpmCoreBenchmarkAssignmentResponse:
+    return DpmCoreBenchmarkAssignmentResponse.model_validate(
+        {
+            "product_name": "BenchmarkAssignment",
+            "product_version": "v1",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+            "as_of_date": date(2026, 5, 3),
+            "effective_from": date(2026, 1, 1),
+            "assignment_source": "IPS",
+            "assignment_status": assignment_status,
+            "assignment_recorded_at": datetime(2026, 5, 3, tzinfo=timezone.utc),
+            "assignment_version": 1,
+        }
+    )
+
+
+def test_try_resolve_optional_source_calls_available_resolver_method() -> None:
+    source, unavailable_family = try_resolve_optional_source(
+        resolver=_Resolver(),
+        method_name="resolve_ready_source",
+        family_name="CLIENT_RESTRICTION_PROFILE",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+    )
+
+    assert source == {"kwargs": {"portfolio_id": "PB_SG_GLOBAL_BAL_001"}}
+    assert unavailable_family is None
+
+
+def test_try_resolve_optional_source_preserves_absent_optional_method() -> None:
+    source, unavailable_family = try_resolve_optional_source(
+        resolver=_Resolver(),
+        method_name="resolve_missing_source",
+        family_name="CLIENT_RESTRICTION_PROFILE",
+    )
+
+    assert source is None
+    assert unavailable_family is None
+
+
+def test_try_resolve_optional_source_maps_resolver_error_to_family() -> None:
+    source, unavailable_family = try_resolve_optional_source(
+        resolver=_Resolver(),
+        method_name="resolve_unavailable_source",
+        family_name="CLIENT_RESTRICTION_PROFILE",
+    )
+
+    assert source is None
+    assert unavailable_family == "CLIENT_RESTRICTION_PROFILE"
+
+
+def test_ready_optional_source_accepts_ready_or_complete_source() -> None:
+    source = _OptionalSource(
+        supportability=_Supportability(state="READY"),
+        data_quality_status="COMPLETE",
+    )
+
+    ready_source, unavailable_family = ready_optional_source(
+        source=source,
+        unavailable_family=None,
+        family_name="SUSTAINABILITY_PREFERENCE_PROFILE",
+    )
+
+    assert ready_source is source
+    assert unavailable_family is None
+
+
+def test_ready_optional_source_rejects_degraded_supportability() -> None:
+    source = _OptionalSource(
+        supportability=_Supportability(state="DEGRADED"),
+        data_quality_status="COMPLETE",
+    )
+
+    ready_source, unavailable_family = ready_optional_source(
+        source=source,
+        unavailable_family=None,
+        family_name="SUSTAINABILITY_PREFERENCE_PROFILE",
+    )
+
+    assert ready_source is None
+    assert unavailable_family == "SUSTAINABILITY_PREFERENCE_PROFILE"
+
+
+def test_ready_optional_source_rejects_unaccepted_data_quality_status() -> None:
+    source = _OptionalSource(
+        supportability=_Supportability(state="READY"),
+        data_quality_status="STALE",
+    )
+
+    ready_source, unavailable_family = ready_optional_source(
+        source=source,
+        unavailable_family=None,
+        family_name="PORTFOLIO_CASHFLOW_PROJECTION",
+    )
+
+    assert ready_source is None
+    assert unavailable_family == "PORTFOLIO_CASHFLOW_PROJECTION"
+
+
+def test_ready_optional_source_preserves_existing_unavailable_family_for_missing_source() -> None:
+    ready_source, unavailable_family = ready_optional_source(
+        source=None,
+        unavailable_family="PLANNED_WITHDRAWAL_SCHEDULE",
+        family_name="PLANNED_WITHDRAWAL_SCHEDULE",
+    )
+
+    assert ready_source is None
+    assert unavailable_family == "PLANNED_WITHDRAWAL_SCHEDULE"
+
+
+def test_ready_benchmark_assignment_source_requires_active_assignment() -> None:
+    assignment = _benchmark_assignment(assignment_status="RETIRED")
+
+    ready_source, unavailable_family = ready_benchmark_assignment_source(
+        source=assignment,
+        unavailable_family=None,
+    )
+
+    assert ready_source is None
+    assert unavailable_family == "BENCHMARK_ASSIGNMENT"
+
+
+def test_service_preserves_optional_source_helper_aliases() -> None:
+    assert mandate_service._try_resolve_optional_source is try_resolve_optional_source
+    assert mandate_service._ready_optional_source is ready_optional_source
+    assert mandate_service._ready_benchmark_assignment_source is ready_benchmark_assignment_source
+
+
+def test_optional_source_helper_exports_public_surface() -> None:
+    assert set(mandate_optional_sources.__all__) == {
+        "ready_benchmark_assignment_source",
+        "ready_optional_source",
+        "try_resolve_optional_source",
+    }

--- a/tests/unit/dpm/mandates/test_mandate_pm_book.py
+++ b/tests/unit/dpm/mandates/test_mandate_pm_book.py
@@ -1,0 +1,103 @@
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from src.api.services import mandate_pm_book, mandate_service
+from src.api.services.mandate_errors import DpmMandateSourceIncompleteError
+from src.api.services.mandate_pm_book import mandate_ids_from_pm_book_membership
+from src.core.dpm_source_context import DpmCorePortfolioManagerBookMembershipResponse
+
+
+class _Repository:
+    def __init__(self, portfolio_to_mandate: dict[str, str]) -> None:
+        self.portfolio_to_mandate = portfolio_to_mandate
+
+    def get_latest_mandate_by_portfolio(self, *, portfolio_id: str) -> object | None:
+        mandate_id = self.portfolio_to_mandate.get(portfolio_id)
+        if mandate_id is None:
+            return None
+        return SimpleNamespace(mandate_id=mandate_id)
+
+
+def _membership(
+    *,
+    portfolio_ids: list[str],
+) -> DpmCorePortfolioManagerBookMembershipResponse:
+    return DpmCorePortfolioManagerBookMembershipResponse.model_validate(
+        {
+            "product_name": "PortfolioManagerBookMembership",
+            "product_version": "v1",
+            "as_of_date": date(2026, 5, 3),
+            "tenant_id": "default",
+            "portfolio_manager_id": "PM_SG_DPM_001",
+            "members": [
+                {
+                    "portfolio_id": portfolio_id,
+                    "client_id": f"CLIENT_{index}",
+                    "booking_center_code": "Singapore",
+                    "portfolio_type": "DISCRETIONARY",
+                    "status": "ACTIVE",
+                    "base_currency": "SGD",
+                }
+                for index, portfolio_id in enumerate(portfolio_ids, start=1)
+            ],
+            "supportability": {
+                "state": "READY",
+                "reason": "PM_BOOK_MEMBERSHIP_READY",
+                "returned_portfolio_count": len(portfolio_ids),
+                "filters_applied": {"portfolio_types": ["DISCRETIONARY"]},
+            },
+        }
+    )
+
+
+def test_mandate_ids_from_pm_book_membership_resolves_portfolio_members() -> None:
+    mandate_ids = mandate_ids_from_pm_book_membership(
+        repository=_Repository(
+            {
+                "PB_SG_GLOBAL_BAL_001": "MANDATE_PB_SG_GLOBAL_BAL_001",
+                "PB_SG_INCOME_002": "MANDATE_PB_SG_INCOME_002",
+            }
+        ),
+        membership=_membership(
+            portfolio_ids=["PB_SG_GLOBAL_BAL_001", "PB_SG_INCOME_002"],
+        ),
+    )
+
+    assert mandate_ids == [
+        "MANDATE_PB_SG_GLOBAL_BAL_001",
+        "MANDATE_PB_SG_INCOME_002",
+    ]
+
+
+def test_mandate_ids_from_pm_book_membership_rejects_missing_snapshot() -> None:
+    with pytest.raises(DpmMandateSourceIncompleteError) as exc_info:
+        mandate_ids_from_pm_book_membership(
+            repository=_Repository({"PB_SG_GLOBAL_BAL_001": "MANDATE_PB_SG_GLOBAL_BAL_001"}),
+            membership=_membership(
+                portfolio_ids=["PB_SG_GLOBAL_BAL_001", "PB_SG_MISSING_002"],
+            ),
+        )
+
+    assert str(exc_info.value) == "DPM_PM_BOOK_MANDATE_SNAPSHOT_MISSING"
+
+
+def test_mandate_ids_from_pm_book_membership_rejects_empty_membership() -> None:
+    with pytest.raises(DpmMandateSourceIncompleteError) as exc_info:
+        mandate_ids_from_pm_book_membership(
+            repository=_Repository({}),
+            membership=_membership(portfolio_ids=[]),
+        )
+
+    assert str(exc_info.value) == "DPM_PM_BOOK_MANDATE_SNAPSHOT_EMPTY"
+
+
+def test_service_preserves_pm_book_helper_import_surface() -> None:
+    assert (
+        mandate_service.mandate_ids_from_pm_book_membership is mandate_ids_from_pm_book_membership
+    )
+
+
+def test_pm_book_helper_exports_public_surface() -> None:
+    assert mandate_pm_book.__all__ == ["mandate_ids_from_pm_book_membership"]

--- a/tests/unit/dpm/mandates/test_mandate_refresh.py
+++ b/tests/unit/dpm/mandates/test_mandate_refresh.py
@@ -1,0 +1,260 @@
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+from pytest import MonkeyPatch
+
+from src.api.services import mandate_refresh, mandate_service
+from src.api.services.mandate_errors import (
+    DpmMandateSourceIncompleteError,
+    DpmMandateSourceUnavailableError,
+)
+from src.api.services.mandate_health_result import DpmMandateHealthCalculationResult
+from src.api.services.mandate_optional_sources import DpmMandateOptionalSources
+from src.api.services.mandate_refresh import (
+    DpmMandateRefreshResult,
+    build_mandate_refresh_result_from_core,
+)
+from src.core.mandates import (
+    DpmMandateDigitalTwin,
+    DpmMandateHealthSnapshot,
+    DpmMonitoringException,
+)
+from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
+
+
+class _Resolver:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def resolve_mandate_binding(self, **kwargs: object) -> SimpleNamespace:
+        self.calls.append(("mandate", kwargs))
+        if self.error is not None:
+            raise self.error
+        return SimpleNamespace(model_portfolio_id="MODEL_DEFAULT")
+
+    def resolve_model_portfolio_targets(self, **kwargs: object) -> SimpleNamespace:
+        self.calls.append(("model_targets", kwargs))
+        return SimpleNamespace(
+            base_currency="SGD",
+            targets=[
+                SimpleNamespace(instrument_id="SG_EQ_001"),
+                SimpleNamespace(instrument_id="US_BOND_001"),
+            ],
+        )
+
+    def resolve_market_data_coverage(self, **kwargs: object) -> SimpleNamespace:
+        self.calls.append(("market_data", kwargs))
+        return SimpleNamespace(source_product_name="MarketDataCoverageWindow")
+
+
+def _optional_sources() -> DpmMandateOptionalSources:
+    return DpmMandateOptionalSources(
+        client_restriction_profile=None,
+        sustainability_preference_profile=None,
+        portfolio_cashflow_projection=None,
+        client_income_needs_schedule=None,
+        liquidity_reserve_requirement=None,
+        planned_withdrawal_schedule=None,
+        benchmark_assignment=None,
+        unavailable_source_families=["CLIENT_RESTRICTION_PROFILE"],
+    )
+
+
+def _twin() -> DpmMandateDigitalTwin:
+    return DpmMandateDigitalTwin.model_construct(
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        source_lineage=[],
+    )
+
+
+def _snapshot() -> DpmMandateHealthSnapshot:
+    return DpmMandateHealthSnapshot.model_construct(
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+    )
+
+
+def _exception() -> DpmMonitoringException:
+    return DpmMonitoringException.model_construct(
+        exception_id="me_refresh_001",
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+    )
+
+
+def test_build_mandate_refresh_result_from_core_resolves_sources_and_health(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    resolver = _Resolver()
+    captured: dict[str, object] = {}
+    twin = _twin()
+    snapshot = _snapshot()
+    exception = _exception()
+
+    def _resolve_optional(**kwargs: object) -> DpmMandateOptionalSources:
+        captured["optional"] = kwargs
+        return _optional_sources()
+
+    def _compile(**kwargs: object) -> DpmMandateDigitalTwin:
+        captured["compile"] = kwargs
+        return twin
+
+    def _build_health_input(**kwargs: object) -> object:
+        captured["health_input"] = kwargs
+        return SimpleNamespace(source="health_input")
+
+    def _calculate(health_input: object) -> DpmMandateHealthCalculationResult:
+        captured["calculate"] = health_input
+        return DpmMandateHealthCalculationResult(
+            snapshot=snapshot,
+            monitoring_exceptions=[exception],
+        )
+
+    monkeypatch.setattr(mandate_refresh, "resolve_mandate_optional_sources", _resolve_optional)
+    monkeypatch.setattr(mandate_refresh, "compile_mandate_digital_twin_from_core", _compile)
+    monkeypatch.setattr(
+        mandate_refresh, "build_health_input_from_core_sources", _build_health_input
+    )
+    monkeypatch.setattr(mandate_refresh, "calculate_mandate_health_result", _calculate)
+
+    result = build_mandate_refresh_result_from_core(
+        core_resolver=resolver,  # type: ignore[arg-type]
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        as_of_date=date(2026, 5, 3),
+        tenant_id="tenant_sg",
+        booking_center_code="SG",
+        model_portfolio_id="MODEL_OVERRIDE",
+        reference_currency="SGD",
+        include_market_data_coverage=True,
+        correlation_id="corr-refresh",
+    )
+
+    assert isinstance(result, DpmMandateRefreshResult)
+    assert result.twin is twin
+    assert result.health_snapshot is snapshot
+    assert result.monitoring_exceptions == [exception]
+    assert resolver.calls == [
+        (
+            "mandate",
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "as_of_date": date(2026, 5, 3),
+                "tenant_id": "tenant_sg",
+                "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+                "booking_center_code": "SG",
+                "include_policy_pack": True,
+                "correlation_id": "corr-refresh",
+            },
+        ),
+        (
+            "model_targets",
+            {
+                "model_portfolio_id": "MODEL_OVERRIDE",
+                "as_of_date": date(2026, 5, 3),
+                "tenant_id": "tenant_sg",
+                "correlation_id": "corr-refresh",
+            },
+        ),
+        (
+            "market_data",
+            {
+                "instrument_ids": ["SG_EQ_001", "US_BOND_001"],
+                "currency_pairs": [],
+                "as_of_date": date(2026, 5, 3),
+                "valuation_currency": "SGD",
+                "tenant_id": "tenant_sg",
+                "correlation_id": "corr-refresh",
+            },
+        ),
+    ]
+    assert captured["calculate"] == SimpleNamespace(source="health_input")
+    assert captured["health_input"]["unavailable_source_families"] == ["CLIENT_RESTRICTION_PROFILE"]
+
+
+def test_build_mandate_refresh_result_from_core_uses_binding_model_when_not_overridden(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    resolver = _Resolver()
+    monkeypatch.setattr(
+        mandate_refresh, "resolve_mandate_optional_sources", lambda **_: _optional_sources()
+    )
+    monkeypatch.setattr(
+        mandate_refresh, "compile_mandate_digital_twin_from_core", lambda **_: _twin()
+    )
+    monkeypatch.setattr(
+        mandate_refresh,
+        "build_health_input_from_core_sources",
+        lambda **_: SimpleNamespace(source="health_input"),
+    )
+    monkeypatch.setattr(
+        mandate_refresh,
+        "calculate_mandate_health_result",
+        lambda _health_input: DpmMandateHealthCalculationResult(
+            snapshot=_snapshot(),
+            monitoring_exceptions=[],
+        ),
+    )
+
+    build_mandate_refresh_result_from_core(
+        core_resolver=resolver,  # type: ignore[arg-type]
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        as_of_date=date(2026, 5, 3),
+        tenant_id=None,
+        booking_center_code=None,
+        model_portfolio_id=None,
+        reference_currency=None,
+        include_market_data_coverage=False,
+        correlation_id=None,
+    )
+
+    assert resolver.calls[1][1]["model_portfolio_id"] == "MODEL_DEFAULT"
+    assert [call[0] for call in resolver.calls] == ["mandate", "model_targets"]
+
+
+@pytest.mark.parametrize(
+    ("source_error", "service_error"),
+    [
+        (
+            DpmCoreResolverUnavailableError("source unavailable"),
+            DpmMandateSourceUnavailableError,
+        ),
+        (DpmCoreResolverError("source incomplete"), DpmMandateSourceIncompleteError),
+    ],
+)
+def test_build_mandate_refresh_result_from_core_maps_core_source_errors(
+    source_error: Exception,
+    service_error: type[Exception],
+) -> None:
+    with pytest.raises(service_error):
+        build_mandate_refresh_result_from_core(
+            core_resolver=_Resolver(error=source_error),  # type: ignore[arg-type]
+            portfolio_id="PB_SG_GLOBAL_BAL_001",
+            mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+            as_of_date=date(2026, 5, 3),
+            tenant_id=None,
+            booking_center_code=None,
+            model_portfolio_id=None,
+            reference_currency=None,
+            include_market_data_coverage=False,
+            correlation_id=None,
+        )
+
+
+def test_mandate_refresh_exports_refresh_result_builder() -> None:
+    assert mandate_refresh.__all__ == [
+        "DpmMandateRefreshResult",
+        "build_mandate_refresh_result_from_core",
+    ]
+
+
+def test_service_preserves_mandate_refresh_import_surface() -> None:
+    assert mandate_service.DpmMandateRefreshResult is DpmMandateRefreshResult
+    assert (
+        mandate_service._build_mandate_refresh_result_from_core
+        is build_mandate_refresh_result_from_core
+    )

--- a/tests/unit/dpm/outcomes/test_outcome_review_creation.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_creation.py
@@ -1,0 +1,76 @@
+from datetime import datetime, timezone
+
+from src.api.services.outcome_review_creation import (
+    build_created_outcome_event,
+    build_review_content_hash,
+    created_event_type,
+)
+from src.core.outcomes import DpmOutcomeReviewComparison
+from tests.unit.infrastructure.test_outcome_review_repository import _review
+
+
+CREATED_AT = datetime(2026, 5, 6, 1, 20, tzinfo=timezone.utc)
+
+
+def _comparison(state: str = "READY") -> DpmOutcomeReviewComparison:
+    review = _review(state=state)
+    return DpmOutcomeReviewComparison(
+        state=state,
+        dimension_results=review.dimension_results,
+        overall_outcome=review.overall_outcome,
+        variance_summary=review.variance_summary,
+        supportability=review.supportability,
+    )
+
+
+def test_created_event_type_maps_review_state_to_bounded_event_type() -> None:
+    assert created_event_type("READY") == "OUTCOME_REVIEW_READY"
+    assert created_event_type("DEGRADED") == "OUTCOME_REVIEW_DEGRADED"
+    assert created_event_type("BLOCKED") == "OUTCOME_REVIEW_BLOCKED"
+    assert created_event_type("PENDING_REVIEW") == "OUTCOME_REVIEW_CREATED"
+
+
+def test_build_created_outcome_event_combines_expected_and_realized_lineage() -> None:
+    review = _review()
+    event = build_created_outcome_event(
+        outcome_review_id=review.outcome_review_id,
+        comparison=_comparison(),
+        expected_snapshot=review.expected_snapshot,
+        realized_snapshot=review.realized_snapshot,
+        actor_id="pm_creation",
+        created_at=CREATED_AT,
+    )
+
+    assert event.event_id == "dor_001_created"
+    assert event.event_type == "OUTCOME_REVIEW_READY"
+    assert event.event_time == CREATED_AT.isoformat()
+    assert event.actor == "pm_creation"
+    assert event.outcome_review_id == "dor_001"
+    assert event.state == "READY"
+    assert event.reason_codes == ["SOURCE_READY"]
+    assert [ref.source_id for ref in event.source_refs] == ["expected", "realized"]
+
+
+def test_build_review_content_hash_is_stable_and_changes_with_source_snapshot() -> None:
+    review = _review()
+    ready_hash = build_review_content_hash(
+        expected_snapshot=review.expected_snapshot,
+        realized_snapshot=review.realized_snapshot,
+        comparison=_comparison(),
+    )
+    changed_realized = review.realized_snapshot.model_copy(
+        update={"source_hashes": {"realized": "sha256:changed-realized"}}
+    )
+    changed_hash = build_review_content_hash(
+        expected_snapshot=review.expected_snapshot,
+        realized_snapshot=changed_realized,
+        comparison=_comparison(),
+    )
+
+    assert ready_hash.startswith("sha256:")
+    assert ready_hash == build_review_content_hash(
+        expected_snapshot=review.expected_snapshot,
+        realized_snapshot=review.realized_snapshot,
+        comparison=_comparison(),
+    )
+    assert changed_hash != ready_hash

--- a/tests/unit/dpm/outcomes/test_outcome_review_creation.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_creation.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from src.api.services.outcome_review_creation import (
     build_created_outcome_event,
+    build_created_outcome_review,
     build_review_content_hash,
     created_event_type,
 )
@@ -74,3 +75,41 @@ def test_build_review_content_hash_is_stable_and_changes_with_source_snapshot() 
         comparison=_comparison(),
     )
     assert changed_hash != ready_hash
+
+
+def test_build_created_outcome_review_preserves_source_lineage_and_identity() -> None:
+    source_review = _review()
+    comparison = _comparison()
+
+    review = build_created_outcome_review(
+        outcome_review_id="dor_created_001",
+        comparison=comparison,
+        expected_snapshot=source_review.expected_snapshot,
+        realized_snapshot=source_review.realized_snapshot,
+        actor_id="pm_creation",
+        correlation_id="corr_created_001",
+        idempotency_key="idem_created_001",
+        content_hash="sha256:created-review",
+        created_at=CREATED_AT,
+    )
+
+    assert review.outcome_review_id == "dor_created_001"
+    assert review.state == comparison.state
+    assert review.portfolio_id == source_review.expected_snapshot.portfolio_id
+    assert review.review_window == source_review.realized_snapshot.review_window
+    assert review.source_hashes == {"expected": "sha256:expected", "realized": "sha256:realized"}
+    assert [ref.source_id for ref in review.source_lineage] == ["expected", "realized"]
+    assert review.events == [
+        build_created_outcome_event(
+            outcome_review_id="dor_created_001",
+            comparison=comparison,
+            expected_snapshot=source_review.expected_snapshot,
+            realized_snapshot=source_review.realized_snapshot,
+            actor_id="pm_creation",
+            created_at=CREATED_AT,
+        )
+    ]
+    assert review.content_hash == "sha256:created-review"
+    assert review.created_by == "pm_creation"
+    assert review.correlation_id == "corr_created_001"
+    assert review.idempotency_key == "idem_created_001"

--- a/tests/unit/dpm/outcomes/test_outcome_review_dimensions.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_dimensions.py
@@ -1,0 +1,121 @@
+from decimal import Decimal
+
+import pytest
+
+from src.api.services import outcome_review_dimensions, outcome_review_service
+from src.api.services.outcome_review_dimensions import (
+    DpmOutcomeDimensionConfig,
+    DpmOutcomeReviewValidationError,
+    dimension_inputs_for_review,
+)
+from src.core.outcomes import (
+    DpmExpectedOutcomeSnapshot,
+    DpmOutcomeMetricValue,
+    DpmOutcomeSupportability,
+    DpmOutcomeTolerance,
+    DpmOutcomeReviewWindow,
+    DpmRealizedOutcomeSnapshot,
+)
+
+
+def _metric(value: str) -> DpmOutcomeMetricValue:
+    return DpmOutcomeMetricValue(value=Decimal(value), unit="ratio")
+
+
+def _expected(
+    *,
+    expected_values: dict[str, DpmOutcomeMetricValue] | None = None,
+) -> DpmExpectedOutcomeSnapshot:
+    return DpmExpectedOutcomeSnapshot.model_construct(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        alternative_set_id="cas_001",
+        selected_alternative_id="alt_selected",
+        proof_pack_id="dpp_001",
+        expected_values=(
+            expected_values
+            if expected_values is not None
+            else {"DRIFT_REDUCTION": _metric("0.012")}
+        ),
+        supportability=DpmOutcomeSupportability(state="READY"),
+    )
+
+
+def _realized(
+    *,
+    realized_values: dict[str, DpmOutcomeMetricValue] | None = None,
+) -> DpmRealizedOutcomeSnapshot:
+    return DpmRealizedOutcomeSnapshot.model_construct(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        review_window=DpmOutcomeReviewWindow(
+            start_at="2026-05-06T01:00:00Z",
+            end_at="2026-05-07T01:00:00Z",
+            as_of_date="2026-05-07",
+        ),
+        realized_values=(
+            realized_values
+            if realized_values is not None
+            else {"DRIFT_REDUCTION": _metric("0.010")}
+        ),
+        supportability=DpmOutcomeSupportability(state="READY"),
+    )
+
+
+def _config() -> DpmOutcomeDimensionConfig:
+    return DpmOutcomeDimensionConfig(
+        dimension="DRIFT_REDUCTION",
+        tolerance=DpmOutcomeTolerance(soft=Decimal("0.0025"), hard=Decimal("0.0100")),
+        materiality=Decimal("0.0050"),
+        direction="LOWER_IS_BETTER",
+    )
+
+
+def test_dimension_inputs_for_review_projects_configured_dimension_evidence() -> None:
+    inputs = dimension_inputs_for_review(
+        expected_snapshot=_expected(),
+        realized_snapshot=_realized(),
+        dimension_configs=[_config()],
+    )
+
+    assert len(inputs) == 1
+    assert inputs[0].dimension == "DRIFT_REDUCTION"
+    assert inputs[0].expected.value == Decimal("0.012")
+    assert inputs[0].realized.value == Decimal("0.010")
+    assert inputs[0].tolerance.soft == Decimal("0.0025")
+    assert inputs[0].materiality == Decimal("0.0050")
+    assert inputs[0].direction == "LOWER_IS_BETTER"
+
+
+@pytest.mark.parametrize(
+    ("expected_values", "realized_values"),
+    [
+        ({}, {"DRIFT_REDUCTION": _metric("0.010")}),
+        ({"DRIFT_REDUCTION": _metric("0.012")}, {}),
+    ],
+)
+def test_dimension_inputs_for_review_rejects_missing_expected_or_realized_evidence(
+    expected_values: dict[str, DpmOutcomeMetricValue],
+    realized_values: dict[str, DpmOutcomeMetricValue],
+) -> None:
+    with pytest.raises(DpmOutcomeReviewValidationError) as exc_info:
+        dimension_inputs_for_review(
+            expected_snapshot=_expected(expected_values=expected_values),
+            realized_snapshot=_realized(realized_values=realized_values),
+            dimension_configs=[_config()],
+        )
+
+    assert str(exc_info.value) == "DPM_OUTCOME_DIMENSION_EVIDENCE_MISSING:DRIFT_REDUCTION"
+
+
+def test_outcome_review_dimensions_exports_dimension_helper_surface() -> None:
+    assert outcome_review_dimensions.__all__ == [
+        "DpmOutcomeDimensionConfig",
+        "DpmOutcomeReviewValidationError",
+        "dimension_inputs_for_review",
+    ]
+
+
+def test_service_preserves_dimension_import_surface() -> None:
+    assert outcome_review_service.DpmOutcomeDimensionConfig is DpmOutcomeDimensionConfig
+    assert outcome_review_service.DpmOutcomeReviewValidationError is DpmOutcomeReviewValidationError
+    assert outcome_review_service._dimension_inputs is dimension_inputs_for_review

--- a/tests/unit/dpm/outcomes/test_outcome_review_persistence.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_persistence.py
@@ -1,0 +1,49 @@
+from datetime import datetime, timedelta, timezone
+
+from src.api.services.outcome_review_persistence import (
+    OUTCOME_REVIEW_RETENTION_DAYS,
+    persist_outcome_review,
+)
+from tests.unit.infrastructure.test_outcome_review_repository import _review
+
+
+class _CapturingOutcomeReviewRepository:
+    def __init__(self) -> None:
+        self.saved: dict[str, object] | None = None
+
+    def save_outcome_review(
+        self,
+        *,
+        review: object,
+        retention_expires_at: datetime | None,
+    ) -> None:
+        self.saved = {
+            "review": review,
+            "retention_expires_at": retention_expires_at,
+        }
+
+
+def test_persist_outcome_review_applies_seven_year_retention_from_persisted_at() -> None:
+    repository = _CapturingOutcomeReviewRepository()
+    review = _review()
+    persisted_at = datetime(2026, 6, 1, 9, 15, tzinfo=timezone.utc)
+
+    persist_outcome_review(
+        repository=repository,  # type: ignore[arg-type]
+        review=review,
+        persisted_at=persisted_at,
+    )
+
+    assert repository.saved == {
+        "review": review,
+        "retention_expires_at": persisted_at + timedelta(days=OUTCOME_REVIEW_RETENTION_DAYS),
+    }
+
+
+def test_outcome_review_persistence_exports_retention_policy_surface() -> None:
+    from src.api.services import outcome_review_persistence
+
+    assert outcome_review_persistence.__all__ == [
+        "OUTCOME_REVIEW_RETENTION_DAYS",
+        "persist_outcome_review",
+    ]

--- a/tests/unit/dpm/outcomes/test_outcome_review_refresh.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_refresh.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+
+from src.api.services.outcome_review_refresh import build_source_refreshed_event
+from src.core.outcomes import DpmOutcomeReviewComparison
+from tests.unit.infrastructure.test_outcome_review_repository import _review
+
+
+REFRESHED_AT = datetime(2026, 5, 6, 2, 15, tzinfo=timezone.utc)
+
+
+def _comparison(state: str = "READY") -> DpmOutcomeReviewComparison:
+    review = _review(state=state)
+    return DpmOutcomeReviewComparison(
+        state=state,
+        dimension_results=review.dimension_results,
+        overall_outcome=review.overall_outcome,
+        variance_summary=review.variance_summary,
+        supportability=review.supportability,
+    )
+
+
+def test_build_source_refreshed_event_projects_state_reason_codes_and_lineage() -> None:
+    review = _review()
+
+    event = build_source_refreshed_event(
+        outcome_review_id=review.outcome_review_id,
+        expected_snapshot=review.expected_snapshot,
+        realized_snapshot=review.realized_snapshot,
+        comparison=_comparison(),
+        actor_id="system",
+        refreshed_at=REFRESHED_AT,
+        event_id_suffix="abc123ef",
+    )
+
+    assert event.event_id == "dor_001_source_refreshed_abc123ef"
+    assert event.event_type == "OUTCOME_REVIEW_SOURCE_REFRESHED"
+    assert event.event_time == REFRESHED_AT.isoformat()
+    assert event.actor == "system"
+    assert event.outcome_review_id == "dor_001"
+    assert event.state == "READY"
+    assert event.reason_codes == ["SOURCE_READY"]
+    assert [ref.source_id for ref in event.source_refs] == ["expected", "realized"]

--- a/tests/unit/dpm/outcomes/test_outcome_review_refresh.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_refresh.py
@@ -1,7 +1,12 @@
 from datetime import datetime, timezone
+from decimal import Decimal
 
-from src.api.services.outcome_review_refresh import build_source_refreshed_event
-from src.core.outcomes import DpmOutcomeReviewComparison
+from src.api.services.outcome_review_dimensions import DpmOutcomeDimensionConfig
+from src.api.services.outcome_review_refresh import (
+    build_source_refresh_result,
+    build_source_refreshed_event,
+)
+from src.core.outcomes import DpmOutcomeReviewComparison, DpmOutcomeTolerance
 from tests.unit.infrastructure.test_outcome_review_repository import _review
 
 
@@ -16,6 +21,15 @@ def _comparison(state: str = "READY") -> DpmOutcomeReviewComparison:
         overall_outcome=review.overall_outcome,
         variance_summary=review.variance_summary,
         supportability=review.supportability,
+    )
+
+
+def _dimension_config() -> DpmOutcomeDimensionConfig:
+    return DpmOutcomeDimensionConfig(
+        dimension="DRIFT_REDUCTION",
+        tolerance=DpmOutcomeTolerance(soft=Decimal("0.0025"), hard=Decimal("0.0100")),
+        materiality=Decimal("0.0050"),
+        direction="LOWER_IS_BETTER",
     )
 
 
@@ -39,4 +53,24 @@ def test_build_source_refreshed_event_projects_state_reason_codes_and_lineage() 
     assert event.outcome_review_id == "dor_001"
     assert event.state == "READY"
     assert event.reason_codes == ["SOURCE_READY"]
+    assert [ref.source_id for ref in event.source_refs] == ["expected", "realized"]
+
+
+def test_build_source_refresh_result_compares_snapshot_and_builds_event() -> None:
+    review = _review()
+
+    event, comparison = build_source_refresh_result(
+        review=review,
+        realized_snapshot=review.realized_snapshot,
+        dimension_configs=[_dimension_config()],
+        actor_id="system",
+        refreshed_at=REFRESHED_AT,
+        event_id_suffix="def456ab",
+    )
+
+    assert comparison.state == "READY"
+    assert [result.dimension for result in comparison.dimension_results] == ["DRIFT_REDUCTION"]
+    assert event.event_id == "dor_001_source_refreshed_def456ab"
+    assert event.state == comparison.state
+    assert event.reason_codes == comparison.supportability.reason_codes
     assert [ref.source_id for ref in event.source_refs] == ["expected", "realized"]

--- a/tests/unit/dpm/outcomes/test_outcome_review_report_inputs.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_report_inputs.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+from pytest import MonkeyPatch
+
+from src.api.services import outcome_review_report_inputs, outcome_review_service
+from src.api.services.outcome_review_report_inputs import (
+    build_outcome_ai_evidence_input,
+    build_outcome_report_input,
+    portfolio_memory_context_for_report,
+)
+from tests.unit.infrastructure.test_outcome_review_repository import _review
+
+
+def test_portfolio_memory_context_for_report_returns_none_without_required_repositories() -> None:
+    assert (
+        portfolio_memory_context_for_report(
+            review=_review(),
+            proof_pack_repository=None,
+            wave_repository=object(),  # type: ignore[arg-type]
+            outcome_review_repository=object(),  # type: ignore[arg-type]
+            mandate_repository=None,
+        )
+        is None
+    )
+    assert (
+        portfolio_memory_context_for_report(
+            review=_review(),
+            proof_pack_repository=object(),  # type: ignore[arg-type]
+            wave_repository=None,
+            outcome_review_repository=object(),  # type: ignore[arg-type]
+            mandate_repository=None,
+        )
+        is None
+    )
+
+
+def test_portfolio_memory_context_for_report_uses_review_portfolio_id(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    context = SimpleNamespace(portfolio_id="PB_SG_GLOBAL_BAL_001")
+
+    def _build(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return context
+
+    monkeypatch.setattr(
+        outcome_review_report_inputs,
+        "build_report_portfolio_memory_context",
+        _build,
+    )
+
+    result = portfolio_memory_context_for_report(
+        review=_review(),
+        proof_pack_repository=object(),  # type: ignore[arg-type]
+        wave_repository=object(),  # type: ignore[arg-type]
+        outcome_review_repository=object(),  # type: ignore[arg-type]
+        mandate_repository=object(),  # type: ignore[arg-type]
+    )
+
+    assert result is context
+    assert captured["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+
+
+def test_build_outcome_report_input_passes_portfolio_memory_context(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    report_input = SimpleNamespace(input_type="report")
+    memory_context = SimpleNamespace(portfolio_id="PB_SG_GLOBAL_BAL_001")
+
+    monkeypatch.setattr(
+        outcome_review_report_inputs,
+        "portfolio_memory_context_for_report",
+        lambda **_kwargs: memory_context,
+    )
+
+    def _build(review: object, *, portfolio_memory_context: object) -> object:
+        captured["review"] = review
+        captured["portfolio_memory_context"] = portfolio_memory_context
+        return report_input
+
+    monkeypatch.setattr(outcome_review_report_inputs, "build_report_input", _build)
+    review = _review()
+
+    result = build_outcome_report_input(
+        review=review,
+        proof_pack_repository=object(),  # type: ignore[arg-type]
+        wave_repository=object(),  # type: ignore[arg-type]
+        outcome_review_repository=object(),  # type: ignore[arg-type]
+        mandate_repository=None,
+    )
+
+    assert result is report_input
+    assert captured == {"review": review, "portfolio_memory_context": memory_context}
+
+
+def test_build_outcome_ai_evidence_input_passes_portfolio_memory_context(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ai_input = SimpleNamespace(input_type="ai")
+    memory_context = SimpleNamespace(portfolio_id="PB_SG_GLOBAL_BAL_001")
+
+    monkeypatch.setattr(
+        outcome_review_report_inputs,
+        "portfolio_memory_context_for_report",
+        lambda **_kwargs: memory_context,
+    )
+    monkeypatch.setattr(
+        outcome_review_report_inputs,
+        "build_ai_evidence_input",
+        lambda review, *, portfolio_memory_context: (review, portfolio_memory_context, ai_input),
+    )
+    review = _review()
+
+    result = build_outcome_ai_evidence_input(
+        review=review,
+        proof_pack_repository=object(),  # type: ignore[arg-type]
+        wave_repository=object(),  # type: ignore[arg-type]
+        outcome_review_repository=object(),  # type: ignore[arg-type]
+        mandate_repository=None,
+    )
+
+    assert result == (review, memory_context, ai_input)
+
+
+def test_outcome_review_report_inputs_exports_report_input_surface() -> None:
+    assert outcome_review_report_inputs.__all__ == [
+        "build_outcome_ai_evidence_input",
+        "build_outcome_report_input",
+        "portfolio_memory_context_for_report",
+    ]
+
+
+def test_service_preserves_portfolio_memory_context_alias() -> None:
+    assert outcome_review_service._portfolio_memory_context_for_report is (
+        portfolio_memory_context_for_report
+    )

--- a/tests/unit/dpm/outcomes/test_outcome_review_search.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_search.py
@@ -1,0 +1,147 @@
+from src.api.services.outcome_review_search import (
+    normalize_outcome_review_search_filter,
+    review_matches_source_lineage_filters,
+    search_outcome_review_page,
+)
+from src.core.outcomes import DpmOutcomeSourceRef
+from src.infrastructure.outcomes import InMemoryDpmOutcomeReviewRepository
+from tests.unit.infrastructure.test_outcome_review_repository import _review
+
+
+def _source_ref(*, source_system: str, source_type: str, source_id: str) -> DpmOutcomeSourceRef:
+    return DpmOutcomeSourceRef(
+        source_system=source_system,
+        source_type=source_type,
+        source_id=source_id,
+        content_hash=f"sha256:{source_id}",
+    )
+
+
+def _review_with_sources(
+    *,
+    outcome_review_id: str,
+    source_refs: list[DpmOutcomeSourceRef],
+):
+    return _review(
+        outcome_review_id=outcome_review_id,
+        content_hash=f"sha256:{outcome_review_id}",
+        idempotency_key=f"idem_{outcome_review_id}",
+    ).model_copy(update={"source_lineage": source_refs})
+
+
+def test_normalize_outcome_review_search_filter_trims_and_drops_blanks() -> None:
+    assert normalize_outcome_review_search_filter(None) is None
+    assert normalize_outcome_review_search_filter("   ") is None
+    assert normalize_outcome_review_search_filter(" lotus-risk ") == "lotus-risk"
+
+
+def test_review_matches_source_lineage_filters_requires_all_requested_filters() -> None:
+    review = _review_with_sources(
+        outcome_review_id="dor_lineage",
+        source_refs=[
+            _source_ref(
+                source_system="lotus-risk",
+                source_type="RiskMetricsReport:v1",
+                source_id="risk_001",
+            )
+        ],
+    )
+
+    assert review_matches_source_lineage_filters(
+        review=review,
+        source_system="lotus-risk",
+        source_type="RiskMetricsReport:v1",
+    )
+    assert not review_matches_source_lineage_filters(
+        review=review,
+        source_system="lotus-performance",
+        source_type="RiskMetricsReport:v1",
+    )
+    assert not review_matches_source_lineage_filters(
+        review=review,
+        source_system="lotus-risk",
+        source_type="PerformanceWindowReturn:v1",
+    )
+
+
+def test_search_outcome_review_page_filters_counts_and_paginates_source_lineage() -> None:
+    repository = InMemoryDpmOutcomeReviewRepository()
+    risk_ref = _source_ref(
+        source_system="lotus-risk",
+        source_type="RiskMetricsReport:v1",
+        source_id="risk_001",
+    )
+    performance_ref = _source_ref(
+        source_system="lotus-performance",
+        source_type="PerformanceWindowReturn:v1",
+        source_id="performance_001",
+    )
+    reviews = [
+        _review_with_sources(outcome_review_id="dor_risk_1", source_refs=[risk_ref]),
+        _review_with_sources(
+            outcome_review_id="dor_risk_performance",
+            source_refs=[risk_ref, performance_ref],
+        ),
+        _review_with_sources(outcome_review_id="dor_performance", source_refs=[performance_ref]),
+    ]
+    for review in reviews:
+        repository.save_outcome_review(review=review, retention_expires_at=None)
+
+    page = search_outcome_review_page(
+        repository=repository,
+        source_system=" lotus-risk ",
+        limit=1,
+        offset=1,
+    )
+
+    assert page.total == 2
+    assert [review.outcome_review_id for review in page.items] == ["dor_risk_1"]
+    assert page.normalized_source_system == "lotus-risk"
+    assert page.normalized_source_type is None
+    assert page.source_owner_counts == {
+        "lotus-performance": 1,
+        "lotus-risk": 2,
+    }
+    assert page.source_type_counts == {
+        "PerformanceWindowReturn:v1": 1,
+        "RiskMetricsReport:v1": 2,
+    }
+
+
+def test_search_outcome_review_page_honors_source_scan_limit_before_lineage_filtering() -> None:
+    repository = InMemoryDpmOutcomeReviewRepository()
+    repository.save_outcome_review(
+        review=_review_with_sources(
+            outcome_review_id="dor_first",
+            source_refs=[
+                _source_ref(
+                    source_system="lotus-risk",
+                    source_type="RiskMetricsReport:v1",
+                    source_id="risk_001",
+                )
+            ],
+        ),
+        retention_expires_at=None,
+    )
+    repository.save_outcome_review(
+        review=_review_with_sources(
+            outcome_review_id="dor_second",
+            source_refs=[
+                _source_ref(
+                    source_system="lotus-risk",
+                    source_type="RiskMetricsReport:v1",
+                    source_id="risk_002",
+                )
+            ],
+        ),
+        retention_expires_at=None,
+    )
+
+    page = search_outcome_review_page(
+        repository=repository,
+        source_system="lotus-risk",
+        source_scan_limit=1,
+    )
+
+    assert page.total == 1
+    assert [review.outcome_review_id for review in page.items] == ["dor_second"]

--- a/tests/unit/dpm/proof_packs/test_proof_pack_generation.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_generation.py
@@ -1,0 +1,112 @@
+from pytest import MonkeyPatch
+
+from src.api.services import proof_pack_generation
+from src.api.services.proof_pack_generation import (
+    build_run_proof_pack,
+    build_selected_alternative_proof_pack,
+)
+from src.api.services.proof_pack_mandate_evidence import ProofPackMandateEvidence
+from src.api.services.proof_pack_selected_source import ProofPackSelectedAlternativeSource
+from src.core.construction import build_alternative_set, build_rebalance_result_alternative
+from tests.unit.dpm.proof_packs.test_proof_pack_builder import (
+    _ready_rebalance_result,
+    _run_record,
+)
+from tests.unit.dpm.proof_packs.test_proof_pack_repository import _proof_pack
+
+
+def test_build_run_proof_pack_passes_resolved_mandate_and_workflow_inputs(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    proof_pack = _proof_pack()
+    run = _run_record()
+    workflow_decisions: list[object] = []
+    mandate_evidence = ProofPackMandateEvidence(
+        twin=object(),  # type: ignore[arg-type]
+        health=object(),  # type: ignore[arg-type]
+        gap_codes=["MANDATE_GAP"],
+    )
+
+    def _build(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return proof_pack
+
+    monkeypatch.setattr(proof_pack_generation, "build_proof_pack_from_run", _build)
+
+    result = build_run_proof_pack(
+        run=run,
+        workflow_decisions=workflow_decisions,  # type: ignore[arg-type]
+        actor_id="pm_generation",
+        reason="Generate proof pack.",
+        correlation_id="corr_generation",
+        mandate_id="mandate_generation",
+        mandate_evidence=mandate_evidence,
+        direct_regime_stress_context=None,
+    )
+
+    assert result is proof_pack
+    assert captured["run"] is run
+    assert captured["workflow_decisions"] is workflow_decisions
+    assert captured["created_by"] == "pm_generation"
+    assert captured["mandate_twin"] is mandate_evidence.twin
+    assert captured["mandate_health"] is mandate_evidence.health
+    assert captured["mandate_evidence_gap_codes"] == ["MANDATE_GAP"]
+
+
+def test_build_selected_alternative_proof_pack_passes_resolved_source_inputs(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+    alternative_set = build_alternative_set(
+        alternative_set_id="cas_generation_001",
+        portfolio_id="pf_generation_001",
+        as_of="2026-06-01",
+        alternatives=[alternative],
+    )
+    selected_source = ProofPackSelectedAlternativeSource(
+        alternative_set=alternative_set,
+        selection=None,
+        run=_run_record(),
+        workflow_decisions=[],
+    )
+    proof_pack = _proof_pack()
+    mandate_evidence = ProofPackMandateEvidence(twin=None, health=None, gap_codes=[])
+
+    def _build(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return proof_pack
+
+    monkeypatch.setattr(
+        proof_pack_generation,
+        "build_proof_pack_from_selected_alternative",
+        _build,
+    )
+
+    result_pack = build_selected_alternative_proof_pack(
+        selected_source=selected_source,
+        selected_alternative_id=alternative.alternative_id,
+        actor_id="pm_generation",
+        reason=None,
+        correlation_id="corr_generation",
+        mandate_id=None,
+        mandate_evidence=mandate_evidence,
+        direct_regime_stress_context=None,
+    )
+
+    assert result_pack is proof_pack
+    assert captured["alternative_set"] is alternative_set
+    assert captured["selected_alternative_id"] == alternative.alternative_id
+    assert captured["run"] is selected_source.run
+    assert captured["selection"] is None
+    assert captured["created_by"] == "pm_generation"
+    assert captured["workflow_decisions"] == []
+
+
+def test_proof_pack_generation_exports_builder_surface() -> None:
+    assert proof_pack_generation.__all__ == [
+        "build_run_proof_pack",
+        "build_selected_alternative_proof_pack",
+    ]

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoff_refs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoff_refs.py
@@ -1,0 +1,153 @@
+from datetime import datetime, timedelta, timezone
+
+from src.api.services.proof_pack_handoff_refs import (
+    ensure_handoff_refs,
+    find_stored_ref,
+    hydrate_handoff_refs,
+    stored_ref_to_evidence_ref,
+)
+from src.core.proof_packs import AI_EVIDENCE_REF_TYPE, REPORT_INPUT_REF_TYPE
+from src.core.proof_packs.models import DpmProofPackStoredRef
+from src.infrastructure.proof_packs import InMemoryDpmProofPackRepository
+from tests.unit.dpm.proof_packs.test_proof_pack_repository import _proof_pack
+
+
+CREATED_AT = datetime(2026, 5, 3, 9, 30, tzinfo=timezone.utc)
+
+
+def _stored_ref(
+    *,
+    ref_type: str,
+    ref_id: str,
+    content_hash: str,
+    created_at: datetime = CREATED_AT,
+) -> DpmProofPackStoredRef:
+    return DpmProofPackStoredRef(
+        proof_pack_id=_proof_pack().proof_pack_id,
+        ref_type=ref_type,
+        ref_id=ref_id,
+        source_system="lotus-manage",
+        content_hash=content_hash,
+        created_at=created_at.isoformat(),
+    )
+
+
+def test_find_stored_ref_returns_latest_matching_append_only_ref() -> None:
+    proof_pack = _proof_pack()
+    repository = InMemoryDpmProofPackRepository()
+    repository.save_proof_pack(
+        proof_pack=proof_pack,
+        idempotency_key=None,
+        retention_expires_at=None,
+    )
+    repository.append_ref(
+        ref=_stored_ref(
+            ref_type=REPORT_INPUT_REF_TYPE,
+            ref_id="dpri_old",
+            content_hash="sha256:old",
+        )
+    )
+    repository.append_ref(
+        ref=_stored_ref(
+            ref_type=AI_EVIDENCE_REF_TYPE,
+            ref_id="dpai_current",
+            content_hash="sha256:ai",
+        )
+    )
+    repository.append_ref(
+        ref=_stored_ref(
+            ref_type=REPORT_INPUT_REF_TYPE,
+            ref_id="dpri_new",
+            content_hash="sha256:new",
+            created_at=CREATED_AT + timedelta(minutes=1),
+        )
+    )
+
+    stored_ref = find_stored_ref(
+        proof_pack_id=proof_pack.proof_pack_id,
+        ref_type=REPORT_INPUT_REF_TYPE,
+        proof_pack_repository=repository,
+    )
+
+    assert stored_ref is not None
+    assert stored_ref.ref_id == "dpri_new"
+    assert stored_ref.content_hash == "sha256:new"
+
+
+def test_hydrate_handoff_refs_overlays_stored_refs_without_mutating_pack() -> None:
+    proof_pack = _proof_pack()
+    repository = InMemoryDpmProofPackRepository()
+    repository.save_proof_pack(
+        proof_pack=proof_pack,
+        idempotency_key=None,
+        retention_expires_at=None,
+    )
+    repository.append_ref(
+        ref=_stored_ref(
+            ref_type=REPORT_INPUT_REF_TYPE,
+            ref_id="dpri_hydrated",
+            content_hash="sha256:report",
+        )
+    )
+    repository.append_ref(
+        ref=_stored_ref(
+            ref_type=AI_EVIDENCE_REF_TYPE,
+            ref_id="dpai_hydrated",
+            content_hash="sha256:ai",
+        )
+    )
+
+    hydrated = hydrate_handoff_refs(
+        proof_pack=proof_pack,
+        proof_pack_repository=repository,
+    )
+
+    assert hydrated is not proof_pack
+    assert proof_pack.report_input_ref is None
+    assert proof_pack.ai_evidence_ref is None
+    assert hydrated.report_input_ref is not None
+    assert hydrated.report_input_ref.ref_id == "dpri_hydrated"
+    assert hydrated.ai_evidence_ref is not None
+    assert hydrated.ai_evidence_ref.ref_id == "dpai_hydrated"
+
+
+def test_ensure_handoff_refs_skips_existing_matching_content_refs() -> None:
+    proof_pack = _proof_pack()
+    repository = InMemoryDpmProofPackRepository()
+    repository.save_proof_pack(
+        proof_pack=proof_pack,
+        idempotency_key=None,
+        retention_expires_at=None,
+    )
+
+    first = ensure_handoff_refs(
+        proof_pack=proof_pack,
+        proof_pack_repository=repository,
+        include_report_input=True,
+        include_ai_evidence_input=True,
+    )
+    second = ensure_handoff_refs(
+        proof_pack=first,
+        proof_pack_repository=repository,
+        include_report_input=True,
+        include_ai_evidence_input=True,
+    )
+
+    assert second.report_input_ref == first.report_input_ref
+    assert second.ai_evidence_ref == first.ai_evidence_ref
+    assert len(repository.list_refs(proof_pack_id=proof_pack.proof_pack_id)) == 2
+
+
+def test_stored_ref_to_evidence_ref_preserves_handoff_identity() -> None:
+    stored_ref = _stored_ref(
+        ref_type=REPORT_INPUT_REF_TYPE,
+        ref_id="dpri_identity",
+        content_hash="sha256:identity",
+    )
+
+    evidence_ref = stored_ref_to_evidence_ref(stored_ref)
+
+    assert evidence_ref.ref_type == stored_ref.ref_type
+    assert evidence_ref.ref_id == stored_ref.ref_id
+    assert evidence_ref.source_system == stored_ref.source_system
+    assert evidence_ref.content_hash == stored_ref.content_hash

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoff_refs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoff_refs.py
@@ -4,6 +4,7 @@ from src.api.services.proof_pack_handoff_refs import (
     ensure_handoff_refs,
     find_stored_ref,
     hydrate_handoff_refs,
+    require_handoff_ref,
     stored_ref_to_evidence_ref,
 )
 from src.core.proof_packs import AI_EVIDENCE_REF_TYPE, REPORT_INPUT_REF_TYPE
@@ -151,3 +152,74 @@ def test_stored_ref_to_evidence_ref_preserves_handoff_identity() -> None:
     assert evidence_ref.ref_id == stored_ref.ref_id
     assert evidence_ref.source_system == stored_ref.source_system
     assert evidence_ref.content_hash == stored_ref.content_hash
+
+
+def test_require_handoff_ref_prefers_hydrated_ref_without_repository_lookup() -> None:
+    proof_pack = _proof_pack()
+    hydrated_ref = stored_ref_to_evidence_ref(
+        _stored_ref(
+            ref_type=REPORT_INPUT_REF_TYPE,
+            ref_id="dpri_hydrated",
+            content_hash="sha256:hydrated",
+        )
+    )
+
+    class _FailingRepository:
+        def list_refs(self, *, proof_pack_id: str):
+            raise AssertionError("repository lookup should not run for hydrated refs")
+
+    ref = require_handoff_ref(
+        proof_pack_id=proof_pack.proof_pack_id,
+        hydrated_ref=hydrated_ref,
+        ref_type=REPORT_INPUT_REF_TYPE,
+        proof_pack_repository=_FailingRepository(),  # type: ignore[arg-type]
+    )
+
+    assert ref is hydrated_ref
+
+
+def test_require_handoff_ref_falls_back_to_latest_stored_ref() -> None:
+    proof_pack = _proof_pack()
+    repository = InMemoryDpmProofPackRepository()
+    repository.save_proof_pack(
+        proof_pack=proof_pack,
+        idempotency_key=None,
+        retention_expires_at=None,
+    )
+    repository.append_ref(
+        ref=_stored_ref(
+            ref_type=REPORT_INPUT_REF_TYPE,
+            ref_id="dpri_required",
+            content_hash="sha256:required",
+        )
+    )
+
+    ref = require_handoff_ref(
+        proof_pack_id=proof_pack.proof_pack_id,
+        hydrated_ref=None,
+        ref_type=REPORT_INPUT_REF_TYPE,
+        proof_pack_repository=repository,
+    )
+
+    assert ref is not None
+    assert ref.ref_id == "dpri_required"
+    assert ref.content_hash == "sha256:required"
+
+
+def test_require_handoff_ref_returns_none_when_no_generated_ref_exists() -> None:
+    proof_pack = _proof_pack()
+    repository = InMemoryDpmProofPackRepository()
+    repository.save_proof_pack(
+        proof_pack=proof_pack,
+        idempotency_key=None,
+        retention_expires_at=None,
+    )
+
+    ref = require_handoff_ref(
+        proof_pack_id=proof_pack.proof_pack_id,
+        hydrated_ref=None,
+        ref_type=REPORT_INPUT_REF_TYPE,
+        proof_pack_repository=repository,
+    )
+
+    assert ref is None

--- a/tests/unit/dpm/proof_packs/test_proof_pack_mandate_evidence.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_mandate_evidence.py
@@ -1,0 +1,84 @@
+from src.api.services.proof_pack_mandate_evidence import resolve_mandate_evidence
+from src.core.mandates import DpmMandateHealthInput, calculate_mandate_health
+from src.infrastructure.mandates import InMemoryDpmMandateRepository
+from tests.unit.dpm.proof_packs.test_proof_pack_builder import _mandate_twin
+
+
+def _repository(*, mandate_id: str, portfolio_id: str) -> InMemoryDpmMandateRepository:
+    repository = InMemoryDpmMandateRepository()
+    twin = _mandate_twin().model_copy(
+        update={
+            "mandate_id": mandate_id,
+            "portfolio_id": portfolio_id,
+        }
+    )
+    repository.save_mandate_snapshot(twin)
+    repository.save_health_snapshot(calculate_mandate_health(DpmMandateHealthInput(twin=twin)))
+    return repository
+
+
+def test_resolve_mandate_evidence_returns_empty_when_optional_inputs_are_missing() -> None:
+    without_mandate_id = resolve_mandate_evidence(
+        mandate_id=None,
+        portfolio_id="pf_mandate_evidence_1",
+        mandate_repository=_repository(
+            mandate_id="mandate_evidence",
+            portfolio_id="pf_mandate_evidence_1",
+        ),
+    )
+    without_repository = resolve_mandate_evidence(
+        mandate_id="mandate_evidence",
+        portfolio_id="pf_mandate_evidence_1",
+        mandate_repository=None,
+    )
+
+    assert without_mandate_id.twin is None
+    assert without_mandate_id.health is None
+    assert without_mandate_id.gap_codes == []
+    assert without_repository.twin is None
+    assert without_repository.health is None
+    assert without_repository.gap_codes == []
+
+
+def test_resolve_mandate_evidence_returns_empty_when_snapshot_is_missing() -> None:
+    evidence = resolve_mandate_evidence(
+        mandate_id="missing",
+        portfolio_id="pf_mandate_evidence_1",
+        mandate_repository=InMemoryDpmMandateRepository(),
+    )
+
+    assert evidence.twin is None
+    assert evidence.health is None
+    assert evidence.gap_codes == []
+
+
+def test_resolve_mandate_evidence_rejects_portfolio_mismatched_twin() -> None:
+    evidence = resolve_mandate_evidence(
+        mandate_id="mandate_evidence",
+        portfolio_id="pf_mandate_evidence_1",
+        mandate_repository=_repository(
+            mandate_id="mandate_evidence",
+            portfolio_id="different_portfolio",
+        ),
+    )
+
+    assert evidence.twin is None
+    assert evidence.health is None
+    assert evidence.gap_codes == ["DPM_MANDATE_TWIN_PORTFOLIO_MISMATCH"]
+
+
+def test_resolve_mandate_evidence_returns_portfolio_matched_twin_and_health() -> None:
+    evidence = resolve_mandate_evidence(
+        mandate_id="mandate_evidence",
+        portfolio_id="pf_mandate_evidence_1",
+        mandate_repository=_repository(
+            mandate_id="mandate_evidence",
+            portfolio_id="pf_mandate_evidence_1",
+        ),
+    )
+
+    assert evidence.twin is not None
+    assert evidence.twin.portfolio_id == "pf_mandate_evidence_1"
+    assert evidence.health is not None
+    assert evidence.health.mandate_id == "mandate_evidence"
+    assert evidence.gap_codes == []

--- a/tests/unit/dpm/proof_packs/test_proof_pack_persistence.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_persistence.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timedelta, timezone
+
+from src.api.services.proof_pack_persistence import (
+    PROOF_PACK_RETENTION_DAYS,
+    persist_proof_pack,
+)
+from tests.unit.dpm.proof_packs.test_proof_pack_repository import _proof_pack
+
+
+class _CapturingProofPackRepository:
+    def __init__(self) -> None:
+        self.saved: dict[str, object] | None = None
+
+    def save_proof_pack(
+        self,
+        *,
+        proof_pack: object,
+        idempotency_key: str | None,
+        retention_expires_at: datetime | None,
+    ) -> None:
+        self.saved = {
+            "proof_pack": proof_pack,
+            "idempotency_key": idempotency_key,
+            "retention_expires_at": retention_expires_at,
+        }
+
+
+def test_persist_proof_pack_applies_seven_year_retention_from_persisted_at() -> None:
+    repository = _CapturingProofPackRepository()
+    proof_pack = _proof_pack()
+    persisted_at = datetime(2026, 6, 1, 8, 30, tzinfo=timezone.utc)
+
+    persist_proof_pack(
+        proof_pack_repository=repository,  # type: ignore[arg-type]
+        proof_pack=proof_pack,
+        idempotency_key="idem-proof-pack-persistence",
+        persisted_at=persisted_at,
+    )
+
+    assert repository.saved == {
+        "proof_pack": proof_pack,
+        "idempotency_key": "idem-proof-pack-persistence",
+        "retention_expires_at": persisted_at + timedelta(days=PROOF_PACK_RETENTION_DAYS),
+    }
+
+
+def test_proof_pack_persistence_exports_retention_policy_surface() -> None:
+    from src.api.services import proof_pack_persistence
+
+    assert proof_pack_persistence.__all__ == [
+        "PROOF_PACK_RETENTION_DAYS",
+        "persist_proof_pack",
+    ]

--- a/tests/unit/dpm/proof_packs/test_proof_pack_replay.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_replay.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timezone
+
+from src.api.services.proof_pack_replay import find_replayable_proof_pack
+from src.infrastructure.proof_packs import InMemoryDpmProofPackRepository
+from tests.unit.dpm.proof_packs.test_proof_pack_repository import _proof_pack
+
+
+RETENTION_EXPIRES_AT = datetime(2033, 5, 3, 9, 30, tzinfo=timezone.utc)
+
+
+def test_find_replayable_proof_pack_prefers_idempotency_match() -> None:
+    repository = InMemoryDpmProofPackRepository()
+    by_idempotency = _proof_pack().model_copy(update={"proof_pack_id": "dpp_by_idempotency"})
+    by_source_identity = _proof_pack().model_copy(update={"proof_pack_id": "dpp_by_source"})
+    repository.save_proof_pack(
+        proof_pack=by_idempotency,
+        idempotency_key="idem-proof-pack-replay",
+        retention_expires_at=RETENTION_EXPIRES_AT,
+    )
+    repository.save_proof_pack(
+        proof_pack=by_source_identity,
+        idempotency_key=None,
+        retention_expires_at=RETENTION_EXPIRES_AT,
+    )
+
+    replay = find_replayable_proof_pack(
+        proof_pack_id=by_source_identity.proof_pack_id,
+        idempotency_key="idem-proof-pack-replay",
+        proof_pack_repository=repository,
+    )
+
+    assert replay == by_idempotency
+
+
+def test_find_replayable_proof_pack_falls_back_to_source_identity() -> None:
+    repository = InMemoryDpmProofPackRepository()
+    proof_pack = _proof_pack()
+    repository.save_proof_pack(
+        proof_pack=proof_pack,
+        idempotency_key=None,
+        retention_expires_at=RETENTION_EXPIRES_AT,
+    )
+
+    replay = find_replayable_proof_pack(
+        proof_pack_id=proof_pack.proof_pack_id,
+        idempotency_key="different-idempotency-key",
+        proof_pack_repository=repository,
+    )
+
+    assert replay == proof_pack
+
+
+def test_find_replayable_proof_pack_returns_none_when_no_replay_exists() -> None:
+    repository = InMemoryDpmProofPackRepository()
+
+    replay = find_replayable_proof_pack(
+        proof_pack_id="dpp_missing",
+        idempotency_key=None,
+        proof_pack_repository=repository,
+    )
+
+    assert replay is None

--- a/tests/unit/dpm/proof_packs/test_proof_pack_report_inputs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_report_inputs.py
@@ -1,0 +1,142 @@
+from types import SimpleNamespace
+
+from pytest import MonkeyPatch
+
+from src.api.services import proof_pack_report_inputs, proof_pack_service
+from src.api.services.proof_pack_report_inputs import (
+    build_proof_pack_ai_evidence_input,
+    build_proof_pack_report_input,
+    portfolio_memory_context_for_report,
+)
+from tests.unit.dpm.proof_packs.test_proof_pack_repository import _proof_pack
+
+
+def test_portfolio_memory_context_for_report_returns_none_without_required_repositories() -> None:
+    assert (
+        portfolio_memory_context_for_report(
+            portfolio_id="PB_SG_GLOBAL_BAL_001",
+            proof_pack_repository=object(),  # type: ignore[arg-type]
+            wave_repository=None,
+            outcome_review_repository=object(),  # type: ignore[arg-type]
+            mandate_repository=None,
+        )
+        is None
+    )
+    assert (
+        portfolio_memory_context_for_report(
+            portfolio_id="PB_SG_GLOBAL_BAL_001",
+            proof_pack_repository=object(),  # type: ignore[arg-type]
+            wave_repository=object(),  # type: ignore[arg-type]
+            outcome_review_repository=None,
+            mandate_repository=None,
+        )
+        is None
+    )
+
+
+def test_portfolio_memory_context_for_report_uses_proof_pack_portfolio_id(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    context = SimpleNamespace(portfolio_id="PB_SG_GLOBAL_BAL_001")
+
+    def _build(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return context
+
+    monkeypatch.setattr(
+        proof_pack_report_inputs,
+        "build_report_portfolio_memory_context",
+        _build,
+    )
+
+    result = portfolio_memory_context_for_report(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        proof_pack_repository=object(),  # type: ignore[arg-type]
+        wave_repository=object(),  # type: ignore[arg-type]
+        outcome_review_repository=object(),  # type: ignore[arg-type]
+        mandate_repository=object(),  # type: ignore[arg-type]
+    )
+
+    assert result is context
+    assert captured["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+
+
+def test_build_proof_pack_report_input_passes_portfolio_memory_context(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    report_input = SimpleNamespace(input_type="report")
+    memory_context = SimpleNamespace(portfolio_id="PB_SG_GLOBAL_BAL_001")
+    proof_pack = _proof_pack()
+
+    monkeypatch.setattr(
+        proof_pack_report_inputs,
+        "portfolio_memory_context_for_report",
+        lambda **_kwargs: memory_context,
+    )
+
+    def _build(proof_pack_arg: object, *, portfolio_memory_context: object) -> object:
+        captured["proof_pack"] = proof_pack_arg
+        captured["portfolio_memory_context"] = portfolio_memory_context
+        return report_input
+
+    monkeypatch.setattr(proof_pack_report_inputs, "build_report_input", _build)
+
+    result = build_proof_pack_report_input(
+        proof_pack=proof_pack,
+        proof_pack_repository=object(),  # type: ignore[arg-type]
+        wave_repository=object(),  # type: ignore[arg-type]
+        outcome_review_repository=object(),  # type: ignore[arg-type]
+        mandate_repository=None,
+    )
+
+    assert result is report_input
+    assert captured == {"proof_pack": proof_pack, "portfolio_memory_context": memory_context}
+
+
+def test_build_proof_pack_ai_evidence_input_passes_portfolio_memory_context(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    ai_input = SimpleNamespace(input_type="ai")
+    memory_context = SimpleNamespace(portfolio_id="PB_SG_GLOBAL_BAL_001")
+    proof_pack = _proof_pack()
+
+    monkeypatch.setattr(
+        proof_pack_report_inputs,
+        "portfolio_memory_context_for_report",
+        lambda **_kwargs: memory_context,
+    )
+    monkeypatch.setattr(
+        proof_pack_report_inputs,
+        "build_ai_evidence_input",
+        lambda proof_pack_arg, *, portfolio_memory_context: (
+            proof_pack_arg,
+            portfolio_memory_context,
+            ai_input,
+        ),
+    )
+
+    result = build_proof_pack_ai_evidence_input(
+        proof_pack=proof_pack,
+        proof_pack_repository=object(),  # type: ignore[arg-type]
+        wave_repository=object(),  # type: ignore[arg-type]
+        outcome_review_repository=object(),  # type: ignore[arg-type]
+        mandate_repository=None,
+    )
+
+    assert result == (proof_pack, memory_context, ai_input)
+
+
+def test_proof_pack_report_inputs_exports_report_input_surface() -> None:
+    assert proof_pack_report_inputs.__all__ == [
+        "build_proof_pack_ai_evidence_input",
+        "build_proof_pack_report_input",
+        "portfolio_memory_context_for_report",
+    ]
+
+
+def test_service_preserves_portfolio_memory_context_alias() -> None:
+    assert proof_pack_service._portfolio_memory_context_for_report is (
+        portfolio_memory_context_for_report
+    )

--- a/tests/unit/dpm/proof_packs/test_proof_pack_selected_source.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_selected_source.py
@@ -1,0 +1,129 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api.services.proof_pack_selected_source import resolve_selected_alternative_source
+from src.core.construction import (
+    ConstructionAlternativeSelection,
+    build_alternative_set,
+    build_rebalance_result_alternative,
+)
+from src.core.proof_packs import ProofPackSourceValidationError
+from src.core.rebalance_runs.models import DpmRunWorkflowDecisionRecord
+from src.core.rebalance_runs.service import DpmRunNotFoundError
+from src.infrastructure.construction import InMemoryConstructionRepository
+from tests.unit.dpm.proof_packs.test_proof_pack_builder import (
+    _ready_rebalance_result,
+    _run_record,
+)
+
+
+CREATED_AT = datetime(2026, 5, 3, 9, 30, tzinfo=timezone.utc)
+
+
+class _RunService:
+    def __init__(self, *, missing: bool = False) -> None:
+        self.missing = missing
+        self.run = _run_record()
+        self.decisions = [
+            DpmRunWorkflowDecisionRecord(
+                decision_id="dwd_selected_source_001",
+                run_id=self.run.rebalance_run_id,
+                action="APPROVE",
+                reason_code="REVIEW_APPROVED",
+                comment="Approved for proof pack.",
+                actor_id="pm_selected_source",
+                decided_at=CREATED_AT,
+                correlation_id="corr-selected-source",
+            )
+        ]
+
+    def get_run_record(self, *, rebalance_run_id: str):
+        if self.missing:
+            raise DpmRunNotFoundError("DPM_RUN_NOT_FOUND")
+        return self.run
+
+    def list_workflow_decision_records(self, *, rebalance_run_id: str):
+        if self.missing:
+            raise DpmRunNotFoundError("DPM_RUN_NOT_FOUND")
+        return self.decisions
+
+
+def _construction_repository() -> tuple[InMemoryConstructionRepository, str, str]:
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+    alternative_set = build_alternative_set(
+        alternative_set_id="cas_selected_source_001",
+        portfolio_id="pf_selected_source_1",
+        as_of="2026-05-03",
+        alternatives=[alternative],
+    ).model_copy(update={"generated_at": CREATED_AT})
+    selection = ConstructionAlternativeSelection(
+        selection_id="casel_selected_source_001",
+        alternative_set_id=alternative_set.alternative_set_id,
+        alternative_id=alternative.alternative_id,
+        actor_id="pm_selected_source",
+        reason_code="MODEL_DRIFT_REVIEW",
+        comment="Use selected alternative.",
+        correlation_id="corr-selected-source",
+    )
+    repository = InMemoryConstructionRepository()
+    repository.save_alternative_set(alternative_set=alternative_set, idempotency_key=None)
+    repository.save_selection(selection=selection)
+    return repository, alternative_set.alternative_set_id, alternative.alternative_id
+
+
+def test_resolve_selected_alternative_source_returns_selection_run_and_decisions() -> None:
+    repository, alternative_set_id, selected_alternative_id = _construction_repository()
+    run_service = _RunService()
+
+    source = resolve_selected_alternative_source(
+        alternative_set_id=alternative_set_id,
+        selected_alternative_id=selected_alternative_id,
+        construction_repository=repository,
+        run_service=run_service,
+    )
+
+    assert source.alternative_set.alternative_set_id == alternative_set_id
+    assert source.selection is not None
+    assert source.selection.alternative_id == selected_alternative_id
+    assert source.run == run_service.run
+    assert source.workflow_decisions == run_service.decisions
+
+
+def test_resolve_selected_alternative_source_degrades_when_linked_run_is_missing() -> None:
+    repository, alternative_set_id, selected_alternative_id = _construction_repository()
+
+    source = resolve_selected_alternative_source(
+        alternative_set_id=alternative_set_id,
+        selected_alternative_id=selected_alternative_id,
+        construction_repository=repository,
+        run_service=_RunService(missing=True),
+    )
+
+    assert source.run is None
+    assert source.workflow_decisions == []
+
+
+def test_resolve_selected_alternative_source_rejects_missing_alternative_set() -> None:
+    repository, _, selected_alternative_id = _construction_repository()
+
+    with pytest.raises(ProofPackSourceValidationError, match="DPM_ALTERNATIVE_SET_NOT_FOUND"):
+        resolve_selected_alternative_source(
+            alternative_set_id="missing",
+            selected_alternative_id=selected_alternative_id,
+            construction_repository=repository,
+            run_service=_RunService(),
+        )
+
+
+def test_resolve_selected_alternative_source_rejects_missing_selected_alternative() -> None:
+    repository, alternative_set_id, _ = _construction_repository()
+
+    with pytest.raises(ProofPackSourceValidationError, match="DPM_SELECTED_ALTERNATIVE_NOT_FOUND"):
+        resolve_selected_alternative_source(
+            alternative_set_id=alternative_set_id,
+            selected_alternative_id="missing",
+            construction_repository=repository,
+            run_service=_RunService(),
+        )

--- a/tests/unit/dpm/proof_packs/test_proof_pack_service.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_service.py
@@ -10,6 +10,7 @@ from src.core.construction import (
     build_rebalance_result_alternative,
 )
 from src.core.mandates import DpmMandateHealthInput, calculate_mandate_health
+from src.core.proof_packs import ProofPackSourceValidationError
 from src.core.proof_packs.models import DpmProofPackStoredRef
 from src.core.proof_packs.repository import DpmProofPackConflictError
 from src.core.rebalance_runs.service import DpmRunNotFoundError
@@ -189,7 +190,7 @@ def test_selected_alternative_service_validates_sources_and_missing_run_degrades
     repository, alternative_set_id, selected_alternative_id = _construction_repository()
     proof_repository = InMemoryDpmProofPackRepository()
 
-    with pytest.raises(proof_pack_service.ProofPackSourceValidationError, match="NOT_FOUND"):
+    with pytest.raises(ProofPackSourceValidationError, match="NOT_FOUND"):
         proof_pack_service.generate_proof_pack_from_selected_alternative(
             alternative_set_id="missing",
             selected_alternative_id=selected_alternative_id,
@@ -204,7 +205,7 @@ def test_selected_alternative_service_validates_sources_and_missing_run_degrades
             proof_pack_repository=proof_repository,
         )
     with pytest.raises(
-        proof_pack_service.ProofPackSourceValidationError,
+        ProofPackSourceValidationError,
         match="DPM_SELECTED_ALTERNATIVE_NOT_FOUND",
     ):
         proof_pack_service.generate_proof_pack_from_selected_alternative(
@@ -501,7 +502,7 @@ def test_proof_pack_http_exception_mapping() -> None:
     mappings = [
         (DpmProofPackConflictError("conflict"), 409, "conflict"),
         (DpmRunNotFoundError("missing"), 404, "missing"),
-        (proof_pack_service.ProofPackSourceValidationError("bad-source"), 404, "bad-source"),
+        (ProofPackSourceValidationError("bad-source"), 404, "bad-source"),
         (
             proof_pack_service.DpmProofPackReportInputNotGeneratedError("no-report"),
             424,

--- a/tests/unit/dpm/waves/test_wave_approval_transition.py
+++ b/tests/unit/dpm/waves/test_wave_approval_transition.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.api.services.wave_approval_transition import build_approved_wave
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWaveTrigger
+
+
+def _item(*, wave_item_id: str, state: str) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id=wave_item_id,
+        portfolio_id=f"PB_SG_{wave_item_id.upper()}",
+        state=state,
+        reason_codes=["INITIAL"],
+        diagnostics={"existing": "value"},
+    )
+
+
+def _wave(*, state: str, items: list[DpmRebalanceWaveItem]) -> DpmRebalanceWave:
+    return DpmRebalanceWave(
+        wave_id="dwv_approval",
+        state=state,
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="manual-approval",
+            rationale="Approve selected wave items.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm_001",
+        correlation_id="corr_approval",
+        items=items,
+        aggregate_metrics=aggregate_wave_items(items),
+    )
+
+
+def test_build_approved_wave_approves_all_eligible_items() -> None:
+    approved = build_approved_wave(
+        wave=_wave(state="SIMULATED", items=[_item(wave_item_id="dwi_1", state="SELECTED")]),
+        actor_id="pm_approval",
+        reason_code="APPROVED_BY_PM",
+        comment="Approved.",
+        correlation_id="corr_approval",
+    )
+
+    assert approved.state == "APPROVED"
+    assert approved.version == 2
+    assert approved.items[0].state == "APPROVED"
+    assert approved.items[0].diagnostics["approval_actor_id"] == "pm_approval"
+    assert approved.aggregate_metrics.state_counts == {"APPROVED": 1}
+    assert approved.events[-1].reason_code == "WAVE_APPROVED"
+    assert approved.events[-1].metadata == {
+        "approved_item_count": 1,
+        "exception_item_count": 0,
+        "approval_reason_code": "APPROVED_BY_PM",
+        "comment": "Approved.",
+    }
+
+
+def test_build_approved_wave_uses_exception_state_for_partially_approved_items() -> None:
+    approved = build_approved_wave(
+        wave=_wave(
+            state="PARTIALLY_SIMULATED",
+            items=[
+                _item(wave_item_id="dwi_1", state="PROOF_PACK_READY"),
+                _item(wave_item_id="dwi_2", state="SIMULATED"),
+            ],
+        ),
+        actor_id="pm_approval",
+        reason_code="APPROVED_WITH_EXCEPTION",
+        comment=None,
+        correlation_id="corr_approval",
+    )
+
+    assert approved.state == "APPROVED_WITH_EXCEPTIONS"
+    assert [item.state for item in approved.items] == ["APPROVED", "SIMULATED"]
+    assert approved.aggregate_metrics.state_counts == {"APPROVED": 1, "SIMULATED": 1}
+    assert approved.events[-1].metadata == {
+        "approved_item_count": 1,
+        "exception_item_count": 1,
+        "approval_reason_code": "APPROVED_WITH_EXCEPTION",
+    }
+
+
+def test_build_approved_wave_rejects_no_eligible_items() -> None:
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        build_approved_wave(
+            wave=_wave(state="SIMULATED", items=[_item(wave_item_id="dwi_1", state="SIMULATED")]),
+            actor_id="pm_approval",
+            reason_code="APPROVED_BY_PM",
+            comment=None,
+            correlation_id="corr_approval",
+        )
+
+    assert exc_info.value.code == "DPM_WAVE_APPROVAL_NO_ELIGIBLE_ITEMS"
+
+
+def test_wave_approval_transition_exports_only_approval_helper() -> None:
+    from src.api.services import wave_approval_transition
+
+    assert wave_approval_transition.__all__ == ["build_approved_wave"]

--- a/tests/unit/dpm/waves/test_wave_cancel_transition.py
+++ b/tests/unit/dpm/waves/test_wave_cancel_transition.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.api.services.wave_cancel_transition import build_cancelled_wave
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWaveTrigger
+
+
+def _item(*, wave_item_id: str, state: str) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id=wave_item_id,
+        portfolio_id=f"PB_SG_{wave_item_id.upper()}",
+        state=state,
+        reason_codes=["INITIAL"],
+        diagnostics={"existing": "value"},
+    )
+
+
+def _wave(*, state: str, items: list[DpmRebalanceWaveItem]) -> DpmRebalanceWave:
+    return DpmRebalanceWave(
+        wave_id="dwv_cancel",
+        state=state,
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="manual-cancel",
+            rationale="Cancel wave before external execution.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm_001",
+        correlation_id="corr_cancel",
+        items=items,
+        aggregate_metrics=aggregate_wave_items(items),
+    )
+
+
+def test_build_cancelled_wave_excludes_items_and_records_no_execution_claim() -> None:
+    cancelled = build_cancelled_wave(
+        wave=_wave(state="STAGED", items=[_item(wave_item_id="dwi_1", state="STAGED")]),
+        actor_id="pm_cancel",
+        reason_code="CLIENT_CANCELLED",
+        comment="Client changed instruction.",
+        correlation_id="corr_cancel",
+    )
+
+    assert cancelled.state == "CANCELLED"
+    assert cancelled.version == 2
+    assert cancelled.items[0].state == "EXCLUDED"
+    assert cancelled.items[0].diagnostics["cancel_actor_id"] == "pm_cancel"
+    assert cancelled.items[0].diagnostics["external_execution_claimed"] is False
+    assert cancelled.aggregate_metrics.state_counts == {"EXCLUDED": 1}
+    assert cancelled.events[-1].reason_code == "WAVE_CANCELLED"
+    assert cancelled.events[-1].metadata == {
+        "cancel_reason_code": "CLIENT_CANCELLED",
+        "cancelled_item_count": 1,
+        "external_execution_claimed": False,
+        "comment": "Client changed instruction.",
+    }
+
+
+def test_build_cancelled_wave_preserves_handoff_ready_item_diagnostics() -> None:
+    cancelled = build_cancelled_wave(
+        wave=_wave(
+            state="STAGED",
+            items=[
+                _item(wave_item_id="dwi_1", state="STAGED"),
+                _item(wave_item_id="dwi_2", state="HANDOFF_READY"),
+            ],
+        ),
+        actor_id="pm_cancel",
+        reason_code="CLIENT_CANCELLED",
+        comment=None,
+        correlation_id="corr_cancel",
+    )
+
+    assert [item.state for item in cancelled.items] == ["EXCLUDED", "HANDOFF_READY"]
+    assert cancelled.aggregate_metrics.state_counts == {"EXCLUDED": 1, "HANDOFF_READY": 1}
+    assert cancelled.events[-1].metadata == {
+        "cancel_reason_code": "CLIENT_CANCELLED",
+        "cancelled_item_count": 2,
+        "external_execution_claimed": False,
+    }
+
+
+def test_build_cancelled_wave_maps_invalid_transition_to_validation_error() -> None:
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        build_cancelled_wave(
+            wave=_wave(
+                state="HANDOFF_READY",
+                items=[_item(wave_item_id="dwi_1", state="HANDOFF_READY")],
+            ),
+            actor_id="pm_cancel",
+            reason_code="CLIENT_CANCELLED",
+            comment=None,
+            correlation_id="corr_cancel",
+        )
+
+    assert exc_info.value.code == "DPM_WAVE_CANCEL_INVALID_STATE"
+
+
+def test_wave_cancel_transition_exports_only_cancel_helper() -> None:
+    from src.api.services import wave_cancel_transition
+
+    assert wave_cancel_transition.__all__ == ["build_cancelled_wave"]

--- a/tests/unit/dpm/waves/test_wave_construction_selection.py
+++ b/tests/unit/dpm/waves/test_wave_construction_selection.py
@@ -1,0 +1,76 @@
+import pytest
+
+from src.api.services import wave_construction_selection, wave_service
+from src.api.services.wave_construction_selection import select_construction_alternative_for_wave
+from src.api.services.wave_errors import DpmWaveLookupError
+
+
+class _ConstructionService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+        self.error: Exception | None = None
+
+    def select_construction_alternative(self, **kwargs: object) -> None:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+
+
+def test_select_construction_alternative_for_wave_delegates_selection(monkeypatch) -> None:
+    service = _ConstructionService()
+    monkeypatch.setattr(wave_construction_selection, "construction_service", service)
+
+    select_construction_alternative_for_wave(
+        repository="repository",
+        alternative_set_id="alt_set_001",
+        alternative_id="alt_balanced",
+        actor_id="pm_001",
+        reason_code="PM_SELECTED",
+        comment="selected for mandate",
+        correlation_id="corr_wave_select",
+    )
+
+    assert service.calls == [
+        {
+            "repository": "repository",
+            "alternative_set_id": "alt_set_001",
+            "alternative_id": "alt_balanced",
+            "actor_id": "pm_001",
+            "reason_code": "PM_SELECTED",
+            "comment": "selected for mandate",
+            "correlation_id": "corr_wave_select",
+        }
+    ]
+
+
+def test_select_construction_alternative_for_wave_maps_selection_failures(
+    monkeypatch,
+) -> None:
+    service = _ConstructionService()
+    service.error = LookupError("alternative missing")
+    monkeypatch.setattr(wave_construction_selection, "construction_service", service)
+
+    with pytest.raises(DpmWaveLookupError) as exc_info:
+        select_construction_alternative_for_wave(
+            repository="repository",
+            alternative_set_id="alt_set_001",
+            alternative_id="missing_alt",
+            actor_id="pm_001",
+            reason_code="PM_SELECTED",
+            comment=None,
+            correlation_id="corr_wave_select",
+        )
+
+    assert exc_info.value.code == "DPM_CONSTRUCTION_ALTERNATIVE_NOT_FOUND"
+    assert exc_info.value.message == "alternative missing"
+
+
+def test_wave_service_preserves_construction_selection_private_alias() -> None:
+    assert (
+        wave_service._select_construction_alternative_for_wave
+        is select_construction_alternative_for_wave
+    )
+
+
+def test_wave_construction_selection_exports_public_surface() -> None:
+    assert wave_construction_selection.__all__ == ["select_construction_alternative_for_wave"]

--- a/tests/unit/dpm/waves/test_wave_creation.py
+++ b/tests/unit/dpm/waves/test_wave_creation.py
@@ -1,4 +1,5 @@
 from src.api.services.wave_creation import (
+    create_created_wave_id,
     create_wave_request_hash,
     promote_preview_to_created_wave,
 )
@@ -72,6 +73,17 @@ def test_create_wave_request_hash_uses_canonical_create_fields() -> None:
     )
 
 
+def test_create_created_wave_id_uses_governed_wave_prefix(monkeypatch) -> None:
+    class _Uuid:
+        hex = "abcdef1234567890"
+
+    from src.api.services import wave_creation
+
+    monkeypatch.setattr(wave_creation.uuid, "uuid4", lambda: _Uuid())
+
+    assert create_created_wave_id() == "dwv_abcdef123456"
+
+
 def test_promote_preview_to_created_wave_rekeys_events_and_records_idempotency_hash() -> None:
     created = promote_preview_to_created_wave(
         preview=_preview_wave(),
@@ -96,6 +108,7 @@ def test_wave_creation_exports_only_creation_helpers() -> None:
     from src.api.services import wave_creation
 
     assert wave_creation.__all__ == [
+        "create_created_wave_id",
         "create_wave_request_hash",
         "promote_preview_to_created_wave",
     ]

--- a/tests/unit/dpm/waves/test_wave_handoff_transition.py
+++ b/tests/unit/dpm/waves/test_wave_handoff_transition.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_handoff_transition import build_handoff_ready_wave
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWaveTrigger
+
+
+def _item(*, wave_item_id: str, state: str) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id=wave_item_id,
+        portfolio_id=f"PB_SG_{wave_item_id.upper()}",
+        state=state,
+        reason_codes=["INITIAL"],
+        diagnostics={"existing": "value"},
+    )
+
+
+def _wave(*, items: list[DpmRebalanceWaveItem]) -> DpmRebalanceWave:
+    return DpmRebalanceWave(
+        wave_id="dwv_handoff",
+        state="STAGED",
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="manual-handoff",
+            rationale="Create internal operations handoff.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm_001",
+        correlation_id="corr_handoff",
+        items=items,
+        aggregate_metrics=aggregate_wave_items(items),
+    )
+
+
+def test_build_handoff_ready_wave_creates_handoff_ref_and_event_metadata() -> None:
+    handoff_ready = build_handoff_ready_wave(
+        wave=_wave(items=[_item(wave_item_id="dwi_1", state="STAGED")]),
+        actor_id="ops_handoff",
+        reason_code="READY_FOR_OPERATIONS",
+        comment="Handoff package ready.",
+        correlation_id="corr_handoff",
+    )
+
+    assert handoff_ready.state == "HANDOFF_READY"
+    assert handoff_ready.version == 2
+    assert handoff_ready.items[0].state == "HANDOFF_READY"
+    assert handoff_ready.items[0].diagnostics["handoff_actor_id"] == "ops_handoff"
+    assert handoff_ready.items[0].diagnostics["external_execution_claimed"] is False
+    assert handoff_ready.aggregate_metrics.state_counts == {"HANDOFF_READY": 1}
+    assert len(handoff_ready.handoff_refs) == 1
+    handoff_ref = handoff_ready.handoff_refs[0]
+    assert handoff_ref.item_ids == ["dwi_1"]
+    assert handoff_ref.external_execution_claimed is False
+    assert handoff_ready.events[-1].reason_code == "WAVE_HANDOFF_READY"
+    assert handoff_ready.events[-1].metadata == {
+        "handoff_ref_id": handoff_ref.handoff_ref_id,
+        "handoff_item_count": 1,
+        "external_execution_claimed": False,
+        "handoff_reason_code": "READY_FOR_OPERATIONS",
+        "comment": "Handoff package ready.",
+    }
+
+
+def test_build_handoff_ready_wave_preserves_non_staged_exception_items() -> None:
+    handoff_ready = build_handoff_ready_wave(
+        wave=_wave(
+            items=[
+                _item(wave_item_id="dwi_1", state="STAGED"),
+                _item(wave_item_id="dwi_2", state="SIMULATED"),
+            ]
+        ),
+        actor_id="ops_handoff",
+        reason_code="PARTIAL_HANDOFF",
+        comment=None,
+        correlation_id="corr_handoff",
+    )
+
+    assert [item.state for item in handoff_ready.items] == ["HANDOFF_READY", "SIMULATED"]
+    assert handoff_ready.handoff_refs[0].item_ids == ["dwi_1"]
+    assert handoff_ready.aggregate_metrics.state_counts == {
+        "HANDOFF_READY": 1,
+        "SIMULATED": 1,
+    }
+
+
+def test_build_handoff_ready_wave_rejects_no_eligible_items() -> None:
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        build_handoff_ready_wave(
+            wave=_wave(items=[_item(wave_item_id="dwi_1", state="APPROVED")]),
+            actor_id="ops_handoff",
+            reason_code="READY_FOR_OPERATIONS",
+            comment=None,
+            correlation_id="corr_handoff",
+        )
+
+    assert exc_info.value.code == "DPM_WAVE_HANDOFF_NO_ELIGIBLE_ITEMS"
+
+
+def test_wave_handoff_transition_exports_only_handoff_helper() -> None:
+    from src.api.services import wave_handoff_transition
+
+    assert wave_handoff_transition.__all__ == ["build_handoff_ready_wave"]

--- a/tests/unit/dpm/waves/test_wave_item_collection.py
+++ b/tests/unit/dpm/waves/test_wave_item_collection.py
@@ -1,0 +1,59 @@
+from src.api.services import wave_item_collection, wave_service
+from src.api.services.wave_item_collection import wave_with_items_and_aggregate
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
+
+
+def _item(
+    *,
+    item_id: str,
+    state: str,
+) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem.model_construct(
+        wave_item_id=item_id,
+        portfolio_id=f"PB_{item_id}",
+        state=state,
+        reason_codes=[],
+        diagnostics={},
+    )
+
+
+def _wave() -> DpmRebalanceWave:
+    return DpmRebalanceWave.model_construct(
+        wave_id="dwv_collection",
+        state="APPROVED",
+        items=[_item(item_id="dwi_old", state="APPROVED")],
+        handoff_refs=[],
+    )
+
+
+def test_wave_with_items_and_aggregate_replaces_items_and_recomputes_metrics() -> None:
+    updated = wave_with_items_and_aggregate(
+        wave=_wave(),
+        items=[
+            _item(item_id="dwi_1", state="STAGED"),
+            _item(item_id="dwi_2", state="BLOCKED"),
+        ],
+    )
+
+    assert [item.wave_item_id for item in updated.items] == ["dwi_1", "dwi_2"]
+    assert updated.aggregate_metrics.item_count == 2
+    assert updated.aggregate_metrics.state_counts == {"STAGED": 1, "BLOCKED": 1}
+
+
+def test_wave_with_items_and_aggregate_preserves_extra_updates() -> None:
+    updated = wave_with_items_and_aggregate(
+        wave=_wave(),
+        items=[_item(item_id="dwi_1", state="HANDOFF_READY")],
+        extra_updates={"handoff_refs": ["handoff:dwv_collection"]},
+    )
+
+    assert updated.handoff_refs == ["handoff:dwv_collection"]
+    assert updated.aggregate_metrics.state_counts == {"HANDOFF_READY": 1}
+
+
+def test_wave_service_preserves_item_collection_helper_alias() -> None:
+    assert wave_service._wave_with_items_and_aggregate is wave_with_items_and_aggregate
+
+
+def test_wave_item_collection_exports_public_surface() -> None:
+    assert wave_item_collection.__all__ == ["wave_with_items_and_aggregate"]

--- a/tests/unit/dpm/waves/test_wave_item_selection_transition.py
+++ b/tests/unit/dpm/waves/test_wave_item_selection_transition.py
@@ -1,0 +1,134 @@
+from datetime import datetime, timezone
+
+from pytest import MonkeyPatch
+
+from src.api.services import wave_selection_item
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.api.services.wave_item_selection_transition import (
+    build_wave_with_selected_item_alternative,
+)
+from src.core.proof_packs.models import DpmPreTradeProofPack
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWaveTrigger
+
+
+def _item(
+    *,
+    wave_item_id: str,
+    state: str = "SIMULATED",
+    alternative_set_id: str | None = "cas_select",
+) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id=wave_item_id,
+        portfolio_id=f"PB_SG_{wave_item_id.upper()}",
+        mandate_id=f"MANDATE_{wave_item_id.upper()}",
+        state=state,
+        alternative_set_id=alternative_set_id,
+        diagnostics={"existing": "value"},
+    )
+
+
+def _wave(*, items: list[DpmRebalanceWaveItem]) -> DpmRebalanceWave:
+    return DpmRebalanceWave(
+        wave_id="dwv_select",
+        state="SIMULATED",
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="manual-selection",
+            rationale="Select an alternative for one wave item.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm_001",
+        correlation_id="corr_select",
+        items=items,
+        aggregate_metrics=aggregate_wave_items(items),
+    )
+
+
+def _build(
+    *,
+    wave: DpmRebalanceWave,
+    selected_item: DpmRebalanceWaveItem,
+    generate_proof_pack: bool = False,
+) -> DpmRebalanceWave:
+    return build_wave_with_selected_item_alternative(
+        wave=wave,
+        selected_item=selected_item,
+        alternative_id="alt_selected",
+        actor_id="pm_select",
+        reason_code="LOWER_TURNOVER_WITH_ACCEPTABLE_DRIFT",
+        comment="Selected by PM desk.",
+        correlation_id="corr-selection-event",
+        generate_proof_pack=generate_proof_pack,
+        construction_repository=object(),  # type: ignore[arg-type]
+        proof_pack_repository=object(),  # type: ignore[arg-type]
+        mandate_repository=object(),  # type: ignore[arg-type]
+        run_service=object(),  # type: ignore[arg-type]
+    )
+
+
+def test_build_wave_with_selected_item_alternative_updates_only_selected_item() -> None:
+    selected_item = _item(wave_item_id="dwi_selected")
+    retained_item = _item(wave_item_id="dwi_retained", alternative_set_id="cas_retained")
+    updated = _build(
+        wave=_wave(items=[selected_item, retained_item]),
+        selected_item=selected_item,
+    )
+
+    assert updated.version == 2
+    assert updated.state == "SIMULATED"
+    assert [item.state for item in updated.items] == ["SELECTED", "SIMULATED"]
+    assert updated.items[0].selected_alternative_id == "alt_selected"
+    assert updated.items[1].selected_alternative_id is None
+    assert updated.aggregate_metrics.state_counts == {"SELECTED": 1, "SIMULATED": 1}
+
+
+def test_build_wave_with_selected_item_alternative_appends_selection_event() -> None:
+    selected_item = _item(wave_item_id="dwi_selected")
+    updated = _build(wave=_wave(items=[selected_item]), selected_item=selected_item)
+
+    assert updated.events[-1].event_type == "ITEM_SELECTION"
+    assert updated.events[-1].reason_code == "WAVE_ITEM_ALTERNATIVE_SELECTED"
+    assert updated.events[-1].actor_id == "pm_select"
+    assert updated.events[-1].correlation_id == "corr-selection-event"
+    assert updated.events[-1].metadata == {
+        "wave_item_id": "dwi_selected",
+        "alternative_set_id": "cas_select",
+        "selected_alternative_id": "alt_selected",
+        "proof_pack_id": None,
+        "proof_pack_state": "DEGRADED",
+    }
+
+
+def test_build_wave_with_selected_item_alternative_records_generated_proof_pack(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def _generate(**_kwargs: object) -> DpmPreTradeProofPack:
+        return DpmPreTradeProofPack.model_construct(
+            proof_pack_id="dpp_selected",
+            status="READY",
+        )
+
+    monkeypatch.setattr(
+        wave_selection_item.proof_pack_service,
+        "generate_proof_pack_from_selected_alternative",
+        _generate,
+    )
+
+    selected_item = _item(wave_item_id="dwi_selected")
+    updated = _build(
+        wave=_wave(items=[selected_item]),
+        selected_item=selected_item,
+        generate_proof_pack=True,
+    )
+
+    assert updated.items[0].state == "PROOF_PACK_READY"
+    assert updated.items[0].proof_pack_id == "dpp_selected"
+    assert updated.events[-1].metadata["proof_pack_id"] == "dpp_selected"
+    assert updated.events[-1].metadata["proof_pack_state"] == "READY"
+
+
+def test_wave_item_selection_transition_exports_only_selection_helper() -> None:
+    from src.api.services import wave_item_selection_transition
+
+    assert wave_item_selection_transition.__all__ == ["build_wave_with_selected_item_alternative"]

--- a/tests/unit/dpm/waves/test_wave_report_input.py
+++ b/tests/unit/dpm/waves/test_wave_report_input.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_report_input import build_report_input_for_wave
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.core.waves import (
+    DpmRebalanceWave,
+    DpmRebalanceWaveItem,
+    DpmWaveHandoffRef,
+    DpmWaveTrigger,
+)
+
+
+def _item() -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id="dwi_report",
+        portfolio_id="PB_SG_REPORT",
+        mandate_id="MANDATE_PB_SG_REPORT",
+        state="HANDOFF_READY",
+        selected_alternative_id="alt_report",
+        proof_pack_id="dpp_report",
+        diagnostics={"proof_pack_state": "READY"},
+    )
+
+
+def _wave(*, handoff_refs: list[DpmWaveHandoffRef] | None = None) -> DpmRebalanceWave:
+    items = [_item()]
+    return DpmRebalanceWave(
+        wave_id="dwv_report_input",
+        state="HANDOFF_READY",
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="manual-report",
+            rationale="Build report input for a governed wave.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm_001",
+        correlation_id="corr-report",
+        items=items,
+        aggregate_metrics=aggregate_wave_items(items),
+        handoff_refs=handoff_refs or [],
+    )
+
+
+def test_build_report_input_for_wave_assembles_supportability_and_proof_pack_posture() -> None:
+    report_input = build_report_input_for_wave(
+        wave=_wave(),
+        wave_repository=object(),  # type: ignore[arg-type]
+    )
+
+    assert report_input.wave_id == "dwv_report_input"
+    assert report_input.wave_state == "HANDOFF_READY"
+    assert report_input.supportability["supportability_state"] == "ready"
+    assert report_input.proof_pack_posture["ready_proof_pack_count"] == 1
+    assert report_input.external_execution_claimed is False
+    assert (
+        report_input.external_execution_boundary.boundary_id
+        == "DPM_WAVE_EXTERNAL_EXECUTION_BOUNDARY"
+    )
+    assert report_input.portfolio_memory_context is None
+
+
+def test_build_report_input_for_wave_maps_external_execution_boundary_error() -> None:
+    unsafe_handoff = DpmWaveHandoffRef(
+        handoff_ref_id="dwh_unsafe",
+        wave_id="dwv_report_input",
+        item_ids=["dwi_report"],
+        actor_id="ops_001",
+        reason_code="UNSAFE_EXTERNAL_EXECUTION_CLAIM",
+        correlation_id="corr-report",
+        external_execution_claimed=True,
+        content_hash="sha256:unsafe",
+    )
+
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        build_report_input_for_wave(
+            wave=_wave(handoff_refs=[unsafe_handoff]),
+            wave_repository=object(),  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.code == "DPM_WAVE_EXTERNAL_EXECUTION_BOUNDARY"
+    assert "cannot propagate external execution claims" in exc_info.value.message
+
+
+def test_wave_report_input_exports_only_report_input_builder() -> None:
+    from src.api.services import wave_report_input
+
+    assert wave_report_input.__all__ == ["build_report_input_for_wave"]

--- a/tests/unit/dpm/waves/test_wave_selection_guard.py
+++ b/tests/unit/dpm/waves/test_wave_selection_guard.py
@@ -1,0 +1,64 @@
+import pytest
+
+from src.api.services import wave_selection_guard, wave_service
+from src.api.services.wave_errors import DpmWaveLookupError, DpmWaveValidationError
+from src.api.services.wave_selection_guard import selectable_wave_item
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
+
+
+def _item(
+    *,
+    item_id: str,
+    alternative_set_id: str | None,
+) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem.model_construct(
+        wave_item_id=item_id,
+        portfolio_id=f"PB_{item_id}",
+        state="SIMULATED",
+        alternative_set_id=alternative_set_id,
+    )
+
+
+def _wave() -> DpmRebalanceWave:
+    return DpmRebalanceWave.model_construct(
+        wave_id="dwv_selection_guard",
+        state="SIMULATED",
+        items=[
+            _item(item_id="dwi_ready", alternative_set_id="alt_set_1"),
+            _item(item_id="dwi_missing_alternatives", alternative_set_id=None),
+        ],
+    )
+
+
+def test_selectable_wave_item_returns_item_with_alternatives() -> None:
+    item = selectable_wave_item(wave=_wave(), wave_item_id="dwi_ready")
+
+    assert item.wave_item_id == "dwi_ready"
+    assert item.alternative_set_id == "alt_set_1"
+
+
+def test_selectable_wave_item_raises_lookup_error_for_missing_item() -> None:
+    with pytest.raises(DpmWaveLookupError) as exc_info:
+        selectable_wave_item(wave=_wave(), wave_item_id="dwi_unknown")
+
+    assert exc_info.value.code == "DPM_WAVE_ITEM_NOT_FOUND"
+    assert exc_info.value.message == "Wave item dwi_unknown not found."
+
+
+def test_selectable_wave_item_raises_validation_error_without_alternatives() -> None:
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        selectable_wave_item(wave=_wave(), wave_item_id="dwi_missing_alternatives")
+
+    assert exc_info.value.code == "DPM_WAVE_ITEM_ALTERNATIVES_MISSING"
+    assert (
+        exc_info.value.message
+        == "Wave item dwi_missing_alternatives has no generated alternatives."
+    )
+
+
+def test_wave_service_preserves_selection_guard_private_alias() -> None:
+    assert wave_service._selectable_wave_item is selectable_wave_item
+
+
+def test_wave_selection_guard_exports_public_surface() -> None:
+    assert wave_selection_guard.__all__ == ["selectable_wave_item"]

--- a/tests/unit/dpm/waves/test_wave_stage_transition.py
+++ b/tests/unit/dpm/waves/test_wave_stage_transition.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_stage_transition import build_staged_wave
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWaveTrigger
+
+
+def _item(*, wave_item_id: str, state: str) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id=wave_item_id,
+        portfolio_id=f"PB_SG_{wave_item_id.upper()}",
+        state=state,
+        reason_codes=["INITIAL"],
+        diagnostics={"existing": "value"},
+    )
+
+
+def _wave(*, state: str, items: list[DpmRebalanceWaveItem]) -> DpmRebalanceWave:
+    return DpmRebalanceWave(
+        wave_id="dwv_stage",
+        state=state,
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="manual-stage",
+            rationale="Stage approved wave items.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm_001",
+        correlation_id="corr_stage",
+        items=items,
+        aggregate_metrics=aggregate_wave_items(items),
+    )
+
+
+def test_build_staged_wave_stages_approved_items_and_event_metadata() -> None:
+    staged = build_staged_wave(
+        wave=_wave(state="APPROVED", items=[_item(wave_item_id="dwi_1", state="APPROVED")]),
+        actor_id="ops_stage",
+        reason_code="READY_FOR_HANDOFF",
+        comment="Ready for operations.",
+        correlation_id="corr_stage",
+    )
+
+    assert staged.state == "STAGED"
+    assert staged.version == 2
+    assert staged.items[0].state == "STAGED"
+    assert staged.items[0].diagnostics["stage_actor_id"] == "ops_stage"
+    assert staged.items[0].diagnostics["external_execution_claimed"] is False
+    assert staged.aggregate_metrics.state_counts == {"STAGED": 1}
+    assert staged.events[-1].reason_code == "WAVE_STAGED"
+    assert staged.events[-1].metadata == {
+        "staged_item_count": 1,
+        "stage_reason_code": "READY_FOR_HANDOFF",
+        "comment": "Ready for operations.",
+    }
+
+
+def test_build_staged_wave_preserves_unapproved_exception_items() -> None:
+    staged = build_staged_wave(
+        wave=_wave(
+            state="APPROVED_WITH_EXCEPTIONS",
+            items=[
+                _item(wave_item_id="dwi_1", state="APPROVED"),
+                _item(wave_item_id="dwi_2", state="SIMULATED"),
+            ],
+        ),
+        actor_id="ops_stage",
+        reason_code="PARTIAL_STAGE",
+        comment=None,
+        correlation_id="corr_stage",
+    )
+
+    assert staged.state == "STAGED"
+    assert [item.state for item in staged.items] == ["STAGED", "SIMULATED"]
+    assert staged.aggregate_metrics.state_counts == {"STAGED": 1, "SIMULATED": 1}
+    assert staged.events[-1].metadata == {
+        "staged_item_count": 1,
+        "stage_reason_code": "PARTIAL_STAGE",
+    }
+
+
+def test_build_staged_wave_rejects_no_eligible_items() -> None:
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        build_staged_wave(
+            wave=_wave(
+                state="APPROVED_WITH_EXCEPTIONS",
+                items=[_item(wave_item_id="dwi_1", state="SIMULATED")],
+            ),
+            actor_id="ops_stage",
+            reason_code="READY_FOR_HANDOFF",
+            comment=None,
+            correlation_id="corr_stage",
+        )
+
+    assert exc_info.value.code == "DPM_WAVE_STAGE_NO_ELIGIBLE_ITEMS"
+
+
+def test_wave_stage_transition_exports_only_stage_helper() -> None:
+    from src.api.services import wave_stage_transition
+
+    assert wave_stage_transition.__all__ == ["build_staged_wave"]

--- a/tests/unit/dpm/waves/test_wave_state_guard.py
+++ b/tests/unit/dpm/waves/test_wave_state_guard.py
@@ -1,0 +1,54 @@
+import pytest
+
+from src.api.services import wave_service, wave_state_guard
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_state_guard import require_wave_state, wave_state_is_idempotent
+from src.core.waves import DpmRebalanceWave
+
+
+def _wave(*, state: str) -> DpmRebalanceWave:
+    return DpmRebalanceWave.model_construct(
+        wave_id="dwv_state_guard",
+        state=state,
+    )
+
+
+def test_wave_state_is_idempotent_matches_replay_states() -> None:
+    wave = _wave(state="SIMULATED")
+
+    assert wave_state_is_idempotent(
+        wave,
+        replay_states={"SIMULATED", "PARTIALLY_SIMULATED"},
+    )
+    assert not wave_state_is_idempotent(wave, replay_states={"SOURCE_CHECKED"})
+
+
+def test_require_wave_state_accepts_allowed_state() -> None:
+    require_wave_state(
+        _wave(state="SOURCE_CHECKED"),
+        allowed_states={"SOURCE_CHECKED"},
+        error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
+        action_phrase="be simulated",
+    )
+
+
+def test_require_wave_state_raises_governed_validation_error() -> None:
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        require_wave_state(
+            _wave(state="CREATED"),
+            allowed_states={"SOURCE_CHECKED"},
+            error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
+            action_phrase="be simulated",
+        )
+
+    assert exc_info.value.code == "DPM_WAVE_SIMULATION_INVALID_STATE"
+    assert exc_info.value.message == "Wave dwv_state_guard cannot be simulated from state CREATED."
+
+
+def test_wave_service_preserves_state_guard_private_aliases() -> None:
+    assert wave_service._wave_state_is_idempotent is wave_state_is_idempotent
+    assert wave_service._require_wave_state is require_wave_state
+
+
+def test_wave_state_guard_exports_public_surface() -> None:
+    assert wave_state_guard.__all__ == ["require_wave_state", "wave_state_is_idempotent"]

--- a/tests/unit/dpm/waves/test_wave_workflow_metadata.py
+++ b/tests/unit/dpm/waves/test_wave_workflow_metadata.py
@@ -3,6 +3,7 @@ from src.api.services.wave_workflow_metadata import (
     approval_event_metadata,
     cancel_event_metadata,
     handoff_event_metadata,
+    selection_event_metadata,
     stage_event_metadata,
 )
 from src.core.waves import DpmWaveHandoffRef
@@ -33,6 +34,22 @@ def test_approval_event_metadata_counts_exceptions_and_preserves_comment() -> No
         "exception_item_count": 1,
         "approval_reason_code": "PM_APPROVED",
         "comment": "approved with exception",
+    }
+
+
+def test_selection_event_metadata_preserves_selected_alternative_and_proof_pack() -> None:
+    assert selection_event_metadata(
+        wave_item_id="dwi_select",
+        alternative_set_id="alt_set_001",
+        selected_alternative_id="alt_balanced",
+        proof_pack_id="proof_pack_001",
+        proof_pack_state="READY_FOR_REVIEW",
+    ) == {
+        "wave_item_id": "dwi_select",
+        "alternative_set_id": "alt_set_001",
+        "selected_alternative_id": "alt_balanced",
+        "proof_pack_id": "proof_pack_001",
+        "proof_pack_state": "READY_FOR_REVIEW",
     }
 
 
@@ -76,6 +93,7 @@ def test_cancel_event_metadata_preserves_no_external_execution_claim() -> None:
 
 def test_wave_service_preserves_workflow_metadata_private_aliases() -> None:
     assert wave_service._approval_event_metadata is approval_event_metadata
+    assert wave_service._selection_event_metadata is selection_event_metadata
     assert wave_service._stage_event_metadata is stage_event_metadata
     assert wave_service._handoff_event_metadata is handoff_event_metadata
     assert wave_service._cancel_event_metadata is cancel_event_metadata
@@ -86,5 +104,6 @@ def test_wave_workflow_metadata_exports_public_surface() -> None:
         "approval_event_metadata",
         "cancel_event_metadata",
         "handoff_event_metadata",
+        "selection_event_metadata",
         "stage_event_metadata",
     ]

--- a/tests/unit/dpm/waves/test_wave_workflow_metadata.py
+++ b/tests/unit/dpm/waves/test_wave_workflow_metadata.py
@@ -1,0 +1,90 @@
+from src.api.services import wave_service, wave_workflow_metadata
+from src.api.services.wave_workflow_metadata import (
+    approval_event_metadata,
+    cancel_event_metadata,
+    handoff_event_metadata,
+    stage_event_metadata,
+)
+from src.core.waves import DpmWaveHandoffRef
+
+
+def _handoff_ref() -> DpmWaveHandoffRef:
+    return DpmWaveHandoffRef.model_construct(
+        handoff_ref_id="dwh_test",
+        wave_id="dwv_test",
+        item_ids=["dwi_1"],
+        actor_id="pm_001",
+        reason_code="READY_FOR_OPERATIONS",
+        correlation_id="corr_handoff",
+        external_execution_claimed=False,
+        content_hash="sha256:test",
+        metadata={},
+    )
+
+
+def test_approval_event_metadata_counts_exceptions_and_preserves_comment() -> None:
+    assert approval_event_metadata(
+        approved_item_count=2,
+        total_item_count=3,
+        reason_code="PM_APPROVED",
+        comment="approved with exception",
+    ) == {
+        "approved_item_count": 2,
+        "exception_item_count": 1,
+        "approval_reason_code": "PM_APPROVED",
+        "comment": "approved with exception",
+    }
+
+
+def test_stage_event_metadata_omits_empty_comment() -> None:
+    assert stage_event_metadata(
+        staged_item_count=2,
+        reason_code="READY_TO_STAGE",
+        comment=None,
+    ) == {
+        "staged_item_count": 2,
+        "stage_reason_code": "READY_TO_STAGE",
+    }
+
+
+def test_handoff_event_metadata_preserves_internal_execution_boundary() -> None:
+    assert handoff_event_metadata(
+        handoff_ref=_handoff_ref(),
+        handoff_item_count=1,
+        reason_code="READY_FOR_OPERATIONS",
+        comment="handoff reviewed",
+    ) == {
+        "handoff_ref_id": "dwh_test",
+        "handoff_item_count": 1,
+        "external_execution_claimed": False,
+        "handoff_reason_code": "READY_FOR_OPERATIONS",
+        "comment": "handoff reviewed",
+    }
+
+
+def test_cancel_event_metadata_preserves_no_external_execution_claim() -> None:
+    assert cancel_event_metadata(
+        cancelled_item_count=3,
+        reason_code="CLIENT_CANCELLED",
+        comment=None,
+    ) == {
+        "cancel_reason_code": "CLIENT_CANCELLED",
+        "cancelled_item_count": 3,
+        "external_execution_claimed": False,
+    }
+
+
+def test_wave_service_preserves_workflow_metadata_private_aliases() -> None:
+    assert wave_service._approval_event_metadata is approval_event_metadata
+    assert wave_service._stage_event_metadata is stage_event_metadata
+    assert wave_service._handoff_event_metadata is handoff_event_metadata
+    assert wave_service._cancel_event_metadata is cancel_event_metadata
+
+
+def test_wave_workflow_metadata_exports_public_surface() -> None:
+    assert wave_workflow_metadata.__all__ == [
+        "approval_event_metadata",
+        "cancel_event_metadata",
+        "handoff_event_metadata",
+        "stage_event_metadata",
+    ]


### PR DESCRIPTION
## Summary
- Continue lotus-manage backend hardening by extracting pure service support logic from orchestration services.
- Added focused helpers and direct tests across mandate, wave, rebalance, proof-pack, outcome-review, and construction-adjacent service boundaries.
- Updated `docs/architecture/CODEBASE-REVIEW-LEDGER.md` through `BACKEND-REVIEW-20260601-417` with implementation evidence and explicit no-wiki-change decisions for internal modularity slices.

## Validation
- `make check` passed: repo-wide Ruff, format check, monetary float guard, no-alias contract guard, mypy over 476 source files, OpenAPI quality gate, API vocabulary inventory validate-only, domain-data-product contract validation, trust telemetry validation, observability contract validation, and unit suite `1980 passed, 13 skipped`.
- `git diff --check` passed.
- Service leakage scan passed: `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP" src/api/services -g "*.py"` returned no matches.
- Stranded truth reconciliation: `git fetch origin --prune`; `git branch -r --no-merged origin/main` returned only `origin/feat/manage-backend-hardening-batch-370`.
- Wiki drift check passed: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reported `DiffCount 0`.

## Governance Notes
- No README/wiki/operator contract changes were required; this batch is internal backend modularity and direct-test hardening without route, payload, supported-feature, or operator-truth changes.
- Branch contains 48 small commits and should be merged with a normal merge commit, not squash.