### PR TITLE
Backend hardening batch 456

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11334,3 +11334,24 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   source-product mapping behavior.
 - Wiki decision: no wiki source change required; this is internal test hardening with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-466: Wave service helper alias regression guard
+
+- Date: 2026-06-02
+- Scope: `tests/unit/dpm/waves/test_wave_service_public_surface.py` and this ledger.
+- Finding: the wave-service hardening slices removed multiple direct helper aliases from
+  `wave_service.py`, but the branch lacked one compact regression proving the retired helper
+  function names are no longer re-exported from the service module.
+- Action: added a wave-service public-surface test that asserts retired persisted-command,
+  read-model, search, preview, and selection helper names are absent from `wave_service.py`.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched test file and ledger; direct
+  wave-service public-surface, preview, read-model, selection-command, and search regressions passed
+  with 12 tests; OpenAPI quality gate passed; API vocabulary inventory validate-only gate passed;
+  `git diff --check` passed with only a ledger line-ending warning; service leakage scan found no
+  router/HTTP imports in service modules; targeted scan found retired helper names only in the
+  negative test list and as qualified owner-module calls from `wave_service.py`.
+- Follow-up: keep public workflow functions on `wave_service.py`, but keep pure helpers and
+  persisted command implementations owned by their dedicated modules.
+- Wiki decision: no wiki source change required; this is internal test hardening with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10750,3 +10750,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   helper coverage.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-442: Mandate health result alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`,
+  `tests/unit/dpm/mandates/test_mandate_health_result.py`, selected mandate health/API regressions,
+  and this ledger.
+- Finding: `mandate_service.py` still exposed a private mandate health-result calculation alias even
+  though the owning helper module has direct behavior and export-surface tests, and the service only
+  needs the calculation helper for recalculation orchestration.
+- Action: removed the private health-result alias, routed recalculation directly through
+  `calculate_mandate_health_result`, and kept only the public calculation-result model re-export
+  required by existing callers.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py`; direct mandate health-result and health-persistence tests plus
+  selected mandate API regressions passed with 29 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules; search found no health-result private alias remaining in
+  `mandate_service.py`.
+- Follow-up: continue pruning mandate service compatibility aliases in small groups with direct
+  helper tests and service call-site evidence.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10252,3 +10252,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   boundaries for smaller directly tested helper seams.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-421: Wave read-model query extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_read_model_queries.py`,
+  `tests/unit/dpm/waves/test_wave_read_model_queries.py`, selected wave read/API regressions, and
+  this ledger.
+- Finding: wave supportability, detail, item listing, proof-pack posture, and report-input read
+  functions repeated wave lookup and projection wiring in `wave_service.py`, keeping read-model
+  assembly mechanics mixed into the lifecycle command facade.
+- Action: extracted wave-id read-model query helpers that load the governed wave once and delegate
+  to the existing projection/report builders, kept the service API as a thin facade, and added
+  direct tests for read-model loading, report-input assembly, export surface, and service
+  delegation aliases.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_read_model_queries.py`; direct wave read-model query tests
+  and selected wave read/API regressions passed with 149 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing wave creation/idempotency orchestration for small support helpers
+  that preserve repository ownership while reducing command-service branching.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11070,3 +11070,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage already proves behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-455: Wave preparation-command helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_preparation_commands.py`, selected wave API regressions, and this
+  ledger.
+- Finding: `wave_service.py` imported and exposed `source_check_persisted_wave` and
+  `simulate_persisted_wave` as facade attributes even though the preparation-command helper module
+  has direct behavior and export-surface tests, and the service only needs these helpers behind
+  `source_check_wave` and `simulate_wave` orchestration.
+- Action: changed `wave_service` to call `wave_preparation_commands` through the owning module and
+  removed preparation-command alias-pinning assertions from the helper tests.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `wave_service.py`; direct wave preparation-command, source-check, and
+  simulation tests plus selected wave API regressions passed with 140 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules; targeted scan found only direct
+  preparation-command helper tests and qualified `wave_preparation_commands` owner-module calls from
+  `wave_service.py`.
+- Follow-up: continue retiring wave-service helper aliases in small groups where direct helper
+  coverage already proves behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11217,3 +11217,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage already proves behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-461: Wave supportability-payload helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_supportability_payload.py`, selected wave supportability/API
+  regressions, and this ledger.
+- Finding: `wave_service.py` imported the supportability payload builder as a private function alias,
+  which kept pure payload assembly wired through the service module rather than the owning helper
+  module.
+- Action: preserved the public `wave_service.wave_supportability_payload` wrapper but changed it to
+  delegate through the owning `wave_supportability_payload` module alias, keeping the helper's direct
+  behavior and export-surface tests as the ownership proof.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `wave_service.py`; direct wave supportability-payload, read-model,
+  detail, report-input, and selected wave API regressions passed with 145 tests; OpenAPI quality
+  gate passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed with
+  only line-ending warnings; service leakage scan found no router/HTTP imports in service modules;
+  targeted scan confirmed the old private `_wave_supportability_payload` function alias is gone and
+  the service delegates through the `wave_supportability_payload` owner-module alias.
+- Follow-up: continue retiring wave-service helper aliases in small groups where direct helper
+  coverage already proves behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10921,3 +10921,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   while preserving explicit injection points needed by stateful source-context tests.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-449: Rebalance async env surface narrowing
+
+- Date: 2026-06-02
+- Scope: `src/api/services/rebalance_simulation_service.py`, `src/api/main.py`,
+  `tests/unit/api/test_runtime_request_model_and_service_edges.py`, selected rebalance runtime/API
+  regressions, and this ledger.
+- Finding: `rebalance_simulation_service.py` and `main.py` still re-exported async environment-flag
+  parsing even though async mode and feature toggles are owned by `rebalance_async_config`.
+- Action: removed the `env_flag` compatibility export from the rebalance simulation facade, removed
+  the unused `main.py` `_env_flag` export, and added direct export-surface coverage for
+  `rebalance_async_config`.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `main.py`, `rebalance_simulation_service.py`, and
+  `rebalance_async_config.py`; rebalance runtime, simulation execution-context, and API regression
+  tests passed with 139 tests; OpenAPI quality gate passed; API vocabulary inventory validate-only
+  gate passed; `git diff --check` passed; service leakage scan found no router/HTTP imports in
+  service modules; targeted scan found no `env_flag` or `_env_flag` compatibility export remaining
+  in `rebalance_simulation_service.py` or `main.py`.
+- Follow-up: continue narrowing `rebalance_simulation_service.py` to runtime orchestration and
+  keep low-level configuration helpers in their owning modules.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10680,3 +10680,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   should be named once near the owning mapper.
 - Wiki decision: no wiki source change required; this is internal mapper maintainability cleanup
   with no route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-439: Mandate command-center alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`,
+  `tests/unit/dpm/mandates/test_mandate_command_center.py`, selected mandate command-center/API
+  regressions, and this ledger.
+- Finding: `mandate_service.py` still imported and exposed private command-center projection
+  aliases even though command-center behavior and export surface are directly covered in the owning
+  helper module.
+- Action: removed unused command-center helper imports and private aliases from the service facade,
+  routed the service through the two helper calls it actually needs, and retired alias-pinning test
+  assertions.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py`; direct mandate command-center tests plus selected mandate API
+  regressions passed with 31 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules; search found no command-center private aliases remaining in
+  `mandate_service.py`.
+- Follow-up: continue reviewing remaining mandate service compatibility aliases with search
+  evidence before pruning them.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10228,3 +10228,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   share transition persistence without obscuring selection-specific source validation.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-420: Wave selection transition execution normalization
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_transition_execution.py`,
+  `tests/unit/dpm/waves/test_wave_transition_execution.py`, selected wave selection/API
+  regressions, and this ledger.
+- Finding: wave alternative selection still performed lookup, state guard, and optimistic update
+  directly in the orchestration service after the common transition helper existed, while the
+  selection flow has no idempotent replay state and should model that explicitly.
+- Action: routed selection through the transition helper with `replay_states=set()`, kept
+  selection-specific source validation and proof-pack builder logic in the service, and added direct
+  helper tests proving empty replay-state transitions still enforce the allowed source state.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_transition_execution.py`; direct wave transition
+  execution tests and selected wave selection/API regressions passed with 149 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing wave selection source-validation and proof-pack generation
+  boundaries for smaller directly tested helper seams.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11312,3 +11312,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `make check` does not depend on stale helper exports.
 - Wiki decision: no wiki source change required; this is test-maintenance for internal service
   ownership and does not change route, payload, supported-feature, or operator-contract truth.
+
+## BACKEND-REVIEW-20260602-465: Construction source-product public surface guard
+
+- Date: 2026-06-02
+- Scope: `tests/unit/dpm/construction/test_source_product_context.py` and this ledger.
+- Finding: after the source-product context orchestrator stopped importing individual mapping
+  helpers directly, the direct tests still lacked a small assertion pinning its intended public
+  export surface to orchestration functions only.
+- Action: added a direct `__all__` regression proving
+  `construction_source_product_context.py` exports only `authority_context_with_source_products` and
+  `source_product_authority_context_updates`.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched test file and ledger; direct
+  source-product context regressions passed with 6 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed with only line-ending
+  warnings; service leakage scan found no router/HTTP imports in service modules; targeted scan
+  confirmed the new `construction_source_product_context.__all__` guard and existing orchestrator
+  function coverage.
+- Follow-up: keep helper modules carrying their own export-surface tests where they own pure
+  source-product mapping behavior.
+- Wiki decision: no wiki source change required; this is internal test hardening with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10405,3 +10405,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   similarly narrow command extraction opportunities without obscuring domain-specific dependencies.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-427: Wave preparation command extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_preparation_commands.py`,
+  `tests/unit/dpm/waves/test_wave_preparation_commands.py`, selected wave preparation/API
+  regressions, and this ledger.
+- Finding: wave source-check and simulation orchestration still repeated transition preparation,
+  idempotent replay handling, domain builder invocation, and optimistic persistence directly in
+  `wave_service.py`, leaving the facade responsible for command execution mechanics.
+- Action: extracted persisted source-check and simulation command helpers, kept source-readiness and
+  construction simulation builders unchanged, preserved service entry points as facades, and added
+  direct tests for persistence, replay, expected-version handling, export surface, and service
+  delegation.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_preparation_commands.py`; direct wave preparation command
+  tests and selected wave source-check/simulation/API regressions passed with 150 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing wave alternative selection as the remaining command path with
+  selection-specific repository side effects and proof-pack generation dependencies.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10638,3 +10638,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   that source-product family mapping and aggregation have clearer ownership.
 - Wiki decision: no wiki source change required; this is internal mapper modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-437: Construction source-context no-overwrite proof
+
+- Date: 2026-06-01
+- Scope: `tests/unit/dpm/construction/test_source_product_context.py`, selected construction
+  source-product/API regressions, and this ledger.
+- Finding: source-product context aggregation had direct no-overwrite coverage for
+  transaction-cost and liquidity contexts, but not for the client restriction, sustainability,
+  currency overlay, and execution acknowledgement authority families.
+- Action: added a direct regression proving all source-derived authority contexts are preserved when
+  already supplied and that `authority_context_with_source_products` returns the existing context
+  object when no source-derived updates are needed.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched test file; focused mypy passed
+  for `construction_source_product_context.py`; direct source-product context tests plus selected
+  construction enrichment/API regressions passed with 55 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: keep no-overwrite tests aligned with any new source-derived authority family added to
+  `ConstructionAuthorityContext`.
+- Wiki decision: no wiki source change required; this is internal test hardening with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11355,3 +11355,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   persisted command implementations owned by their dedicated modules.
 - Wiki decision: no wiki source change required; this is internal test hardening with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-467: Refactor health report checkpoint refresh
+
+- Date: 2026-06-02
+- Scope: `quality/refactor_health_report.md` and this ledger.
+- Finding: after the wave-service and construction source-product hardening slices, the branch-level
+  health report still pointed at an earlier commit and no longer reflected the current checkpoint
+  evidence for a roughly 50-commit PR batch.
+- Action: regenerated the dependency-free refactor health report against `origin/main` so the PR
+  carries current report-only evidence for code size, test count, boundary findings, router
+  infrastructure import findings, largest files/functions, and OpenAPI completeness.
+- Status: hardened
+- Evidence: report generation completed and wrote `quality/refactor_health_report.md`; refreshed
+  report points at current ref `8dc39c9`, shows 768 current-branch Python files versus 754 on
+  `origin/main`, 145874 current Python LOC versus 144347 on `origin/main`, 1855 current test
+  functions versus 1834 on `origin/main`, zero service boundary findings in both snapshots, 135
+  current OpenAPI operations, and three operations missing a 4xx/5xx response marker; `git diff
+  --check` passed with only line-ending warnings.
+- Follow-up: optimize baseline loading before making this report a CI gate, then extend report-only
+  baselines toward complexity, dead-code, dependency, security, coverage, architecture, docs, and
+  observability checks.
+- Wiki decision: no wiki source change required yet; this is internal engineering-health evidence
+  and does not change route behavior, product feature truth, or operator procedure.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10277,3 +10277,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   that preserve repository ownership while reducing command-service branching.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-422: Wave create command extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_create_command.py`,
+  `tests/unit/dpm/waves/test_wave_create_command.py`, selected wave create/API regressions, and
+  this ledger.
+- Finding: wave creation orchestration still embedded idempotent replay lookup, request-hash
+  construction, preview promotion, and durable save wiring in `wave_service.py`, keeping command
+  persistence mechanics mixed into the public service facade.
+- Action: extracted the idempotent create command into a focused helper that owns replay lookup,
+  preview construction, created-wave promotion, and durable persistence, kept the service API as a
+  stable facade, and added direct tests for replay, persistence request hash, export surface, and
+  service delegation alias.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_create_command.py`; direct wave create-command tests and
+  selected wave create/API regressions passed with 150 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing wave command orchestration for lifecycle-specific source and
+  supportability boundaries that can be isolated without hiding domain decisions.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11195,3 +11195,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage already proves behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-460: Wave search helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/wave_service.py`, `tests/unit/dpm/waves/test_wave_search.py`, selected
+  wave search/API regressions, and this ledger.
+- Finding: `wave_service.py` imported and exposed `search_wave_summaries` as a facade attribute even
+  though the wave-search module has direct behavior and export-surface tests, and the service only
+  needs the helper behind the public `search_waves` query function.
+- Action: changed `wave_service` to call `wave_search.search_wave_summaries` through the owning
+  module.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `wave_service.py`; direct wave search tests and selected wave API
+  regressions passed with 135 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed with only line-ending warnings; service
+  leakage scan found no router/HTTP imports in service modules; targeted scan found only direct
+  search helper tests and the qualified `wave_search` owner-module call from `wave_service.py`.
+- Follow-up: continue retiring wave-service helper aliases in small groups where direct helper
+  coverage already proves behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10616,3 +10616,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   opportunities that do not obscure router-facing orchestration.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-436: Construction source-product context update builders
+
+- Date: 2026-06-01
+- Scope: `src/api/services/construction_source_product_context.py`, direct source-product context
+  tests, selected construction enrichment/API regressions, and this ledger.
+- Finding: the source-product authority-context aggregator still mixed transaction-cost,
+  liquidity, treasury, execution acknowledgement, client restriction, and sustainability update
+  assembly in one inline function after the individual family mappers had been extracted.
+- Action: split the aggregator into focused family-specific update builders and kept
+  `source_product_authority_context_updates` as a small composition point that preserves the public
+  helper contract and no-overwrite semantics.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `construction_source_product_context.py`; direct source-product context tests plus
+  selected construction enrichment/API regressions passed with 54 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue checking construction enrichment helpers for similar local complexity now
+  that source-product family mapping and aggregation have clearer ownership.
+- Wiki decision: no wiki source change required; this is internal mapper modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11170,3 +11170,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage already proves behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-459: Wave selection-command helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_selection_command.py`, selected wave selection/API regressions,
+  and this ledger.
+- Finding: `wave_service.py` imported and exposed `select_persisted_wave_item_alternative` as a
+  facade attribute even though the selection-command module has direct behavior and export-surface
+  tests, and the service only needs the helper behind the public `select_wave_item_alternative`
+  workflow command.
+- Action: changed `wave_service` to call `wave_selection_command` through the owning module and
+  removed the selection-command alias-pinning assertion from the helper tests.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `wave_service.py`; direct wave selection-command tests and selected wave
+  API regressions passed with 134 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed with only line-ending warnings; service
+  leakage scan found no router/HTTP imports in service modules; targeted scan found only direct
+  selection-command helper tests and the qualified `wave_selection_command` owner-module call from
+  `wave_service.py`.
+- Follow-up: continue retiring wave-service helper aliases in small groups where direct helper
+  coverage already proves behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10455,3 +10455,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   test-only surface that can be retired safely in a later cleanup slice.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-429: Wave service stale alias removal
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, selected wave helper/facade regressions, and this
+  ledger.
+- Finding: after wave create, preparation, lifecycle, and selection command extraction,
+  `wave_service.py` still imported and re-exported several private compatibility aliases that were
+  no longer used by service code or direct helper tests.
+- Action: removed stale private aliases and their imports for simulation result state, create helper
+  internals, lifecycle transition builders, and event construction, moved remaining API tests to the
+  owning helper modules, and preserved explicitly covered compatibility aliases that still document
+  helper ownership boundaries.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for `wave_service.py` and the touched wave API
+  regression file; focused mypy passed for `wave_service.py`; selected wave helper/facade tests and
+  wave API regressions passed with 190 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules.
+- Follow-up: continue retiring remaining compatibility aliases only when their direct tests have
+  moved to the owning helper module and no service facade contract depends on them.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10870,3 +10870,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   orchestration and have direct helper-module coverage.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-447: Outcome review dimension alias retirement
+
+- Date: 2026-06-02
+- Scope: `src/api/services/outcome_review_service.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_dimensions.py`, selected outcome review/API
+  regressions, and this ledger.
+- Finding: `outcome_review_service.py` still exposed a private `_dimension_inputs` alias even though
+  preview orchestration already calls the owning `outcome_review_dimensions` helper directly and
+  the helper has direct behavior plus export-surface tests.
+- Action: removed the stale private alias from the service facade and retired the alias-pinning test
+  assertion while preserving the public dimension model and validation-error import surface used by
+  callers.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `outcome_review_service.py`; direct outcome dimension tests plus selected
+  outcome creation/API regressions passed with 14 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules; targeted scan found no `_dimension_inputs`
+  service alias remaining.
+- Follow-up: continue scanning outcome/proof-pack service facades for private aliases that are not
+  required by orchestration and can be covered directly in helper modules.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10330,3 +10330,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   clarity.
 - Wiki decision: no wiki source change required; this is internal mapper modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-424: Construction execution source identity normalization
+
+- Date: 2026-06-01
+- Scope: `src/api/services/construction_source_identity.py`,
+  `src/api/services/construction_transaction_cost_source_context.py`,
+  `src/api/services/construction_execution_source_context.py`,
+  `tests/unit/dpm/construction/test_source_identity.py`, selected construction transaction-cost and
+  execution source-context regressions, and this ledger.
+- Finding: transaction-cost and external execution acknowledgement mappers still assembled
+  source-product identity fields locally after the shared identity helper existed; transaction-cost
+  also needed its governed page fingerprint fallback preserved explicitly.
+- Action: extended `source_product_identity` with an explicit fallback source-id parameter, routed
+  transaction-cost and execution acknowledgement mappers through the shared helper, and added direct
+  tests proving explicit fallback lineage remains available when source lineage is absent.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `construction_source_identity.py`,
+  `construction_transaction_cost_source_context.py`, and
+  `construction_execution_source_context.py`; direct construction source identity tests and
+  selected transaction-cost/execution source-context/API regressions passed with 41 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: review treasury currency-overlay source identity helpers separately because its
+  multi-source aggregate hash and optional child-source fields require a narrower treatment than
+  single-source mappers.
+- Wiki decision: no wiki source change required; this is internal mapper modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10547,3 +10547,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   and selection helper aliases without changing public wave route behavior.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-433: Wave state trigger alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `tests/unit/dpm/waves/test_wave_state_guard.py`,
+  `tests/unit/dpm/waves/test_wave_trigger_validation.py`, selected wave API regressions, and this
+  ledger.
+- Finding: `wave_service.py` still retained private state guard and trigger validation aliases even
+  though wave command helpers own guard invocation and direct helper tests prove the validation
+  behavior.
+- Action: removed state guard and trigger validation imports and aliases from the service facade,
+  and retired facade-alias assertions while preserving helper behavior and export-surface coverage.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py`; direct wave state guard and trigger validation tests plus selected
+  wave API regressions passed with 143 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules.
+- Follow-up: continue retiring transition execution and selection helper aliases now that remaining
+  service imports are concentrated around command facade delegation and public read/write entry
+  points.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10726,3 +10726,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   orchestration can call owning helpers directly and direct helper tests cover behavior.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-441: Mandate health persistence alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`,
+  `tests/unit/dpm/mandates/test_mandate_health_persistence.py`, selected mandate persistence/API
+  regressions, and this ledger.
+- Finding: `mandate_service.py` still exposed a private health-persistence alias even though the
+  owning helper has direct behavior and export-surface tests, and service orchestration can call the
+  helper directly.
+- Action: removed the private health-persistence alias, routed refresh, recalculation, and
+  monitoring persistence through `persist_mandate_health_evidence`, and retired the alias-pinning
+  test assertion.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py`; direct mandate health-persistence tests plus selected mandate
+  refresh, monitoring, and API regressions passed with 40 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules; search found no health-persistence private alias
+  remaining in `mandate_service.py`.
+- Follow-up: continue reducing remaining mandate service aliases in cohesive groups with direct
+  helper coverage.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10500,3 +10500,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   helper tests already prove ownership and no route or service API depends on the alias.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-431: Wave event collection alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_event_append.py`,
+  `tests/unit/dpm/waves/test_wave_item_collection.py`, selected wave event/item API regressions,
+  and this ledger.
+- Finding: `wave_service.py` still imported and exposed private compatibility aliases for wave event
+  append and item collection helpers even though the owning helper modules already carry direct
+  behavior and export-surface tests.
+- Action: removed the stale event append and item collection imports and aliases from the service
+  facade, and retired tests that pinned obsolete private facade surface while keeping direct helper
+  behavior coverage.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py`; direct wave event append and item collection tests plus selected
+  wave API regressions passed with 139 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules.
+- Follow-up: continue retiring lookup, persistence, state-guard, transition, and selection
+  compatibility aliases in similarly narrow slices when their owning helper tests provide direct
+  coverage.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11264,3 +11264,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage already proves behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-463: Construction source-product helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/construction_source_product_context.py`,
+  `tests/unit/dpm/construction/test_source_product_context.py`, selected construction source-product
+  helper regressions, and this ledger.
+- Finding: `construction_source_product_context.py` imported individual source-product mapping
+  helpers directly, leaving the orchestration module with facade attributes for liquidity,
+  transaction-cost, treasury, execution, restriction, and sustainability mapping functions that are
+  already owned and tested by dedicated helper modules.
+- Action: changed the source-product context orchestrator to call the dedicated mapping helpers
+  through their owning modules while preserving its public `authority_context_with_source_products`
+  and `source_product_authority_context_updates` surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `construction_source_product_context.py`; direct source-product,
+  liquidity, and client-profile context regressions passed with 21 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; scoped `git diff --check` passed with
+  only line-ending warnings; service leakage scan found no router/HTTP imports in service modules;
+  targeted scan found no direct construction helper imports in the orchestrator and only
+  owner-module qualified helper calls.
+- Follow-up: keep pure source-product mapping helpers owned by dedicated modules and reserve
+  `construction_source_product_context.py` for authority-context orchestration only.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10178,3 +10178,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   and summary-input boundaries that can be clarified without hiding repository ownership.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-418: Wave transition execution extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_transition_execution.py`,
+  `tests/unit/dpm/waves/test_wave_transition_execution.py`, selected wave regressions, and this
+  ledger.
+- Finding: wave source-check, simulation, approval, staging, and handoff orchestration repeated
+  the same lookup, idempotent replay, state guard, and optimistic update flow, increasing the
+  chance of inconsistent transition enforcement across DPM wave lifecycle endpoints.
+- Action: extracted common wave transition preparation and persistence into a focused helper,
+  preserved transition-specific builder logic in the service, and added direct tests for replay
+  handling, required-state validation, expected-version update behavior, export surface, and
+  service compatibility aliases.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_transition_execution.py`; direct wave transition
+  execution tests and selected wave lifecycle/API regressions passed with 154 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing wave cancellation and selection flows for transition semantics that
+  can be normalized without hiding route-level business decisions.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10998,3 +10998,24 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   override hooks, keeping only explicit orchestration seams needed by API behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-452: Main async-runner override cleanup
+
+- Date: 2026-06-02
+- Scope: `src/api/main.py`, `tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  selected rebalance runtime/API regressions, and this ledger.
+- Finding: `main.py` still imported and exported `_run_analyze_async_operation` as a compatibility
+  override even though no API route, service, or test used that main-module hook; active runtime
+  override coverage remains on `_execute_batch_analysis` and `run_simulation`.
+- Action: removed the unused `_run_analyze_async_operation` import/export from `main.py` and added a
+  regression proving the stale override hook is no longer published.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `main.py`; rebalance runtime and API regression tests passed with 139
+  tests; OpenAPI quality gate passed; API vocabulary inventory validate-only gate passed; `git diff
+  --check` passed; service leakage scan found no router/HTTP imports in service modules; targeted
+  scan found no `_run_analyze_async_operation` export remaining in `main.py`.
+- Follow-up: preserve active `main.py` runtime override hooks only where tests or runtime override
+  helpers still prove they are intentional.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11290,3 +11290,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `construction_source_product_context.py` for authority-context orchestration only.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-464: Construction API core-resolver test hook ownership
+
+- Date: 2026-06-02
+- Scope: `tests/unit/dpm/api/test_construction_api.py` and this ledger.
+- Finding: selected construction API regressions still monkeypatched
+  `rebalance_simulation_service.build_core_resolver_client`, a stale facade hook removed earlier in
+  this hardening branch after core-resolver ownership moved to `core_resolver_service`.
+- Action: changed the construction API tests to monkeypatch
+  `core_resolver_service.build_core_resolver_client`, the hook currently used by rebalance
+  simulation stateful sourcing.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched test file and ledger;
+  construction API regressions passed with 25 tests, including the previously failing stateful
+  source-product cases; OpenAPI quality gate passed; API vocabulary inventory validate-only gate
+  passed; scoped `git diff --check` passed with only a ledger line-ending warning; service leakage
+  scan found no router/HTTP imports in service modules; targeted scan found no stale
+  `rebalance_service` monkeypatch hook references in `test_construction_api.py`.
+- Follow-up: keep tests patching owner modules instead of retired service facade attributes so full
+  `make check` does not depend on stale helper exports.
+- Wiki decision: no wiki source change required; this is test-maintenance for internal service
+  ownership and does not change route, payload, supported-feature, or operator-contract truth.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10302,3 +10302,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   supportability boundaries that can be isolated without hiding domain decisions.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-423: Construction source-product identity extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/construction_source_identity.py`,
+  `src/api/services/construction_liquidity_source_context.py`,
+  `src/api/services/construction_client_profile_source_context.py`,
+  `tests/unit/dpm/construction/test_source_identity.py`, selected construction source-context
+  regressions, and this ledger.
+- Finding: construction source-product mappers repeated the same product name, product version,
+  source system, source id, and content-hash assembly across liquidity reserve, planned
+  withdrawal, income-needs, restriction, and sustainability contexts, increasing lineage drift risk.
+- Action: introduced a reusable `SourceProductIdentity` bundle in the construction source identity
+  helper, routed liquidity and client-profile source-product mappers through it, removed unused
+  mapper-local source response aliases, and added direct tests proving product identity and lineage
+  hashing are assembled consistently.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `construction_source_identity.py`, `construction_liquidity_source_context.py`, and
+  `construction_client_profile_source_context.py`; direct construction source identity tests and
+  selected construction source-context/API regressions passed with 49 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue applying the source-product identity helper to treasury, transaction-cost,
+  and execution acknowledgement mappers where it reduces duplication without weakening contract
+  clarity.
+- Wiki decision: no wiki source change required; this is internal mapper modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11146,3 +11146,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage already proves behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-458: Wave read-model query helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_read_model_queries.py`, selected wave read-model/API
+  regressions, and this ledger.
+- Finding: `wave_service.py` imported and exposed read-model query helpers as facade attributes even
+  though the read-model query module has direct behavior and export-surface tests, and the service
+  only needs those helpers behind public wave query orchestration functions.
+- Action: changed `wave_service` to call `wave_read_model_queries` through the owning module and
+  removed read-model alias-pinning assertions from the helper tests.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `wave_service.py`; direct wave read-model, detail, proof-pack posture,
+  report-input, and selected wave API regressions passed with 144 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed with only
+  line-ending warnings; service leakage scan found no router/HTTP imports in service modules;
+  targeted scan found only direct read-model helper tests and qualified `wave_read_model_queries`
+  owner-module calls from `wave_service.py`.
+- Follow-up: continue retiring wave-service helper aliases in small groups where direct helper
+  coverage already proves behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10844,3 +10844,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   intentional public re-exports remain.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-446: Report-input portfolio-memory alias retirement
+
+- Date: 2026-06-02
+- Scope: `src/api/services/proof_pack_service.py`, `src/api/services/outcome_review_service.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_report_inputs.py`,
+  `tests/unit/dpm/outcomes/test_outcome_review_report_inputs.py`, selected report-input/API
+  regressions, and this ledger.
+- Finding: proof-pack and outcome-review services still imported and exposed private
+  portfolio-memory report-context aliases even though the owning report-input helper modules have
+  direct behavior and export-surface tests.
+- Action: removed stale portfolio-memory context imports and private aliases from both service
+  facades, and retired alias-pinning assertions while preserving direct report-input helper
+  coverage.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `proof_pack_service.py` and `outcome_review_service.py`; direct proof-pack and outcome
+  report-input tests plus selected proof-pack/outcome API regressions passed with 23 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules; search found no
+  portfolio-memory report-context private aliases remaining in the proof-pack or outcome-review
+  service facades.
+- Follow-up: continue scanning remaining services for private aliases that are no longer used by
+  orchestration and have direct helper-module coverage.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10203,3 +10203,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   can be normalized without hiding route-level business decisions.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-419: Wave cancellation transition normalization
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_transition_execution.py`,
+  `tests/unit/dpm/waves/test_wave_transition_execution.py`, selected wave cancellation/API
+  regressions, and this ledger.
+- Finding: wave cancellation still repeated load, replay, and optimistic update behavior outside
+  the shared transition execution helper because cancellation is intentionally available without a
+  required source state guard.
+- Action: extended the transition helper to model explicitly unguarded transitions with
+  `allowed_states=None`, routed cancellation through the same preparation and persistence helpers,
+  and added direct tests proving unguarded transitions still load the wave and report non-replay
+  state without applying a state guard.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_transition_execution.py`; direct wave transition
+  execution tests and selected wave cancellation/API regressions passed with 143 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing wave selection flow for remaining lifecycle orchestration that can
+  share transition persistence without obscuring selection-specific source validation.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11095,3 +11095,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage already proves behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-456: Refactor health report baseline
+
+- Date: 2026-06-02
+- Scope: `scripts/engineering_health_report.py`, `quality/refactor_health_report.md`, and this
+  ledger.
+- Finding: The refactor branch had detailed per-slice ledger evidence but no compact measurable
+  branch-level health report comparing current code health against `origin/main`, despite the
+  refactor objective requiring tangible baseline/current quality evidence.
+- Action: added a dependency-free engineering health report generator that compares `origin/main`
+  with the current branch for Python file count, LOC, test count, largest files/functions, service
+  boundary findings, router infrastructure imports, and current OpenAPI completeness; generated the
+  first report under `quality/refactor_health_report.md`.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the report script and ledger; focused mypy
+  passed for `engineering_health_report.py`; report generation wrote
+  `quality/refactor_health_report.md`; report content shows 767 current-branch Python files versus
+  754 on `origin/main`, 145857 current Python LOC versus 144347 on `origin/main`, 1856 current test
+  functions versus 1834 on `origin/main`, zero service boundary findings in both snapshots, 135
+  current OpenAPI operations, and three operations missing a 4xx/5xx response marker; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: optimize baseline loading before making this report a CI gate, then add richer
+  optional-tool measurements in later slices, including complexity, dead-code, dependency, security,
+  coverage, and architecture contracts once report-only baselines are stable.
+- Wiki decision: no wiki source change required yet; this is internal engineering-health evidence
+  and does not change route behavior, product feature truth, or operator procedure.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10774,3 +10774,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   helper tests and service call-site evidence.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-443: Mandate refresh alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `tests/unit/dpm/mandates/test_mandate_refresh.py`,
+  selected mandate refresh/API regressions, and this ledger.
+- Finding: `mandate_service.py` still exposed a private mandate-refresh builder alias even though
+  the owning refresh helper has direct source-resolution, health-calculation, error-mapping, and
+  export-surface tests.
+- Action: removed the private refresh builder alias, routed refresh orchestration directly through
+  `build_mandate_refresh_result_from_core`, and kept the public refresh-result model re-export for
+  existing callers.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py`; direct mandate refresh and health-persistence tests plus selected
+  mandate API regressions passed with 32 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules; search found no refresh private alias remaining in
+  `mandate_service.py`.
+- Follow-up: continue reviewing optional-source and monitoring-run alias groups separately because
+  they have broader service orchestration call surfaces.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10660,3 +10660,23 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `ConstructionAuthorityContext`.
 - Wiki decision: no wiki source change required; this is internal test hardening with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-438: Liquidity source policy constants
+
+- Date: 2026-06-01
+- Scope: `src/api/services/construction_liquidity_source_context.py`, selected liquidity
+  source-context/API regressions, and this ledger.
+- Finding: the liquidity source-context mapper repeated manage-owned settlement policy identity,
+  minimum cash-weight, liquidity tiers, and source-family reason codes directly inside assembly.
+- Action: moved manage-owned liquidity policy literals into module-local constants while preserving
+  the public mapper contract, source-product lineage fields, and reason-code output.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `construction_liquidity_source_context.py`; direct liquidity source-context tests plus
+  selected construction source-product/enrichment/API regressions passed with 66 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: review other source-family mappers for similar manage-owned policy literals that
+  should be named once near the owning mapper.
+- Wiki decision: no wiki source change required; this is internal mapper maintainability cleanup
+  with no route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10945,3 +10945,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   keep low-level configuration helpers in their owning modules.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-450: Rebalance async configuration ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/rebalance_simulation_service.py`, `src/api/main.py`,
+  `tests/unit/api/test_runtime_request_model_and_service_edges.py`, selected rebalance runtime/API
+  regressions, and this ledger.
+- Finding: `rebalance_simulation_service.py` still imported async configuration helpers as facade
+  attributes and exposed them in `__all__`, while `main.py` also re-exported unused async
+  configuration compatibility names.
+- Action: changed the simulation service to call `rebalance_async_config` through the owning module,
+  removed async configuration helper names from the simulation facade export list, removed the
+  unused `main.py` compatibility exports, and added a direct regression asserting the simulation
+  service no longer publishes async configuration helpers.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `main.py`, `rebalance_simulation_service.py`, and
+  `rebalance_async_config.py`; rebalance runtime, simulation execution-context, and API regression
+  tests passed with 140 tests; OpenAPI quality gate passed; API vocabulary inventory validate-only
+  gate passed; `git diff --check` passed; service leakage scan found no router/HTTP imports in
+  service modules; targeted scans found no direct async-config helper import, no `_async_*`
+  compatibility exports in `main.py`, and no async configuration helper names in
+  `rebalance_simulation_service.py` `__all__`.
+- Follow-up: continue reviewing `rebalance_simulation_service.py` for public exports that are
+  runtime orchestration dependencies rather than durable service API.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10894,3 +10894,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   required by orchestration and can be covered directly in helper modules.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-448: Rebalance core-resolver env surface narrowing
+
+- Date: 2026-06-02
+- Scope: `src/api/services/rebalance_simulation_service.py`, `src/api/main.py`,
+  `tests/unit/api/test_runtime_request_model_and_service_edges.py`, selected rebalance runtime/API
+  regressions, and this ledger.
+- Finding: `rebalance_simulation_service.py` still re-exported low-level core-resolver environment
+  parsing helpers even though environment parsing and resolver configuration belong to
+  `core_resolver_service`; tests reached through the simulation facade to validate the lower-level
+  helper behavior.
+- Action: removed `env_int` and `env_float` from the rebalance simulation service facade, removed
+  the unused `main.py` `_env_int` compatibility export, moved helper assertions to
+  `core_resolver_service`, and added direct export-surface coverage for the core resolver
+  configuration helper module.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `main.py`, `rebalance_simulation_service.py`, and
+  `core_resolver_service.py`; rebalance runtime, simulation execution-context, and API regression
+  tests passed with 138 tests; OpenAPI quality gate passed; API vocabulary inventory validate-only
+  gate passed; `git diff --check` passed; service leakage scan found no router/HTTP imports in
+  service modules; targeted scan found no `env_int`, `env_float`, or `_env_int` compatibility
+  export remaining in `rebalance_simulation_service.py` or `main.py`.
+- Follow-up: continue narrowing `rebalance_simulation_service.py` to orchestration-only behavior
+  while preserving explicit injection points needed by stateful source-context tests.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10525,3 +10525,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-432: Wave lookup persistence alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`, `tests/unit/dpm/waves/test_wave_lookup.py`,
+  `tests/unit/dpm/waves/test_wave_persistence.py`, selected wave lookup/write API regressions, and
+  this ledger.
+- Finding: `wave_service.py` still exposed private lookup and persistence aliases after command
+  extraction moved persisted wave reads and writes into owning helper modules.
+- Action: removed the stale lookup, save, and update imports and aliases from the service facade,
+  and retired alias-pinning assertions so tests verify `wave_lookup` and `wave_persistence`
+  directly.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py`; direct wave lookup and persistence tests plus selected wave API
+  regressions passed with 141 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules.
+- Follow-up: continue retiring the remaining state guard, trigger validation, transition execution,
+  and selection helper aliases without changing public wave route behavior.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10972,3 +10972,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   runtime orchestration dependencies rather than durable service API.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-451: Rebalance core-resolver helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/rebalance_simulation_service.py`,
+  `tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  `tests/unit/dpm/api/test_api_rebalance.py`, selected rebalance runtime/API regressions, and this
+  ledger.
+- Finding: `rebalance_simulation_service.py` still exposed core-resolver construction and stateful
+  sourcing flag aliases purely as test patch points even though `core_resolver_service` owns those
+  helpers and already has direct export-surface coverage.
+- Action: changed stateful source-context orchestration to call `core_resolver_service` directly,
+  moved runtime-edge tests to patch the owning module, and added a regression proving the simulation
+  service no longer exposes core-resolver helper aliases.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `rebalance_simulation_service.py` and `core_resolver_service.py`;
+  rebalance runtime, simulation execution-context, and API regression tests passed with 141 tests;
+  OpenAPI quality gate passed; API vocabulary inventory validate-only gate passed; `git diff
+  --check` passed; service leakage scan found no router/HTTP imports in service modules; targeted
+  scan found no core-resolver helper alias assignments or stale `rebalance_service` test patching
+  remaining in the touched service/test files.
+- Follow-up: continue reviewing `rebalance_simulation_service.py` public exports and runtime
+  override hooks, keeping only explicit orchestration seams needed by API behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11242,3 +11242,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage already proves behavior.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-462: Wave preview helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/wave_service.py`, `tests/unit/dpm/waves/test_wave_preview.py`, selected
+  wave preview/API regressions, and this ledger.
+- Finding: `wave_service.py` imported and exposed `build_preview_wave` as a facade attribute even
+  though the wave-preview module has direct behavior and export-surface tests, and the service only
+  needs the helper behind the public `preview_wave` workflow function.
+- Action: changed `wave_service.preview_wave` to call `wave_preview.build_preview_wave` through the
+  owning module.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `wave_service.py`; direct wave preview tests and selected wave API
+  regressions passed with 135 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed with only line-ending warnings; service
+  leakage scan found no router/HTTP imports in service modules; targeted scan found only direct
+  preview helper tests and the qualified `wave_preview` owner-module call from `wave_service.py`.
+- Follow-up: continue retiring wave-service helper aliases in small groups where direct helper
+  coverage already proves behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10592,3 +10592,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `wave_service.py` that are not public facade entry points or response read models.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-435: Wave selection helper alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_construction_selection.py`,
+  `tests/unit/dpm/waves/test_wave_selection_guard.py`, selected wave selection/API regressions, and
+  this ledger.
+- Finding: `wave_service.py` still retained private selection helper aliases after persisted
+  selection command extraction made the command helper responsible for selection validation,
+  construction side effects, and item transition assembly.
+- Action: removed construction-selection, item-selection-transition, and selection-guard helper
+  imports and aliases from the service facade, and retired remaining facade-alias assertions while
+  preserving direct helper behavior and export-surface coverage.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py`; direct wave construction selection, selection guard, and item
+  selection transition tests plus selected wave API regressions passed with 143 tests; OpenAPI
+  quality gate passed; API vocabulary inventory validate-only gate passed; `git diff --check`
+  passed; service leakage scan found no router/HTTP imports in service modules.
+- Follow-up: review `wave_service.py` after alias retirement for further public facade slimming
+  opportunities that do not obscure router-facing orchestration.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10380,3 +10380,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   identity has a consistent helper across single-source and treasury multi-source mappers.
 - Wiki decision: no wiki source change required; this is internal mapper modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-426: Wave lifecycle command extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_lifecycle_commands.py`,
+  `tests/unit/dpm/waves/test_wave_lifecycle_commands.py`, selected wave lifecycle/API regressions,
+  and this ledger.
+- Finding: wave approval, staging, handoff, and cancellation repeated transition preparation,
+  idempotent replay handling, transition builder invocation, and optimistic persistence directly in
+  `wave_service.py`, even after shared transition execution helpers existed.
+- Action: extracted persisted wave lifecycle command helpers for approval, staging, handoff, and
+  cancellation, kept the public service API as a facade, preserved service compatibility aliases,
+  and added direct tests for command persistence, expected-version handling, replay, export surface,
+  and service delegation.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_lifecycle_commands.py`; direct wave lifecycle command
+  tests and selected wave lifecycle/API regressions passed with 162 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing source-check, simulation, and selection command boundaries for
+  similarly narrow command extraction opportunities without obscuring domain-specific dependencies.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11045,3 +11045,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   facade exports for lower-level core functions.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-454: Wave create-command helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_create_command.py`, selected wave API regressions, and this
+  ledger.
+- Finding: `wave_service.py` imported and exposed `create_persisted_wave` as a facade attribute even
+  though the create-command helper has direct behavior and export-surface tests, and the service
+  only needs it as an implementation dependency of `create_wave`.
+- Action: changed `wave_service.create_wave` to call `wave_create_command.create_persisted_wave`
+  through the owning module and removed the alias-pinning test assertion from the create-command
+  helper tests.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `wave_service.py`; direct wave create-command and wave-creation tests
+  plus selected wave API regressions passed with 139 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules; targeted scan found only direct create-command
+  helper tests and the qualified `wave_create_command.create_persisted_wave` owner-module call from
+  `wave_service.py`.
+- Follow-up: continue retiring wave-service helper aliases in small groups where direct helper
+  coverage already proves behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10797,3 +10797,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   they have broader service orchestration call surfaces.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-444: Mandate optional-source alias retirement
+
+- Date: 2026-06-02
+- Scope: `src/api/services/mandate_service.py`,
+  `tests/unit/dpm/mandates/test_mandate_optional_sources.py`, selected mandate refresh/API
+  regressions, and this ledger.
+- Finding: `mandate_service.py` still imported and exposed private optional-source resolution
+  aliases after mandate refresh extraction made `mandate_refresh` the owner of optional-source
+  dependency flow.
+- Action: removed stale optional-source imports and private aliases from the service facade, and
+  retired alias-pinning assertions while preserving direct optional-source helper behavior and
+  export-surface tests.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py`; direct mandate optional-source and refresh tests plus selected
+  mandate API regressions passed with 39 tests; OpenAPI quality gate passed; API vocabulary
+  inventory validate-only gate passed; `git diff --check` passed; service leakage scan found no
+  router/HTTP imports in service modules; search found no optional-source private aliases remaining
+  in `mandate_service.py`.
+- Follow-up: review the remaining monitoring-run aliases separately because they are still used by
+  service orchestration.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11019,3 +11019,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   helpers still prove they are intentional.
 - Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-453: Rebalance core engine runner ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/rebalance_simulation_service.py`, `src/api/main.py`,
+  `tests/unit/api/test_runtime_request_model_and_service_edges.py`, selected rebalance runtime/API
+  regressions, and this ledger.
+- Finding: `rebalance_simulation_service.py` still exported the core `run_simulation` engine
+  function even though the service only needs it as an internal default and the active runtime
+  override hook is `src.api.main.run_simulation`.
+- Action: changed the service to use a private `_run_simulation` default, removed the core engine
+  runner from the service export surface, imported `run_simulation` directly in `main.py` for the
+  existing override hook, and added a regression proving the service no longer publishes the core
+  engine runner.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `main.py` and `rebalance_simulation_service.py`; rebalance runtime and API
+  regression tests passed with 140 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules; targeted scans confirmed `main.py` owns the public `run_simulation`
+  override import, the service uses private `_run_simulation`, and `run_simulation` is no longer in
+  `rebalance_simulation_service.py` `__all__`.
+- Follow-up: continue keeping runtime override hooks explicit at `main.py` while avoiding service
+  facade exports for lower-level core functions.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10570,3 +10570,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   points.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-434: Wave transition execution alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_transition_execution.py`, selected wave transition/API
+  regressions, and this ledger.
+- Finding: `wave_service.py` still retained private transition execution aliases after persisted
+  lifecycle, preparation, and selection command helpers became the owners of transition preparation
+  and optimistic persistence.
+- Action: removed transition execution imports and aliases from the service facade, and retired the
+  facade-alias assertion while preserving direct helper behavior and export-surface tests.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py`; direct wave transition execution tests plus selected wave API
+  regressions passed with 140 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules.
+- Follow-up: review the remaining selection helper aliases as the last private helper imports in
+  `wave_service.py` that are not public facade entry points or response read models.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11122,3 +11122,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   coverage, and architecture contracts once report-only baselines are stable.
 - Wiki decision: no wiki source change required yet; this is internal engineering-health evidence
   and does not change route behavior, product feature truth, or operator procedure.
+
+## BACKEND-REVIEW-20260602-457: Wave lifecycle-command helper ownership
+
+- Date: 2026-06-02
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_lifecycle_commands.py`, selected wave API regressions, and this
+  ledger.
+- Finding: `wave_service.py` imported and exposed persisted lifecycle command helpers as facade
+  attributes even though the lifecycle-command module has direct behavior and export-surface tests,
+  and the service only needs them behind public wave workflow commands.
+- Action: changed `wave_service` to call `wave_lifecycle_commands` through the owning module and
+  removed lifecycle-command alias-pinning assertions from the helper tests.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files and ledger;
+  focused mypy passed for `wave_service.py`; direct wave lifecycle, approval, stage, handoff, and
+  cancellation tests plus selected wave API regressions passed with 152 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules; targeted scan found only direct
+  lifecycle-command helper tests and qualified `wave_lifecycle_commands` owner-module calls from
+  `wave_service.py`.
+- Follow-up: continue retiring wave-service helper aliases in small groups where direct helper
+  coverage already proves behavior.
+- Wiki decision: no wiki source change required; this is internal service-boundary cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10478,3 +10478,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   moved to the owning helper module and no service facade contract depends on them.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-430: Wave workflow metadata alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `tests/unit/dpm/waves/test_wave_workflow_metadata.py`, selected wave workflow metadata/API
+  regressions, and this ledger.
+- Finding: `wave_service.py` still retained private aliases for workflow metadata helpers even
+  though the owning `wave_workflow_metadata` module has direct behavior and export-surface tests.
+- Action: removed workflow metadata helper imports and private aliases from the service facade, and
+  retired the service-alias assertion so tests verify the owning helper module instead of preserving
+  stale facade surface.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py`; direct workflow metadata tests and selected wave command/API
+  regressions passed with 146 tests; OpenAPI quality gate passed; API vocabulary inventory
+  validate-only gate passed; `git diff --check` passed; service leakage scan found no router/HTTP
+  imports in service modules.
+- Follow-up: continue retiring remaining service compatibility aliases in small batches when direct
+  helper tests already prove ownership and no route or service API depends on the alias.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10358,3 +10358,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   single-source mappers.
 - Wiki decision: no wiki source change required; this is internal mapper modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-425: Treasury currency-overlay source identity normalization
+
+- Date: 2026-06-01
+- Scope: `src/api/services/construction_treasury_source_context.py`, selected treasury
+  source-context/API regressions, and this ledger.
+- Finding: the treasury currency-overlay mapper retained bespoke optional source-id and content-hash
+  assembly for hedge readiness, currency exposure, hedge policy, eligible instruments, and FX
+  forward curves after the shared source-product identity helper existed.
+- Action: introduced a treasury-local optional identity adapter backed by `source_product_identity`,
+  preserved the aggregate currency-overlay content hash and hedge-readiness aggregate fallback, and
+  routed all optional child source-product identity fields through the shared identity bundle.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `construction_treasury_source_context.py`; direct treasury source-context tests and
+  selected construction source-context/API regressions passed with 35 tests; OpenAPI quality gate
+  passed; API vocabulary inventory validate-only gate passed; `git diff --check` passed; service
+  leakage scan found no router/HTTP imports in service modules.
+- Follow-up: continue reviewing construction service orchestration now that source-product lineage
+  identity has a consistent helper across single-source and treasury multi-source mappers.
+- Wiki decision: no wiki source change required; this is internal mapper modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10704,3 +10704,25 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   evidence before pruning them.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-440: Mandate diff alias retirement
+
+- Date: 2026-06-01
+- Scope: `src/api/services/mandate_service.py`, `tests/unit/dpm/mandates/test_mandate_diff.py`,
+  selected mandate diff/API regressions, and this ledger.
+- Finding: `mandate_service.py` still imported and exposed private mandate-diff helper aliases even
+  though the owning `mandate_diff` module has direct behavior and export-surface tests; the service
+  only needs the version-comparison builder for its public diff endpoint.
+- Action: removed unused mandate-diff helper imports and private aliases from the service facade,
+  routed the public diff endpoint directly through `build_mandate_diff_for_versions`, and kept only
+  the public diff model re-exports required by existing callers.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py`; direct mandate diff tests plus selected mandate API regressions
+  passed with 33 tests; OpenAPI quality gate passed; API vocabulary inventory validate-only gate
+  passed; `git diff --check` passed; service leakage scan found no router/HTTP imports in service
+  modules; search found no mandate-diff private aliases remaining in `mandate_service.py`.
+- Follow-up: continue retiring remaining mandate service compatibility aliases only when service
+  orchestration can call owning helpers directly and direct helper tests cover behavior.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10821,3 +10821,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   service orchestration.
 - Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
   payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260602-445: Mandate monitoring-run alias retirement
+
+- Date: 2026-06-02
+- Scope: `src/api/services/mandate_service.py`,
+  `tests/unit/dpm/mandates/test_mandate_monitoring_run.py`, selected mandate monitoring/API
+  regressions, and this ledger.
+- Finding: `mandate_service.py` still routed monitoring-run orchestration through private helper
+  aliases and imported helper functions used only to preserve that private facade surface.
+- Action: replaced private monitoring-run aliases with direct calls to the owning helper module,
+  removed unused monitoring helper imports, and retired alias-pinning assertions while retaining
+  public monitoring model re-exports required by callers.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `mandate_service.py`; direct mandate monitoring-run and health-persistence tests plus
+  selected mandate API regressions passed with 34 tests; OpenAPI quality gate passed; API
+  vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage scan
+  found no router/HTTP imports in service modules; search found no monitoring-run private aliases
+  remaining in `mandate_service.py`.
+- Follow-up: run a final mandate-service alias scan before the PR checkpoint to confirm only
+  intentional public re-exports remain.
+- Wiki decision: no wiki source change required; this is internal dead-code cleanup with no route,
+  payload, supported-feature, or operator-contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -10430,3 +10430,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   selection-specific repository side effects and proof-pack generation dependencies.
 - Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
   route, payload, supported-feature, or operator-contract change.
+
+## BACKEND-REVIEW-20260601-428: Wave selection command extraction
+
+- Date: 2026-06-01
+- Scope: `src/api/services/wave_service.py`,
+  `src/api/services/wave_selection_command.py`,
+  `tests/unit/dpm/waves/test_wave_selection_command.py`, selected wave selection/API regressions,
+  and this ledger.
+- Finding: wave alternative selection remained the last command body in `wave_service.py`, mixing
+  transition preparation, selectable-item validation, construction alternative selection, proof-pack
+  transition building, and optimistic persistence in the service facade.
+- Action: extracted a persisted wave selection command helper, kept selection-specific side effects
+  and proof-pack generation wiring together, preserved service compatibility aliases, and added
+  direct tests for selection side-effect wiring, expected-version persistence, export surface, and
+  service delegation.
+- Status: hardened
+- Evidence: focused Ruff and format checks passed for the touched source/test files; focused mypy
+  passed for `wave_service.py` and `wave_selection_command.py`; direct wave selection command tests
+  and selected wave selection/API regressions passed with 148 tests; OpenAPI quality gate passed;
+  API vocabulary inventory validate-only gate passed; `git diff --check` passed; service leakage
+  scan found no router/HTTP imports in service modules.
+- Follow-up: review `wave_service.py` compatibility aliases and remaining facade imports for stale
+  test-only surface that can be retired safely in a later cleanup slice.
+- Wiki decision: no wiki source change required; this is internal service modularity cleanup with no
+  route, payload, supported-feature, or operator-contract change.

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-01T23:17:06+00:00`
+- Generated at: `2026-06-01T23:39:43+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `6bffc2e`
+- Current ref: `8dc39c9`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 754 | 767 | +13 |
-| Total Python LOC | 144347 | 145857 | +1510 |
-| Test functions | 1834 | 1856 | +22 |
+| Python files | 754 | 768 | +14 |
+| Total Python LOC | 144347 | 145874 | +1527 |
+| Test functions | 1834 | 1855 | +21 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,0 +1,156 @@
+# lotus-manage Refactor Health Report
+
+- Generated at: `2026-06-01T23:17:06+00:00`
+
+- Baseline ref: `origin/main`
+
+- Current ref: `6bffc2e`
+
+- Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
+
+## Scorecard
+
+| Metric | origin/main | current branch | Delta |
+| --- | --- | --- | --- |
+| Python files | 754 | 767 | +13 |
+| Total Python LOC | 144347 | 145857 | +1510 |
+| Test functions | 1834 | 1856 | +22 |
+| Service boundary findings | 0 | 0 | +0 |
+| Router infrastructure imports | 18 | 18 | +0 |
+
+## Current OpenAPI Completeness
+
+| Metric | Current |
+| --- | --- |
+| Operations | 135 |
+| Missing summary | 0 |
+| Missing description | 0 |
+| Missing tags | 0 |
+| Missing 4xx/5xx response | 3 |
+| Missing examples marker | 0 |
+
+## Largest Files
+
+### origin/main
+
+| Rank | File | Lines |
+| --- | --- | --- |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 6399 |
+| 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
+| 3 | tests/unit/test_documentation_current_state.py | 2721 |
+| 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
+| 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
+| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2099 |
+| 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
+| 8 | src/core/dpm_source_context.py | 1878 |
+| 9 | tests/unit/dpm/api/test_construction_api.py | 1667 |
+| 10 | src/infrastructure/core_sourcing/client.py | 1639 |
+
+### current branch
+
+| Rank | File | Lines |
+| --- | --- | --- |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 6402 |
+| 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
+| 3 | tests/unit/test_documentation_current_state.py | 2721 |
+| 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
+| 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
+| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2099 |
+| 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
+| 8 | src/core/dpm_source_context.py | 1878 |
+| 9 | tests/unit/dpm/api/test_construction_api.py | 1667 |
+| 10 | src/infrastructure/core_sourcing/client.py | 1639 |
+
+## Largest Functions
+
+### origin/main
+
+| Rank | Function | File | Lines |
+| --- | --- | --- | --- |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1546 |
+| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 754 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 465 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
+| 5 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
+| 6 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
+| 7 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
+| 8 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
+| 9 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
+| 10 | generate_intents | src/core/rebalance/intents.py | 236 |
+
+### current branch
+
+| Rank | Function | File | Lines |
+| --- | --- | --- | --- |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1546 |
+| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 754 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 465 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
+| 5 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
+| 6 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
+| 7 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
+| 8 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
+| 9 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
+| 10 | generate_intents | src/core/rebalance/intents.py | 236 |
+
+## Boundary Findings
+
+### Service boundary findings (origin/main)
+
+No findings.
+
+
+### Service boundary findings (current branch)
+
+No findings.
+
+
+### Router infrastructure imports (origin/main)
+
+- `src/api/routers/construction_generate_routes.py:25: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+- `src/api/routers/mandate_refresh_routes.py:24: from src.infrastructure.core_sourcing import DpmCoreResolverClient`
+- `src/api/routers/mandates.py:7: from src.infrastructure.core_sourcing import DpmCoreResolverClient`
+- `src/api/routers/monitoring.py:7: from src.infrastructure.core_sourcing import DpmCoreResolverClient`
+- `src/api/routers/monitoring_http.py:7: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/monitoring_run_once_routes.py:25: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/pm_operating_quality_book_scope_builder.py:24: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/pm_operating_quality_http.py:13: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/wave_core_portfolio_universe_resolution.py:19: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/wave_core_source_resolution.py:22: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/wave_create_preview_http.py:12: from src.infrastructure.advise_authority import LotusAdviseAuthorityClient`
+- `src/api/routers/wave_create_preview_http.py:13: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+- `src/api/routers/wave_create_preview_routes.py:28: from src.infrastructure.advise_authority import LotusAdviseAuthorityClient`
+- `src/api/routers/wave_create_preview_routes.py:29: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+- `src/api/routers/wave_portfolio_resolution.py:38: from src.infrastructure.advise_authority import (`
+- `src/api/routers/wave_portfolio_resolution.py:42: from src.infrastructure.risk_authority import (`
+- `src/api/routers/wave_simulation_http.py:14: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+- `src/api/routers/wave_simulation_routes.py:18: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+
+
+### Router infrastructure imports (current branch)
+
+- `src/api/routers/construction_generate_routes.py:25: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+- `src/api/routers/mandate_refresh_routes.py:24: from src.infrastructure.core_sourcing import DpmCoreResolverClient`
+- `src/api/routers/mandates.py:7: from src.infrastructure.core_sourcing import DpmCoreResolverClient`
+- `src/api/routers/monitoring.py:7: from src.infrastructure.core_sourcing import DpmCoreResolverClient`
+- `src/api/routers/monitoring_http.py:7: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/monitoring_run_once_routes.py:25: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/pm_operating_quality_book_scope_builder.py:24: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/pm_operating_quality_http.py:13: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/wave_core_portfolio_universe_resolution.py:19: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/wave_core_source_resolution.py:22: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
+- `src/api/routers/wave_create_preview_http.py:12: from src.infrastructure.advise_authority import LotusAdviseAuthorityClient`
+- `src/api/routers/wave_create_preview_http.py:13: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+- `src/api/routers/wave_create_preview_routes.py:28: from src.infrastructure.advise_authority import LotusAdviseAuthorityClient`
+- `src/api/routers/wave_create_preview_routes.py:29: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+- `src/api/routers/wave_portfolio_resolution.py:38: from src.infrastructure.advise_authority import (`
+- `src/api/routers/wave_portfolio_resolution.py:42: from src.infrastructure.risk_authority import (`
+- `src/api/routers/wave_simulation_http.py:14: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+- `src/api/routers/wave_simulation_routes.py:18: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
+
+
+## Notes
+
+- This report is intentionally dependency-free and repeatable in local and CI environments.
+
+- It is a first measurable baseline; future phases can add radon, vulture, deptry, bandit, pip-audit, Spectral, import-linter, and coverage thresholds.

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+DEFAULT_BASE_REF = "origin/main"
+DEFAULT_OUTPUT = REPO_ROOT / "quality" / "refactor_health_report.md"
+PYTHON_ROOTS = ("src", "tests", "scripts")
+SERVICE_LEAKAGE_PATTERNS = (
+    "from src.api.routers",
+    "import src.api.routers",
+    "HTTPException",
+    "status.HTTP",
+)
+ROUTER_INFRA_PATTERNS = (
+    "from src.infrastructure",
+    "import src.infrastructure",
+)
+
+
+@dataclass(frozen=True)
+class FileMetric:
+    path: str
+    lines: int
+
+
+@dataclass(frozen=True)
+class FunctionMetric:
+    path: str
+    name: str
+    lines: int
+
+
+@dataclass(frozen=True)
+class SnapshotMetrics:
+    label: str
+    python_file_count: int
+    total_loc: int
+    test_count: int
+    largest_files: list[FileMetric]
+    largest_functions: list[FunctionMetric]
+    service_boundary_violations: list[str]
+    router_infra_imports: list[str]
+
+
+def _git(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return completed.stdout
+
+
+def _python_paths_from_git(ref: str) -> list[str]:
+    paths = _git("ls-tree", "-r", "--name-only", ref).splitlines()
+    return [
+        path
+        for path in paths
+        if path.endswith(".py") and path.startswith(tuple(f"{root}/" for root in PYTHON_ROOTS))
+    ]
+
+
+def _python_paths_from_worktree() -> list[str]:
+    paths: list[str] = []
+    for root in PYTHON_ROOTS:
+        for path in (REPO_ROOT / root).rglob("*.py"):
+            if any(part.startswith(".") for part in path.relative_to(REPO_ROOT).parts):
+                continue
+            paths.append(path.relative_to(REPO_ROOT).as_posix())
+    return sorted(paths)
+
+
+def _text_from_git(ref: str, path: str) -> str:
+    return _git("show", f"{ref}:{path}")
+
+
+def _text_from_worktree(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _function_metrics(path: str, text: str) -> list[FunctionMetric]:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+    metrics: list[FunctionMetric] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            end_lineno = getattr(node, "end_lineno", node.lineno)
+            metrics.append(
+                FunctionMetric(path=path, name=node.name, lines=end_lineno - node.lineno + 1)
+            )
+    return metrics
+
+
+def _test_count(text: str) -> int:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return 0
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        and node.name.startswith("test_")
+    )
+
+
+def _matching_lines(path: str, text: str, patterns: Iterable[str]) -> list[str]:
+    matches: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if any(pattern in line for pattern in patterns):
+            matches.append(f"{path}:{lineno}: {line.strip()}")
+    return matches
+
+
+def _snapshot_metrics(label: str, paths: list[str], reader: Any) -> SnapshotMetrics:
+    files: list[FileMetric] = []
+    functions: list[FunctionMetric] = []
+    service_boundary_violations: list[str] = []
+    router_infra_imports: list[str] = []
+    total_loc = 0
+    test_count = 0
+    for path in paths:
+        text = reader(path)
+        lines = len(text.splitlines())
+        total_loc += lines
+        files.append(FileMetric(path=path, lines=lines))
+        functions.extend(_function_metrics(path, text))
+        if path.startswith("tests/"):
+            test_count += _test_count(text)
+        if path.startswith("src/api/services/"):
+            service_boundary_violations.extend(
+                _matching_lines(path, text, SERVICE_LEAKAGE_PATTERNS)
+            )
+        if path.startswith("src/api/routers/"):
+            router_infra_imports.extend(_matching_lines(path, text, ROUTER_INFRA_PATTERNS))
+    return SnapshotMetrics(
+        label=label,
+        python_file_count=len(paths),
+        total_loc=total_loc,
+        test_count=test_count,
+        largest_files=sorted(files, key=lambda item: item.lines, reverse=True)[:10],
+        largest_functions=sorted(functions, key=lambda item: item.lines, reverse=True)[:10],
+        service_boundary_violations=service_boundary_violations,
+        router_infra_imports=router_infra_imports,
+    )
+
+
+def _delta(current: int, baseline: int) -> str:
+    value = current - baseline
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value}"
+
+
+def _table(headers: list[str], rows: list[list[str]]) -> str:
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    lines.extend("| " + " | ".join(row) + " |" for row in rows)
+    return "\n".join(lines)
+
+
+def _metric_summary(base: SnapshotMetrics, current: SnapshotMetrics) -> str:
+    rows = [
+        [
+            "Python files",
+            str(base.python_file_count),
+            str(current.python_file_count),
+            _delta(current.python_file_count, base.python_file_count),
+        ],
+        [
+            "Total Python LOC",
+            str(base.total_loc),
+            str(current.total_loc),
+            _delta(current.total_loc, base.total_loc),
+        ],
+        [
+            "Test functions",
+            str(base.test_count),
+            str(current.test_count),
+            _delta(current.test_count, base.test_count),
+        ],
+        [
+            "Service boundary findings",
+            str(len(base.service_boundary_violations)),
+            str(len(current.service_boundary_violations)),
+            _delta(len(current.service_boundary_violations), len(base.service_boundary_violations)),
+        ],
+        [
+            "Router infrastructure imports",
+            str(len(base.router_infra_imports)),
+            str(len(current.router_infra_imports)),
+            _delta(len(current.router_infra_imports), len(base.router_infra_imports)),
+        ],
+    ]
+    return _table(["Metric", base.label, current.label, "Delta"], rows)
+
+
+def _top_file_table(title: str, files: list[FileMetric]) -> str:
+    return f"### {title}\n\n" + _table(
+        ["Rank", "File", "Lines"],
+        [[str(index), item.path, str(item.lines)] for index, item in enumerate(files, start=1)],
+    )
+
+
+def _top_function_table(title: str, functions: list[FunctionMetric]) -> str:
+    return f"### {title}\n\n" + _table(
+        ["Rank", "Function", "File", "Lines"],
+        [
+            [str(index), item.name, item.path, str(item.lines)]
+            for index, item in enumerate(functions, start=1)
+        ],
+    )
+
+
+def _openapi_metrics() -> dict[str, int]:
+    try:
+        from src.api.main import app
+    except Exception:
+        return {
+            "operations": 0,
+            "missing_summary": -1,
+            "missing_description": -1,
+            "missing_tags": -1,
+            "missing_error_response": -1,
+            "missing_examples": -1,
+        }
+    schema = app.openapi()
+    operations = 0
+    missing_summary = 0
+    missing_description = 0
+    missing_tags = 0
+    missing_error_response = 0
+    missing_examples = 0
+    for path_item in schema.get("paths", {}).values():
+        if not isinstance(path_item, dict):
+            continue
+        for method, operation in path_item.items():
+            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
+                continue
+            if not isinstance(operation, dict):
+                continue
+            operations += 1
+            if not operation.get("summary"):
+                missing_summary += 1
+            if not operation.get("description"):
+                missing_description += 1
+            if not operation.get("tags"):
+                missing_tags += 1
+            responses = operation.get("responses", {})
+            if not any(str(code).startswith(("4", "5")) for code in responses):
+                missing_error_response += 1
+            if "examples" not in str(operation):
+                missing_examples += 1
+    return {
+        "operations": operations,
+        "missing_summary": missing_summary,
+        "missing_description": missing_description,
+        "missing_tags": missing_tags,
+        "missing_error_response": missing_error_response,
+        "missing_examples": missing_examples,
+    }
+
+
+def _bounded_findings(title: str, findings: list[str]) -> str:
+    if not findings:
+        return f"### {title}\n\nNo findings.\n"
+    shown = findings[:20]
+    suffix = "" if len(findings) <= len(shown) else f"\n\n... {len(findings) - len(shown)} more."
+    return f"### {title}\n\n" + "\n".join(f"- `{item}`" for item in shown) + suffix + "\n"
+
+
+def build_report(base_ref: str = DEFAULT_BASE_REF) -> str:
+    base_paths = _python_paths_from_git(base_ref)
+    current_paths = _python_paths_from_worktree()
+    base = _snapshot_metrics(
+        label=base_ref,
+        paths=base_paths,
+        reader=lambda path: _text_from_git(base_ref, path),
+    )
+    current = _snapshot_metrics(
+        label="current branch",
+        paths=current_paths,
+        reader=_text_from_worktree,
+    )
+    openapi = _openapi_metrics()
+    generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    sections = [
+        "# lotus-manage Refactor Health Report",
+        f"- Generated at: `{generated_at}`",
+        f"- Baseline ref: `{base_ref}`",
+        f"- Current ref: `{_git('rev-parse', '--short', 'HEAD').strip()}`",
+        "- Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.",
+        "## Scorecard",
+        _metric_summary(base, current),
+        "## Current OpenAPI Completeness",
+        _table(
+            ["Metric", "Current"],
+            [
+                ["Operations", str(openapi["operations"])],
+                ["Missing summary", str(openapi["missing_summary"])],
+                ["Missing description", str(openapi["missing_description"])],
+                ["Missing tags", str(openapi["missing_tags"])],
+                ["Missing 4xx/5xx response", str(openapi["missing_error_response"])],
+                ["Missing examples marker", str(openapi["missing_examples"])],
+            ],
+        ),
+        "## Largest Files",
+        _top_file_table(f"{base.label}", base.largest_files),
+        _top_file_table(f"{current.label}", current.largest_files),
+        "## Largest Functions",
+        _top_function_table(f"{base.label}", base.largest_functions),
+        _top_function_table(f"{current.label}", current.largest_functions),
+        "## Boundary Findings",
+        _bounded_findings(
+            f"Service boundary findings ({base.label})", base.service_boundary_violations
+        ),
+        _bounded_findings(
+            "Service boundary findings (current branch)", current.service_boundary_violations
+        ),
+        _bounded_findings(
+            f"Router infrastructure imports ({base.label})", base.router_infra_imports
+        ),
+        _bounded_findings(
+            "Router infrastructure imports (current branch)", current.router_infra_imports
+        ),
+        "## Notes",
+        "- This report is intentionally dependency-free and repeatable in local and CI environments.",
+        "- It is a first measurable baseline; future phases can add radon, vulture, deptry, bandit, pip-audit, Spectral, import-linter, and coverage thresholds.",
+    ]
+    return "\n\n".join(sections) + "\n"
+
+
+def main() -> None:
+    report = build_report()
+    DEFAULT_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    DEFAULT_OUTPUT.write_text(report, encoding="utf-8")
+    print(f"Wrote {DEFAULT_OUTPUT.relative_to(REPO_ROOT).as_posix()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -57,9 +57,6 @@ from src.api.services.rebalance_simulation_service import (
 from src.api.services.rebalance_simulation_service import (
     execute_batch_analysis as _execute_batch_analysis,
 )
-from src.api.services.rebalance_simulation_service import (
-    run_analyze_async_operation as _run_analyze_async_operation,
-)
 
 
 class HealthStatusResponse(BaseModel):
@@ -270,7 +267,6 @@ async def unhandled_exception_to_problem_details(request: Request, exc: Exceptio
 __all__ = [
     "HealthStatusResponse",
     "_execute_batch_analysis",
-    "_run_analyze_async_operation",
     "analyze_scenarios",
     "analyze_scenarios_async",
     "app",

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -61,9 +61,6 @@ from src.api.services.rebalance_simulation_service import (
     env_flag as _env_flag,
 )
 from src.api.services.rebalance_simulation_service import (
-    env_int as _env_int,
-)
-from src.api.services.rebalance_simulation_service import (
     execute_batch_analysis as _execute_batch_analysis,
 )
 from src.api.services.rebalance_simulation_service import (
@@ -283,7 +280,6 @@ __all__ = [
     "HealthStatusResponse",
     "_async_manual_execution_enabled",
     "_env_flag",
-    "_env_int",
     "_execute_batch_analysis",
     "_resolve_async_execution_mode",
     "_run_analyze_async_operation",

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -52,11 +52,9 @@ from src.api.routers.outcome_reviews import (
 )
 from src.api.routers.waves import router as waves_router
 from src.api.services.rebalance_simulation_service import (
-    run_simulation,
-)
-from src.api.services.rebalance_simulation_service import (
     execute_batch_analysis as _execute_batch_analysis,
 )
+from src.core.rebalance.engine import run_simulation
 
 
 class HealthStatusResponse(BaseModel):

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -58,9 +58,6 @@ from src.api.services.rebalance_simulation_service import (
     async_manual_execution_enabled as _async_manual_execution_enabled,
 )
 from src.api.services.rebalance_simulation_service import (
-    env_flag as _env_flag,
-)
-from src.api.services.rebalance_simulation_service import (
     execute_batch_analysis as _execute_batch_analysis,
 )
 from src.api.services.rebalance_simulation_service import (
@@ -279,7 +276,6 @@ async def unhandled_exception_to_problem_details(request: Request, exc: Exceptio
 __all__ = [
     "HealthStatusResponse",
     "_async_manual_execution_enabled",
-    "_env_flag",
     "_execute_batch_analysis",
     "_resolve_async_execution_mode",
     "_run_analyze_async_operation",

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -55,13 +55,7 @@ from src.api.services.rebalance_simulation_service import (
     run_simulation,
 )
 from src.api.services.rebalance_simulation_service import (
-    async_manual_execution_enabled as _async_manual_execution_enabled,
-)
-from src.api.services.rebalance_simulation_service import (
     execute_batch_analysis as _execute_batch_analysis,
-)
-from src.api.services.rebalance_simulation_service import (
-    resolve_async_execution_mode as _resolve_async_execution_mode,
 )
 from src.api.services.rebalance_simulation_service import (
     run_analyze_async_operation as _run_analyze_async_operation,
@@ -275,9 +269,7 @@ async def unhandled_exception_to_problem_details(request: Request, exc: Exceptio
 
 __all__ = [
     "HealthStatusResponse",
-    "_async_manual_execution_enabled",
     "_execute_batch_analysis",
-    "_resolve_async_execution_mode",
     "_run_analyze_async_operation",
     "analyze_scenarios",
     "analyze_scenarios_async",

--- a/src/api/services/construction_client_profile_source_context.py
+++ b/src/api/services/construction_client_profile_source_context.py
@@ -1,11 +1,5 @@
-from typing import TypeAlias
-
 from src.api.services.construction_source_product_status import source_status_to_method_status
-from src.api.services.construction_source_identity import (
-    response_source_id,
-    source_hash,
-    source_payload,
-)
+from src.api.services.construction_source_identity import source_product_identity
 from src.core.construction.models import (
     AuthoritativeClientRestrictionContext,
     AuthoritativeClientRestrictionRule,
@@ -17,25 +11,20 @@ from src.core.dpm_source_context import (
     DpmCoreSustainabilityPreferenceProfileResponse,
 )
 
-_ClientProfileSourceResponse: TypeAlias = (
-    DpmCoreClientRestrictionProfileResponse | DpmCoreSustainabilityPreferenceProfileResponse
-)
-
 
 def client_restriction_profile_context(
     restriction_profile: DpmCoreClientRestrictionProfileResponse,
 ) -> AuthoritativeClientRestrictionContext:
-    payload = source_payload(restriction_profile)
-    source_hash_value = source_hash(payload)
+    identity = source_product_identity(restriction_profile)
     return AuthoritativeClientRestrictionContext(
         supportability_status=source_status_to_method_status(
             restriction_profile.supportability.state
         ),
-        source_system="lotus-core",
-        source_product_name=restriction_profile.product_name,
-        source_product_version=restriction_profile.product_version,
-        source_id=response_source_id(restriction_profile, source_hash_value),
-        content_hash=source_hash_value,
+        source_system=identity.source_system,
+        source_product_name=identity.source_product_name,
+        source_product_version=identity.source_product_version,
+        source_id=identity.source_id,
+        content_hash=identity.content_hash,
         portfolio_id=restriction_profile.portfolio_id,
         client_id=restriction_profile.client_id,
         mandate_id=restriction_profile.mandate_id,
@@ -53,17 +42,16 @@ def client_restriction_profile_context(
 def sustainability_preference_profile_context(
     sustainability_profile: DpmCoreSustainabilityPreferenceProfileResponse,
 ) -> AuthoritativeSustainabilityPreferenceContext:
-    payload = source_payload(sustainability_profile)
-    source_hash_value = source_hash(payload)
+    identity = source_product_identity(sustainability_profile)
     return AuthoritativeSustainabilityPreferenceContext(
         supportability_status=source_status_to_method_status(
             sustainability_profile.supportability.state
         ),
-        source_system="lotus-core",
-        source_product_name=sustainability_profile.product_name,
-        source_product_version=sustainability_profile.product_version,
-        source_id=response_source_id(sustainability_profile, source_hash_value),
-        content_hash=source_hash_value,
+        source_system=identity.source_system,
+        source_product_name=identity.source_product_name,
+        source_product_version=identity.source_product_version,
+        source_id=identity.source_id,
+        content_hash=identity.content_hash,
         portfolio_id=sustainability_profile.portfolio_id,
         client_id=sustainability_profile.client_id,
         mandate_id=sustainability_profile.mandate_id,

--- a/src/api/services/construction_execution_source_context.py
+++ b/src/api/services/construction_execution_source_context.py
@@ -1,9 +1,5 @@
 from src.api.services.construction_source_product_status import source_status_to_method_status
-from src.api.services.construction_source_identity import (
-    response_source_id,
-    source_hash,
-    source_payload,
-)
+from src.api.services.construction_source_identity import source_product_identity
 from src.core.construction.models import AuthoritativeExecutionAcknowledgementContext
 from src.core.dpm_source_context import DpmCoreExternalOrderExecutionAcknowledgementResponse
 
@@ -13,15 +9,14 @@ def external_order_execution_acknowledgement_context(
 ) -> AuthoritativeExecutionAcknowledgementContext | None:
     if acknowledgement is None:
         return None
-    payload = source_payload(acknowledgement)
-    source_hash_value = source_hash(payload)
+    identity = source_product_identity(acknowledgement)
     return AuthoritativeExecutionAcknowledgementContext(
         supportability_status=source_status_to_method_status(acknowledgement.supportability.state),
-        source_system="lotus-core",
-        source_product_name=acknowledgement.product_name,
-        source_product_version=acknowledgement.product_version,
-        source_id=response_source_id(acknowledgement, source_hash_value),
-        content_hash=source_hash_value,
+        source_system=identity.source_system,
+        source_product_name=identity.source_product_name,
+        source_product_version=identity.source_product_version,
+        source_id=identity.source_id,
+        content_hash=identity.content_hash,
         acknowledgement_count=acknowledgement.supportability.acknowledgement_count,
         missing_data_families=acknowledgement.supportability.missing_data_families,
         blocked_capabilities=acknowledgement.supportability.blocked_capabilities,

--- a/src/api/services/construction_liquidity_source_context.py
+++ b/src/api/services/construction_liquidity_source_context.py
@@ -1,9 +1,9 @@
 from decimal import Decimal
-from typing import TypeAlias
 
 from src.api.services.construction_source_product_status import source_status_to_method_status
 from src.api.services.construction_source_identity import (
     response_source_id,
+    source_product_identity,
     source_hash,
     source_payload,
 )
@@ -22,13 +22,6 @@ from src.core.dpm_source_context import (
     DpmCorePortfolioCashflowProjectionResponse,
 )
 from src.core.models import Money
-
-_LiquiditySourceResponse: TypeAlias = (
-    DpmCoreClientIncomeNeedsScheduleResponse
-    | DpmCoreLiquidityReserveRequirementResponse
-    | DpmCorePlannedWithdrawalScheduleResponse
-    | DpmCorePortfolioCashflowProjectionResponse
-)
 
 
 def _liquidity_reason_codes(
@@ -53,14 +46,13 @@ def _liquidity_reason_codes(
 def client_income_needs_schedule_context(
     income_needs: DpmCoreClientIncomeNeedsScheduleResponse,
 ) -> AuthoritativeClientIncomeNeedsSchedule:
-    payload = source_payload(income_needs)
-    source_hash_value = source_hash(payload)
+    identity = source_product_identity(income_needs)
     return AuthoritativeClientIncomeNeedsSchedule(
-        source_product_name=income_needs.product_name,
-        source_product_version=income_needs.product_version,
-        source_system="lotus-core",
-        source_id=response_source_id(income_needs, source_hash_value),
-        content_hash=source_hash_value,
+        source_product_name=identity.source_product_name,
+        source_product_version=identity.source_product_version,
+        source_system=identity.source_system,
+        source_id=identity.source_id,
+        content_hash=identity.content_hash,
         schedule_count=income_needs.supportability.schedule_count,
         currencies=sorted({entry.currency for entry in income_needs.schedules}),
         highest_priority=(
@@ -104,14 +96,13 @@ def liquidity_cashflow_projection_context(
 def liquidity_reserve_requirement_context(
     reserve_requirement: DpmCoreLiquidityReserveRequirementResponse,
 ) -> AuthoritativeLiquidityReserveRequirement:
-    payload = source_payload(reserve_requirement)
-    source_hash_value = source_hash(payload)
+    identity = source_product_identity(reserve_requirement)
     return AuthoritativeLiquidityReserveRequirement(
-        source_product_name=reserve_requirement.product_name,
-        source_product_version=reserve_requirement.product_version,
-        source_system="lotus-core",
-        source_id=response_source_id(reserve_requirement, source_hash_value),
-        content_hash=source_hash_value,
+        source_product_name=identity.source_product_name,
+        source_product_version=identity.source_product_version,
+        source_system=identity.source_system,
+        source_id=identity.source_id,
+        content_hash=identity.content_hash,
         requirement_count=reserve_requirement.supportability.requirement_count,
         currencies=sorted({entry.currency for entry in reserve_requirement.requirements}),
         maximum_horizon_days=(
@@ -132,14 +123,13 @@ def liquidity_reserve_requirement_context(
 def planned_withdrawal_schedule_context(
     planned_withdrawals: DpmCorePlannedWithdrawalScheduleResponse,
 ) -> AuthoritativePlannedWithdrawalSchedule:
-    payload = source_payload(planned_withdrawals)
-    source_hash_value = source_hash(payload)
+    identity = source_product_identity(planned_withdrawals)
     return AuthoritativePlannedWithdrawalSchedule(
-        source_product_name=planned_withdrawals.product_name,
-        source_product_version=planned_withdrawals.product_version,
-        source_system="lotus-core",
-        source_id=response_source_id(planned_withdrawals, source_hash_value),
-        content_hash=source_hash_value,
+        source_product_name=identity.source_product_name,
+        source_product_version=identity.source_product_version,
+        source_system=identity.source_system,
+        source_id=identity.source_id,
+        content_hash=identity.content_hash,
         withdrawal_count=planned_withdrawals.supportability.withdrawal_count,
         currencies=sorted({entry.currency for entry in planned_withdrawals.withdrawals}),
         horizon_days=planned_withdrawals.horizon_days,

--- a/src/api/services/construction_liquidity_source_context.py
+++ b/src/api/services/construction_liquidity_source_context.py
@@ -23,6 +23,13 @@ from src.core.dpm_source_context import (
 )
 from src.core.models import Money
 
+_MANAGE_LIQUIDITY_SOURCE_SYSTEM = "lotus-manage-settlement-engine"
+_MANAGE_LIQUIDITY_POLICY_ID = "manage-liquidity-policy.v1"
+_MANAGE_MINIMUM_CASH_WEIGHT = Decimal("0.02")
+_MANAGE_ALLOWED_LIQUIDITY_TIERS = ["L1", "L2", "L3"]
+_MANAGE_LIQUIDITY_POLICY_REASON = "LIQUIDITY_POLICY_DERIVED_FROM_MANAGE_SETTLEMENT_RULES"
+_CORE_LIQUIDITY_SOURCE_REASON = "CORE_LIQUIDITY_SOURCE_CONTEXT_PRESENT"
+
 
 def _liquidity_reason_codes(
     *,
@@ -31,8 +38,8 @@ def _liquidity_reason_codes(
     has_planned_withdrawals: bool,
 ) -> list[str]:
     reason_codes = [
-        "LIQUIDITY_POLICY_DERIVED_FROM_MANAGE_SETTLEMENT_RULES",
-        "CORE_LIQUIDITY_SOURCE_CONTEXT_PRESENT",
+        _MANAGE_LIQUIDITY_POLICY_REASON,
+        _CORE_LIQUIDITY_SOURCE_REASON,
     ]
     if has_income_needs:
         reason_codes.append("CLIENT_INCOME_NEEDS_SOURCE_PRESENT")
@@ -179,10 +186,10 @@ def source_liquidity_context(
 
     return AuthoritativeLiquidityContext(
         supportability_status=ConstructionMethodStatus.READY,
-        source_system="lotus-manage-settlement-engine",
-        policy_id="manage-liquidity-policy.v1",
-        minimum_cash_weight=Decimal("0.02"),
-        allowed_liquidity_tiers=["L1", "L2", "L3"],
+        source_system=_MANAGE_LIQUIDITY_SOURCE_SYSTEM,
+        policy_id=_MANAGE_LIQUIDITY_POLICY_ID,
+        minimum_cash_weight=_MANAGE_MINIMUM_CASH_WEIGHT,
+        allowed_liquidity_tiers=_MANAGE_ALLOWED_LIQUIDITY_TIERS,
         cashflow_projection=cashflow_context,
         client_income_needs_schedule=income_context,
         liquidity_reserve_requirement=reserve_context,

--- a/src/api/services/construction_source_identity.py
+++ b/src/api/services/construction_source_identity.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, TypeAlias
 
 from pydantic import BaseModel
@@ -5,6 +6,15 @@ from pydantic import BaseModel
 from src.core.common.canonical import hash_canonical_payload
 
 JsonPayload: TypeAlias = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class SourceProductIdentity:
+    source_product_name: str
+    source_product_version: str
+    source_system: str
+    source_id: str
+    content_hash: str
 
 
 def source_payload(response: BaseModel) -> JsonPayload:
@@ -27,4 +37,34 @@ def response_source_id(response: BaseModel, fallback_hash: str) -> str:
     return fallback_hash
 
 
-__all__ = ["JsonPayload", "response_source_id", "source_hash", "source_payload"]
+def _required_str_attr(response: BaseModel, attr_name: str) -> str:
+    value = getattr(response, attr_name)
+    if not isinstance(value, str):
+        raise TypeError(f"{attr_name} must be a string source-product field")
+    return value
+
+
+def source_product_identity(
+    response: BaseModel,
+    *,
+    source_system: str = "lotus-core",
+) -> SourceProductIdentity:
+    payload = source_payload(response)
+    content_hash = source_hash(payload)
+    return SourceProductIdentity(
+        source_product_name=_required_str_attr(response, "product_name"),
+        source_product_version=_required_str_attr(response, "product_version"),
+        source_system=source_system,
+        source_id=response_source_id(response, content_hash),
+        content_hash=content_hash,
+    )
+
+
+__all__ = [
+    "JsonPayload",
+    "SourceProductIdentity",
+    "response_source_id",
+    "source_hash",
+    "source_payload",
+    "source_product_identity",
+]

--- a/src/api/services/construction_source_identity.py
+++ b/src/api/services/construction_source_identity.py
@@ -48,6 +48,7 @@ def source_product_identity(
     response: BaseModel,
     *,
     source_system: str = "lotus-core",
+    fallback_source_id: str | None = None,
 ) -> SourceProductIdentity:
     payload = source_payload(response)
     content_hash = source_hash(payload)
@@ -55,7 +56,7 @@ def source_product_identity(
         source_product_name=_required_str_attr(response, "product_name"),
         source_product_version=_required_str_attr(response, "product_version"),
         source_system=source_system,
-        source_id=response_source_id(response, content_hash),
+        source_id=response_source_id(response, fallback_source_id or content_hash),
         content_hash=content_hash,
     )
 

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -1,17 +1,8 @@
-from src.api.services.construction_client_profile_source_context import (
-    client_restriction_profile_context,
-    sustainability_preference_profile_context,
-)
-from src.api.services.construction_execution_source_context import (
-    external_order_execution_acknowledgement_context,
-)
-from src.api.services.construction_liquidity_source_context import source_liquidity_context
-from src.api.services.construction_transaction_cost_source_context import (
-    transaction_cost_context_from_curve,
-)
-from src.api.services.construction_treasury_source_context import (
-    external_treasury_currency_overlay_context,
-)
+from src.api.services import construction_client_profile_source_context
+from src.api.services import construction_execution_source_context
+from src.api.services import construction_liquidity_source_context
+from src.api.services import construction_transaction_cost_source_context
+from src.api.services import construction_treasury_source_context
 from src.core.construction.models import ConstructionAuthorityContext
 from src.core.dpm_source_context import DpmCoreExecutionContext, DpmResolvedSourceContext
 
@@ -28,7 +19,10 @@ def _transaction_cost_context_update(
     curve = getattr(source_context, "transaction_cost_curve", None)
     if curve is None:
         return None
-    return "transaction_cost_context", transaction_cost_context_from_curve(curve)
+    return (
+        "transaction_cost_context",
+        construction_transaction_cost_source_context.transaction_cost_context_from_curve(curve),
+    )
 
 
 def _liquidity_context_update(
@@ -38,7 +32,7 @@ def _liquidity_context_update(
 ) -> AuthorityContextUpdate | None:
     if authority_context.liquidity_context is not None:
         return None
-    liquidity_context = source_liquidity_context(
+    liquidity_context = construction_liquidity_source_context.source_liquidity_context(
         cashflow_projection=getattr(source_context, "portfolio_cashflow_projection", None),
         income_needs=getattr(source_context, "client_income_needs_schedule", None),
         reserve_requirement=getattr(source_context, "liquidity_reserve_requirement", None),
@@ -56,14 +50,16 @@ def _currency_overlay_context_update(
 ) -> AuthorityContextUpdate | None:
     if authority_context.currency_overlay_context is not None:
         return None
-    currency_context = external_treasury_currency_overlay_context(
-        hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
-        currency_exposure=getattr(source_context, "external_currency_exposure", None),
-        hedge_policy=getattr(source_context, "external_hedge_policy", None),
-        eligible_hedge_instruments=getattr(
-            source_context, "external_eligible_hedge_instruments", None
-        ),
-        fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
+    currency_context = (
+        construction_treasury_source_context.external_treasury_currency_overlay_context(
+            hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
+            currency_exposure=getattr(source_context, "external_currency_exposure", None),
+            hedge_policy=getattr(source_context, "external_hedge_policy", None),
+            eligible_hedge_instruments=getattr(
+                source_context, "external_eligible_hedge_instruments", None
+            ),
+            fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
+        )
     )
     if currency_context is None:
         return None
@@ -77,8 +73,10 @@ def _execution_acknowledgement_context_update(
 ) -> AuthorityContextUpdate | None:
     if authority_context.execution_acknowledgement_context is not None:
         return None
-    acknowledgement_context = external_order_execution_acknowledgement_context(
-        getattr(source_context, "external_order_execution_acknowledgement", None)
+    acknowledgement_context = (
+        construction_execution_source_context.external_order_execution_acknowledgement_context(
+            getattr(source_context, "external_order_execution_acknowledgement", None)
+        )
     )
     if acknowledgement_context is None:
         return None
@@ -95,7 +93,12 @@ def _client_restriction_context_update(
     restriction_profile = getattr(source_context, "client_restriction_profile", None)
     if restriction_profile is None:
         return None
-    return "client_restriction_context", client_restriction_profile_context(restriction_profile)
+    return (
+        "client_restriction_context",
+        construction_client_profile_source_context.client_restriction_profile_context(
+            restriction_profile
+        ),
+    )
 
 
 def _sustainability_preference_context_update(
@@ -110,7 +113,9 @@ def _sustainability_preference_context_update(
         return None
     return (
         "sustainability_preference_context",
-        sustainability_preference_profile_context(sustainability_profile),
+        construction_client_profile_source_context.sustainability_preference_profile_context(
+            sustainability_profile
+        ),
     )
 
 

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -15,6 +15,104 @@ from src.api.services.construction_treasury_source_context import (
 from src.core.construction.models import ConstructionAuthorityContext
 from src.core.dpm_source_context import DpmCoreExecutionContext, DpmResolvedSourceContext
 
+AuthorityContextUpdate = tuple[str, object]
+
+
+def _transaction_cost_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.transaction_cost_context is not None:
+        return None
+    curve = getattr(source_context, "transaction_cost_curve", None)
+    if curve is None:
+        return None
+    return "transaction_cost_context", transaction_cost_context_from_curve(curve)
+
+
+def _liquidity_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.liquidity_context is not None:
+        return None
+    liquidity_context = source_liquidity_context(
+        cashflow_projection=getattr(source_context, "portfolio_cashflow_projection", None),
+        income_needs=getattr(source_context, "client_income_needs_schedule", None),
+        reserve_requirement=getattr(source_context, "liquidity_reserve_requirement", None),
+        planned_withdrawals=getattr(source_context, "planned_withdrawal_schedule", None),
+    )
+    if liquidity_context is None:
+        return None
+    return "liquidity_context", liquidity_context
+
+
+def _currency_overlay_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.currency_overlay_context is not None:
+        return None
+    currency_context = external_treasury_currency_overlay_context(
+        hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
+        currency_exposure=getattr(source_context, "external_currency_exposure", None),
+        hedge_policy=getattr(source_context, "external_hedge_policy", None),
+        eligible_hedge_instruments=getattr(
+            source_context, "external_eligible_hedge_instruments", None
+        ),
+        fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
+    )
+    if currency_context is None:
+        return None
+    return "currency_overlay_context", currency_context
+
+
+def _execution_acknowledgement_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.execution_acknowledgement_context is not None:
+        return None
+    acknowledgement_context = external_order_execution_acknowledgement_context(
+        getattr(source_context, "external_order_execution_acknowledgement", None)
+    )
+    if acknowledgement_context is None:
+        return None
+    return "execution_acknowledgement_context", acknowledgement_context
+
+
+def _client_restriction_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.client_restriction_context is not None:
+        return None
+    restriction_profile = getattr(source_context, "client_restriction_profile", None)
+    if restriction_profile is None:
+        return None
+    return "client_restriction_context", client_restriction_profile_context(restriction_profile)
+
+
+def _sustainability_preference_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.sustainability_preference_context is not None:
+        return None
+    sustainability_profile = getattr(source_context, "sustainability_preference_profile", None)
+    if sustainability_profile is None:
+        return None
+    return (
+        "sustainability_preference_context",
+        sustainability_preference_profile_context(sustainability_profile),
+    )
+
 
 def source_product_authority_context_updates(
     *,
@@ -22,49 +120,18 @@ def source_product_authority_context_updates(
     authority_context: ConstructionAuthorityContext,
 ) -> dict[str, object]:
     context_updates: dict[str, object] = {}
-    if authority_context.transaction_cost_context is None:
-        curve = getattr(source_context, "transaction_cost_curve", None)
-        if curve is not None:
-            context_updates["transaction_cost_context"] = transaction_cost_context_from_curve(curve)
-    if authority_context.liquidity_context is None:
-        liquidity_context = source_liquidity_context(
-            cashflow_projection=getattr(source_context, "portfolio_cashflow_projection", None),
-            income_needs=getattr(source_context, "client_income_needs_schedule", None),
-            reserve_requirement=getattr(source_context, "liquidity_reserve_requirement", None),
-            planned_withdrawals=getattr(source_context, "planned_withdrawal_schedule", None),
-        )
-        if liquidity_context is not None:
-            context_updates["liquidity_context"] = liquidity_context
-    if authority_context.currency_overlay_context is None:
-        currency_context = external_treasury_currency_overlay_context(
-            hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
-            currency_exposure=getattr(source_context, "external_currency_exposure", None),
-            hedge_policy=getattr(source_context, "external_hedge_policy", None),
-            eligible_hedge_instruments=getattr(
-                source_context, "external_eligible_hedge_instruments", None
-            ),
-            fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
-        )
-        if currency_context is not None:
-            context_updates["currency_overlay_context"] = currency_context
-    if authority_context.execution_acknowledgement_context is None:
-        acknowledgement_context = external_order_execution_acknowledgement_context(
-            getattr(source_context, "external_order_execution_acknowledgement", None)
-        )
-        if acknowledgement_context is not None:
-            context_updates["execution_acknowledgement_context"] = acknowledgement_context
-    if authority_context.client_restriction_context is None:
-        restriction_profile = getattr(source_context, "client_restriction_profile", None)
-        if restriction_profile is not None:
-            context_updates["client_restriction_context"] = client_restriction_profile_context(
-                restriction_profile
-            )
-    if authority_context.sustainability_preference_context is None:
-        sustainability_profile = getattr(source_context, "sustainability_preference_profile", None)
-        if sustainability_profile is not None:
-            context_updates["sustainability_preference_context"] = (
-                sustainability_preference_profile_context(sustainability_profile)
-            )
+    for update_builder in (
+        _transaction_cost_context_update,
+        _liquidity_context_update,
+        _currency_overlay_context_update,
+        _execution_acknowledgement_context_update,
+        _client_restriction_context_update,
+        _sustainability_preference_context_update,
+    ):
+        update = update_builder(source_context=source_context, authority_context=authority_context)
+        if update is not None:
+            context_key, context_value = update
+            context_updates[context_key] = context_value
     return context_updates
 
 

--- a/src/api/services/construction_transaction_cost_source_context.py
+++ b/src/api/services/construction_transaction_cost_source_context.py
@@ -1,9 +1,5 @@
 from src.api.services.construction_source_product_status import source_status_to_method_status
-from src.api.services.construction_source_identity import (
-    response_source_id,
-    source_hash,
-    source_payload,
-)
+from src.api.services.construction_source_identity import source_product_identity
 from src.core.construction.models import (
     AuthoritativeTransactionCostContext,
     AuthoritativeTransactionCostPoint,
@@ -36,16 +32,17 @@ def _transaction_cost_point(
 def transaction_cost_context_from_curve(
     curve: DpmCoreTransactionCostCurveResponse,
 ) -> AuthoritativeTransactionCostContext:
-    curve_payload = source_payload(curve)
-    source_hash_value = source_hash(curve_payload)
-    source_id = response_source_id(curve, curve.page.request_scope_fingerprint)
+    identity = source_product_identity(
+        curve,
+        fallback_source_id=curve.page.request_scope_fingerprint,
+    )
     return AuthoritativeTransactionCostContext(
         supportability_status=source_status_to_method_status(curve.supportability.state),
-        source_system="lotus-core",
-        source_product_name=curve.product_name,
-        source_product_version=curve.product_version,
-        source_id=source_id,
-        content_hash=source_hash_value,
+        source_system=identity.source_system,
+        source_product_name=identity.source_product_name,
+        source_product_version=identity.source_product_version,
+        source_id=identity.source_id,
+        content_hash=identity.content_hash,
         as_of_date=curve.as_of_date,
         window_start_date=curve.window.start_date,
         window_end_date=curve.window.end_date,

--- a/src/api/services/construction_treasury_source_context.py
+++ b/src/api/services/construction_treasury_source_context.py
@@ -4,8 +4,8 @@ from typing import TypeAlias
 from src.api.services.construction_source_product_status import source_status_to_method_status
 from src.api.services.construction_source_identity import (
     JsonPayload,
-    response_source_id,
-    source_hash,
+    SourceProductIdentity,
+    source_product_identity,
     source_payload,
 )
 from src.core.common.canonical import hash_canonical_payload
@@ -31,17 +31,13 @@ def _optional_source_payload(response: _TreasurySourceResponse | None) -> JsonPa
     return source_payload(response) if response is not None else None
 
 
-def _optional_source_hash(payload: JsonPayload | None) -> str | None:
-    return source_hash(payload) if payload is not None else None
-
-
-def _optional_response_source_id(
+def _optional_source_identity(
     response: _TreasurySourceResponse | None,
-    fallback_hash: str | None,
-) -> str | None:
-    if response is None or fallback_hash is None:
+    fallback_source_id: str | None = None,
+) -> SourceProductIdentity | None:
+    if response is None:
         return None
-    return response_source_id(response, fallback_hash)
+    return source_product_identity(response, fallback_source_id=fallback_source_id)
 
 
 def _missing_data_families(response: _TreasurySourceResponse | None) -> list[str]:
@@ -144,12 +140,11 @@ def external_treasury_currency_overlay_context(
         supportability_reason = fx_forward_curve.supportability.reason
         exposure_currencies = fx_forward_curve.exposure_currencies
 
-    exposure_source_hash = _optional_source_hash(exposure_payload)
-    hedge_policy_source_hash = _optional_source_hash(hedge_policy_payload)
-    eligible_hedge_instruments_source_hash = _optional_source_hash(
-        eligible_hedge_instruments_payload
-    )
-    fx_forward_curve_source_hash = _optional_source_hash(fx_forward_curve_payload)
+    readiness_identity = _optional_source_identity(hedge_readiness, source_hash)
+    exposure_identity = _optional_source_identity(currency_exposure)
+    hedge_policy_identity = _optional_source_identity(hedge_policy)
+    eligible_hedge_instruments_identity = _optional_source_identity(eligible_hedge_instruments)
+    fx_forward_curve_identity = _optional_source_identity(fx_forward_curve)
     reason_codes = _fail_closed_reason_codes(
         primary_reason=supportability_reason,
         hedge_readiness=hedge_readiness,
@@ -166,11 +161,13 @@ def external_treasury_currency_overlay_context(
         hedge_ratio_min=Decimal("0.00"),
         hedge_ratio_max=Decimal("0.00"),
         eligible_currencies=exposure_currencies,
-        source_product_name=hedge_readiness.product_name if hedge_readiness is not None else None,
-        source_product_version=(
-            hedge_readiness.product_version if hedge_readiness is not None else None
+        source_product_name=(
+            readiness_identity.source_product_name if readiness_identity is not None else None
         ),
-        source_id=_optional_response_source_id(hedge_readiness, source_hash) or source_hash,
+        source_product_version=(
+            readiness_identity.source_product_version if readiness_identity is not None else None
+        ),
+        source_id=readiness_identity.source_id if readiness_identity is not None else source_hash,
         content_hash=source_hash,
         missing_data_families=_merged_missing_data_families(
             hedge_readiness,
@@ -188,16 +185,17 @@ def external_treasury_currency_overlay_context(
         ),
         readiness_checks=hedge_readiness.readiness_checks if hedge_readiness is not None else [],
         external_currency_exposure_source_product_name=(
-            currency_exposure.product_name if currency_exposure is not None else None
+            exposure_identity.source_product_name if exposure_identity is not None else None
         ),
         external_currency_exposure_source_product_version=(
-            currency_exposure.product_version if currency_exposure is not None else None
+            exposure_identity.source_product_version if exposure_identity is not None else None
         ),
-        external_currency_exposure_source_id=_optional_response_source_id(
-            currency_exposure,
-            exposure_source_hash,
+        external_currency_exposure_source_id=(
+            exposure_identity.source_id if exposure_identity is not None else None
         ),
-        external_currency_exposure_content_hash=exposure_source_hash,
+        external_currency_exposure_content_hash=(
+            exposure_identity.content_hash if exposure_identity is not None else None
+        ),
         external_currency_exposure_count=(
             currency_exposure.supportability.exposure_count if currency_exposure is not None else 0
         ),
@@ -205,35 +203,43 @@ def external_treasury_currency_overlay_context(
             currency_exposure.exposures if currency_exposure is not None else []
         ),
         external_hedge_policy_source_product_name=(
-            hedge_policy.product_name if hedge_policy is not None else None
+            hedge_policy_identity.source_product_name if hedge_policy_identity is not None else None
         ),
         external_hedge_policy_source_product_version=(
-            hedge_policy.product_version if hedge_policy is not None else None
+            hedge_policy_identity.source_product_version
+            if hedge_policy_identity is not None
+            else None
         ),
-        external_hedge_policy_source_id=_optional_response_source_id(
-            hedge_policy,
-            hedge_policy_source_hash,
+        external_hedge_policy_source_id=(
+            hedge_policy_identity.source_id if hedge_policy_identity is not None else None
         ),
-        external_hedge_policy_content_hash=hedge_policy_source_hash,
+        external_hedge_policy_content_hash=(
+            hedge_policy_identity.content_hash if hedge_policy_identity is not None else None
+        ),
         external_hedge_policy_rule_count=(
             hedge_policy.supportability.policy_rule_count if hedge_policy is not None else 0
         ),
         external_hedge_policy_rules=(hedge_policy.policy_rules if hedge_policy is not None else []),
         external_eligible_hedge_instrument_source_product_name=(
-            eligible_hedge_instruments.product_name
-            if eligible_hedge_instruments is not None
+            eligible_hedge_instruments_identity.source_product_name
+            if eligible_hedge_instruments_identity is not None
             else None
         ),
         external_eligible_hedge_instrument_source_product_version=(
-            eligible_hedge_instruments.product_version
-            if eligible_hedge_instruments is not None
+            eligible_hedge_instruments_identity.source_product_version
+            if eligible_hedge_instruments_identity is not None
             else None
         ),
-        external_eligible_hedge_instrument_source_id=_optional_response_source_id(
-            eligible_hedge_instruments,
-            eligible_hedge_instruments_source_hash,
+        external_eligible_hedge_instrument_source_id=(
+            eligible_hedge_instruments_identity.source_id
+            if eligible_hedge_instruments_identity is not None
+            else None
         ),
-        external_eligible_hedge_instrument_content_hash=(eligible_hedge_instruments_source_hash),
+        external_eligible_hedge_instrument_content_hash=(
+            eligible_hedge_instruments_identity.content_hash
+            if eligible_hedge_instruments_identity is not None
+            else None
+        ),
         external_eligible_hedge_instrument_count=(
             eligible_hedge_instruments.supportability.instrument_count
             if eligible_hedge_instruments is not None
@@ -245,16 +251,23 @@ def external_treasury_currency_overlay_context(
             else []
         ),
         external_fx_forward_curve_source_product_name=(
-            fx_forward_curve.product_name if fx_forward_curve is not None else None
+            fx_forward_curve_identity.source_product_name
+            if fx_forward_curve_identity is not None
+            else None
         ),
         external_fx_forward_curve_source_product_version=(
-            fx_forward_curve.product_version if fx_forward_curve is not None else None
+            fx_forward_curve_identity.source_product_version
+            if fx_forward_curve_identity is not None
+            else None
         ),
-        external_fx_forward_curve_source_id=_optional_response_source_id(
-            fx_forward_curve,
-            fx_forward_curve_source_hash,
+        external_fx_forward_curve_source_id=(
+            fx_forward_curve_identity.source_id if fx_forward_curve_identity is not None else None
         ),
-        external_fx_forward_curve_content_hash=fx_forward_curve_source_hash,
+        external_fx_forward_curve_content_hash=(
+            fx_forward_curve_identity.content_hash
+            if fx_forward_curve_identity is not None
+            else None
+        ),
         external_fx_forward_curve_point_count=(
             fx_forward_curve.supportability.curve_point_count if fx_forward_curve is not None else 0
         ),

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -68,7 +68,6 @@ _increment_distribution = increment_distribution
 _exceptions_for_monitoring_run = exceptions_for_monitoring_run
 _calculate_monitoring_run_mandate_result = calculate_monitoring_run_mandate_result
 _build_monitoring_run = build_monitoring_run
-_build_mandate_refresh_result_from_core = build_mandate_refresh_result_from_core
 
 
 def refresh_mandate_from_core(
@@ -85,7 +84,7 @@ def refresh_mandate_from_core(
     include_market_data_coverage: bool,
     correlation_id: Optional[str],
 ) -> DpmMandateRefreshResult:
-    refresh_result = _build_mandate_refresh_result_from_core(
+    refresh_result = build_mandate_refresh_result_from_core(
         core_resolver=core_resolver,
         portfolio_id=portfolio_id,
         mandate_id=mandate_id,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -4,13 +4,8 @@ from datetime import date, datetime, timezone
 from typing import Optional
 
 from src.api.services.mandate_command_center import (
-    attention_buckets,
     build_command_center_summary,
-    command_center_supportability_state,
     latest_command_center_run,
-    recommended_actions,
-    run_matches_command_center_filters,
-    severity_rank,
 )
 from src.api.services.mandate_errors import (
     DpmMandateDiffUnavailableError as DpmMandateDiffUnavailableError,
@@ -67,13 +62,6 @@ from src.core.mandates import (
 )
 from src.infrastructure.core_sourcing import DpmCoreResolverClient
 
-_severity_rank = severity_rank
-_attention_buckets = attention_buckets
-_build_command_center_summary = build_command_center_summary
-_latest_command_center_run = latest_command_center_run
-_command_center_supportability_state = command_center_supportability_state
-_run_matches_command_center_filters = run_matches_command_center_filters
-_recommended_actions = recommended_actions
 _build_mandate_diff = build_mandate_diff
 _diff_payloads = diff_payloads
 _iter_changed_fields = iter_changed_fields
@@ -301,7 +289,7 @@ def get_command_center_summary(
     limit: int,
 ) -> DpmCommandCenterSummary:
     runs, _ = repository.list_monitoring_runs(status=None, limit=200, cursor=None)
-    latest_run = _latest_command_center_run(
+    latest_run = latest_command_center_run(
         runs,
         tenant_id=tenant_id,
         portfolio_manager_id=portfolio_manager_id,
@@ -317,7 +305,7 @@ def get_command_center_summary(
         cursor=None,
     )
 
-    return _build_command_center_summary(
+    return build_command_center_summary(
         tenant_id=tenant_id,
         portfolio_manager_id=portfolio_manager_id,
         book_id=book_id,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -18,11 +18,7 @@ from src.api.services.mandate_errors import (
 from src.api.services.mandate_diff import (
     DpmMandateDiff as DpmMandateDiff,
     DpmMandateFieldChange as DpmMandateFieldChange,
-    build_mandate_diff,
     build_mandate_diff_for_versions,
-    diff_payloads,
-    iter_changed_fields,
-    materiality_for_field,
 )
 from src.api.services.mandate_health_result import (
     DpmMandateHealthCalculationResult as DpmMandateHealthCalculationResult,
@@ -62,11 +58,6 @@ from src.core.mandates import (
 )
 from src.infrastructure.core_sourcing import DpmCoreResolverClient
 
-_build_mandate_diff = build_mandate_diff
-_diff_payloads = diff_payloads
-_iter_changed_fields = iter_changed_fields
-_materiality_for_field = materiality_for_field
-_build_mandate_diff_for_versions = build_mandate_diff_for_versions
 _try_resolve_optional_source = try_resolve_optional_source
 _ready_optional_source = ready_optional_source
 _ready_benchmark_assignment_source = ready_benchmark_assignment_source
@@ -329,7 +320,7 @@ def diff_mandate_versions(
     if not versions:
         raise DpmMandateNotFoundError("DPM_MANDATE_NOT_FOUND")
 
-    return _build_mandate_diff_for_versions(
+    return build_mandate_diff_for_versions(
         mandate_id=mandate_id,
         versions=versions,
         from_version=from_version,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -63,7 +63,6 @@ _ready_optional_source = ready_optional_source
 _ready_benchmark_assignment_source = ready_benchmark_assignment_source
 _resolve_mandate_optional_sources = resolve_mandate_optional_sources
 _calculate_mandate_health_result = calculate_mandate_health_result
-_persist_mandate_health_evidence = persist_mandate_health_evidence
 _monitoring_run_accumulator = DpmMonitoringRunAccumulator
 _monitoring_run_id_for = monitoring_run_id_for
 _increment_distribution = increment_distribution
@@ -100,7 +99,7 @@ def refresh_mandate_from_core(
         correlation_id=correlation_id,
     )
 
-    _persist_mandate_health_evidence(
+    persist_mandate_health_evidence(
         repository=repository,
         twin=refresh_result.twin,
         health_snapshot=refresh_result.health_snapshot,
@@ -163,7 +162,7 @@ def recalculate_mandate_health(
     if health_input.twin.mandate_id != mandate_id:
         raise DpmMandateSourceIncompleteError("DPM_MANDATE_HEALTH_INPUT_MISMATCH")
     health_result = _calculate_mandate_health_result(health_input)
-    _persist_mandate_health_evidence(
+    persist_mandate_health_evidence(
         repository=repository,
         twin=health_input.twin,
         health_snapshot=health_result.snapshot,
@@ -191,7 +190,7 @@ def run_mandate_monitoring_once(
             monitoring_run_id=monitoring_run_id,
         )
         snapshot = mandate_result.health_snapshot
-        _persist_mandate_health_evidence(
+        persist_mandate_health_evidence(
             repository=repository,
             health_snapshot=snapshot,
             monitoring_exceptions=mandate_result.monitoring_exceptions,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -62,7 +62,6 @@ _try_resolve_optional_source = try_resolve_optional_source
 _ready_optional_source = ready_optional_source
 _ready_benchmark_assignment_source = ready_benchmark_assignment_source
 _resolve_mandate_optional_sources = resolve_mandate_optional_sources
-_calculate_mandate_health_result = calculate_mandate_health_result
 _monitoring_run_accumulator = DpmMonitoringRunAccumulator
 _monitoring_run_id_for = monitoring_run_id_for
 _increment_distribution = increment_distribution
@@ -161,7 +160,7 @@ def recalculate_mandate_health(
 ) -> DpmMandateHealthSnapshot:
     if health_input.twin.mandate_id != mandate_id:
         raise DpmMandateSourceIncompleteError("DPM_MANDATE_HEALTH_INPUT_MISMATCH")
-    health_result = _calculate_mandate_health_result(health_input)
+    health_result = calculate_mandate_health_result(health_input)
     persist_mandate_health_evidence(
         repository=repository,
         twin=health_input.twin,

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -34,12 +34,6 @@ from src.api.services.mandate_monitoring_run import (
     increment_distribution,
     monitoring_run_id_for,
 )
-from src.api.services.mandate_optional_sources import (
-    ready_benchmark_assignment_source,
-    ready_optional_source,
-    resolve_mandate_optional_sources,
-    try_resolve_optional_source,
-)
 from src.api.services.mandate_pm_book import (
     mandate_ids_from_pm_book_membership as mandate_ids_from_pm_book_membership,
 )
@@ -58,10 +52,6 @@ from src.core.mandates import (
 )
 from src.infrastructure.core_sourcing import DpmCoreResolverClient
 
-_try_resolve_optional_source = try_resolve_optional_source
-_ready_optional_source = ready_optional_source
-_ready_benchmark_assignment_source = ready_benchmark_assignment_source
-_resolve_mandate_optional_sources = resolve_mandate_optional_sources
 _monitoring_run_accumulator = DpmMonitoringRunAccumulator
 _monitoring_run_id_for = monitoring_run_id_for
 _increment_distribution = increment_distribution

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -30,8 +30,6 @@ from src.api.services.mandate_monitoring_run import (
     DpmMonitoringRunMandateResult as DpmMonitoringRunMandateResult,
     build_monitoring_run,
     calculate_monitoring_run_mandate_result,
-    exceptions_for_monitoring_run,
-    increment_distribution,
     monitoring_run_id_for,
 )
 from src.api.services.mandate_pm_book import (
@@ -51,13 +49,6 @@ from src.core.mandates import (
     DpmMonitoringRun,
 )
 from src.infrastructure.core_sourcing import DpmCoreResolverClient
-
-_monitoring_run_accumulator = DpmMonitoringRunAccumulator
-_monitoring_run_id_for = monitoring_run_id_for
-_increment_distribution = increment_distribution
-_exceptions_for_monitoring_run = exceptions_for_monitoring_run
-_calculate_monitoring_run_mandate_result = calculate_monitoring_run_mandate_result
-_build_monitoring_run = build_monitoring_run
 
 
 def refresh_mandate_from_core(
@@ -167,12 +158,12 @@ def run_mandate_monitoring_once(
     filters: dict[str, str],
 ) -> DpmMonitoringRun:
     requested_at = datetime.now(timezone.utc)
-    monitoring_run_id = _monitoring_run_id_for(requested_at)
-    accumulator = _monitoring_run_accumulator.empty()
+    monitoring_run_id = monitoring_run_id_for(requested_at)
+    accumulator = DpmMonitoringRunAccumulator.empty()
 
     for mandate_id in mandate_ids:
         twin = get_latest_mandate(repository=repository, mandate_id=mandate_id)
-        mandate_result = _calculate_monitoring_run_mandate_result(
+        mandate_result = calculate_monitoring_run_mandate_result(
             twin=twin,
             as_of_date=as_of_date,
             monitoring_run_id=monitoring_run_id,
@@ -185,7 +176,7 @@ def run_mandate_monitoring_once(
         )
         accumulator.record(mandate_result)
 
-    run = _build_monitoring_run(
+    run = build_monitoring_run(
         monitoring_run_id=monitoring_run_id,
         as_of_date=as_of_date,
         requested_at=requested_at,

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -27,7 +27,6 @@ from src.api.services.outcome_review_persistence import persist_outcome_review
 from src.api.services.outcome_review_report_inputs import (
     build_outcome_ai_evidence_input,
     build_outcome_report_input,
-    portfolio_memory_context_for_report,
 )
 from src.api.services.outcome_review_search import (
     normalize_outcome_review_search_filter as _normalize_outcome_review_search_filter,
@@ -44,7 +43,6 @@ class DpmOutcomeReviewNotFoundError(Exception):
 
 
 _dimension_inputs = dimension_inputs_for_review
-_portfolio_memory_context_for_report = portfolio_memory_context_for_report
 
 
 def preview_outcome_review(

--- a/src/api/services/outcome_review_service.py
+++ b/src/api/services/outcome_review_service.py
@@ -42,9 +42,6 @@ class DpmOutcomeReviewNotFoundError(Exception):
     pass
 
 
-_dimension_inputs = dimension_inputs_for_review
-
-
 def preview_outcome_review(
     *,
     expected_snapshot: DpmExpectedOutcomeSnapshot,

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -13,7 +13,6 @@ from src.core.proof_packs.handoffs import DpmProofPackAiEvidenceInput, DpmProofP
 from src.api.services.proof_pack_report_inputs import (
     build_proof_pack_ai_evidence_input,
     build_proof_pack_report_input,
-    portfolio_memory_context_for_report,
 )
 from src.api.services.proof_pack_handoff_refs import (
     ensure_handoff_refs as _ensure_handoff_refs,
@@ -44,9 +43,6 @@ class DpmProofPackReportInputNotGeneratedError(Exception):
 
 class DpmProofPackAiEvidenceInputNotGeneratedError(Exception):
     pass
-
-
-_portfolio_memory_context_for_report = portfolio_memory_context_for_report
 
 
 def generate_proof_pack_from_run(

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -35,7 +35,6 @@ from src.api.services.rebalance_request_envelope_resolution import (
 from src.api.services.rebalance_async_config import (
     async_manual_execution_enabled,
     async_operations_enabled,
-    env_flag,
     resolve_async_execution_mode,
 )
 from src.api.services.rebalance_async_operation_runner import (
@@ -323,7 +322,6 @@ __all__ = [
     "DpmRebalanceSupportabilityStoreUnavailableError",
     "async_manual_execution_enabled",
     "async_operations_enabled",
-    "env_flag",
     "execute_batch_analysis",
     "execute_dpm_async_operation",
     "resolve_async_execution_mode",

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -67,7 +67,7 @@ from src.core.dpm_source_context import (
     build_batch_rebalance_request_from_core_context,
     build_rebalance_request_from_core_context,
 )
-from src.core.rebalance.engine import run_simulation
+from src.core.rebalance.engine import run_simulation as _run_simulation
 from src.api.services.rebalance_simulation_execution_context import (
     DpmSimulationExecutionContext as DpmSimulationExecutionContext,
     build_simulation_execution_context,
@@ -170,7 +170,7 @@ def simulate_rebalance(
         replay_enabled=execution_context.replay_enabled,
         source_context=source_context,
         support_service_factory=get_dpm_run_support_service,
-        run_simulation_fn=resolve_callable_override("run_simulation", run_simulation),
+        run_simulation_fn=resolve_callable_override("run_simulation", _run_simulation),
         record_for_support=resolve_callable_override(
             "record_dpm_run_for_support",
             record_dpm_run_for_support,
@@ -209,7 +209,7 @@ def execute_batch_analysis(
         correlation_id=correlation_id,
         policy_definition=execution_context.policy_pack_definition,
         source_context=source_context,
-        run_simulation_fn=resolve_callable_override("run_simulation", run_simulation),
+        run_simulation_fn=resolve_callable_override("run_simulation", _run_simulation),
         record_for_support=resolve_callable_override(
             "record_dpm_run_for_support",
             record_dpm_run_for_support,
@@ -316,6 +316,5 @@ __all__ = [
     "execute_batch_analysis",
     "execute_dpm_async_operation",
     "run_analyze_async_operation",
-    "run_simulation",
     "simulate_rebalance",
 ]

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -91,8 +91,6 @@ from src.core.models import (
 logger = logging.getLogger(__name__)
 
 build_core_resolver_client = core_resolver_service.build_core_resolver_client
-env_float = core_resolver_service.env_float
-env_int = core_resolver_service.env_int
 stateful_core_sourcing_enabled = core_resolver_service.stateful_core_sourcing_enabled
 
 
@@ -326,7 +324,6 @@ __all__ = [
     "async_manual_execution_enabled",
     "async_operations_enabled",
     "env_flag",
-    "env_int",
     "execute_batch_analysis",
     "execute_dpm_async_operation",
     "resolve_async_execution_mode",

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -32,11 +32,7 @@ from src.api.services.rebalance_request_envelope_resolution import (
     resolve_batch_request_envelope as resolve_batch_request_envelope_from_source,
     resolve_rebalance_request_envelope as resolve_rebalance_request_envelope_from_source,
 )
-from src.api.services.rebalance_async_config import (
-    async_manual_execution_enabled,
-    async_operations_enabled,
-    resolve_async_execution_mode,
-)
+from src.api.services import rebalance_async_config
 from src.api.services.rebalance_async_operation_runner import (
     run_analyze_async_operation_from_store,
 )
@@ -253,7 +249,7 @@ def submit_and_optionally_execute_async_analysis(
     source_context: Optional[DpmResolvedSourceContext] = None,
 ) -> DpmAsyncAcceptedResponse:
     current_logger = _resolved_logger()
-    if not async_operations_enabled():
+    if not rebalance_async_config.async_operations_enabled():
         raise DpmRebalanceAsyncOperationsDisabledError("DPM_ASYNC_OPERATIONS_DISABLED")
     submission_context = build_async_submission_context(
         request=request,
@@ -290,9 +286,9 @@ def submit_and_optionally_execute_async_analysis(
 def execute_dpm_async_operation(
     *, operation_id: str, service: DpmRunSupportService
 ) -> DpmAsyncOperationStatusResponse:
-    if not async_operations_enabled():
+    if not rebalance_async_config.async_operations_enabled():
         raise DpmRebalanceAsyncOperationsDisabledError("DPM_ASYNC_OPERATIONS_DISABLED")
-    if not async_manual_execution_enabled():
+    if not rebalance_async_config.async_manual_execution_enabled():
         raise DpmRebalanceAsyncManualExecutionDisabledError("DPM_ASYNC_MANUAL_EXECUTION_DISABLED")
     return execute_analyze_async_operation_now(
         operation_id=operation_id,
@@ -320,11 +316,8 @@ __all__ = [
     "DpmRebalanceSimulationError",
     "DpmRebalanceStatefulInputDisabledError",
     "DpmRebalanceSupportabilityStoreUnavailableError",
-    "async_manual_execution_enabled",
-    "async_operations_enabled",
     "execute_batch_analysis",
     "execute_dpm_async_operation",
-    "resolve_async_execution_mode",
     "run_analyze_async_operation",
     "run_simulation",
     "simulate_rebalance",

--- a/src/api/services/rebalance_simulation_service.py
+++ b/src/api/services/rebalance_simulation_service.py
@@ -85,9 +85,6 @@ from src.core.models import (
 
 logger = logging.getLogger(__name__)
 
-build_core_resolver_client = core_resolver_service.build_core_resolver_client
-stateful_core_sourcing_enabled = core_resolver_service.stateful_core_sourcing_enabled
-
 
 def _resolved_logger() -> logging.Logger | Any:
     return resolve_logger(logger)
@@ -100,12 +97,12 @@ def _resolve_stateful_source_context(
 ) -> DpmResolvedSourceContext:
     resolver_factory = resolve_callable_override(
         "build_core_resolver_client",
-        build_core_resolver_client,
+        core_resolver_service.build_core_resolver_client,
     )
     return resolve_stateful_source_context(
         envelope=envelope,
         correlation_id=correlation_id,
-        stateful_enabled=stateful_core_sourcing_enabled(),
+        stateful_enabled=core_resolver_service.stateful_core_sourcing_enabled(),
         resolver_factory=resolver_factory,
     )
 

--- a/src/api/services/wave_create_command.py
+++ b/src/api/services/wave_create_command.py
@@ -1,0 +1,63 @@
+from src.api.services.wave_creation import (
+    create_created_wave_id,
+    create_wave_request_hash,
+    promote_preview_to_created_wave,
+)
+from src.api.services.wave_persistence import save_wave_or_raise
+from src.api.services.wave_preview import build_preview_wave
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.waves import DpmRebalanceWave, DpmWaveRepository
+
+
+def create_persisted_wave(
+    *,
+    trigger_type: str,
+    trigger_id: str,
+    rationale: str,
+    as_of_date: str,
+    actor_id: str,
+    correlation_id: str,
+    portfolios: list[dict[str, object]],
+    idempotency_key: str,
+    mandate_repository: DpmMandateRepository,
+    wave_repository: DpmWaveRepository,
+) -> tuple[DpmRebalanceWave, bool]:
+    request_hash = create_wave_request_hash(
+        trigger_type=trigger_type,
+        trigger_id=trigger_id,
+        rationale=rationale,
+        as_of_date=as_of_date,
+        actor_id=actor_id,
+        portfolios=portfolios,
+    )
+    existing = wave_repository.get_wave_by_idempotency(idempotency_key=idempotency_key)
+    if existing is not None:
+        return existing, True
+
+    preview = build_preview_wave(
+        trigger_type=trigger_type,
+        trigger_id=trigger_id,
+        rationale=rationale,
+        as_of_date=as_of_date,
+        actor_id=actor_id,
+        correlation_id=correlation_id,
+        portfolios=portfolios,
+        mandate_repository=mandate_repository,
+    )
+    wave = promote_preview_to_created_wave(
+        preview=preview,
+        wave_id=create_created_wave_id(),
+        actor_id=actor_id,
+        correlation_id=correlation_id,
+        idempotency_key=idempotency_key,
+    )
+    save_wave_or_raise(
+        wave_repository=wave_repository,
+        wave=wave,
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+    )
+    return wave, False
+
+
+__all__ = ["create_persisted_wave"]

--- a/src/api/services/wave_lifecycle_commands.py
+++ b/src/api/services/wave_lifecycle_commands.py
@@ -1,0 +1,157 @@
+from src.api.services.wave_approval_transition import build_approved_wave
+from src.api.services.wave_cancel_transition import build_cancelled_wave
+from src.api.services.wave_handoff_transition import build_handoff_ready_wave
+from src.api.services.wave_stage_transition import build_staged_wave
+from src.api.services.wave_transition_execution import (
+    persist_transitioned_wave,
+    prepare_wave_transition,
+)
+from src.core.waves import DpmRebalanceWave, DpmWaveRepository
+
+
+def approve_persisted_wave(
+    *,
+    wave_id: str,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+    wave_repository: DpmWaveRepository,
+) -> tuple[DpmRebalanceWave, bool]:
+    prepared = prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
+        allowed_states={"SIMULATED", "PARTIALLY_SIMULATED", "REVIEW_REQUIRED"},
+        error_code="DPM_WAVE_APPROVAL_INVALID_STATE",
+        action_phrase="be approved",
+    )
+    if prepared.replayed:
+        return prepared.wave, True
+
+    approved = build_approved_wave(
+        wave=prepared.wave,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+    )
+    persist_transitioned_wave(
+        wave_repository=wave_repository,
+        source_wave=prepared.wave,
+        transitioned_wave=approved,
+    )
+    return approved, False
+
+
+def stage_persisted_wave(
+    *,
+    wave_id: str,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+    wave_repository: DpmWaveRepository,
+) -> tuple[DpmRebalanceWave, bool]:
+    prepared = prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"STAGED", "HANDOFF_READY"},
+        allowed_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
+        error_code="DPM_WAVE_STAGE_INVALID_STATE",
+        action_phrase="be staged",
+    )
+    if prepared.replayed:
+        return prepared.wave, True
+
+    staged = build_staged_wave(
+        wave=prepared.wave,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+    )
+    persist_transitioned_wave(
+        wave_repository=wave_repository,
+        source_wave=prepared.wave,
+        transitioned_wave=staged,
+    )
+    return staged, False
+
+
+def handoff_persisted_wave(
+    *,
+    wave_id: str,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+    wave_repository: DpmWaveRepository,
+) -> tuple[DpmRebalanceWave, bool]:
+    prepared = prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"HANDOFF_READY"},
+        allowed_states={"STAGED"},
+        error_code="DPM_WAVE_HANDOFF_INVALID_STATE",
+        action_phrase="create handoff evidence",
+    )
+    if prepared.replayed:
+        return prepared.wave, True
+
+    handoff_ready = build_handoff_ready_wave(
+        wave=prepared.wave,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+    )
+    persist_transitioned_wave(
+        wave_repository=wave_repository,
+        source_wave=prepared.wave,
+        transitioned_wave=handoff_ready,
+    )
+    return handoff_ready, False
+
+
+def cancel_persisted_wave(
+    *,
+    wave_id: str,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+    wave_repository: DpmWaveRepository,
+) -> tuple[DpmRebalanceWave, bool]:
+    prepared = prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"CANCELLED"},
+        allowed_states=None,
+        error_code="DPM_WAVE_CANCEL_INVALID_STATE",
+        action_phrase="be cancelled",
+    )
+    if prepared.replayed:
+        return prepared.wave, True
+
+    cancelled = build_cancelled_wave(
+        wave=prepared.wave,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+    )
+    persist_transitioned_wave(
+        wave_repository=wave_repository,
+        source_wave=prepared.wave,
+        transitioned_wave=cancelled,
+    )
+    return cancelled, False
+
+
+__all__ = [
+    "approve_persisted_wave",
+    "cancel_persisted_wave",
+    "handoff_persisted_wave",
+    "stage_persisted_wave",
+]

--- a/src/api/services/wave_preparation_commands.py
+++ b/src/api/services/wave_preparation_commands.py
@@ -1,0 +1,94 @@
+from src.api.request_models import RebalanceRequest
+from src.api.services.wave_simulation import build_simulated_wave
+from src.api.services.wave_simulation_item import DpmWaveSimulationInput
+from src.api.services.wave_source_check import build_source_checked_wave
+from src.api.services.wave_transition_execution import (
+    persist_transitioned_wave,
+    prepare_wave_transition,
+)
+from src.core.construction.repository import ConstructionRepository
+from src.core.construction.vocabulary import ConstructionMethod
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.rebalance_runs.service import DpmRunSupportService
+from src.core.waves import DpmRebalanceWave, DpmWaveRepository
+from src.infrastructure.risk_authority import LotusRiskAuthorityClient
+
+
+def source_check_persisted_wave(
+    *,
+    wave_id: str,
+    actor_id: str,
+    correlation_id: str,
+    mandate_repository: DpmMandateRepository,
+    wave_repository: DpmWaveRepository,
+) -> tuple[DpmRebalanceWave, bool]:
+    prepared = prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"SOURCE_CHECKED"},
+        allowed_states={"CREATED"},
+        error_code="DPM_WAVE_SOURCE_CHECK_INVALID_STATE",
+        action_phrase="be source-checked",
+    )
+    if prepared.replayed:
+        return prepared.wave, True
+
+    checked = build_source_checked_wave(
+        wave=prepared.wave,
+        actor_id=actor_id,
+        correlation_id=correlation_id,
+        mandate_repository=mandate_repository,
+    )
+    persist_transitioned_wave(
+        wave_repository=wave_repository,
+        source_wave=prepared.wave,
+        transitioned_wave=checked,
+    )
+    return checked, False
+
+
+def simulate_persisted_wave(
+    *,
+    wave_id: str,
+    actor_id: str,
+    correlation_id: str,
+    item_inputs: dict[str, RebalanceRequest | DpmWaveSimulationInput],
+    methods: list[ConstructionMethod] | None,
+    construction_repository: ConstructionRepository,
+    run_service: DpmRunSupportService,
+    wave_repository: DpmWaveRepository,
+    risk_authority_client: LotusRiskAuthorityClient | None = None,
+) -> tuple[DpmRebalanceWave, bool]:
+    prepared = prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"SIMULATED", "PARTIALLY_SIMULATED", "SIMULATION_FAILED"},
+        allowed_states={"SOURCE_CHECKED"},
+        error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
+        action_phrase="be simulated",
+    )
+    if prepared.replayed:
+        return prepared.wave, True
+
+    completed = build_simulated_wave(
+        wave=prepared.wave,
+        actor_id=actor_id,
+        correlation_id=correlation_id,
+        item_inputs=item_inputs,
+        methods=methods,
+        construction_repository=construction_repository,
+        run_service=run_service,
+        risk_authority_client=risk_authority_client,
+    )
+    persist_transitioned_wave(
+        wave_repository=wave_repository,
+        source_wave=prepared.wave,
+        transitioned_wave=completed,
+    )
+    return completed, False
+
+
+__all__ = [
+    "simulate_persisted_wave",
+    "source_check_persisted_wave",
+]

--- a/src/api/services/wave_read_model_queries.py
+++ b/src/api/services/wave_read_model_queries.py
@@ -1,0 +1,72 @@
+from src.api.services.wave_detail_projection import wave_detail_payload, wave_items_payload
+from src.api.services.wave_lookup import get_wave_or_raise
+from src.api.services.wave_proof_pack_posture import proof_pack_posture_for_wave
+from src.api.services.wave_report_input import build_report_input_for_wave
+from src.api.services.wave_supportability_payload import wave_supportability_payload
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.outcomes.repository import DpmOutcomeReviewRepository
+from src.core.proof_packs.repository import DpmProofPackRepository
+from src.core.waves import DpmWaveReportInput, DpmWaveRepository
+
+
+def wave_supportability_for_id(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+) -> dict[str, object]:
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    return wave_supportability_payload(wave)
+
+
+def wave_detail_for_id(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+) -> dict[str, object]:
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    return wave_detail_payload(wave)
+
+
+def wave_items_for_id(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+) -> dict[str, object]:
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    return wave_items_payload(wave)
+
+
+def wave_proof_pack_posture_for_id(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+) -> dict[str, object]:
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    return proof_pack_posture_for_wave(wave=wave)
+
+
+def wave_report_input_for_id(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+    proof_pack_repository: DpmProofPackRepository | None = None,
+    outcome_review_repository: DpmOutcomeReviewRepository | None = None,
+    mandate_repository: DpmMandateRepository | None = None,
+) -> DpmWaveReportInput:
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    return build_report_input_for_wave(
+        wave=wave,
+        wave_repository=wave_repository,
+        proof_pack_repository=proof_pack_repository,
+        outcome_review_repository=outcome_review_repository,
+        mandate_repository=mandate_repository,
+    )
+
+
+__all__ = [
+    "wave_detail_for_id",
+    "wave_items_for_id",
+    "wave_proof_pack_posture_for_id",
+    "wave_report_input_for_id",
+    "wave_supportability_for_id",
+]

--- a/src/api/services/wave_selection_command.py
+++ b/src/api/services/wave_selection_command.py
@@ -1,0 +1,75 @@
+from src.api.services.wave_construction_selection import select_construction_alternative_for_wave
+from src.api.services.wave_item_selection_transition import (
+    build_wave_with_selected_item_alternative,
+)
+from src.api.services.wave_selection_guard import selectable_wave_item
+from src.api.services.wave_transition_execution import (
+    persist_transitioned_wave,
+    prepare_wave_transition,
+)
+from src.core.construction.repository import ConstructionRepository
+from src.core.mandate_repository import DpmMandateRepository
+from src.core.proof_packs.repository import DpmProofPackRepository
+from src.core.rebalance_runs.service import DpmRunSupportService
+from src.core.waves import DpmRebalanceWave, DpmWaveRepository
+
+
+def select_persisted_wave_item_alternative(
+    *,
+    wave_id: str,
+    wave_item_id: str,
+    alternative_id: str,
+    actor_id: str,
+    reason_code: str,
+    comment: str | None,
+    correlation_id: str,
+    generate_proof_pack: bool,
+    construction_repository: ConstructionRepository,
+    proof_pack_repository: DpmProofPackRepository,
+    mandate_repository: DpmMandateRepository,
+    run_service: DpmRunSupportService,
+    wave_repository: DpmWaveRepository,
+) -> DpmRebalanceWave:
+    prepared = prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states=set(),
+        allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
+        error_code="DPM_WAVE_SELECTION_INVALID_STATE",
+        action_phrase="record alternative selection",
+    )
+    selected_item = selectable_wave_item(wave=prepared.wave, wave_item_id=wave_item_id)
+    assert selected_item.alternative_set_id is not None
+    select_construction_alternative_for_wave(
+        repository=construction_repository,
+        alternative_set_id=selected_item.alternative_set_id,
+        alternative_id=alternative_id,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+    )
+
+    updated = build_wave_with_selected_item_alternative(
+        wave=prepared.wave,
+        selected_item=selected_item,
+        alternative_id=alternative_id,
+        actor_id=actor_id,
+        reason_code=reason_code,
+        comment=comment,
+        correlation_id=correlation_id,
+        generate_proof_pack=generate_proof_pack,
+        construction_repository=construction_repository,
+        proof_pack_repository=proof_pack_repository,
+        mandate_repository=mandate_repository,
+        run_service=run_service,
+    )
+    persist_transitioned_wave(
+        wave_repository=wave_repository,
+        source_wave=prepared.wave,
+        transitioned_wave=updated,
+    )
+    return updated
+
+
+__all__ = ["select_persisted_wave_item_alternative"]

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -6,11 +6,11 @@ from src.api.services.wave_errors import (
 )
 from src.api.services import wave_lifecycle_commands
 from src.api.services import wave_preparation_commands
+from src.api.services import wave_preview
 from src.api.services import wave_read_model_queries
 from src.api.services import wave_selection_command
 from src.api.services import wave_search
 from src.api.services import wave_supportability_payload as wave_supportability_payload_module
-from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
 )
@@ -39,7 +39,7 @@ def preview_wave(
     portfolios: list[dict[str, object]],
     mandate_repository: DpmMandateRepository,
 ) -> DpmRebalanceWave:
-    return build_preview_wave(
+    return wave_preview.build_preview_wave(
         trigger_type=trigger_type,
         trigger_id=trigger_id,
         rationale=rationale,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -16,7 +16,6 @@ from src.api.services.wave_errors import (
     DpmWaveLookupError as DpmWaveLookupError,
     DpmWaveValidationError as DpmWaveValidationError,
 )
-from src.api.services.wave_detail_projection import wave_detail_payload, wave_items_payload
 from src.api.services.wave_event_append import append_same_state_event
 from src.api.services.wave_event_evidence import build_wave_event
 from src.api.services.wave_handoff_transition import (
@@ -26,14 +25,19 @@ from src.api.services.wave_item_collection import wave_with_items_and_aggregate
 from src.api.services.wave_item_selection_transition import (
     build_wave_with_selected_item_alternative as _build_wave_with_selected_item_alternative,
 )
-from src.api.services.wave_lookup import get_wave_or_raise as _get_wave_or_raise
+from src.api.services.wave_lookup import get_wave_or_raise
 from src.api.services.wave_persistence import (
     save_wave_or_raise as _save_wave_or_raise,
     update_wave_or_raise,
 )
 from src.api.services.wave_preview import build_preview_wave
-from src.api.services.wave_proof_pack_posture import proof_pack_posture_for_wave
-from src.api.services.wave_report_input import build_report_input_for_wave
+from src.api.services.wave_read_model_queries import (
+    wave_detail_for_id,
+    wave_items_for_id,
+    wave_proof_pack_posture_for_id,
+    wave_report_input_for_id,
+    wave_supportability_for_id,
+)
 from src.api.services.wave_selection_guard import selectable_wave_item as _selectable_wave_item
 from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation import build_simulated_wave
@@ -75,6 +79,7 @@ from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 _simulation_result_state = simulation_result_state
+_get_wave_or_raise = get_wave_or_raise
 _wave_state_is_idempotent = wave_state_is_idempotent
 _require_wave_state = require_wave_state
 _update_wave_or_raise = update_wave_or_raise
@@ -446,8 +451,7 @@ def wave_supportability(
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    return wave_supportability_payload(wave)
+    return wave_supportability_for_id(wave_id=wave_id, wave_repository=wave_repository)
 
 
 def search_waves(
@@ -476,8 +480,7 @@ def retrieve_wave_detail(
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    return wave_detail_payload(wave)
+    return wave_detail_for_id(wave_id=wave_id, wave_repository=wave_repository)
 
 
 def list_wave_items(
@@ -485,8 +488,7 @@ def list_wave_items(
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    return wave_items_payload(wave)
+    return wave_items_for_id(wave_id=wave_id, wave_repository=wave_repository)
 
 
 def proof_pack_posture(
@@ -494,8 +496,7 @@ def proof_pack_posture(
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    return proof_pack_posture_for_wave(wave=wave)
+    return wave_proof_pack_posture_for_id(wave_id=wave_id, wave_repository=wave_repository)
 
 
 def get_report_input(
@@ -506,9 +507,8 @@ def get_report_input(
     outcome_review_repository: DpmOutcomeReviewRepository | None = None,
     mandate_repository: DpmMandateRepository | None = None,
 ) -> DpmWaveReportInput:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    return build_report_input_for_wave(
-        wave=wave,
+    return wave_report_input_for_id(
+        wave_id=wave_id,
         wave_repository=wave_repository,
         proof_pack_repository=proof_pack_repository,
         outcome_review_repository=outcome_review_repository,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -4,12 +4,7 @@ from src.api.services.wave_errors import (
     DpmWaveLookupError as DpmWaveLookupError,
     DpmWaveValidationError as DpmWaveValidationError,
 )
-from src.api.services.wave_lifecycle_commands import (
-    approve_persisted_wave,
-    cancel_persisted_wave,
-    handoff_persisted_wave,
-    stage_persisted_wave,
-)
+from src.api.services import wave_lifecycle_commands
 from src.api.services import wave_preparation_commands
 from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_read_model_queries import (
@@ -175,7 +170,7 @@ def approve_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    return approve_persisted_wave(
+    return wave_lifecycle_commands.approve_persisted_wave(
         wave_id=wave_id,
         actor_id=actor_id,
         reason_code=reason_code,
@@ -194,7 +189,7 @@ def stage_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    return stage_persisted_wave(
+    return wave_lifecycle_commands.stage_persisted_wave(
         wave_id=wave_id,
         actor_id=actor_id,
         reason_code=reason_code,
@@ -213,7 +208,7 @@ def handoff_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    return handoff_persisted_wave(
+    return wave_lifecycle_commands.handoff_persisted_wave(
         wave_id=wave_id,
         actor_id=actor_id,
         reason_code=reason_code,
@@ -232,7 +227,7 @@ def cancel_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    return cancel_persisted_wave(
+    return wave_lifecycle_commands.cancel_persisted_wave(
         wave_id=wave_id,
         actor_id=actor_id,
         reason_code=reason_code,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -7,8 +7,8 @@ from src.api.services.wave_errors import (
 from src.api.services import wave_lifecycle_commands
 from src.api.services import wave_preparation_commands
 from src.api.services import wave_read_model_queries
+from src.api.services import wave_selection_command
 from src.api.services.wave_preview import build_preview_wave
-from src.api.services.wave_selection_command import select_persisted_wave_item_alternative
 from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
@@ -138,7 +138,7 @@ def select_wave_item_alternative(
     run_service: DpmRunSupportService,
     wave_repository: DpmWaveRepository,
 ) -> DpmRebalanceWave:
-    return select_persisted_wave_item_alternative(
+    return wave_selection_command.select_persisted_wave_item_alternative(
         wave_id=wave_id,
         wave_item_id=wave_item_id,
         alternative_id=alternative_id,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -1,23 +1,11 @@
 from src.api.request_models import RebalanceRequest
-from src.api.services.wave_aggregate_metrics import (
-    simulation_result_state,
-)
-from src.api.services.wave_approval_transition import build_approved_wave
-from src.api.services.wave_cancel_transition import build_cancelled_wave
 from src.api.services.wave_construction_selection import select_construction_alternative_for_wave
-from src.api.services.wave_creation import (
-    create_created_wave_id,
-    create_wave_request_hash,
-    promote_preview_to_created_wave,
-)
 from src.api.services.wave_create_command import create_persisted_wave
 from src.api.services.wave_errors import (
     DpmWaveLookupError as DpmWaveLookupError,
     DpmWaveValidationError as DpmWaveValidationError,
 )
 from src.api.services.wave_event_append import append_same_state_event
-from src.api.services.wave_event_evidence import build_wave_event
-from src.api.services.wave_handoff_transition import build_handoff_ready_wave
 from src.api.services.wave_item_collection import wave_with_items_and_aggregate
 from src.api.services.wave_item_selection_transition import (
     build_wave_with_selected_item_alternative,
@@ -52,7 +40,6 @@ from src.api.services.wave_state_guard import (
     require_wave_state,
     wave_state_is_idempotent,
 )
-from src.api.services.wave_stage_transition import build_staged_wave
 from src.api.services.wave_supportability_payload import (
     wave_supportability_payload as _wave_supportability_payload,
 )
@@ -81,20 +68,12 @@ from src.core.waves import (
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
-_simulation_result_state = simulation_result_state
-_create_created_wave_id = create_created_wave_id
-_create_wave_request_hash = create_wave_request_hash
-_promote_preview_to_created_wave = promote_preview_to_created_wave
 _get_wave_or_raise = get_wave_or_raise
 _wave_state_is_idempotent = wave_state_is_idempotent
 _require_wave_state = require_wave_state
 _save_wave_or_raise = save_wave_or_raise
 _update_wave_or_raise = update_wave_or_raise
 _validate_trigger = validate_trigger_or_raise
-_build_approved_wave = build_approved_wave
-_build_cancelled_wave = build_cancelled_wave
-_build_handoff_ready_wave = build_handoff_ready_wave
-_build_staged_wave = build_staged_wave
 _select_construction_alternative_for_wave = select_construction_alternative_for_wave
 _build_wave_with_selected_item_alternative = build_wave_with_selected_item_alternative
 _selectable_wave_item = selectable_wave_item
@@ -103,7 +82,6 @@ _stage_event_metadata = stage_event_metadata
 _handoff_event_metadata = handoff_event_metadata
 _cancel_event_metadata = cancel_event_metadata
 _selection_event_metadata = selection_event_metadata
-_event = build_wave_event
 _append_event = append_same_state_event
 _wave_with_items_and_aggregate = wave_with_items_and_aggregate
 _prepare_wave_transition = prepare_wave_transition

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -10,10 +10,7 @@ from src.api.services.wave_lifecycle_commands import (
     handoff_persisted_wave,
     stage_persisted_wave,
 )
-from src.api.services.wave_preparation_commands import (
-    simulate_persisted_wave,
-    source_check_persisted_wave,
-)
+from src.api.services import wave_preparation_commands
 from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_read_model_queries import (
     wave_detail_for_id,
@@ -102,7 +99,7 @@ def source_check_wave(
     mandate_repository: DpmMandateRepository,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    return source_check_persisted_wave(
+    return wave_preparation_commands.source_check_persisted_wave(
         wave_id=wave_id,
         actor_id=actor_id,
         correlation_id=correlation_id,
@@ -123,7 +120,7 @@ def simulate_wave(
     wave_repository: DpmWaveRepository,
     risk_authority_client: LotusRiskAuthorityClient | None = None,
 ) -> tuple[DpmRebalanceWave, bool]:
-    return simulate_persisted_wave(
+    return wave_preparation_commands.simulate_persisted_wave(
         wave_id=wave_id,
         actor_id=actor_id,
         correlation_id=correlation_id,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -8,8 +8,8 @@ from src.api.services import wave_lifecycle_commands
 from src.api.services import wave_preparation_commands
 from src.api.services import wave_read_model_queries
 from src.api.services import wave_selection_command
+from src.api.services import wave_search
 from src.api.services.wave_preview import build_preview_wave
-from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
 )
@@ -256,7 +256,7 @@ def search_waves(
     limit: int = 50,
     offset: int = 0,
 ) -> list[dict[str, object]]:
-    return search_wave_summaries(
+    return wave_search.search_wave_summaries(
         wave_repository=wave_repository,
         state=state,
         trigger_type=trigger_type,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -2,8 +2,8 @@ from src.api.request_models import RebalanceRequest
 from src.api.services.wave_aggregate_metrics import (
     simulation_result_state,
 )
-from src.api.services.wave_approval_transition import build_approved_wave as _build_approved_wave
-from src.api.services.wave_cancel_transition import build_cancelled_wave as _build_cancelled_wave
+from src.api.services.wave_approval_transition import build_approved_wave
+from src.api.services.wave_cancel_transition import build_cancelled_wave
 from src.api.services.wave_construction_selection import (
     select_construction_alternative_for_wave as _select_construction_alternative_for_wave,
 )
@@ -19,12 +19,16 @@ from src.api.services.wave_errors import (
 )
 from src.api.services.wave_event_append import append_same_state_event
 from src.api.services.wave_event_evidence import build_wave_event
-from src.api.services.wave_handoff_transition import (
-    build_handoff_ready_wave as _build_handoff_ready_wave,
-)
+from src.api.services.wave_handoff_transition import build_handoff_ready_wave
 from src.api.services.wave_item_collection import wave_with_items_and_aggregate
 from src.api.services.wave_item_selection_transition import (
     build_wave_with_selected_item_alternative as _build_wave_with_selected_item_alternative,
+)
+from src.api.services.wave_lifecycle_commands import (
+    approve_persisted_wave,
+    cancel_persisted_wave,
+    handoff_persisted_wave,
+    stage_persisted_wave,
 )
 from src.api.services.wave_lookup import get_wave_or_raise
 from src.api.services.wave_persistence import save_wave_or_raise, update_wave_or_raise
@@ -47,7 +51,7 @@ from src.api.services.wave_state_guard import (
     require_wave_state,
     wave_state_is_idempotent,
 )
-from src.api.services.wave_stage_transition import build_staged_wave as _build_staged_wave
+from src.api.services.wave_stage_transition import build_staged_wave
 from src.api.services.wave_supportability_payload import (
     wave_supportability_payload as _wave_supportability_payload,
 )
@@ -86,6 +90,10 @@ _require_wave_state = require_wave_state
 _save_wave_or_raise = save_wave_or_raise
 _update_wave_or_raise = update_wave_or_raise
 _validate_trigger = validate_trigger_or_raise
+_build_approved_wave = build_approved_wave
+_build_cancelled_wave = build_cancelled_wave
+_build_handoff_ready_wave = build_handoff_ready_wave
+_build_staged_wave = build_staged_wave
 _approval_event_metadata = approval_event_metadata
 _stage_event_metadata = stage_event_metadata
 _handoff_event_metadata = handoff_event_metadata
@@ -289,30 +297,14 @@ def approve_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    prepared = _prepare_wave_transition(
+    return approve_persisted_wave(
         wave_id=wave_id,
-        wave_repository=wave_repository,
-        replay_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
-        allowed_states={"SIMULATED", "PARTIALLY_SIMULATED", "REVIEW_REQUIRED"},
-        error_code="DPM_WAVE_APPROVAL_INVALID_STATE",
-        action_phrase="be approved",
-    )
-    if prepared.replayed:
-        return prepared.wave, True
-
-    approved = _build_approved_wave(
-        wave=prepared.wave,
         actor_id=actor_id,
         reason_code=reason_code,
         comment=comment,
         correlation_id=correlation_id,
-    )
-    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        source_wave=prepared.wave,
-        transitioned_wave=approved,
     )
-    return approved, False
 
 
 def stage_wave(
@@ -324,30 +316,14 @@ def stage_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    prepared = _prepare_wave_transition(
+    return stage_persisted_wave(
         wave_id=wave_id,
-        wave_repository=wave_repository,
-        replay_states={"STAGED", "HANDOFF_READY"},
-        allowed_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
-        error_code="DPM_WAVE_STAGE_INVALID_STATE",
-        action_phrase="be staged",
-    )
-    if prepared.replayed:
-        return prepared.wave, True
-
-    staged = _build_staged_wave(
-        wave=prepared.wave,
         actor_id=actor_id,
         reason_code=reason_code,
         comment=comment,
         correlation_id=correlation_id,
-    )
-    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        source_wave=prepared.wave,
-        transitioned_wave=staged,
     )
-    return staged, False
 
 
 def handoff_wave(
@@ -359,30 +335,14 @@ def handoff_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    prepared = _prepare_wave_transition(
+    return handoff_persisted_wave(
         wave_id=wave_id,
-        wave_repository=wave_repository,
-        replay_states={"HANDOFF_READY"},
-        allowed_states={"STAGED"},
-        error_code="DPM_WAVE_HANDOFF_INVALID_STATE",
-        action_phrase="create handoff evidence",
-    )
-    if prepared.replayed:
-        return prepared.wave, True
-
-    handoff_ready = _build_handoff_ready_wave(
-        wave=prepared.wave,
         actor_id=actor_id,
         reason_code=reason_code,
         comment=comment,
         correlation_id=correlation_id,
-    )
-    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        source_wave=prepared.wave,
-        transitioned_wave=handoff_ready,
     )
-    return handoff_ready, False
 
 
 def cancel_wave(
@@ -394,30 +354,14 @@ def cancel_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    prepared = _prepare_wave_transition(
+    return cancel_persisted_wave(
         wave_id=wave_id,
-        wave_repository=wave_repository,
-        replay_states={"CANCELLED"},
-        allowed_states=None,
-        error_code="DPM_WAVE_CANCEL_INVALID_STATE",
-        action_phrase="be cancelled",
-    )
-    if prepared.replayed:
-        return prepared.wave, True
-
-    cancelled = _build_cancelled_wave(
-        wave=prepared.wave,
         actor_id=actor_id,
         reason_code=reason_code,
         comment=comment,
         correlation_id=correlation_id,
-    )
-    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        source_wave=prepared.wave,
-        transitioned_wave=cancelled,
     )
-    return cancelled, False
 
 
 def wave_supportability_payload(wave: DpmRebalanceWave) -> dict[str, object]:

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -8,10 +8,11 @@ from src.api.services.wave_construction_selection import (
     select_construction_alternative_for_wave as _select_construction_alternative_for_wave,
 )
 from src.api.services.wave_creation import (
-    create_created_wave_id as _create_created_wave_id,
-    create_wave_request_hash as _create_wave_request_hash,
-    promote_preview_to_created_wave as _promote_preview_to_created_wave,
+    create_created_wave_id,
+    create_wave_request_hash,
+    promote_preview_to_created_wave,
 )
+from src.api.services.wave_create_command import create_persisted_wave
 from src.api.services.wave_errors import (
     DpmWaveLookupError as DpmWaveLookupError,
     DpmWaveValidationError as DpmWaveValidationError,
@@ -26,10 +27,7 @@ from src.api.services.wave_item_selection_transition import (
     build_wave_with_selected_item_alternative as _build_wave_with_selected_item_alternative,
 )
 from src.api.services.wave_lookup import get_wave_or_raise
-from src.api.services.wave_persistence import (
-    save_wave_or_raise as _save_wave_or_raise,
-    update_wave_or_raise,
-)
+from src.api.services.wave_persistence import save_wave_or_raise, update_wave_or_raise
 from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_read_model_queries import (
     wave_detail_for_id,
@@ -79,9 +77,13 @@ from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 _simulation_result_state = simulation_result_state
+_create_created_wave_id = create_created_wave_id
+_create_wave_request_hash = create_wave_request_hash
+_promote_preview_to_created_wave = promote_preview_to_created_wave
 _get_wave_or_raise = get_wave_or_raise
 _wave_state_is_idempotent = wave_state_is_idempotent
 _require_wave_state = require_wave_state
+_save_wave_or_raise = save_wave_or_raise
 _update_wave_or_raise = update_wave_or_raise
 _validate_trigger = validate_trigger_or_raise
 _approval_event_metadata = approval_event_metadata
@@ -132,19 +134,7 @@ def create_wave(
     mandate_repository: DpmMandateRepository,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    request_hash = _create_wave_request_hash(
-        trigger_type=trigger_type,
-        trigger_id=trigger_id,
-        rationale=rationale,
-        as_of_date=as_of_date,
-        actor_id=actor_id,
-        portfolios=portfolios,
-    )
-    existing = wave_repository.get_wave_by_idempotency(idempotency_key=idempotency_key)
-    if existing is not None:
-        return existing, True
-
-    preview = preview_wave(
+    return create_persisted_wave(
         trigger_type=trigger_type,
         trigger_id=trigger_id,
         rationale=rationale,
@@ -152,22 +142,10 @@ def create_wave(
         actor_id=actor_id,
         correlation_id=correlation_id,
         portfolios=portfolios,
+        idempotency_key=idempotency_key,
         mandate_repository=mandate_repository,
-    )
-    wave = _promote_preview_to_created_wave(
-        preview=preview,
-        wave_id=_create_created_wave_id(),
-        actor_id=actor_id,
-        correlation_id=correlation_id,
-        idempotency_key=idempotency_key,
-    )
-    _save_wave_or_raise(
         wave_repository=wave_repository,
-        wave=wave,
-        idempotency_key=idempotency_key,
-        request_hash=request_hash,
     )
-    return wave, False
 
 
 def source_check_wave(

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -32,10 +32,6 @@ from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
 )
-from src.api.services.wave_state_guard import (
-    require_wave_state,
-    wave_state_is_idempotent,
-)
 from src.api.services.wave_supportability_payload import (
     wave_supportability_payload as _wave_supportability_payload,
 )
@@ -43,7 +39,6 @@ from src.api.services.wave_transition_execution import (
     persist_transitioned_wave,
     prepare_wave_transition,
 )
-from src.api.services.wave_trigger_validation import validate_trigger_or_raise
 from src.core.construction.repository import ConstructionRepository
 from src.core.construction.vocabulary import ConstructionMethod
 from src.core.mandate_repository import DpmMandateRepository
@@ -57,9 +52,6 @@ from src.core.waves import (
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
-_wave_state_is_idempotent = wave_state_is_idempotent
-_require_wave_state = require_wave_state
-_validate_trigger = validate_trigger_or_raise
 _select_construction_alternative_for_wave = select_construction_alternative_for_wave
 _build_wave_with_selected_item_alternative = build_wave_with_selected_item_alternative
 _selectable_wave_item = selectable_wave_item

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -6,14 +6,8 @@ from src.api.services.wave_errors import (
 )
 from src.api.services import wave_lifecycle_commands
 from src.api.services import wave_preparation_commands
+from src.api.services import wave_read_model_queries
 from src.api.services.wave_preview import build_preview_wave
-from src.api.services.wave_read_model_queries import (
-    wave_detail_for_id,
-    wave_items_for_id,
-    wave_proof_pack_posture_for_id,
-    wave_report_input_for_id,
-    wave_supportability_for_id,
-)
 from src.api.services.wave_selection_command import select_persisted_wave_item_alternative
 from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation_item import (
@@ -246,7 +240,10 @@ def wave_supportability(
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
-    return wave_supportability_for_id(wave_id=wave_id, wave_repository=wave_repository)
+    return wave_read_model_queries.wave_supportability_for_id(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+    )
 
 
 def search_waves(
@@ -275,7 +272,10 @@ def retrieve_wave_detail(
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
-    return wave_detail_for_id(wave_id=wave_id, wave_repository=wave_repository)
+    return wave_read_model_queries.wave_detail_for_id(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+    )
 
 
 def list_wave_items(
@@ -283,7 +283,10 @@ def list_wave_items(
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
-    return wave_items_for_id(wave_id=wave_id, wave_repository=wave_repository)
+    return wave_read_model_queries.wave_items_for_id(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+    )
 
 
 def proof_pack_posture(
@@ -291,7 +294,10 @@ def proof_pack_posture(
     wave_id: str,
     wave_repository: DpmWaveRepository,
 ) -> dict[str, object]:
-    return wave_proof_pack_posture_for_id(wave_id=wave_id, wave_repository=wave_repository)
+    return wave_read_model_queries.wave_proof_pack_posture_for_id(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+    )
 
 
 def get_report_input(
@@ -302,7 +308,7 @@ def get_report_input(
     outcome_review_repository: DpmOutcomeReviewRepository | None = None,
     mandate_repository: DpmMandateRepository | None = None,
 ) -> DpmWaveReportInput:
-    return wave_report_input_for_id(
+    return wave_read_model_queries.wave_report_input_for_id(
         wave_id=wave_id,
         wave_repository=wave_repository,
         proof_pack_repository=proof_pack_repository,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -1,12 +1,8 @@
 from src.api.request_models import RebalanceRequest
-from src.api.services.wave_construction_selection import select_construction_alternative_for_wave
 from src.api.services.wave_create_command import create_persisted_wave
 from src.api.services.wave_errors import (
     DpmWaveLookupError as DpmWaveLookupError,
     DpmWaveValidationError as DpmWaveValidationError,
-)
-from src.api.services.wave_item_selection_transition import (
-    build_wave_with_selected_item_alternative,
 )
 from src.api.services.wave_lifecycle_commands import (
     approve_persisted_wave,
@@ -27,7 +23,6 @@ from src.api.services.wave_read_model_queries import (
     wave_supportability_for_id,
 )
 from src.api.services.wave_selection_command import select_persisted_wave_item_alternative
-from src.api.services.wave_selection_guard import selectable_wave_item
 from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
@@ -47,10 +42,6 @@ from src.core.waves import (
 )
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.infrastructure.risk_authority import LotusRiskAuthorityClient
-
-_select_construction_alternative_for_wave = select_construction_alternative_for_wave
-_build_wave_with_selected_item_alternative = build_wave_with_selected_item_alternative
-_selectable_wave_item = selectable_wave_item
 
 
 def preview_wave(

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -5,8 +5,6 @@ from src.api.services.wave_errors import (
     DpmWaveLookupError as DpmWaveLookupError,
     DpmWaveValidationError as DpmWaveValidationError,
 )
-from src.api.services.wave_event_append import append_same_state_event
-from src.api.services.wave_item_collection import wave_with_items_and_aggregate
 from src.api.services.wave_item_selection_transition import (
     build_wave_with_selected_item_alternative,
 )
@@ -70,8 +68,6 @@ _validate_trigger = validate_trigger_or_raise
 _select_construction_alternative_for_wave = select_construction_alternative_for_wave
 _build_wave_with_selected_item_alternative = build_wave_with_selected_item_alternative
 _selectable_wave_item = selectable_wave_item
-_append_event = append_same_state_event
-_wave_with_items_and_aggregate = wave_with_items_and_aggregate
 _prepare_wave_transition = prepare_wave_transition
 _persist_transitioned_wave = persist_transitioned_wave
 

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -4,9 +4,7 @@ from src.api.services.wave_aggregate_metrics import (
 )
 from src.api.services.wave_approval_transition import build_approved_wave
 from src.api.services.wave_cancel_transition import build_cancelled_wave
-from src.api.services.wave_construction_selection import (
-    select_construction_alternative_for_wave as _select_construction_alternative_for_wave,
-)
+from src.api.services.wave_construction_selection import select_construction_alternative_for_wave
 from src.api.services.wave_creation import (
     create_created_wave_id,
     create_wave_request_hash,
@@ -22,7 +20,7 @@ from src.api.services.wave_event_evidence import build_wave_event
 from src.api.services.wave_handoff_transition import build_handoff_ready_wave
 from src.api.services.wave_item_collection import wave_with_items_and_aggregate
 from src.api.services.wave_item_selection_transition import (
-    build_wave_with_selected_item_alternative as _build_wave_with_selected_item_alternative,
+    build_wave_with_selected_item_alternative,
 )
 from src.api.services.wave_lifecycle_commands import (
     approve_persisted_wave,
@@ -44,7 +42,8 @@ from src.api.services.wave_read_model_queries import (
     wave_report_input_for_id,
     wave_supportability_for_id,
 )
-from src.api.services.wave_selection_guard import selectable_wave_item as _selectable_wave_item
+from src.api.services.wave_selection_command import select_persisted_wave_item_alternative
+from src.api.services.wave_selection_guard import selectable_wave_item
 from src.api.services.wave_search import search_wave_summaries
 from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
@@ -96,6 +95,9 @@ _build_approved_wave = build_approved_wave
 _build_cancelled_wave = build_cancelled_wave
 _build_handoff_ready_wave = build_handoff_ready_wave
 _build_staged_wave = build_staged_wave
+_select_construction_alternative_for_wave = select_construction_alternative_for_wave
+_build_wave_with_selected_item_alternative = build_wave_with_selected_item_alternative
+_selectable_wave_item = selectable_wave_item
 _approval_event_metadata = approval_event_metadata
 _stage_event_metadata = stage_event_metadata
 _handoff_event_metadata = handoff_event_metadata
@@ -216,29 +218,9 @@ def select_wave_item_alternative(
     run_service: DpmRunSupportService,
     wave_repository: DpmWaveRepository,
 ) -> DpmRebalanceWave:
-    prepared = _prepare_wave_transition(
+    return select_persisted_wave_item_alternative(
         wave_id=wave_id,
-        wave_repository=wave_repository,
-        replay_states=set(),
-        allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
-        error_code="DPM_WAVE_SELECTION_INVALID_STATE",
-        action_phrase="record alternative selection",
-    )
-    selected_item = _selectable_wave_item(wave=prepared.wave, wave_item_id=wave_item_id)
-    assert selected_item.alternative_set_id is not None
-    _select_construction_alternative_for_wave(
-        repository=construction_repository,
-        alternative_set_id=selected_item.alternative_set_id,
-        alternative_id=alternative_id,
-        actor_id=actor_id,
-        reason_code=reason_code,
-        comment=comment,
-        correlation_id=correlation_id,
-    )
-
-    updated = _build_wave_with_selected_item_alternative(
-        wave=prepared.wave,
-        selected_item=selected_item,
+        wave_item_id=wave_item_id,
         alternative_id=alternative_id,
         actor_id=actor_id,
         reason_code=reason_code,
@@ -249,13 +231,8 @@ def select_wave_item_alternative(
         proof_pack_repository=proof_pack_repository,
         mandate_repository=mandate_repository,
         run_service=run_service,
-    )
-    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        source_wave=prepared.wave,
-        transitioned_wave=updated,
     )
-    return updated
 
 
 def approve_wave(

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -14,8 +14,6 @@ from src.api.services.wave_lifecycle_commands import (
     handoff_persisted_wave,
     stage_persisted_wave,
 )
-from src.api.services.wave_lookup import get_wave_or_raise
-from src.api.services.wave_persistence import save_wave_or_raise, update_wave_or_raise
 from src.api.services.wave_preparation_commands import (
     simulate_persisted_wave,
     source_check_persisted_wave,
@@ -59,11 +57,8 @@ from src.core.waves import (
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
-_get_wave_or_raise = get_wave_or_raise
 _wave_state_is_idempotent = wave_state_is_idempotent
 _require_wave_state = require_wave_state
-_save_wave_or_raise = save_wave_or_raise
-_update_wave_or_raise = update_wave_or_raise
 _validate_trigger = validate_trigger_or_raise
 _select_construction_alternative_for_wave = select_construction_alternative_for_wave
 _build_wave_with_selected_item_alternative = build_wave_with_selected_item_alternative

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -49,6 +49,10 @@ from src.api.services.wave_stage_transition import build_staged_wave as _build_s
 from src.api.services.wave_supportability_payload import (
     wave_supportability_payload as _wave_supportability_payload,
 )
+from src.api.services.wave_transition_execution import (
+    persist_transitioned_wave,
+    prepare_wave_transition,
+)
 from src.api.services.wave_trigger_validation import validate_trigger_or_raise
 from src.api.services.wave_workflow_metadata import (
     approval_event_metadata,
@@ -80,6 +84,8 @@ _selection_event_metadata = selection_event_metadata
 _event = build_wave_event
 _append_event = append_same_state_event
 _wave_with_items_and_aggregate = wave_with_items_and_aggregate
+_prepare_wave_transition = prepare_wave_transition
+_persist_transitioned_wave = persist_transitioned_wave
 
 
 def preview_wave(
@@ -164,26 +170,27 @@ def source_check_wave(
     mandate_repository: DpmMandateRepository,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if _wave_state_is_idempotent(wave, replay_states={"SOURCE_CHECKED"}):
-        return wave, True
-    _require_wave_state(
-        wave,
+    prepared = _prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"SOURCE_CHECKED"},
         allowed_states={"CREATED"},
         error_code="DPM_WAVE_SOURCE_CHECK_INVALID_STATE",
         action_phrase="be source-checked",
     )
+    if prepared.replayed:
+        return prepared.wave, True
 
     checked = build_source_checked_wave(
-        wave=wave,
+        wave=prepared.wave,
         actor_id=actor_id,
         correlation_id=correlation_id,
         mandate_repository=mandate_repository,
     )
-    _update_wave_or_raise(
+    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        wave=checked,
-        expected_version=wave.version,
+        source_wave=prepared.wave,
+        transitioned_wave=checked,
     )
     return checked, False
 
@@ -200,21 +207,19 @@ def simulate_wave(
     wave_repository: DpmWaveRepository,
     risk_authority_client: LotusRiskAuthorityClient | None = None,
 ) -> tuple[DpmRebalanceWave, bool]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if _wave_state_is_idempotent(
-        wave,
+    prepared = _prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
         replay_states={"SIMULATED", "PARTIALLY_SIMULATED", "SIMULATION_FAILED"},
-    ):
-        return wave, True
-    _require_wave_state(
-        wave,
         allowed_states={"SOURCE_CHECKED"},
         error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
         action_phrase="be simulated",
     )
+    if prepared.replayed:
+        return prepared.wave, True
 
     completed = build_simulated_wave(
-        wave=wave,
+        wave=prepared.wave,
         actor_id=actor_id,
         correlation_id=correlation_id,
         item_inputs=item_inputs,
@@ -223,10 +228,10 @@ def simulate_wave(
         run_service=run_service,
         risk_authority_client=risk_authority_client,
     )
-    _update_wave_or_raise(
+    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        wave=completed,
-        expected_version=wave.version,
+        source_wave=prepared.wave,
+        transitioned_wave=completed,
     )
     return completed, False
 
@@ -297,30 +302,28 @@ def approve_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if _wave_state_is_idempotent(
-        wave,
+    prepared = _prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
         replay_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
-    ):
-        return wave, True
-    _require_wave_state(
-        wave,
         allowed_states={"SIMULATED", "PARTIALLY_SIMULATED", "REVIEW_REQUIRED"},
         error_code="DPM_WAVE_APPROVAL_INVALID_STATE",
         action_phrase="be approved",
     )
+    if prepared.replayed:
+        return prepared.wave, True
 
     approved = _build_approved_wave(
-        wave=wave,
+        wave=prepared.wave,
         actor_id=actor_id,
         reason_code=reason_code,
         comment=comment,
         correlation_id=correlation_id,
     )
-    _update_wave_or_raise(
+    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        wave=approved,
-        expected_version=wave.version,
+        source_wave=prepared.wave,
+        transitioned_wave=approved,
     )
     return approved, False
 
@@ -334,27 +337,28 @@ def stage_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if _wave_state_is_idempotent(wave, replay_states={"STAGED", "HANDOFF_READY"}):
-        return wave, True
-    _require_wave_state(
-        wave,
+    prepared = _prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"STAGED", "HANDOFF_READY"},
         allowed_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
         error_code="DPM_WAVE_STAGE_INVALID_STATE",
         action_phrase="be staged",
     )
+    if prepared.replayed:
+        return prepared.wave, True
 
     staged = _build_staged_wave(
-        wave=wave,
+        wave=prepared.wave,
         actor_id=actor_id,
         reason_code=reason_code,
         comment=comment,
         correlation_id=correlation_id,
     )
-    _update_wave_or_raise(
+    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        wave=staged,
-        expected_version=wave.version,
+        source_wave=prepared.wave,
+        transitioned_wave=staged,
     )
     return staged, False
 
@@ -368,27 +372,28 @@ def handoff_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if _wave_state_is_idempotent(wave, replay_states={"HANDOFF_READY"}):
-        return wave, True
-    _require_wave_state(
-        wave,
+    prepared = _prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"HANDOFF_READY"},
         allowed_states={"STAGED"},
         error_code="DPM_WAVE_HANDOFF_INVALID_STATE",
         action_phrase="create handoff evidence",
     )
+    if prepared.replayed:
+        return prepared.wave, True
 
     handoff_ready = _build_handoff_ready_wave(
-        wave=wave,
+        wave=prepared.wave,
         actor_id=actor_id,
         reason_code=reason_code,
         comment=comment,
         correlation_id=correlation_id,
     )
-    _update_wave_or_raise(
+    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        wave=handoff_ready,
-        expected_version=wave.version,
+        source_wave=prepared.wave,
+        transitioned_wave=handoff_ready,
     )
     return handoff_ready, False
 

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -35,10 +35,6 @@ from src.api.services.wave_simulation_item import (
 from src.api.services.wave_supportability_payload import (
     wave_supportability_payload as _wave_supportability_payload,
 )
-from src.api.services.wave_transition_execution import (
-    persist_transitioned_wave,
-    prepare_wave_transition,
-)
 from src.core.construction.repository import ConstructionRepository
 from src.core.construction.vocabulary import ConstructionMethod
 from src.core.mandate_repository import DpmMandateRepository
@@ -55,8 +51,6 @@ from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 _select_construction_alternative_for_wave = select_construction_alternative_for_wave
 _build_wave_with_selected_item_alternative = build_wave_with_selected_item_alternative
 _selectable_wave_item = selectable_wave_item
-_prepare_wave_transition = prepare_wave_transition
-_persist_transitioned_wave = persist_transitioned_wave
 
 
 def preview_wave(

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -43,7 +43,7 @@ from src.api.services.wave_simulation_item import (
 from src.api.services.wave_source_check import build_source_checked_wave
 from src.api.services.wave_state_guard import (
     require_wave_state as _require_wave_state,
-    wave_state_is_idempotent as _wave_state_is_idempotent,
+    wave_state_is_idempotent,
 )
 from src.api.services.wave_stage_transition import build_staged_wave as _build_staged_wave
 from src.api.services.wave_supportability_payload import (
@@ -75,6 +75,7 @@ from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 _simulation_result_state = simulation_result_state
+_wave_state_is_idempotent = wave_state_is_idempotent
 _validate_trigger = validate_trigger_or_raise
 _approval_event_metadata = approval_event_metadata
 _stage_event_metadata = stage_event_metadata
@@ -407,21 +408,28 @@ def cancel_wave(
     correlation_id: str,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    if _wave_state_is_idempotent(wave, replay_states={"CANCELLED"}):
-        return wave, True
+    prepared = _prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states={"CANCELLED"},
+        allowed_states=None,
+        error_code="DPM_WAVE_CANCEL_INVALID_STATE",
+        action_phrase="be cancelled",
+    )
+    if prepared.replayed:
+        return prepared.wave, True
 
     cancelled = _build_cancelled_wave(
-        wave=wave,
+        wave=prepared.wave,
         actor_id=actor_id,
         reason_code=reason_code,
         comment=comment,
         correlation_id=correlation_id,
     )
-    _update_wave_or_raise(
+    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        wave=cancelled,
-        expected_version=wave.version,
+        source_wave=prepared.wave,
+        transitioned_wave=cancelled,
     )
     return cancelled, False
 

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -9,12 +9,10 @@ from src.api.services import wave_preparation_commands
 from src.api.services import wave_read_model_queries
 from src.api.services import wave_selection_command
 from src.api.services import wave_search
+from src.api.services import wave_supportability_payload as wave_supportability_payload_module
 from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
-)
-from src.api.services.wave_supportability_payload import (
-    wave_supportability_payload as _wave_supportability_payload,
 )
 from src.core.construction.repository import ConstructionRepository
 from src.core.construction.vocabulary import ConstructionMethod
@@ -232,7 +230,7 @@ def cancel_wave(
 
 
 def wave_supportability_payload(wave: DpmRebalanceWave) -> dict[str, object]:
-    return _wave_supportability_payload(wave)
+    return wave_supportability_payload_module.wave_supportability_payload(wave)
 
 
 def wave_supportability(

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -32,6 +32,10 @@ from src.api.services.wave_lifecycle_commands import (
 )
 from src.api.services.wave_lookup import get_wave_or_raise
 from src.api.services.wave_persistence import save_wave_or_raise, update_wave_or_raise
+from src.api.services.wave_preparation_commands import (
+    simulate_persisted_wave,
+    source_check_persisted_wave,
+)
 from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_read_model_queries import (
     wave_detail_for_id,
@@ -42,11 +46,9 @@ from src.api.services.wave_read_model_queries import (
 )
 from src.api.services.wave_selection_guard import selectable_wave_item as _selectable_wave_item
 from src.api.services.wave_search import search_wave_summaries
-from src.api.services.wave_simulation import build_simulated_wave
 from src.api.services.wave_simulation_item import (
     DpmWaveSimulationInput as DpmWaveSimulationInput,
 )
-from src.api.services.wave_source_check import build_source_checked_wave
 from src.api.services.wave_state_guard import (
     require_wave_state,
     wave_state_is_idempotent,
@@ -164,29 +166,13 @@ def source_check_wave(
     mandate_repository: DpmMandateRepository,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    prepared = _prepare_wave_transition(
+    return source_check_persisted_wave(
         wave_id=wave_id,
-        wave_repository=wave_repository,
-        replay_states={"SOURCE_CHECKED"},
-        allowed_states={"CREATED"},
-        error_code="DPM_WAVE_SOURCE_CHECK_INVALID_STATE",
-        action_phrase="be source-checked",
-    )
-    if prepared.replayed:
-        return prepared.wave, True
-
-    checked = build_source_checked_wave(
-        wave=prepared.wave,
         actor_id=actor_id,
         correlation_id=correlation_id,
         mandate_repository=mandate_repository,
-    )
-    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        source_wave=prepared.wave,
-        transitioned_wave=checked,
     )
-    return checked, False
 
 
 def simulate_wave(
@@ -201,33 +187,17 @@ def simulate_wave(
     wave_repository: DpmWaveRepository,
     risk_authority_client: LotusRiskAuthorityClient | None = None,
 ) -> tuple[DpmRebalanceWave, bool]:
-    prepared = _prepare_wave_transition(
+    return simulate_persisted_wave(
         wave_id=wave_id,
-        wave_repository=wave_repository,
-        replay_states={"SIMULATED", "PARTIALLY_SIMULATED", "SIMULATION_FAILED"},
-        allowed_states={"SOURCE_CHECKED"},
-        error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
-        action_phrase="be simulated",
-    )
-    if prepared.replayed:
-        return prepared.wave, True
-
-    completed = build_simulated_wave(
-        wave=prepared.wave,
         actor_id=actor_id,
         correlation_id=correlation_id,
         item_inputs=item_inputs,
         methods=methods,
         construction_repository=construction_repository,
         run_service=run_service,
+        wave_repository=wave_repository,
         risk_authority_client=risk_authority_client,
     )
-    _persist_transitioned_wave(
-        wave_repository=wave_repository,
-        source_wave=prepared.wave,
-        transitioned_wave=completed,
-    )
-    return completed, False
 
 
 def select_wave_item_alternative(

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -1,5 +1,5 @@
 from src.api.request_models import RebalanceRequest
-from src.api.services.wave_create_command import create_persisted_wave
+from src.api.services import wave_create_command
 from src.api.services.wave_errors import (
     DpmWaveLookupError as DpmWaveLookupError,
     DpmWaveValidationError as DpmWaveValidationError,
@@ -80,7 +80,7 @@ def create_wave(
     mandate_repository: DpmMandateRepository,
     wave_repository: DpmWaveRepository,
 ) -> tuple[DpmRebalanceWave, bool]:
-    return create_persisted_wave(
+    return wave_create_command.create_persisted_wave(
         trigger_type=trigger_type,
         trigger_id=trigger_id,
         rationale=rationale,

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -29,7 +29,7 @@ from src.api.services.wave_item_selection_transition import (
 from src.api.services.wave_lookup import get_wave_or_raise as _get_wave_or_raise
 from src.api.services.wave_persistence import (
     save_wave_or_raise as _save_wave_or_raise,
-    update_wave_or_raise as _update_wave_or_raise,
+    update_wave_or_raise,
 )
 from src.api.services.wave_preview import build_preview_wave
 from src.api.services.wave_proof_pack_posture import proof_pack_posture_for_wave
@@ -42,7 +42,7 @@ from src.api.services.wave_simulation_item import (
 )
 from src.api.services.wave_source_check import build_source_checked_wave
 from src.api.services.wave_state_guard import (
-    require_wave_state as _require_wave_state,
+    require_wave_state,
     wave_state_is_idempotent,
 )
 from src.api.services.wave_stage_transition import build_staged_wave as _build_staged_wave
@@ -76,6 +76,8 @@ from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 _simulation_result_state = simulation_result_state
 _wave_state_is_idempotent = wave_state_is_idempotent
+_require_wave_state = require_wave_state
+_update_wave_or_raise = update_wave_or_raise
 _validate_trigger = validate_trigger_or_raise
 _approval_event_metadata = approval_event_metadata
 _stage_event_metadata = stage_event_metadata
@@ -253,14 +255,15 @@ def select_wave_item_alternative(
     run_service: DpmRunSupportService,
     wave_repository: DpmWaveRepository,
 ) -> DpmRebalanceWave:
-    wave = _get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
-    _require_wave_state(
-        wave,
+    prepared = _prepare_wave_transition(
+        wave_id=wave_id,
+        wave_repository=wave_repository,
+        replay_states=set(),
         allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
         error_code="DPM_WAVE_SELECTION_INVALID_STATE",
         action_phrase="record alternative selection",
     )
-    selected_item = _selectable_wave_item(wave=wave, wave_item_id=wave_item_id)
+    selected_item = _selectable_wave_item(wave=prepared.wave, wave_item_id=wave_item_id)
     assert selected_item.alternative_set_id is not None
     _select_construction_alternative_for_wave(
         repository=construction_repository,
@@ -273,7 +276,7 @@ def select_wave_item_alternative(
     )
 
     updated = _build_wave_with_selected_item_alternative(
-        wave=wave,
+        wave=prepared.wave,
         selected_item=selected_item,
         alternative_id=alternative_id,
         actor_id=actor_id,
@@ -286,10 +289,10 @@ def select_wave_item_alternative(
         mandate_repository=mandate_repository,
         run_service=run_service,
     )
-    _update_wave_or_raise(
+    _persist_transitioned_wave(
         wave_repository=wave_repository,
-        wave=updated,
-        expected_version=wave.version,
+        source_wave=prepared.wave,
+        transitioned_wave=updated,
     )
     return updated
 

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -48,13 +48,6 @@ from src.api.services.wave_transition_execution import (
     prepare_wave_transition,
 )
 from src.api.services.wave_trigger_validation import validate_trigger_or_raise
-from src.api.services.wave_workflow_metadata import (
-    approval_event_metadata,
-    cancel_event_metadata,
-    handoff_event_metadata,
-    selection_event_metadata,
-    stage_event_metadata,
-)
 from src.core.construction.repository import ConstructionRepository
 from src.core.construction.vocabulary import ConstructionMethod
 from src.core.mandate_repository import DpmMandateRepository
@@ -77,11 +70,6 @@ _validate_trigger = validate_trigger_or_raise
 _select_construction_alternative_for_wave = select_construction_alternative_for_wave
 _build_wave_with_selected_item_alternative = build_wave_with_selected_item_alternative
 _selectable_wave_item = selectable_wave_item
-_approval_event_metadata = approval_event_metadata
-_stage_event_metadata = stage_event_metadata
-_handoff_event_metadata = handoff_event_metadata
-_cancel_event_metadata = cancel_event_metadata
-_selection_event_metadata = selection_event_metadata
 _append_event = append_same_state_event
 _wave_with_items_and_aggregate = wave_with_items_and_aggregate
 _prepare_wave_transition = prepare_wave_transition

--- a/src/api/services/wave_transition_execution.py
+++ b/src/api/services/wave_transition_execution.py
@@ -19,19 +19,20 @@ def prepare_wave_transition(
     wave_id: str,
     wave_repository: DpmWaveRepository,
     replay_states: set[str],
-    allowed_states: set[str],
+    allowed_states: set[str] | None,
     error_code: str,
     action_phrase: str,
 ) -> PreparedWaveTransition:
     wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
     if wave_state_is_idempotent(wave, replay_states=replay_states):
         return PreparedWaveTransition(wave=wave, replayed=True)
-    require_wave_state(
-        wave,
-        allowed_states=allowed_states,
-        error_code=error_code,
-        action_phrase=action_phrase,
-    )
+    if allowed_states is not None:
+        require_wave_state(
+            wave,
+            allowed_states=allowed_states,
+            error_code=error_code,
+            action_phrase=action_phrase,
+        )
     return PreparedWaveTransition(wave=wave, replayed=False)
 
 

--- a/src/api/services/wave_transition_execution.py
+++ b/src/api/services/wave_transition_execution.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.api.services.wave_lookup import get_wave_or_raise
+from src.api.services.wave_persistence import update_wave_or_raise
+from src.api.services.wave_state_guard import require_wave_state, wave_state_is_idempotent
+from src.core.waves import DpmRebalanceWave, DpmWaveRepository
+
+
+@dataclass(frozen=True)
+class PreparedWaveTransition:
+    wave: DpmRebalanceWave
+    replayed: bool
+
+
+def prepare_wave_transition(
+    *,
+    wave_id: str,
+    wave_repository: DpmWaveRepository,
+    replay_states: set[str],
+    allowed_states: set[str],
+    error_code: str,
+    action_phrase: str,
+) -> PreparedWaveTransition:
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    if wave_state_is_idempotent(wave, replay_states=replay_states):
+        return PreparedWaveTransition(wave=wave, replayed=True)
+    require_wave_state(
+        wave,
+        allowed_states=allowed_states,
+        error_code=error_code,
+        action_phrase=action_phrase,
+    )
+    return PreparedWaveTransition(wave=wave, replayed=False)
+
+
+def persist_transitioned_wave(
+    *,
+    wave_repository: DpmWaveRepository,
+    source_wave: DpmRebalanceWave,
+    transitioned_wave: DpmRebalanceWave,
+) -> None:
+    update_wave_or_raise(
+        wave_repository=wave_repository,
+        wave=transitioned_wave,
+        expected_version=source_wave.version,
+    )
+
+
+__all__ = [
+    "PreparedWaveTransition",
+    "persist_transitioned_wave",
+    "prepare_wave_transition",
+]

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -502,6 +502,11 @@ def test_rebalance_simulation_service_does_not_export_core_resolver_helpers() ->
     assert not hasattr(service, "stateful_core_sourcing_enabled")
 
 
+def test_rebalance_simulation_service_does_not_export_core_engine_runner() -> None:
+    assert not hasattr(service, "run_simulation")
+    assert "run_simulation" not in service.__all__
+
+
 def test_rebalance_async_operation_payload_supports_current_and_legacy_shapes() -> None:
     batch_payload = valid_api_payload()
     batch_payload.pop("options")

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -149,7 +149,9 @@ def test_stateful_source_context_maps_validation_and_resolver_errors(monkeypatch
         def resolve_execution_context(self, **_kwargs):
             raise DpmCoreResolverUnavailableError("down")
 
-    monkeypatch.setattr(service, "build_core_resolver_client", lambda: _UnavailableResolver())
+    monkeypatch.setattr(
+        core_resolver_service, "build_core_resolver_client", lambda: _UnavailableResolver()
+    )
     with pytest.raises(service.DpmRebalanceCoreResolverUnavailableError) as unavailable:
         service._resolve_stateful_source_context(envelope=envelope, correlation_id="corr")
     assert rebalance_envelope_http_exception(unavailable.value).status_code == 503
@@ -158,7 +160,9 @@ def test_stateful_source_context_maps_validation_and_resolver_errors(monkeypatch
         def resolve_execution_context(self, **_kwargs):
             raise DpmCoreResolverError("bad")
 
-    monkeypatch.setattr(service, "build_core_resolver_client", lambda: _IncompleteResolver())
+    monkeypatch.setattr(
+        core_resolver_service, "build_core_resolver_client", lambda: _IncompleteResolver()
+    )
     with pytest.raises(service.DpmRebalanceCoreContextIncompleteError) as incomplete:
         service._resolve_stateful_source_context(envelope=envelope, correlation_id="corr")
     assert incomplete.value.detail == "DPM_CORE_CONTEXT_INCOMPLETE"
@@ -168,7 +172,9 @@ def test_stateful_source_context_maps_validation_and_resolver_errors(monkeypatch
         def resolve_execution_context(self, **_kwargs):
             raise DpmCoreContextIncompleteError("MARKET_DATA_STALE")
 
-    monkeypatch.setattr(service, "build_core_resolver_client", lambda: _DerivedIncompleteResolver())
+    monkeypatch.setattr(
+        core_resolver_service, "build_core_resolver_client", lambda: _DerivedIncompleteResolver()
+    )
     with pytest.raises(service.DpmRebalanceCoreContextIncompleteError) as derived_incomplete:
         service._resolve_stateful_source_context(envelope=envelope, correlation_id="corr")
     assert derived_incomplete.value.detail == "DPM_CORE_CONTEXT_INCOMPLETE"
@@ -178,7 +184,9 @@ def test_stateful_source_context_maps_validation_and_resolver_errors(monkeypatch
         def resolve_execution_context(self, **_kwargs):
             DpmStatefulInput.model_validate({})
 
-    monkeypatch.setattr(service, "build_core_resolver_client", lambda: _InvalidResolver())
+    monkeypatch.setattr(
+        core_resolver_service, "build_core_resolver_client", lambda: _InvalidResolver()
+    )
     with pytest.raises(service.DpmRebalanceCoreContextIncompleteError) as invalid:
         service._resolve_stateful_source_context(envelope=envelope, correlation_id="corr")
     assert rebalance_envelope_http_exception(invalid.value).status_code == 424
@@ -481,6 +489,11 @@ def test_rebalance_simulation_service_does_not_export_async_configuration_helper
     assert "async_manual_execution_enabled" not in service.__all__
     assert "async_operations_enabled" not in service.__all__
     assert "resolve_async_execution_mode" not in service.__all__
+
+
+def test_rebalance_simulation_service_does_not_export_core_resolver_helpers() -> None:
+    assert not hasattr(service, "build_core_resolver_client")
+    assert not hasattr(service, "stateful_core_sourcing_enabled")
 
 
 def test_rebalance_async_operation_payload_supports_current_and_legacy_shapes() -> None:

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -477,6 +477,12 @@ def test_rebalance_async_config_exports_async_configuration_surface() -> None:
     ]
 
 
+def test_rebalance_simulation_service_does_not_export_async_configuration_helpers() -> None:
+    assert "async_manual_execution_enabled" not in service.__all__
+    assert "async_operations_enabled" not in service.__all__
+    assert "resolve_async_execution_mode" not in service.__all__
+
+
 def test_rebalance_async_operation_payload_supports_current_and_legacy_shapes() -> None:
     batch_payload = valid_api_payload()
     batch_payload.pop("options")

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -355,20 +355,20 @@ def test_async_manual_execution_disabled_is_reported(monkeypatch) -> None:
     assert exc_info.value.detail == "DPM_ASYNC_MANUAL_EXECUTION_DISABLED"
 
 
-def test_service_env_helpers_reject_invalid_values(monkeypatch) -> None:
+def test_core_resolver_service_env_helpers_reject_invalid_values(monkeypatch) -> None:
     monkeypatch.setenv("DPM_TEST_INT", "not-int")
     monkeypatch.setenv("DPM_TEST_FLOAT", "0")
     monkeypatch.setenv("DPM_TEST_BAD_FLOAT", "not-float")
     monkeypatch.delenv("DPM_TEST_MISSING", raising=False)
     monkeypatch.delenv("DPM_CORE_BASE_URL", raising=False)
 
-    assert service.env_int("DPM_TEST_INT", 3) == 3
-    assert service.env_int("DPM_TEST_FLOAT", 3) == 3
-    assert service.env_float("DPM_TEST_FLOAT", 2.5) == 2.5
-    assert service.env_float("DPM_TEST_BAD_FLOAT", 2.5) == 2.5
-    assert service.env_float("DPM_TEST_MISSING", 2.5) == 2.5
+    assert core_resolver_service.env_int("DPM_TEST_INT", 3) == 3
+    assert core_resolver_service.env_int("DPM_TEST_FLOAT", 3) == 3
+    assert core_resolver_service.env_float("DPM_TEST_FLOAT", 2.5) == 2.5
+    assert core_resolver_service.env_float("DPM_TEST_BAD_FLOAT", 2.5) == 2.5
+    assert core_resolver_service.env_float("DPM_TEST_MISSING", 2.5) == 2.5
     with pytest.raises(DpmCoreResolverUnavailableError, match="DPM_CORE_RESOLVER_UNAVAILABLE"):
-        service.build_core_resolver_client()
+        core_resolver_service.build_core_resolver_client()
 
 
 def test_core_resolver_service_builds_config_from_environment(monkeypatch) -> None:
@@ -385,6 +385,16 @@ def test_core_resolver_service_builds_config_from_environment(monkeypatch) -> No
     assert resolver._config.transaction_cost_lookback_days == 30
     assert resolver._config.timeout_seconds == 3.5
     assert resolver._config.max_attempts == 4
+
+
+def test_core_resolver_service_exports_resolver_configuration_surface() -> None:
+    assert core_resolver_service.__all__ == [
+        "build_core_resolver_client",
+        "env_float",
+        "env_flag",
+        "env_int",
+        "stateful_core_sourcing_enabled",
+    ]
 
 
 def test_rebalance_source_lineage_stamps_result_metadata() -> None:

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -468,6 +468,15 @@ def test_rebalance_async_config_normalizes_modes_and_flags(monkeypatch) -> None:
     assert async_config.resolve_async_execution_mode() == "INLINE"
 
 
+def test_rebalance_async_config_exports_async_configuration_surface() -> None:
+    assert async_config.__all__ == [
+        "async_manual_execution_enabled",
+        "async_operations_enabled",
+        "env_flag",
+        "resolve_async_execution_mode",
+    ]
+
+
 def test_rebalance_async_operation_payload_supports_current_and_legacy_shapes() -> None:
     batch_payload = valid_api_payload()
     batch_payload.pop("options")

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -25,6 +25,7 @@ import src.api.services.rebalance_sync_execution as sync_execution
 import src.api.services.rebalance_supportability_write as supportability_write
 from src.api.services.rebalance_batch_analysis import resolve_base_snapshot_ids
 import src.api.services.rebalance_run_support_service as run_support_service
+import src.api.main as api_main
 from src.api.request_models import (
     BatchExecutionRequestEnvelope,
     RebalanceExecutionRequestEnvelope,
@@ -106,6 +107,11 @@ def test_rebalance_runtime_overrides_fall_back_for_missing_main_exports() -> Non
         is _default_callable
     )
     assert runtime_overrides.resolve_main_override("__missing_lotus_manage_override__") is None
+
+
+def test_main_does_not_export_unused_async_runner_override() -> None:
+    assert not hasattr(api_main, "_run_analyze_async_operation")
+    assert "_run_analyze_async_operation" not in api_main.__all__
 
 
 def test_rebalance_run_support_provider_raises_application_error(monkeypatch) -> None:

--- a/tests/unit/dpm/api/test_api_rebalance.py
+++ b/tests/unit/dpm/api/test_api_rebalance.py
@@ -15,7 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 import src.api.routers.rebalance_runs as dpm_runs_router
-import src.api.services.rebalance_simulation_service as rebalance_service
+import src.api.services.core_resolver_service as core_resolver_service
 from src.api.main import app, get_db_session
 from src.api.routers.rebalance_runs import (
     get_dpm_run_support_service,
@@ -154,7 +154,7 @@ def _install_fake_core_resolver(monkeypatch) -> _FakeCoreResolver:
     fake_resolver = _FakeCoreResolver()
     monkeypatch.setenv("DPM_STATEFUL_CORE_SOURCING_ENABLED", "true")
     monkeypatch.setattr(
-        rebalance_service,
+        core_resolver_service,
         "build_core_resolver_client",
         lambda: fake_resolver,
     )

--- a/tests/unit/dpm/api/test_construction_api.py
+++ b/tests/unit/dpm/api/test_construction_api.py
@@ -7,7 +7,7 @@ from src.api.dependencies import (
 )
 from src.api.main import app
 import src.api.services.construction_service as construction_service
-import src.api.services.rebalance_simulation_service as rebalance_service
+import src.api.services.core_resolver_service as core_resolver_service
 from src.core.dpm_source_context import DpmCoreExecutionContext
 from src.infrastructure.construction import InMemoryConstructionRepository
 from tests.shared.factories import valid_api_payload
@@ -1310,7 +1310,7 @@ def test_generate_construction_alternative_set_preserves_degraded_stateful_sourc
     repository = InMemoryConstructionRepository()
     monkeypatch.setenv("DPM_STATEFUL_CORE_SOURCING_ENABLED", "true")
     monkeypatch.setattr(
-        rebalance_service,
+        core_resolver_service,
         "build_core_resolver_client",
         lambda: _FakeCoreResolver(),
     )
@@ -1337,7 +1337,7 @@ def test_stateful_construction_attaches_core_transaction_cost_curve(monkeypatch)
     repository = InMemoryConstructionRepository()
     monkeypatch.setenv("DPM_STATEFUL_CORE_SOURCING_ENABLED", "true")
     monkeypatch.setattr(
-        rebalance_service,
+        core_resolver_service,
         "build_core_resolver_client",
         lambda: _TransactionCostCoreResolver(),
     )
@@ -1375,7 +1375,7 @@ def test_stateful_construction_attaches_core_cashflow_projection(monkeypatch) ->
     repository = InMemoryConstructionRepository()
     monkeypatch.setenv("DPM_STATEFUL_CORE_SOURCING_ENABLED", "true")
     monkeypatch.setattr(
-        rebalance_service,
+        core_resolver_service,
         "build_core_resolver_client",
         lambda: _TransactionCostCoreResolver(),
     )
@@ -1416,7 +1416,7 @@ def test_stateful_currency_overlay_preserves_external_hedge_readiness_fail_close
     repository = InMemoryConstructionRepository()
     monkeypatch.setenv("DPM_STATEFUL_CORE_SOURCING_ENABLED", "true")
     monkeypatch.setattr(
-        rebalance_service,
+        core_resolver_service,
         "build_core_resolver_client",
         lambda: _ExternalHedgeReadinessCoreResolver(),
     )
@@ -1497,7 +1497,7 @@ def test_stateful_construction_preserves_external_order_execution_acknowledgemen
     repository = InMemoryConstructionRepository()
     monkeypatch.setenv("DPM_STATEFUL_CORE_SOURCING_ENABLED", "true")
     monkeypatch.setattr(
-        rebalance_service,
+        core_resolver_service,
         "build_core_resolver_client",
         lambda: _ExternalOrderExecutionAcknowledgementCoreResolver(),
     )
@@ -1552,7 +1552,7 @@ def test_stateful_construction_marks_degraded_core_cashflow_projection(monkeypat
     repository = InMemoryConstructionRepository()
     monkeypatch.setenv("DPM_STATEFUL_CORE_SOURCING_ENABLED", "true")
     monkeypatch.setattr(
-        rebalance_service,
+        core_resolver_service,
         "build_core_resolver_client",
         lambda: _DegradedCashflowCoreResolver(),
     )

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -23,6 +23,9 @@ from src.api.routers import waves as waves_router
 from src.api.routers.wave_campaign_models import DpmBulkReviewCampaignDefinitionRequest
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services import construction_service, proof_pack_service, wave_service
+from src.api.services.wave_aggregate_metrics import simulation_result_state
+from src.api.services.wave_event_append import append_same_state_event
+from src.api.services.wave_event_evidence import build_wave_event
 from src.core.mandates import (
     DpmMandateConstraintSet,
     DpmMandateDigitalTwin,
@@ -5585,7 +5588,7 @@ def test_wave_append_event_rejects_identity_and_state_mismatches() -> None:
             source_degraded_item_count=0,
         ),
     )
-    event = wave_service._event(  # noqa: SLF001
+    event = build_wave_event(
         wave_id=wave.wave_id,
         from_state=wave.state,
         to_state=wave.state,
@@ -5597,14 +5600,14 @@ def test_wave_append_event_rejects_identity_and_state_mismatches() -> None:
     )
 
     with pytest.raises(wave_service.DpmWaveValidationError) as wave_exc:
-        wave_service._append_event(  # noqa: SLF001
+        append_same_state_event(
             wave=wave,
             event=event.model_copy(update={"wave_id": "dwv_other"}),
         )
     assert wave_exc.value.code == "DPM_WAVE_EVENT_WAVE_MISMATCH"
 
     with pytest.raises(wave_service.DpmWaveValidationError) as state_exc:
-        wave_service._append_event(  # noqa: SLF001
+        append_same_state_event(
             wave=wave,
             event=event.model_copy(update={"to_state": "APPROVED"}),
         )
@@ -5809,7 +5812,7 @@ def test_wave_supportability_service_reports_degraded_and_blocked_actions() -> N
 
 
 def test_wave_simulation_rollup_treats_degraded_and_review_items_as_partial() -> None:
-    result_state = wave_service._simulation_result_state(  # noqa: SLF001
+    result_state = simulation_result_state(
         [
             _wave_item(
                 wave_item_id="dwi_simulated",

--- a/tests/unit/dpm/construction/test_source_identity.py
+++ b/tests/unit/dpm/construction/test_source_identity.py
@@ -1,9 +1,11 @@
 from pydantic import BaseModel
 
 from src.api.services.construction_source_identity import (
+    SourceProductIdentity,
     response_source_id,
     source_hash,
     source_payload,
+    source_product_identity,
 )
 from src.core.common.canonical import hash_canonical_payload
 from tests.unit.dpm.construction.source_product_context_fixtures import (
@@ -43,3 +45,19 @@ def test_response_source_id_falls_back_to_lineage_then_hash() -> None:
         == "lineage-fingerprint"
     )
     assert response_source_id(_MinimalSourceResponse(), "sha256:fallback") == "sha256:fallback"
+
+
+def test_source_product_identity_bundles_product_and_lineage_fields() -> None:
+    response = client_income_needs_schedule_response()
+    expected_payload = response.model_dump(mode="json", exclude_none=True)
+    expected_hash = hash_canonical_payload(expected_payload)
+
+    identity = source_product_identity(response)
+
+    assert identity == SourceProductIdentity(
+        source_product_name="ClientIncomeNeedsSchedule",
+        source_product_version=response.product_version,
+        source_system="lotus-core",
+        source_id="income-lineage",
+        content_hash=expected_hash,
+    )

--- a/tests/unit/dpm/construction/test_source_identity.py
+++ b/tests/unit/dpm/construction/test_source_identity.py
@@ -61,3 +61,13 @@ def test_source_product_identity_bundles_product_and_lineage_fields() -> None:
         source_id="income-lineage",
         content_hash=expected_hash,
     )
+
+
+def test_source_product_identity_uses_explicit_fallback_when_lineage_is_absent() -> None:
+    response = client_income_needs_schedule_response().model_copy(
+        update={"source_batch_fingerprint": None, "lineage": {}}
+    )
+
+    identity = source_product_identity(response, fallback_source_id="page-fingerprint")
+
+    assert identity.source_id == "page-fingerprint"

--- a/tests/unit/dpm/construction/test_source_product_context.py
+++ b/tests/unit/dpm/construction/test_source_product_context.py
@@ -1,6 +1,13 @@
 from src.api.services.construction_liquidity_source_context import (
     source_liquidity_context,
 )
+from src.api.services.construction_client_profile_source_context import (
+    client_restriction_profile_context,
+    sustainability_preference_profile_context,
+)
+from src.api.services.construction_execution_source_context import (
+    external_order_execution_acknowledgement_context,
+)
 from src.api.services.construction_source_product_context import (
     authority_context_with_source_products,
     source_product_authority_context_updates,
@@ -8,8 +15,11 @@ from src.api.services.construction_source_product_context import (
 from src.api.services.construction_transaction_cost_source_context import (
     transaction_cost_context_from_curve,
 )
+from src.api.services.construction_treasury_source_context import (
+    external_treasury_currency_overlay_context,
+)
 from src.core.construction.models import ConstructionAuthorityContext
-from src.core.dpm_source_context import DpmCoreExecutionContext
+from src.core.dpm_source_context import DpmCoreExecutionContext, DpmResolvedSourceContext
 from tests.unit.dpm.construction.source_product_context_fixtures import (
     cashflow_projection_response,
     client_income_needs_schedule_response,
@@ -120,3 +130,62 @@ def test_source_product_authority_context_updates_preserves_existing_contexts() 
     assert "transaction_cost_context" not in updates
     assert "liquidity_context" not in updates
     assert sorted(updates) == ["execution_acknowledgement_context"]
+
+
+def test_source_product_authority_context_updates_preserves_all_existing_source_contexts() -> None:
+    existing_liquidity_context = source_liquidity_context(
+        cashflow_projection=cashflow_projection_response(),
+        income_needs=client_income_needs_schedule_response(),
+        reserve_requirement=liquidity_reserve_requirement_response(),
+        planned_withdrawals=planned_withdrawal_schedule_response(),
+    )
+    existing_currency_context = external_treasury_currency_overlay_context(
+        hedge_readiness=hedge_readiness_response(),
+        currency_exposure=None,
+        hedge_policy=None,
+        eligible_hedge_instruments=None,
+        fx_forward_curve=None,
+    )
+    existing_execution_context = external_order_execution_acknowledgement_context(
+        external_order_acknowledgement_response()
+    )
+    assert existing_liquidity_context is not None
+    assert existing_currency_context is not None
+    assert existing_execution_context is not None
+    authority_context = ConstructionAuthorityContext(
+        transaction_cost_context=transaction_cost_context_from_curve(
+            transaction_cost_curve_response()
+        ),
+        liquidity_context=existing_liquidity_context,
+        currency_overlay_context=existing_currency_context,
+        execution_acknowledgement_context=existing_execution_context,
+        client_restriction_context=client_restriction_profile_context(
+            client_restriction_profile_response()
+        ),
+        sustainability_preference_context=sustainability_preference_profile_context(
+            sustainability_preference_profile_response()
+        ),
+    )
+    source_context = _source_execution_context(
+        transaction_cost_curve=transaction_cost_curve_response(),
+        portfolio_cashflow_projection=cashflow_projection_response(),
+        client_income_needs_schedule=client_income_needs_schedule_response(),
+        liquidity_reserve_requirement=liquidity_reserve_requirement_response(),
+        planned_withdrawal_schedule=planned_withdrawal_schedule_response(),
+        external_hedge_execution_readiness=hedge_readiness_response(),
+        external_order_execution_acknowledgement=external_order_acknowledgement_response(),
+        client_restriction_profile=client_restriction_profile_response(),
+        sustainability_preference_profile=sustainability_preference_profile_response(),
+    )
+
+    updates = source_product_authority_context_updates(
+        source_context=source_context,
+        authority_context=authority_context,
+    )
+    resolved_context = authority_context_with_source_products(
+        authority_context=authority_context,
+        source_context=DpmResolvedSourceContext.model_construct(context=source_context),
+    )
+
+    assert updates == {}
+    assert resolved_context is authority_context

--- a/tests/unit/dpm/construction/test_source_product_context.py
+++ b/tests/unit/dpm/construction/test_source_product_context.py
@@ -8,6 +8,7 @@ from src.api.services.construction_client_profile_source_context import (
 from src.api.services.construction_execution_source_context import (
     external_order_execution_acknowledgement_context,
 )
+from src.api.services import construction_source_product_context
 from src.api.services.construction_source_product_context import (
     authority_context_with_source_products,
     source_product_authority_context_updates,
@@ -189,3 +190,10 @@ def test_source_product_authority_context_updates_preserves_all_existing_source_
 
     assert updates == {}
     assert resolved_context is authority_context
+
+
+def test_construction_source_product_context_exports_only_orchestration_surface() -> None:
+    assert construction_source_product_context.__all__ == [
+        "authority_context_with_source_products",
+        "source_product_authority_context_updates",
+    ]

--- a/tests/unit/dpm/mandates/test_mandate_command_center.py
+++ b/tests/unit/dpm/mandates/test_mandate_command_center.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime, timezone
 
-from src.api.services import mandate_service
 from src.api.services.mandate_command_center import (
     attention_buckets,
     build_command_center_summary,
@@ -282,26 +281,6 @@ def test_build_command_center_summary_projects_empty_state_without_run() -> None
     assert summary.health_distribution == {}
     assert summary.supportability.state == "EMPTY"
     assert summary.supportability.reason == "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
-
-
-def test_mandate_service_preserves_command_center_private_aliases() -> None:
-    from src.api.services import mandate_command_center
-
-    assert mandate_service._build_command_center_summary is (
-        mandate_command_center.build_command_center_summary
-    )
-    assert mandate_service._latest_command_center_run is (
-        mandate_command_center.latest_command_center_run
-    )
-    assert mandate_service._command_center_supportability_state is (
-        mandate_command_center.command_center_supportability_state
-    )
-    assert mandate_service._run_matches_command_center_filters is (
-        mandate_command_center.run_matches_command_center_filters
-    )
-    assert mandate_service._attention_buckets is mandate_command_center.attention_buckets
-    assert mandate_service._recommended_actions is mandate_command_center.recommended_actions
-    assert mandate_service._severity_rank is mandate_command_center.severity_rank
 
 
 def test_mandate_command_center_exports_only_projection_helpers() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_diff.py
+++ b/tests/unit/dpm/mandates/test_mandate_diff.py
@@ -1,7 +1,7 @@
 from datetime import date
 from decimal import Decimal
 
-from src.api.services import mandate_diff, mandate_service
+from src.api.services import mandate_diff
 from src.api.services.mandate_errors import DpmMandateDiffUnavailableError
 from src.api.services.mandate_diff import (
     DpmMandateDiff,
@@ -164,12 +164,10 @@ def test_build_mandate_diff_for_versions_rejects_unknown_requested_version() -> 
 
 
 def test_service_preserves_existing_diff_import_surface() -> None:
+    from src.api.services import mandate_service
+
     assert mandate_service.DpmMandateDiff is DpmMandateDiff
     assert mandate_service.DpmMandateFieldChange is DpmMandateFieldChange
-    assert mandate_service._build_mandate_diff_for_versions is build_mandate_diff_for_versions
-    assert mandate_service._diff_payloads is diff_payloads
-    assert mandate_service._iter_changed_fields is iter_changed_fields
-    assert mandate_service._materiality_for_field is materiality_for_field
 
 
 def test_mandate_diff_exports_public_helper_surface() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_health_persistence.py
+++ b/tests/unit/dpm/mandates/test_mandate_health_persistence.py
@@ -1,4 +1,4 @@
-from src.api.services import mandate_health_persistence, mandate_service
+from src.api.services import mandate_health_persistence
 from src.api.services.mandate_health_persistence import persist_mandate_health_evidence
 from src.core.mandates import DpmMandateHealthInput
 from tests.unit.dpm.mandates.test_mandate_health_result import _twin
@@ -52,10 +52,6 @@ def test_persist_mandate_health_evidence_supports_health_only_monitoring_results
     assert repository.saved_twins == []
     assert repository.saved_snapshots == [health_result.snapshot]
     assert repository.saved_exceptions == health_result.monitoring_exceptions
-
-
-def test_mandate_service_preserves_health_persistence_private_alias() -> None:
-    assert mandate_service._persist_mandate_health_evidence is persist_mandate_health_evidence
 
 
 def test_mandate_health_persistence_exports_public_surface() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_health_result.py
+++ b/tests/unit/dpm/mandates/test_mandate_health_result.py
@@ -1,7 +1,7 @@
 from datetime import date
 from decimal import Decimal
 
-from src.api.services import mandate_health_result, mandate_service
+from src.api.services import mandate_health_result
 from src.api.services.mandate_health_result import (
     DpmMandateHealthCalculationResult,
     calculate_mandate_health_result,
@@ -49,8 +49,9 @@ def test_calculate_mandate_health_result_returns_snapshot_and_exceptions() -> No
 
 
 def test_service_preserves_health_result_import_surface() -> None:
+    from src.api.services import mandate_service
+
     assert mandate_service.DpmMandateHealthCalculationResult is DpmMandateHealthCalculationResult
-    assert mandate_service._calculate_mandate_health_result is calculate_mandate_health_result
 
 
 def test_health_result_helper_exports_public_surface() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_monitoring_run.py
+++ b/tests/unit/dpm/mandates/test_mandate_monitoring_run.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
-from src.api.services import mandate_monitoring_run, mandate_service
+from src.api.services import mandate_monitoring_run
 from src.api.services.mandate_monitoring_run import (
     DpmMonitoringRunAccumulator,
     DpmMonitoringRunMandateResult,
@@ -146,17 +146,10 @@ def test_build_monitoring_run_projects_terminal_success_summary() -> None:
 
 
 def test_service_preserves_monitoring_run_helper_aliases() -> None:
+    from src.api.services import mandate_service
+
     assert mandate_service.DpmMonitoringRunAccumulator is DpmMonitoringRunAccumulator
-    assert mandate_service._monitoring_run_accumulator is DpmMonitoringRunAccumulator
     assert mandate_service.DpmMonitoringRunMandateResult is DpmMonitoringRunMandateResult
-    assert mandate_service._monitoring_run_id_for is monitoring_run_id_for
-    assert mandate_service._increment_distribution is increment_distribution
-    assert mandate_service._exceptions_for_monitoring_run is exceptions_for_monitoring_run
-    assert (
-        mandate_service._calculate_monitoring_run_mandate_result
-        is calculate_monitoring_run_mandate_result
-    )
-    assert mandate_service._build_monitoring_run is build_monitoring_run
 
 
 def test_monitoring_run_helper_exports_public_surface() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_optional_sources.py
+++ b/tests/unit/dpm/mandates/test_mandate_optional_sources.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from typing import Any
 
-from src.api.services import mandate_optional_sources, mandate_service
+from src.api.services import mandate_optional_sources
 from src.api.services.mandate_optional_sources import (
     DpmMandateOptionalSources,
     ready_benchmark_assignment_source,
@@ -228,13 +228,6 @@ def test_resolve_mandate_optional_sources_builds_typed_bundle_and_family_gaps() 
     assert calls["planned_withdrawal_schedule"]["horizon_days"] == 365
     assert calls["planned_withdrawal_schedule"]["include_inactive_withdrawals"] is False
     assert calls["benchmark_assignment"]["reporting_currency"] == "SGD"
-
-
-def test_service_preserves_optional_source_helper_aliases() -> None:
-    assert mandate_service._try_resolve_optional_source is try_resolve_optional_source
-    assert mandate_service._ready_optional_source is ready_optional_source
-    assert mandate_service._ready_benchmark_assignment_source is ready_benchmark_assignment_source
-    assert mandate_service._resolve_mandate_optional_sources is resolve_mandate_optional_sources
 
 
 def test_optional_source_helper_exports_public_surface() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_refresh.py
+++ b/tests/unit/dpm/mandates/test_mandate_refresh.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 from pytest import MonkeyPatch
 
-from src.api.services import mandate_refresh, mandate_service
+from src.api.services import mandate_refresh
 from src.api.services.mandate_errors import (
     DpmMandateSourceIncompleteError,
     DpmMandateSourceUnavailableError,
@@ -253,8 +253,6 @@ def test_mandate_refresh_exports_refresh_result_builder() -> None:
 
 
 def test_service_preserves_mandate_refresh_import_surface() -> None:
+    from src.api.services import mandate_service
+
     assert mandate_service.DpmMandateRefreshResult is DpmMandateRefreshResult
-    assert (
-        mandate_service._build_mandate_refresh_result_from_core
-        is build_mandate_refresh_result_from_core
-    )

--- a/tests/unit/dpm/outcomes/test_outcome_review_dimensions.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_dimensions.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 import pytest
 
-from src.api.services import outcome_review_dimensions, outcome_review_service
+from src.api.services import outcome_review_dimensions
 from src.api.services.outcome_review_dimensions import (
     DpmOutcomeDimensionConfig,
     DpmOutcomeReviewValidationError,
@@ -116,6 +116,7 @@ def test_outcome_review_dimensions_exports_dimension_helper_surface() -> None:
 
 
 def test_service_preserves_dimension_import_surface() -> None:
+    from src.api.services import outcome_review_service
+
     assert outcome_review_service.DpmOutcomeDimensionConfig is DpmOutcomeDimensionConfig
     assert outcome_review_service.DpmOutcomeReviewValidationError is DpmOutcomeReviewValidationError
-    assert outcome_review_service._dimension_inputs is dimension_inputs_for_review

--- a/tests/unit/dpm/outcomes/test_outcome_review_report_inputs.py
+++ b/tests/unit/dpm/outcomes/test_outcome_review_report_inputs.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 from pytest import MonkeyPatch
 
-from src.api.services import outcome_review_report_inputs, outcome_review_service
+from src.api.services import outcome_review_report_inputs
 from src.api.services.outcome_review_report_inputs import (
     build_outcome_ai_evidence_input,
     build_outcome_report_input,
@@ -130,9 +130,3 @@ def test_outcome_review_report_inputs_exports_report_input_surface() -> None:
         "build_outcome_report_input",
         "portfolio_memory_context_for_report",
     ]
-
-
-def test_service_preserves_portfolio_memory_context_alias() -> None:
-    assert outcome_review_service._portfolio_memory_context_for_report is (
-        portfolio_memory_context_for_report
-    )

--- a/tests/unit/dpm/proof_packs/test_proof_pack_report_inputs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_report_inputs.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 from pytest import MonkeyPatch
 
-from src.api.services import proof_pack_report_inputs, proof_pack_service
+from src.api.services import proof_pack_report_inputs
 from src.api.services.proof_pack_report_inputs import (
     build_proof_pack_ai_evidence_input,
     build_proof_pack_report_input,
@@ -134,9 +134,3 @@ def test_proof_pack_report_inputs_exports_report_input_surface() -> None:
         "build_proof_pack_report_input",
         "portfolio_memory_context_for_report",
     ]
-
-
-def test_service_preserves_portfolio_memory_context_alias() -> None:
-    assert proof_pack_service._portfolio_memory_context_for_report is (
-        portfolio_memory_context_for_report
-    )

--- a/tests/unit/dpm/waves/test_wave_construction_selection.py
+++ b/tests/unit/dpm/waves/test_wave_construction_selection.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.api.services import wave_construction_selection, wave_service
+from src.api.services import wave_construction_selection
 from src.api.services.wave_construction_selection import select_construction_alternative_for_wave
 from src.api.services.wave_errors import DpmWaveLookupError
 
@@ -63,13 +63,6 @@ def test_select_construction_alternative_for_wave_maps_selection_failures(
 
     assert exc_info.value.code == "DPM_CONSTRUCTION_ALTERNATIVE_NOT_FOUND"
     assert exc_info.value.message == "alternative missing"
-
-
-def test_wave_service_preserves_construction_selection_private_alias() -> None:
-    assert (
-        wave_service._select_construction_alternative_for_wave
-        is select_construction_alternative_for_wave
-    )
 
 
 def test_wave_construction_selection_exports_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_create_command.py
+++ b/tests/unit/dpm/waves/test_wave_create_command.py
@@ -1,0 +1,118 @@
+from src.api.services import wave_create_command, wave_service
+from src.api.services.wave_create_command import create_persisted_wave
+from src.api.services.wave_creation import create_wave_request_hash
+from src.core.mandates import DpmMandateDigitalTwin
+from src.core.waves import DpmRebalanceWave
+
+
+class _MandateRepository:
+    def get_latest_mandate_by_portfolio(
+        self,
+        *,
+        portfolio_id: str,
+    ) -> DpmMandateDigitalTwin | None:
+        return None
+
+
+class _WaveRepository:
+    def __init__(self, existing: DpmRebalanceWave | None = None) -> None:
+        self.existing = existing
+        self.idempotency_lookups: list[str] = []
+        self.saved_wave: DpmRebalanceWave | None = None
+        self.idempotency_key: str | None = None
+        self.request_hash: str | None = None
+
+    def get_wave_by_idempotency(self, *, idempotency_key: str) -> DpmRebalanceWave | None:
+        self.idempotency_lookups.append(idempotency_key)
+        return self.existing
+
+    def save_wave(
+        self,
+        *,
+        wave: DpmRebalanceWave,
+        idempotency_key: str | None,
+        request_hash: str | None,
+    ) -> None:
+        self.saved_wave = wave
+        self.idempotency_key = idempotency_key
+        self.request_hash = request_hash
+
+
+def _source_ref() -> dict[str, object]:
+    return {
+        "source_system": "lotus-core",
+        "source_type": "PORTFOLIO_SNAPSHOT",
+        "source_id": "snapshot_create_command",
+        "source_version": "2026-06-01",
+        "supportability_state": "READY",
+    }
+
+
+def _portfolios() -> list[dict[str, object]]:
+    return [{"portfolio_id": "PB_SG_CREATE_COMMAND", "source_refs": [_source_ref()]}]
+
+
+def test_create_persisted_wave_replays_existing_idempotent_wave() -> None:
+    existing = DpmRebalanceWave.model_construct(wave_id="dwv_existing", state="CREATED")
+    repository = _WaveRepository(existing=existing)
+
+    wave, replayed = create_persisted_wave(
+        trigger_type="EXPLICIT_PORTFOLIO_LIST",
+        trigger_id="manual-create-command",
+        rationale="Create command replay.",
+        as_of_date="2026-06-01",
+        actor_id="pm_001",
+        correlation_id="corr-create-command",
+        portfolios=_portfolios(),
+        idempotency_key="idem-create-command",
+        mandate_repository=_MandateRepository(),  # type: ignore[arg-type]
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert wave is existing
+    assert replayed is True
+    assert repository.idempotency_lookups == ["idem-create-command"]
+    assert repository.saved_wave is None
+
+
+def test_create_persisted_wave_promotes_preview_and_persists_request_hash(
+    monkeypatch,
+) -> None:
+    repository = _WaveRepository()
+    portfolios = _portfolios()
+    monkeypatch.setattr(wave_create_command, "create_created_wave_id", lambda: "dwv_created")
+
+    wave, replayed = create_persisted_wave(
+        trigger_type="EXPLICIT_PORTFOLIO_LIST",
+        trigger_id="manual-create-command",
+        rationale="Create command persists.",
+        as_of_date="2026-06-01",
+        actor_id="pm_001",
+        correlation_id="corr-create-command",
+        portfolios=portfolios,
+        idempotency_key="idem-create-command",
+        mandate_repository=_MandateRepository(),  # type: ignore[arg-type]
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert wave is repository.saved_wave
+    assert replayed is False
+    assert wave.wave_id == "dwv_created"
+    assert wave.state == "CREATED"
+    assert repository.idempotency_key == "idem-create-command"
+    assert repository.request_hash == create_wave_request_hash(
+        trigger_type="EXPLICIT_PORTFOLIO_LIST",
+        trigger_id="manual-create-command",
+        rationale="Create command persists.",
+        as_of_date="2026-06-01",
+        actor_id="pm_001",
+        portfolios=portfolios,
+    )
+
+
+def test_wave_service_delegates_create_command() -> None:
+    assert wave_service.create_persisted_wave is create_persisted_wave
+
+
+def test_wave_create_command_exports_public_surface() -> None:
+    assert wave_create_command.__all__ == ["create_persisted_wave"]

--- a/tests/unit/dpm/waves/test_wave_create_command.py
+++ b/tests/unit/dpm/waves/test_wave_create_command.py
@@ -1,4 +1,4 @@
-from src.api.services import wave_create_command, wave_service
+from src.api.services import wave_create_command
 from src.api.services.wave_create_command import create_persisted_wave
 from src.api.services.wave_creation import create_wave_request_hash
 from src.core.mandates import DpmMandateDigitalTwin
@@ -108,10 +108,6 @@ def test_create_persisted_wave_promotes_preview_and_persists_request_hash(
         actor_id="pm_001",
         portfolios=portfolios,
     )
-
-
-def test_wave_service_delegates_create_command() -> None:
-    assert wave_service.create_persisted_wave is create_persisted_wave
 
 
 def test_wave_create_command_exports_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_event_append.py
+++ b/tests/unit/dpm/waves/test_wave_event_append.py
@@ -1,6 +1,5 @@
 import pytest
 
-from src.api.services import wave_service
 from src.api.services.wave_errors import DpmWaveValidationError
 from src.api.services.wave_event_append import append_same_state_event
 from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveEvent
@@ -61,12 +60,6 @@ def test_append_same_state_event_rejects_state_mismatch() -> None:
 
     assert exc_info.value.code == "DPM_WAVE_EVENT_STATE_MISMATCH"
     assert exc_info.value.message == "Wave event state mismatch."
-
-
-def test_wave_service_preserves_private_event_append_alias() -> None:
-    from src.api.services import wave_event_append
-
-    assert wave_service._append_event is wave_event_append.append_same_state_event
 
 
 def test_wave_event_append_exports_only_append_helper() -> None:

--- a/tests/unit/dpm/waves/test_wave_item_collection.py
+++ b/tests/unit/dpm/waves/test_wave_item_collection.py
@@ -1,4 +1,4 @@
-from src.api.services import wave_item_collection, wave_service
+from src.api.services import wave_item_collection
 from src.api.services.wave_item_collection import wave_with_items_and_aggregate
 from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
 
@@ -49,10 +49,6 @@ def test_wave_with_items_and_aggregate_preserves_extra_updates() -> None:
 
     assert updated.handoff_refs == ["handoff:dwv_collection"]
     assert updated.aggregate_metrics.state_counts == {"HANDOFF_READY": 1}
-
-
-def test_wave_service_preserves_item_collection_helper_alias() -> None:
-    assert wave_service._wave_with_items_and_aggregate is wave_with_items_and_aggregate
 
 
 def test_wave_item_collection_exports_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_lifecycle_commands.py
+++ b/tests/unit/dpm/waves/test_wave_lifecycle_commands.py
@@ -1,0 +1,153 @@
+from datetime import datetime, timezone
+
+from src.api.services import wave_lifecycle_commands, wave_service
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.api.services.wave_lifecycle_commands import (
+    approve_persisted_wave,
+    cancel_persisted_wave,
+    handoff_persisted_wave,
+    stage_persisted_wave,
+)
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWaveTrigger
+
+
+class _WaveRepository:
+    def __init__(self, wave: DpmRebalanceWave) -> None:
+        self.wave = wave
+        self.updated_wave: DpmRebalanceWave | None = None
+        self.expected_version: int | None = None
+
+    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+        if wave_id == self.wave.wave_id:
+            return self.wave
+        return None
+
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+        self.updated_wave = wave
+        self.expected_version = expected_version
+
+
+def _item(*, state: str) -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id=f"dwi_{state.lower()}",
+        portfolio_id=f"PB_SG_{state}",
+        state=state,
+    )
+
+
+def _wave(*, wave_id: str, state: str, item_state: str) -> DpmRebalanceWave:
+    items = [_item(state=item_state)]
+    return DpmRebalanceWave(
+        wave_id=wave_id,
+        state=state,
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id=f"manual-{wave_id}",
+            rationale="Execute governed wave lifecycle command.",
+        ),
+        as_of_date="2026-06-01",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        created_by="pm_001",
+        correlation_id=f"corr-{wave_id}",
+        items=items,
+        aggregate_metrics=aggregate_wave_items(items),
+        version=7,
+    )
+
+
+def test_approve_persisted_wave_builds_and_persists_approved_transition() -> None:
+    wave = _wave(wave_id="dwv_lifecycle_approve", state="SIMULATED", item_state="SELECTED")
+    repository = _WaveRepository(wave)
+
+    approved, replayed = approve_persisted_wave(
+        wave_id=wave.wave_id,
+        actor_id="pm_approve",
+        reason_code="APPROVED_BY_PM",
+        comment=None,
+        correlation_id="corr-approve",
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert replayed is False
+    assert approved.state == "APPROVED"
+    assert repository.updated_wave is approved
+    assert repository.expected_version == 7
+
+
+def test_stage_handoff_and_cancel_persisted_wave_commands_update_expected_version() -> None:
+    stage_source = _wave(wave_id="dwv_lifecycle_stage", state="APPROVED", item_state="APPROVED")
+    stage_repository = _WaveRepository(stage_source)
+
+    staged, stage_replayed = stage_persisted_wave(
+        wave_id=stage_source.wave_id,
+        actor_id="ops_stage",
+        reason_code="READY_FOR_HANDOFF",
+        comment=None,
+        correlation_id="corr-stage",
+        wave_repository=stage_repository,  # type: ignore[arg-type]
+    )
+
+    handoff_repository = _WaveRepository(staged)
+    handoff_ready, handoff_replayed = handoff_persisted_wave(
+        wave_id=staged.wave_id,
+        actor_id="ops_handoff",
+        reason_code="READY_FOR_OPERATIONS",
+        comment=None,
+        correlation_id="corr-handoff",
+        wave_repository=handoff_repository,  # type: ignore[arg-type]
+    )
+
+    cancel_source = _wave(wave_id="dwv_lifecycle_cancel", state="STAGED", item_state="STAGED")
+    cancel_repository = _WaveRepository(cancel_source)
+    cancelled, cancel_replayed = cancel_persisted_wave(
+        wave_id=cancel_source.wave_id,
+        actor_id="pm_cancel",
+        reason_code="CLIENT_CANCELLED",
+        comment=None,
+        correlation_id="corr-cancel",
+        wave_repository=cancel_repository,  # type: ignore[arg-type]
+    )
+
+    assert stage_replayed is False
+    assert staged.state == "STAGED"
+    assert stage_repository.expected_version == 7
+    assert handoff_replayed is False
+    assert handoff_ready.state == "HANDOFF_READY"
+    assert handoff_repository.expected_version == staged.version
+    assert cancel_replayed is False
+    assert cancelled.state == "CANCELLED"
+    assert cancel_repository.expected_version == 7
+
+
+def test_cancel_persisted_wave_replays_existing_cancelled_wave() -> None:
+    wave = _wave(wave_id="dwv_lifecycle_cancel_replay", state="CANCELLED", item_state="EXCLUDED")
+    repository = _WaveRepository(wave)
+
+    cancelled, replayed = cancel_persisted_wave(
+        wave_id=wave.wave_id,
+        actor_id="pm_cancel",
+        reason_code="CLIENT_CANCELLED",
+        comment=None,
+        correlation_id="corr-cancel",
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert cancelled is wave
+    assert replayed is True
+    assert repository.updated_wave is None
+
+
+def test_wave_service_delegates_lifecycle_commands() -> None:
+    assert wave_service.approve_persisted_wave is approve_persisted_wave
+    assert wave_service.stage_persisted_wave is stage_persisted_wave
+    assert wave_service.handoff_persisted_wave is handoff_persisted_wave
+    assert wave_service.cancel_persisted_wave is cancel_persisted_wave
+
+
+def test_wave_lifecycle_commands_export_public_surface() -> None:
+    assert wave_lifecycle_commands.__all__ == [
+        "approve_persisted_wave",
+        "cancel_persisted_wave",
+        "handoff_persisted_wave",
+        "stage_persisted_wave",
+    ]

--- a/tests/unit/dpm/waves/test_wave_lifecycle_commands.py
+++ b/tests/unit/dpm/waves/test_wave_lifecycle_commands.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from src.api.services import wave_lifecycle_commands, wave_service
+from src.api.services import wave_lifecycle_commands
 from src.api.services.wave_aggregate_metrics import aggregate_wave_items
 from src.api.services.wave_lifecycle_commands import (
     approve_persisted_wave,
@@ -135,13 +135,6 @@ def test_cancel_persisted_wave_replays_existing_cancelled_wave() -> None:
     assert cancelled is wave
     assert replayed is True
     assert repository.updated_wave is None
-
-
-def test_wave_service_delegates_lifecycle_commands() -> None:
-    assert wave_service.approve_persisted_wave is approve_persisted_wave
-    assert wave_service.stage_persisted_wave is stage_persisted_wave
-    assert wave_service.handoff_persisted_wave is handoff_persisted_wave
-    assert wave_service.cancel_persisted_wave is cancel_persisted_wave
 
 
 def test_wave_lifecycle_commands_export_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_lookup.py
+++ b/tests/unit/dpm/waves/test_wave_lookup.py
@@ -1,6 +1,5 @@
 import pytest
 
-from src.api.services import wave_service
 from src.api.services.wave_errors import DpmWaveLookupError
 from src.api.services.wave_lookup import get_wave_or_raise
 from src.core.waves import DpmRebalanceWave
@@ -41,12 +40,6 @@ def test_get_wave_or_raise_raises_governed_lookup_error_for_missing_wave() -> No
     assert exc_info.value.code == "DPM_WAVE_NOT_FOUND"
     assert exc_info.value.message == "Wave dwv_missing was not found."
     assert repository.requested_wave_ids == ["dwv_missing"]
-
-
-def test_wave_service_preserves_private_lookup_alias() -> None:
-    from src.api.services import wave_lookup
-
-    assert wave_service._get_wave_or_raise is wave_lookup.get_wave_or_raise
 
 
 def test_wave_lookup_exports_only_lookup_helper() -> None:

--- a/tests/unit/dpm/waves/test_wave_persistence.py
+++ b/tests/unit/dpm/waves/test_wave_persistence.py
@@ -1,6 +1,5 @@
 import pytest
 
-from src.api.services import wave_service
 from src.api.services.wave_errors import DpmWaveValidationError
 from src.api.services.wave_persistence import save_wave_or_raise, update_wave_or_raise
 from src.core.waves import (
@@ -110,13 +109,6 @@ def test_update_wave_or_raise_translates_version_conflict() -> None:
 
     assert exc_info.value.code == "DPM_WAVE_VERSION_CONFLICT"
     assert exc_info.value.message == "expected version mismatch"
-
-
-def test_wave_service_uses_shared_update_helper_alias() -> None:
-    from src.api.services import wave_persistence
-
-    assert wave_service._save_wave_or_raise is wave_persistence.save_wave_or_raise
-    assert wave_service._update_wave_or_raise is wave_persistence.update_wave_or_raise
 
 
 def test_wave_persistence_exports_only_write_helpers() -> None:

--- a/tests/unit/dpm/waves/test_wave_preparation_commands.py
+++ b/tests/unit/dpm/waves/test_wave_preparation_commands.py
@@ -1,4 +1,4 @@
-from src.api.services import wave_preparation_commands, wave_service
+from src.api.services import wave_preparation_commands
 from src.api.services.wave_preparation_commands import (
     simulate_persisted_wave,
     source_check_persisted_wave,
@@ -129,11 +129,6 @@ def test_simulate_persisted_wave_replays_completed_simulation() -> None:
     assert simulated is wave
     assert replayed is True
     assert repository.updated_wave is None
-
-
-def test_wave_service_delegates_preparation_commands() -> None:
-    assert wave_service.source_check_persisted_wave is source_check_persisted_wave
-    assert wave_service.simulate_persisted_wave is simulate_persisted_wave
 
 
 def test_wave_preparation_commands_export_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_preparation_commands.py
+++ b/tests/unit/dpm/waves/test_wave_preparation_commands.py
@@ -1,0 +1,143 @@
+from src.api.services import wave_preparation_commands, wave_service
+from src.api.services.wave_preparation_commands import (
+    simulate_persisted_wave,
+    source_check_persisted_wave,
+)
+from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthSnapshot
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWaveAggregateMetrics
+
+
+class _MandateRepository:
+    def get_latest_mandate(
+        self,
+        *,
+        mandate_id: str,
+    ) -> DpmMandateDigitalTwin | None:
+        return None
+
+    def get_latest_mandate_by_portfolio(
+        self,
+        *,
+        portfolio_id: str,
+    ) -> DpmMandateDigitalTwin | None:
+        return None
+
+    def get_latest_health_snapshot(
+        self,
+        *,
+        mandate_id: str,
+    ) -> DpmMandateHealthSnapshot | None:
+        return None
+
+
+class _WaveRepository:
+    def __init__(self, wave: DpmRebalanceWave) -> None:
+        self.wave = wave
+        self.updated_wave: DpmRebalanceWave | None = None
+        self.expected_version: int | None = None
+
+    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+        if wave_id == self.wave.wave_id:
+            return self.wave
+        return None
+
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+        self.updated_wave = wave
+        self.expected_version = expected_version
+
+
+def _wave(*, state: str, item_state: str, version: int = 4) -> DpmRebalanceWave:
+    item = DpmRebalanceWaveItem(
+        wave_item_id=f"dwi_{item_state.lower()}",
+        portfolio_id=f"PB_SG_{item_state}",
+        state=item_state,
+    )
+    return DpmRebalanceWave.model_construct(
+        wave_id=f"dwv_{state.lower()}",
+        state=state,
+        as_of_date="2026-06-01",
+        version=version,
+        items=[item],
+        aggregate_metrics=DpmWaveAggregateMetrics(
+            item_count=1,
+            state_counts={item_state: 1},
+            ready_item_count=1,
+            blocked_item_count=0,
+            review_required_item_count=0,
+            source_degraded_item_count=0,
+        ),
+        events=[],
+    )
+
+
+def test_source_check_persisted_wave_classifies_and_persists_transition() -> None:
+    wave = _wave(state="CREATED", item_state="CANDIDATE")
+    repository = _WaveRepository(wave)
+
+    checked, replayed = source_check_persisted_wave(
+        wave_id=wave.wave_id,
+        actor_id="pm_source",
+        correlation_id="corr-source",
+        mandate_repository=_MandateRepository(),  # type: ignore[arg-type]
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert replayed is False
+    assert checked.state == "SOURCE_CHECKED"
+    assert checked.items[0].state == "SOURCE_BLOCKED"
+    assert repository.updated_wave is checked
+    assert repository.expected_version == 4
+
+
+def test_simulate_persisted_wave_blocks_missing_inputs_and_persists_transition() -> None:
+    wave = _wave(state="SOURCE_CHECKED", item_state="SOURCE_READY")
+    repository = _WaveRepository(wave)
+
+    simulated, replayed = simulate_persisted_wave(
+        wave_id=wave.wave_id,
+        actor_id="pm_simulate",
+        correlation_id="corr-simulate",
+        item_inputs={},
+        methods=None,
+        construction_repository=object(),  # type: ignore[arg-type]
+        run_service=object(),  # type: ignore[arg-type]
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert replayed is False
+    assert simulated.state == "SIMULATION_FAILED"
+    assert simulated.items[0].state == "SIMULATION_BLOCKED"
+    assert repository.updated_wave is simulated
+    assert repository.expected_version == 4
+
+
+def test_simulate_persisted_wave_replays_completed_simulation() -> None:
+    wave = _wave(state="SIMULATION_FAILED", item_state="SIMULATION_BLOCKED")
+    repository = _WaveRepository(wave)
+
+    simulated, replayed = simulate_persisted_wave(
+        wave_id=wave.wave_id,
+        actor_id="pm_simulate",
+        correlation_id="corr-simulate",
+        item_inputs={},
+        methods=None,
+        construction_repository=object(),  # type: ignore[arg-type]
+        run_service=object(),  # type: ignore[arg-type]
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert simulated is wave
+    assert replayed is True
+    assert repository.updated_wave is None
+
+
+def test_wave_service_delegates_preparation_commands() -> None:
+    assert wave_service.source_check_persisted_wave is source_check_persisted_wave
+    assert wave_service.simulate_persisted_wave is simulate_persisted_wave
+
+
+def test_wave_preparation_commands_export_public_surface() -> None:
+    assert wave_preparation_commands.__all__ == [
+        "simulate_persisted_wave",
+        "source_check_persisted_wave",
+    ]

--- a/tests/unit/dpm/waves/test_wave_read_model_queries.py
+++ b/tests/unit/dpm/waves/test_wave_read_model_queries.py
@@ -1,0 +1,121 @@
+from datetime import datetime, timezone
+
+from src.api.services import wave_read_model_queries, wave_service
+from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.api.services.wave_read_model_queries import (
+    wave_detail_for_id,
+    wave_items_for_id,
+    wave_proof_pack_posture_for_id,
+    wave_report_input_for_id,
+    wave_supportability_for_id,
+)
+from src.core.waves import (
+    DpmRebalanceWave,
+    DpmRebalanceWaveItem,
+    DpmWaveTrigger,
+)
+
+
+class _WaveRepository:
+    def __init__(self, wave: DpmRebalanceWave) -> None:
+        self.wave = wave
+        self.requested_wave_ids: list[str] = []
+
+    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+        self.requested_wave_ids.append(wave_id)
+        if wave_id == self.wave.wave_id:
+            return self.wave
+        return None
+
+
+def _item() -> DpmRebalanceWaveItem:
+    return DpmRebalanceWaveItem(
+        wave_item_id="dwi_read_model",
+        portfolio_id="PB_SG_READ_MODEL",
+        mandate_id="MANDATE_PB_SG_READ_MODEL",
+        state="HANDOFF_READY",
+        selected_alternative_id="alt_read_model",
+        proof_pack_id="dpp_read_model",
+        diagnostics={"proof_pack_state": "READY"},
+    )
+
+
+def _wave() -> DpmRebalanceWave:
+    items = [_item()]
+    return DpmRebalanceWave(
+        wave_id="dwv_read_model",
+        state="HANDOFF_READY",
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="manual-read-model",
+            rationale="Build read-model payloads for a governed wave.",
+        ),
+        as_of_date="2026-06-01",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        created_by="pm_001",
+        correlation_id="corr-read-model",
+        items=items,
+        aggregate_metrics=aggregate_wave_items(items),
+        handoff_refs=[],
+    )
+
+
+def test_wave_read_model_queries_load_wave_before_projection() -> None:
+    wave = _wave()
+    repository = _WaveRepository(wave)
+
+    supportability = wave_supportability_for_id(
+        wave_id=wave.wave_id,
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+    detail = wave_detail_for_id(
+        wave_id=wave.wave_id,
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+    items = wave_items_for_id(
+        wave_id=wave.wave_id,
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+    posture = wave_proof_pack_posture_for_id(
+        wave_id=wave.wave_id,
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert repository.requested_wave_ids == [wave.wave_id] * 4
+    assert supportability["supportability_state"] == "ready"
+    assert detail["wave"] is wave
+    assert items["items"] == wave.items
+    assert posture["ready_proof_pack_count"] == 1
+
+
+def test_wave_report_input_query_loads_wave_before_report_assembly() -> None:
+    wave = _wave()
+    repository = _WaveRepository(wave)
+
+    report_input = wave_report_input_for_id(
+        wave_id=wave.wave_id,
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert repository.requested_wave_ids == [wave.wave_id]
+    assert report_input.wave_id == wave.wave_id
+    assert report_input.wave_state == "HANDOFF_READY"
+    assert report_input.proof_pack_posture["ready_proof_pack_count"] == 1
+
+
+def test_wave_service_delegates_read_model_queries() -> None:
+    assert wave_service.wave_supportability_for_id is wave_supportability_for_id
+    assert wave_service.wave_detail_for_id is wave_detail_for_id
+    assert wave_service.wave_items_for_id is wave_items_for_id
+    assert wave_service.wave_proof_pack_posture_for_id is wave_proof_pack_posture_for_id
+    assert wave_service.wave_report_input_for_id is wave_report_input_for_id
+
+
+def test_wave_read_model_queries_export_public_surface() -> None:
+    assert wave_read_model_queries.__all__ == [
+        "wave_detail_for_id",
+        "wave_items_for_id",
+        "wave_proof_pack_posture_for_id",
+        "wave_report_input_for_id",
+        "wave_supportability_for_id",
+    ]

--- a/tests/unit/dpm/waves/test_wave_read_model_queries.py
+++ b/tests/unit/dpm/waves/test_wave_read_model_queries.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from src.api.services import wave_read_model_queries, wave_service
+from src.api.services import wave_read_model_queries
 from src.api.services.wave_aggregate_metrics import aggregate_wave_items
 from src.api.services.wave_read_model_queries import (
     wave_detail_for_id,
@@ -101,14 +101,6 @@ def test_wave_report_input_query_loads_wave_before_report_assembly() -> None:
     assert report_input.wave_id == wave.wave_id
     assert report_input.wave_state == "HANDOFF_READY"
     assert report_input.proof_pack_posture["ready_proof_pack_count"] == 1
-
-
-def test_wave_service_delegates_read_model_queries() -> None:
-    assert wave_service.wave_supportability_for_id is wave_supportability_for_id
-    assert wave_service.wave_detail_for_id is wave_detail_for_id
-    assert wave_service.wave_items_for_id is wave_items_for_id
-    assert wave_service.wave_proof_pack_posture_for_id is wave_proof_pack_posture_for_id
-    assert wave_service.wave_report_input_for_id is wave_report_input_for_id
 
 
 def test_wave_read_model_queries_export_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_selection_command.py
+++ b/tests/unit/dpm/waves/test_wave_selection_command.py
@@ -1,0 +1,97 @@
+from src.api.services import wave_selection_command, wave_service
+from src.api.services.wave_selection_command import select_persisted_wave_item_alternative
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
+
+
+class _WaveRepository:
+    def __init__(self, wave: DpmRebalanceWave) -> None:
+        self.wave = wave
+        self.updated_wave: DpmRebalanceWave | None = None
+        self.expected_version: int | None = None
+
+    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+        if wave_id == self.wave.wave_id:
+            return self.wave
+        return None
+
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+        self.updated_wave = wave
+        self.expected_version = expected_version
+
+
+def _wave() -> DpmRebalanceWave:
+    return DpmRebalanceWave.model_construct(
+        wave_id="dwv_selection_command",
+        state="SIMULATED",
+        version=6,
+        items=[
+            DpmRebalanceWaveItem(
+                wave_item_id="dwi_selection_command",
+                portfolio_id="PB_SG_SELECTION_COMMAND",
+                state="SIMULATED",
+                alternative_set_id="cas_selection_command",
+            )
+        ],
+    )
+
+
+def test_select_persisted_wave_item_alternative_records_selection_and_persists(
+    monkeypatch,
+) -> None:
+    wave = _wave()
+    repository = _WaveRepository(wave)
+    captured: dict[str, object] = {}
+    transitioned = wave.model_copy(update={"version": 7}, deep=True)
+
+    def _select_construction_alternative_for_wave(**kwargs: object) -> None:
+        captured["selection"] = kwargs
+
+    def _build_wave_with_selected_item_alternative(**kwargs: object) -> DpmRebalanceWave:
+        captured["build"] = kwargs
+        return transitioned
+
+    monkeypatch.setattr(
+        wave_selection_command,
+        "select_construction_alternative_for_wave",
+        _select_construction_alternative_for_wave,
+    )
+    monkeypatch.setattr(
+        wave_selection_command,
+        "build_wave_with_selected_item_alternative",
+        _build_wave_with_selected_item_alternative,
+    )
+
+    selected = select_persisted_wave_item_alternative(
+        wave_id=wave.wave_id,
+        wave_item_id="dwi_selection_command",
+        alternative_id="alt_selected",
+        actor_id="pm_select",
+        reason_code="CLIENT_PREFERENCE",
+        comment="Client preference.",
+        correlation_id="corr-select",
+        generate_proof_pack=True,
+        construction_repository=object(),  # type: ignore[arg-type]
+        proof_pack_repository=object(),  # type: ignore[arg-type]
+        mandate_repository=object(),  # type: ignore[arg-type]
+        run_service=object(),  # type: ignore[arg-type]
+        wave_repository=repository,  # type: ignore[arg-type]
+    )
+
+    assert selected is transitioned
+    assert repository.updated_wave is transitioned
+    assert repository.expected_version == 6
+    assert captured["selection"]["alternative_set_id"] == "cas_selection_command"
+    assert captured["selection"]["alternative_id"] == "alt_selected"
+    assert captured["build"]["selected_item"] is wave.items[0]
+    assert captured["build"]["generate_proof_pack"] is True
+
+
+def test_wave_service_delegates_selection_command() -> None:
+    assert (
+        wave_service.select_persisted_wave_item_alternative
+        is select_persisted_wave_item_alternative
+    )
+
+
+def test_wave_selection_command_exports_public_surface() -> None:
+    assert wave_selection_command.__all__ == ["select_persisted_wave_item_alternative"]

--- a/tests/unit/dpm/waves/test_wave_selection_command.py
+++ b/tests/unit/dpm/waves/test_wave_selection_command.py
@@ -1,4 +1,4 @@
-from src.api.services import wave_selection_command, wave_service
+from src.api.services import wave_selection_command
 from src.api.services.wave_selection_command import select_persisted_wave_item_alternative
 from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
 
@@ -84,13 +84,6 @@ def test_select_persisted_wave_item_alternative_records_selection_and_persists(
     assert captured["selection"]["alternative_id"] == "alt_selected"
     assert captured["build"]["selected_item"] is wave.items[0]
     assert captured["build"]["generate_proof_pack"] is True
-
-
-def test_wave_service_delegates_selection_command() -> None:
-    assert (
-        wave_service.select_persisted_wave_item_alternative
-        is select_persisted_wave_item_alternative
-    )
 
 
 def test_wave_selection_command_exports_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_selection_guard.py
+++ b/tests/unit/dpm/waves/test_wave_selection_guard.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.api.services import wave_selection_guard, wave_service
+from src.api.services import wave_selection_guard
 from src.api.services.wave_errors import DpmWaveLookupError, DpmWaveValidationError
 from src.api.services.wave_selection_guard import selectable_wave_item
 from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
@@ -54,10 +54,6 @@ def test_selectable_wave_item_raises_validation_error_without_alternatives() -> 
         exc_info.value.message
         == "Wave item dwi_missing_alternatives has no generated alternatives."
     )
-
-
-def test_wave_service_preserves_selection_guard_private_alias() -> None:
-    assert wave_service._selectable_wave_item is selectable_wave_item
 
 
 def test_wave_selection_guard_exports_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_service_public_surface.py
+++ b/tests/unit/dpm/waves/test_wave_service_public_surface.py
@@ -1,0 +1,27 @@
+from src.api.services import wave_service
+
+
+def test_wave_service_does_not_reexport_owned_helper_functions() -> None:
+    retired_helper_aliases = [
+        "approve_persisted_wave",
+        "build_preview_wave",
+        "cancel_persisted_wave",
+        "create_persisted_wave",
+        "handoff_persisted_wave",
+        "search_wave_summaries",
+        "select_persisted_wave_item_alternative",
+        "simulate_persisted_wave",
+        "source_check_persisted_wave",
+        "stage_persisted_wave",
+        "wave_detail_for_id",
+        "wave_items_for_id",
+        "wave_proof_pack_posture_for_id",
+        "wave_report_input_for_id",
+        "wave_supportability_for_id",
+    ]
+
+    assert [
+        helper_alias
+        for helper_alias in retired_helper_aliases
+        if hasattr(wave_service, helper_alias)
+    ] == []

--- a/tests/unit/dpm/waves/test_wave_state_guard.py
+++ b/tests/unit/dpm/waves/test_wave_state_guard.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.api.services import wave_service, wave_state_guard
+from src.api.services import wave_state_guard
 from src.api.services.wave_errors import DpmWaveValidationError
 from src.api.services.wave_state_guard import require_wave_state, wave_state_is_idempotent
 from src.core.waves import DpmRebalanceWave
@@ -43,11 +43,6 @@ def test_require_wave_state_raises_governed_validation_error() -> None:
 
     assert exc_info.value.code == "DPM_WAVE_SIMULATION_INVALID_STATE"
     assert exc_info.value.message == "Wave dwv_state_guard cannot be simulated from state CREATED."
-
-
-def test_wave_service_preserves_state_guard_private_aliases() -> None:
-    assert wave_service._wave_state_is_idempotent is wave_state_is_idempotent
-    assert wave_service._require_wave_state is require_wave_state
 
 
 def test_wave_state_guard_exports_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_transition_execution.py
+++ b/tests/unit/dpm/waves/test_wave_transition_execution.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.api.services import wave_service, wave_transition_execution
+from src.api.services import wave_transition_execution
 from src.api.services.wave_errors import DpmWaveValidationError
 from src.api.services.wave_transition_execution import (
     PreparedWaveTransition,
@@ -139,11 +139,6 @@ def test_persist_transitioned_wave_uses_source_wave_version_for_optimistic_updat
 
     assert repository.updated_wave is transitioned_wave
     assert repository.expected_version == 7
-
-
-def test_wave_service_preserves_transition_execution_private_aliases() -> None:
-    assert wave_service._prepare_wave_transition is prepare_wave_transition
-    assert wave_service._persist_transitioned_wave is persist_transitioned_wave
 
 
 def test_wave_transition_execution_exports_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_transition_execution.py
+++ b/tests/unit/dpm/waves/test_wave_transition_execution.py
@@ -64,6 +64,37 @@ def test_prepare_wave_transition_requires_allowed_state_for_new_transition() -> 
     assert prepared == PreparedWaveTransition(wave=wave, replayed=False)
 
 
+def test_prepare_wave_transition_supports_non_replayable_allowed_transition() -> None:
+    wave = _wave(state="SIMULATED")
+
+    prepared = prepare_wave_transition(
+        wave_id=wave.wave_id,
+        wave_repository=_WaveRepository(wave),  # type: ignore[arg-type]
+        replay_states=set(),
+        allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
+        error_code="DPM_WAVE_SELECTION_INVALID_STATE",
+        action_phrase="record alternative selection",
+    )
+
+    assert prepared == PreparedWaveTransition(wave=wave, replayed=False)
+
+
+def test_prepare_wave_transition_with_empty_replay_states_requires_allowed_state() -> None:
+    wave = _wave(state="APPROVED")
+
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        prepare_wave_transition(
+            wave_id=wave.wave_id,
+            wave_repository=_WaveRepository(wave),  # type: ignore[arg-type]
+            replay_states=set(),
+            allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
+            error_code="DPM_WAVE_SELECTION_INVALID_STATE",
+            action_phrase="record alternative selection",
+        )
+
+    assert exc_info.value.code == "DPM_WAVE_SELECTION_INVALID_STATE"
+
+
 def test_prepare_wave_transition_supports_explicitly_unguarded_transition() -> None:
     wave = _wave(state="CREATED")
 

--- a/tests/unit/dpm/waves/test_wave_transition_execution.py
+++ b/tests/unit/dpm/waves/test_wave_transition_execution.py
@@ -1,0 +1,108 @@
+import pytest
+
+from src.api.services import wave_service, wave_transition_execution
+from src.api.services.wave_errors import DpmWaveValidationError
+from src.api.services.wave_transition_execution import (
+    PreparedWaveTransition,
+    persist_transitioned_wave,
+    prepare_wave_transition,
+)
+from src.core.waves import DpmRebalanceWave
+
+
+class _WaveRepository:
+    def __init__(self, wave: DpmRebalanceWave) -> None:
+        self.wave = wave
+        self.updated_wave: DpmRebalanceWave | None = None
+        self.expected_version: int | None = None
+
+    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+        if wave_id == self.wave.wave_id:
+            return self.wave
+        return None
+
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+        self.updated_wave = wave
+        self.expected_version = expected_version
+
+
+def _wave(*, state: str = "SOURCE_CHECKED", version: int = 3) -> DpmRebalanceWave:
+    return DpmRebalanceWave.model_construct(
+        wave_id="dwv_transition_execution",
+        state=state,
+        version=version,
+    )
+
+
+def test_prepare_wave_transition_returns_replayed_wave_without_state_guard() -> None:
+    wave = _wave(state="SIMULATED")
+
+    prepared = prepare_wave_transition(
+        wave_id=wave.wave_id,
+        wave_repository=_WaveRepository(wave),  # type: ignore[arg-type]
+        replay_states={"SIMULATED"},
+        allowed_states={"SOURCE_CHECKED"},
+        error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
+        action_phrase="be simulated",
+    )
+
+    assert prepared == PreparedWaveTransition(wave=wave, replayed=True)
+
+
+def test_prepare_wave_transition_requires_allowed_state_for_new_transition() -> None:
+    wave = _wave(state="SOURCE_CHECKED")
+
+    prepared = prepare_wave_transition(
+        wave_id=wave.wave_id,
+        wave_repository=_WaveRepository(wave),  # type: ignore[arg-type]
+        replay_states={"SIMULATED"},
+        allowed_states={"SOURCE_CHECKED"},
+        error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
+        action_phrase="be simulated",
+    )
+
+    assert prepared == PreparedWaveTransition(wave=wave, replayed=False)
+
+
+def test_prepare_wave_transition_preserves_state_validation_error() -> None:
+    wave = _wave(state="CREATED")
+
+    with pytest.raises(DpmWaveValidationError) as exc_info:
+        prepare_wave_transition(
+            wave_id=wave.wave_id,
+            wave_repository=_WaveRepository(wave),  # type: ignore[arg-type]
+            replay_states={"SIMULATED"},
+            allowed_states={"SOURCE_CHECKED"},
+            error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
+            action_phrase="be simulated",
+        )
+
+    assert exc_info.value.code == "DPM_WAVE_SIMULATION_INVALID_STATE"
+
+
+def test_persist_transitioned_wave_uses_source_wave_version_for_optimistic_update() -> None:
+    source_wave = _wave(version=7)
+    transitioned_wave = _wave(state="SIMULATED", version=8)
+    repository = _WaveRepository(source_wave)
+
+    persist_transitioned_wave(
+        wave_repository=repository,  # type: ignore[arg-type]
+        source_wave=source_wave,
+        transitioned_wave=transitioned_wave,
+    )
+
+    assert repository.updated_wave is transitioned_wave
+    assert repository.expected_version == 7
+
+
+def test_wave_service_preserves_transition_execution_private_aliases() -> None:
+    assert wave_service._prepare_wave_transition is prepare_wave_transition
+    assert wave_service._persist_transitioned_wave is persist_transitioned_wave
+
+
+def test_wave_transition_execution_exports_public_surface() -> None:
+    assert wave_transition_execution.__all__ == [
+        "PreparedWaveTransition",
+        "persist_transitioned_wave",
+        "prepare_wave_transition",
+    ]

--- a/tests/unit/dpm/waves/test_wave_transition_execution.py
+++ b/tests/unit/dpm/waves/test_wave_transition_execution.py
@@ -64,6 +64,21 @@ def test_prepare_wave_transition_requires_allowed_state_for_new_transition() -> 
     assert prepared == PreparedWaveTransition(wave=wave, replayed=False)
 
 
+def test_prepare_wave_transition_supports_explicitly_unguarded_transition() -> None:
+    wave = _wave(state="CREATED")
+
+    prepared = prepare_wave_transition(
+        wave_id=wave.wave_id,
+        wave_repository=_WaveRepository(wave),  # type: ignore[arg-type]
+        replay_states={"CANCELLED"},
+        allowed_states=None,
+        error_code="DPM_WAVE_CANCEL_INVALID_STATE",
+        action_phrase="be cancelled",
+    )
+
+    assert prepared == PreparedWaveTransition(wave=wave, replayed=False)
+
+
 def test_prepare_wave_transition_preserves_state_validation_error() -> None:
     wave = _wave(state="CREATED")
 

--- a/tests/unit/dpm/waves/test_wave_trigger_validation.py
+++ b/tests/unit/dpm/waves/test_wave_trigger_validation.py
@@ -1,6 +1,5 @@
 import pytest
 
-from src.api.services import wave_service
 from src.api.services.wave_errors import DpmWaveValidationError
 from src.api.services.wave_trigger_validation import (
     SUPPORTED_CREATE_TRIGGER_TYPES,
@@ -49,12 +48,6 @@ def test_validate_trigger_or_raise_raises_governed_validation_error() -> None:
         exc_info.value.message
         == "Trigger type RISK_EVENT requires at least one source-backed portfolio."
     )
-
-
-def test_wave_service_preserves_private_trigger_validation_alias() -> None:
-    from src.api.services import wave_trigger_validation
-
-    assert wave_service._validate_trigger is wave_trigger_validation.validate_trigger_or_raise
 
 
 def test_supported_trigger_set_stays_private_banking_specific() -> None:

--- a/tests/unit/dpm/waves/test_wave_workflow_metadata.py
+++ b/tests/unit/dpm/waves/test_wave_workflow_metadata.py
@@ -1,4 +1,4 @@
-from src.api.services import wave_service, wave_workflow_metadata
+from src.api.services import wave_workflow_metadata
 from src.api.services.wave_workflow_metadata import (
     approval_event_metadata,
     cancel_event_metadata,
@@ -89,14 +89,6 @@ def test_cancel_event_metadata_preserves_no_external_execution_claim() -> None:
         "cancelled_item_count": 3,
         "external_execution_claimed": False,
     }
-
-
-def test_wave_service_preserves_workflow_metadata_private_aliases() -> None:
-    assert wave_service._approval_event_metadata is approval_event_metadata
-    assert wave_service._selection_event_metadata is selection_event_metadata
-    assert wave_service._stage_event_metadata is stage_event_metadata
-    assert wave_service._handoff_event_metadata is handoff_event_metadata
-    assert wave_service._cancel_event_metadata is cancel_event_metadata
 
 
 def test_wave_workflow_metadata_exports_public_surface() -> None:


### PR DESCRIPTION
## Summary

This PR continues lotus-manage backend hardening in a 50-commit non-squash batch. It reduces service facade surfaces, moves helper ownership to dedicated modules, adds regression guards for retired aliases, and refreshes branch-level refactor health evidence.

Key changes:
- Extracted and/or re-owned wave transition, create, preparation, lifecycle, selection, read-model, search, preview, and supportability helper surfaces behind dedicated modules.
- Tightened construction source-product context orchestration so pure source mapping remains in owner modules.
- Retargeted stale construction API core-resolver test hooks to `core_resolver_service`.
- Added guard tests for wave-service helper aliases and construction source-product public surface.
- Added/refreshed `scripts/engineering_health_report.py` and `quality/refactor_health_report.md` as report-only baseline evidence.
- Updated `docs/architecture/CODEBASE-REVIEW-LEDGER.md` through `BACKEND-REVIEW-20260602-467`.

## Evidence

Static:
- `make check` passed.
- Ruff check passed across repo via `make check`.
- Ruff format check passed across repo via `make check`.
- Mypy passed across 482 source files via `make check`.

Unit:
- `python -m pytest tests/unit` passed via `make check`: 2014 passed.

Governance:
- `python scripts/openapi_quality_gate.py` passed via `make check`.
- `python scripts/api_vocabulary_inventory.py --validate-only` passed via `make check`.
- `python scripts/validate_domain_data_product_contracts.py` passed via `make check`.
- `python scripts/validate_trust_telemetry_contracts.py` passed via `make check`.
- `python scripts/validate_observability_contracts.py` passed via `make check`.
- `git diff --check` passed during final checkpoint with only line-ending warnings before commit.
- Service leakage scan found no router/HTTP imports in service modules during focused slices.

Stranded truth:
- `git fetch origin --prune` completed.
- `git branch -r --no-merged origin/main` returned only `origin/feat/manage-backend-hardening-batch-456`, the active PR branch.

Wiki:
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`.
- No wiki source change required; this batch changes internal service/test/quality-report truth, not published operator or route behavior.

## CI tiering

Feature Lane and PR Merge Gate should cover lint, typecheck, unit, OpenAPI/vocabulary, and repository governance checks. Heavy platform end-to-end validation is not required for this internal service-boundary and test-hardening batch because no external route payloads or gateway contracts changed.

## Notes

`quality/refactor_health_report.md` remains report-only. The generator is intentionally dependency-free but baseline loading should be optimized before making it a blocking CI gate.