### PR TITLE
refactor(wave): extract core portfolio-universe resolution to service

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11885,3 +11885,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   or another narrow treasury overlay helper extraction if it stays behavior-preserving.
 - Wiki decision: no wiki source change required; this preserves source-product mapping behavior and
   improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-487: Rebalance intent tax-budget sell limit helper
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`, generated quality reports, and this ledger.
+- Finding: `generate_intents` remained the top source hotspot after earlier refactors because it
+  still carried a nested tax-aware sell limiter with `nonlocal` realized-gain/loss and budget-used
+  state.
+- Action: extracted `_TaxBudgetAccumulator` and `_tax_budget_limited_sell_quantity`, then routed
+  `generate_intents` through the explicit accumulator. Added direct helper tests for realized-gain
+  budget capping and disabled tax-awareness passthrough behavior.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/intents.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py`, `python -m ruff format
+  src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`, `python -m pytest
+  tests/unit/dpm/engine/test_engine_safety_rules.py tests/unit/dpm/engine/test_engine_tax_awareness.py
+  tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows `generate_intents` reduced from
+  complexity 38 / 207 lines to complexity 24 / 149 lines.
+- Follow-up: continue with the refreshed top source hotspots:
+  `external_treasury_currency_overlay_context`, `validate_definition`, and `build_search_row`.
+- Wiki decision: no wiki source change required; this preserves engine behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11643,3 +11643,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `src/core/rebalance/intents.py::generate_intents` or the remaining proof-pack dispatcher branches.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-478: Rebalance intent tax-lot HIFO helper extraction
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`, generated quality reports, and this ledger.
+- Finding: the refreshed complexity report moved `generate_intents` to the top source hotspot after
+  proof-pack dispatcher reductions. The function still contained nested tax-lot currency conversion
+  and HIFO lot sorting helpers that inflated parent complexity.
+- Action: extracted `_lot_cost_in_instrument_ccy` and `_hifo_sorted_lots` as private helpers and
+  routed tax-aware sell limiting through them. Added direct tests proving HIFO ordering and
+  missing-FX fallback logging.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/intents.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py`, `python -m ruff format
+  src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`, `python -m pytest
+  tests/unit/dpm/engine/test_engine_safety_rules.py tests/unit/dpm/engine/test_engine_tax_awareness.py
+  tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows `generate_intents` reduced from
+  complexity 58 / 236 lines to complexity 52 / 217 lines.
+- Follow-up: continue decomposing `generate_intents`, especially sell quantity limiting and trade
+  construction, with direct tests around tax budget and constraint labels.
+- Wiki decision: no wiki source change required; this preserves engine behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12138,3 +12138,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `_section_payload`, `_infer_example`, or `summarize_enrichment_posture`.
 - Wiki decision: no wiki source change required; this preserves heuristic target-generation
   behavior and improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-496: Rebalance intent valuation helper
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`, generated quality reports, and this ledger.
+- Finding: `generate_intents` still computed current instrument value and per-unit sizing inputs
+  inline, mixing trusted market-value handling with target-loop orchestration and sell/buy sizing.
+- Action: extracted `_current_instrument_value_and_unit_value` and routed intent generation through
+  it. Added direct tests for no-position pricing, calculated position value, trusted market value,
+  and trusted zero-quantity fallback behavior.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/intents.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py`, `python -m ruff format
+  src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`, `python -m pytest
+  tests/unit/dpm/engine/test_engine_safety_rules.py
+  tests/unit/dpm/engine/test_engine_tax_awareness.py
+  tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `generate_intents` out of the top-ten
+  current source functions after it previously ranked first at complexity 23 / 149 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `_section_payload`,
+  `_infer_example`, `summarize_enrichment_posture`, or `_proof_pack_governance_section_payload`.
+- Wiki decision: no wiki source change required; this preserves rebalance intent behavior and
+  improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11997,3 +11997,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `compile_mandate_digital_twin_from_core`, `generate_fx_and_simulate`, or `generate_intents`.
 - Wiki decision: no wiki source change required; this preserves portfolio-memory search behavior
   and improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-491: Mandate twin field-gap helper extraction
+
+- Date: 2026-06-02
+- Scope: `src/core/mandates.py`, `tests/unit/dpm/core/test_mandate_health.py`, generated quality
+  reports, and this ledger.
+- Finding: `compile_mandate_digital_twin_from_core` still mixed field-gap reason-code projection
+  with constraint, preference, lineage, and twin assembly, keeping source completeness decisions
+  embedded in the compiler body.
+- Action: extracted `_mandate_twin_field_gap_codes` and routed the compiler through it. Added direct
+  helper tests for fully missing core products and fully sourced core products.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/mandates.py
+  tests/unit/dpm/core/test_mandate_health.py`, `python -m ruff format src/core/mandates.py
+  tests/unit/dpm/core/test_mandate_health.py`, `python -m mypy --config-file mypy.ini
+  src/core/mandates.py`, `python -m pytest tests/unit/dpm/core/test_mandate_health.py
+  tests/unit/dpm/mandates/test_mandate_health_result.py
+  tests/unit/dpm/mandates/test_mandate_refresh.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report moves `compile_mandate_digital_twin_from_core` out of the top-ten current source functions
+  after it previously ranked at complexity 26 / 182 lines.
+- Follow-up: continue reducing the refreshed top source hotspots, starting with
+  `generate_fx_and_simulate`, `generate_intents`, or `_section_payload`.
+- Wiki decision: no wiki source change required; this preserves mandate twin behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12463,3 +12463,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   receive a further traversal-focused extraction later.
 - Wiki decision: no wiki source change required; this preserves generated OpenAPI example behavior
   and improves internal API-governance maintainability only.
+
+## BACKEND-REVIEW-20260602-507: OpenAPI operation example enrichment helper
+
+- Date: 2026-06-02
+- Scope: `src/api/openapi_enrichment.py`,
+  `tests/unit/api/test_openapi_enrichment_helpers.py`, generated quality reports, and this ledger.
+- Finding: `_ensure_request_and_response_examples` mixed path traversal, metrics response handling,
+  request-body example generation, response example generation, and standard error response
+  enrichment in one OpenAPI governance pass.
+- Action: extracted `_ensure_operation_examples` so normal HTTP operation request, response, and
+  error example enrichment is directly testable while the top-level function keeps route traversal
+  and metrics special-case handling. Added direct tests for request payload examples, successful
+  JSON response examples, and RFC-style conflict error example content.
+- Status: hardened
+- Evidence: `python -m ruff check src/api/openapi_enrichment.py
+  tests/unit/api/test_openapi_enrichment_helpers.py`, `python -m ruff format
+  src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`, `python -m pytest
+  tests/unit/api/test_openapi_enrichment_helpers.py tests/unit/test_openapi_quality_gate.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves
+  `_ensure_request_and_response_examples` out of the top-ten current source functions after it
+  previously ranked first at complexity 18 / 75 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `evaluate`,
+  `generate_intents`, `generate_targets_solver`, or `summarize_enrichment_posture`.
+- Wiki decision: no wiki source change required; this preserves generated OpenAPI example behavior
+  and improves internal API-governance maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12436,3 +12436,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `_ensure_request_and_response_examples`, `evaluate`, or `generate_intents`.
 - Wiki decision: no wiki source change required; this preserves heuristic target-generation
   behavior and improves internal allocation maintainability only.
+
+## BACKEND-REVIEW-20260602-506: OpenAPI declared schema example helper
+
+- Date: 2026-06-02
+- Scope: `src/api/openapi_enrichment.py`,
+  `tests/unit/api/test_openapi_enrichment_helpers.py`, generated quality reports, and this ledger.
+- Finding: `_example_from_schema` mixed explicit schema example selection with reference
+  resolution, composite schemas, object properties, arrays, maps, and inferred fallback examples.
+- Action: extracted `_schema_declared_example` so `example` and `examples` precedence is directly
+  testable before broader schema traversal. Added direct tests for explicit object examples, first
+  list example selection, empty examples, and schemas without declared examples.
+- Status: hardened
+- Evidence: `python -m ruff check src/api/openapi_enrichment.py
+  tests/unit/api/test_openapi_enrichment_helpers.py`, `python -m ruff format
+  src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`, `python -m pytest
+  tests/unit/api/test_openapi_enrichment_helpers.py tests/unit/test_openapi_quality_gate.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report reduces `_example_from_schema` from
+  complexity 19 / 66 lines to complexity 17 / 64 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `_ensure_request_and_response_examples`, `evaluate`, `generate_intents`, or
+  `generate_targets_solver`. `_example_from_schema` remains a top-ten source hotspot and should
+  receive a further traversal-focused extraction later.
+- Wiki decision: no wiki source change required; this preserves generated OpenAPI example behavior
+  and improves internal API-governance maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11395,15 +11395,40 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   gates from planned instrumentation.
 - Status: hardened
 - Evidence: `python -m ruff check scripts/engineering_health_report.py
-  tests/unit/test_engineering_health_report.py docs/architecture/CODEBASE-REVIEW-LEDGER.md`,
+  tests/unit/test_engineering_health_report.py`,
   `python -m ruff format --check scripts/engineering_health_report.py
   tests/unit/test_engineering_health_report.py`, `python -m mypy --config-file mypy.ini
   scripts/engineering_health_report.py`, `python -m pytest
   tests/unit/test_engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
-  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, service
-  leakage scan, and generated-artifact sanity scan passed.
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, ledger diff
+  review, service leakage scan, and generated-artifact sanity scan passed.
 - Follow-up: optimize baseline loading before CI integration, then add report-only optional-tool
   collectors for complexity, dead code, dependency architecture, security depth, documentation gaps,
   and observability gaps before enforcing thresholds.
 - Wiki decision: no wiki source change required yet; this is internal quality-governance evidence
   and does not change route behavior, product feature truth, or operator procedure.
+
+## BACKEND-REVIEW-20260602-469: Batch baseline loading for engineering health reports
+
+- Date: 2026-06-02
+- Scope: `scripts/engineering_health_report.py`, `tests/unit/test_engineering_health_report.py`,
+  generated quality reports, and this ledger.
+- Finding: the new quality report generator loaded baseline file contents with one `git show`
+  invocation per Python file, which made report-only evidence unnecessarily slow and unsuitable for
+  later CI integration.
+- Action: replaced per-file baseline reads with one `git archive` stream over `src`, `tests`, and
+  `scripts`; added a focused unit test that proves only Python files are read from the archive
+  payload and non-Python files are ignored.
+- Status: hardened
+- Evidence: `python -m ruff check scripts/engineering_health_report.py
+  tests/unit/test_engineering_health_report.py`, `python -m ruff format --check
+  scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py`,
+  `python -m mypy --config-file mypy.ini scripts/engineering_health_report.py`, `python -m pytest
+  tests/unit/test_engineering_health_report.py`, `Measure-Command { python
+  scripts/engineering_health_report.py }` reported 12.87 seconds, `python
+  scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`, service leakage scan, and targeted archive-reader sanity scan passed.
+- Follow-up: if the report still needs CI integration, profile OpenAPI schema generation separately
+  and keep the generator report-only until runtime is consistently acceptable.
+- Wiki decision: no wiki source change required; this is internal quality-tool performance and
+  maintainability work.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12251,3 +12251,33 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   or `build_simulated_state`.
 - Wiki decision: no wiki source change required; this preserves construction enrichment behavior
   and improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-500: Proof-pack approval requirements helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_proof_pack_governance_section_payload` mixed approval-state derivation and workflow
+  decision ordering with operations handoff, timeline, lineage, and supportability section routing.
+- Action: extracted `_approval_requirements_section_payload` and routed approval requirements
+  through it. Added direct tests for workflow decision ordering, pending-review posture, blocked-run
+  posture, workflow decision metrics, and empty workflow-decision facts.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_markdown.py
+  tests/unit/dpm/proof_packs/test_proof_pack_repository.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves
+  `_proof_pack_governance_section_payload` out of the top-ten current source functions after it
+  previously ranked first at complexity 21 / 60 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `generate_targets_solver`, `generate_fx_and_simulate`, `build_simulated_state`, or
+  `validate_search_page_metadata`.
+- Wiki decision: no wiki source change required; this preserves proof-pack approval evidence
+  behavior and improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12109,3 +12109,32 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `_section_payload`, `generate_targets_heuristic`, or `_infer_example`.
 - Wiki decision: no wiki source change required; this preserves rebalance execution behavior and
   improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-495: Heuristic target sell-only excess helper
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/targets.py`,
+  `tests/unit/dpm/engine/coverage/test_engine_target_generation.py`, generated quality reports, and
+  this ledger.
+- Finding: `generate_targets_heuristic` still mixed sell-only excess redistribution with group
+  constraints, total-weight normalization, single-position caps, cash-buffer scaling, and trace
+  assembly.
+- Action: extracted `_redistribute_sell_only_excess` and routed heuristic target generation through
+  it. Added direct tests for proportional redistribution to buyable recipients, no-excess no-op
+  behavior, and pending-review status when no recipient weight is available.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/targets.py
+  tests/unit/dpm/engine/coverage/test_engine_target_generation.py`, `python -m ruff format
+  src/core/rebalance/targets.py tests/unit/dpm/engine/coverage/test_engine_target_generation.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/targets.py`, `python -m pytest
+  tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+  tests/unit/dpm/engine/test_engine_target_generation.py
+  tests/unit/dpm/engine/test_engine_solver_behavior.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `generate_targets_heuristic` reduced from complexity 22 / 74 lines to complexity 19 /
+  71 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `generate_intents`,
+  `_section_payload`, `_infer_example`, or `summarize_enrichment_posture`.
+- Wiki decision: no wiki source change required; this preserves heuristic target-generation
+  behavior and improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11432,3 +11432,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   and keep the generator report-only until runtime is consistently acceptable.
 - Wiki decision: no wiki source change required; this is internal quality-tool performance and
   maintainability work.
+
+## BACKEND-REVIEW-20260602-470: Report-only AST complexity baseline
+
+- Date: 2026-06-02
+- Scope: `scripts/engineering_health_report.py`, `quality/complexity_report.md`,
+  `quality/baseline_report.md`, `quality/quality_scorecard.md`,
+  `quality/refactor_health_report.md`, `tests/unit/test_engineering_health_report.py`, and this
+  ledger.
+- Finding: complexity and maintainability were still listed as planned rather than measured, which
+  made the quality baseline weaker than the stated enterprise-readiness objective.
+- Action: added dependency-free AST branch counting, surfaced the most complex functions in the
+  refactor report, generated a standalone report-only complexity baseline, and updated the baseline
+  report and scorecard to treat complexity as measured phase-1 evidence instead of an uninstrumented
+  gap.
+- Status: hardened
+- Evidence: `python -m ruff check scripts/engineering_health_report.py
+  tests/unit/test_engineering_health_report.py`, `python -m ruff format --check
+  scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py`,
+  `python -m mypy --config-file mypy.ini scripts/engineering_health_report.py`, `python -m pytest
+  tests/unit/test_engineering_health_report.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, service leakage scan, and generated complexity-artifact
+  sanity scan passed.
+- Follow-up: review the largest test and source complexity findings before setting thresholds; keep
+  the detector report-only until the expected baseline is agreed.
+- Wiki decision: no wiki source change required; this is internal quality-governance evidence and
+  does not change route behavior, product feature truth, or operator procedure.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11510,3 +11510,27 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   behavior tests until source complexity is no longer concentrated in the dispatcher.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-473: Proof-pack adapter section payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still contained repeated adapter-reference section payload assembly
+  for reporting and AI evidence refs after the source-analytics extraction.
+- Action: extracted `_adapter_section_payload` and routed `reporting_refs` and `ai_refs` through it;
+  added a direct helper test proving the ready-state adapter contract tuple shape.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` line count reduced from 426 to 420 while complexity remains 81.
+- Follow-up: prioritize branch-reducing extractions next; this slice improved reuse/readability but
+  did not lower the branch-count score.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11459,3 +11459,26 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   the detector report-only until the expected baseline is agreed.
 - Wiki decision: no wiki source change required; this is internal quality-governance evidence and
   does not change route behavior, product feature truth, or operator procedure.
+
+## BACKEND-REVIEW-20260602-471: Source/test split for complexity rankings
+
+- Date: 2026-06-02
+- Scope: `scripts/engineering_health_report.py`, `quality/complexity_report.md`,
+  `tests/unit/test_engineering_health_report.py`, and this ledger.
+- Finding: the initial complexity report was useful but combined source and test functions in one
+  ranking, so very large contract tests could obscure source-code refactor targets.
+- Action: added source and test filtered complexity rankings while keeping the combined top list;
+  updated renderer tests to prove both sections remain present in the report-only artifact.
+- Status: hardened
+- Evidence: `python -m ruff check scripts/engineering_health_report.py
+  tests/unit/test_engineering_health_report.py`, `python -m ruff format --check
+  scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py`,
+  `python -m mypy --config-file mypy.ini scripts/engineering_health_report.py`, `python -m pytest
+  tests/unit/test_engineering_health_report.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, service leakage scan, and source/test complexity artifact
+  sanity scan passed.
+- Follow-up: use the separated source ranking to choose small source refactors without losing the
+  signal that oversized tests also need maintenance work.
+- Wiki decision: no wiki source change required; this is internal quality-governance evidence and
+  does not change route behavior, product feature truth, or operator procedure.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12578,3 +12578,33 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   further solver constraint-construction extraction.
 - Wiki decision: no wiki source change required; this preserves target-solver behavior and improves
   internal solver resilience maintainability only.
+
+## BACKEND-REVIEW-20260602-511: Construction cost enrichment status helper
+
+- Date: 2026-06-02
+- Scope: `src/core/construction/enrichment.py`,
+  `tests/unit/dpm/construction/test_enrichment.py`, generated quality reports, and this ledger.
+- Finding: `summarize_enrichment_posture` mixed transaction-cost source posture with tax, FX,
+  liquidity, turnover, risk, and performance enrichment aggregation.
+- Action: extracted `_cost_enrichment_status` so local authoritative-cost availability and
+  source-owned transaction-cost context status are directly testable before summary aggregation.
+  Added direct tests for missing authoritative cost, local available cost posture, and source-owned
+  transaction-cost context reason-code propagation.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/construction/enrichment.py
+  tests/unit/dpm/construction/test_enrichment.py`, `python -m ruff format
+  src/core/construction/enrichment.py tests/unit/dpm/construction/test_enrichment.py`,
+  `python -m mypy --config-file mypy.ini src/core/construction/enrichment.py`, `python -m pytest
+  tests/unit/dpm/construction/test_enrichment.py
+  tests/unit/dpm/construction/test_method_readiness.py
+  tests/unit/dpm/construction/test_supportability_application.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `summarize_enrichment_posture` out of
+  the top-ten current source functions after it previously ranked first at complexity 17 / 87
+  lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `_example_from_schema`,
+  `validate_search_item_metadata`, `compile_mandate_digital_twin_from_core`, or
+  `resolve_core_dpm_portfolio_universe_candidates`.
+- Wiki decision: no wiki source change required; this preserves construction enrichment behavior
+  and improves internal transaction-cost source posture maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11856,3 +11856,32 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   complexity ranking.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-486: Treasury overlay payload and supportability helpers
+
+- Date: 2026-06-02
+- Scope: `src/api/services/construction_treasury_source_context.py`,
+  `tests/unit/dpm/construction/test_treasury_source_context.py`, generated quality reports, and
+  this ledger.
+- Finding: `external_treasury_currency_overlay_context` was the top source hotspot and still
+  assembled aggregate source payloads and primary source-family fallback selection inline before
+  building the authoritative currency-overlay context.
+- Action: extracted `_treasury_source_payloads` and `_primary_treasury_supportability`, then routed
+  the public currency-overlay mapper through them. Added direct helper tests proving aggregate hash
+  inputs and first-available source-family supportability selection.
+- Status: hardened
+- Evidence: `python -m ruff check src/api/services/construction_treasury_source_context.py
+  tests/unit/dpm/construction/test_treasury_source_context.py`, `python -m ruff format
+  src/api/services/construction_treasury_source_context.py
+  tests/unit/dpm/construction/test_treasury_source_context.py`, `python -m mypy --config-file
+  mypy.ini src/api/services/construction_treasury_source_context.py`, `python -m pytest
+  tests/unit/dpm/construction/test_treasury_source_context.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows
+  `external_treasury_currency_overlay_context` reduced from complexity 39 / 189 lines to complexity
+  30 / 164 lines.
+- Follow-up: continue reducing the refreshed top source hotspots, starting with `generate_intents`
+  or another narrow treasury overlay helper extraction if it stays behavior-preserving.
+- Wiki decision: no wiki source change required; this preserves source-product mapping behavior and
+  improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11534,3 +11534,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   did not lower the branch-count score.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-474: Proof-pack run-state section payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still carried several simple run-state section branches for before,
+  target, trade-intent, and after-state payloads, keeping the dispatcher as the top source
+  complexity hotspot.
+- Action: extracted `_run_state_section_payload` for the cohesive run-state section family and left
+  `_section_payload` responsible for orchestration/dispatch. Added direct tests for blocked
+  trade-intent evidence and unrelated-section passthrough.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 81 / 420 lines to complexity 75 / 383
+  lines.
+- Follow-up: continue with branch-reducing section-family helpers, then revisit whether the
+  dispatcher should become table-driven once helper boundaries are stable.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11670,3 +11670,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   construction, with direct tests around tax budget and constraint labels.
 - Wiki decision: no wiki source change required; this preserves engine behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-479: Rebalance intent sell clamp and tax-budget event helpers
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`, generated quality reports, and this ledger.
+- Finding: after HIFO helper extraction, `generate_intents` still handled sell quantity clamping and
+  tax-budget event recording inline in the main target loop.
+- Action: extracted `_clamped_sell_quantity` and `_record_tax_budget_limit_reached`; added direct
+  tests proving sell-clamp warning de-duplication and tax-budget event payloads without duplicate
+  warnings.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/intents.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py`, `python -m ruff format
+  src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`, `python -m pytest
+  tests/unit/dpm/engine/test_engine_safety_rules.py tests/unit/dpm/engine/test_engine_tax_awareness.py
+  tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows `generate_intents` reduced from
+  complexity 52 / 217 lines to complexity 48 / 210 lines.
+- Follow-up: continue with trade construction and threshold/suppression helper extraction from
+  `generate_intents`, preserving tax-aware behavior.
+- Wiki decision: no wiki source change required; this preserves engine behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12547,3 +12547,34 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `validate_search_item_metadata`.
 - Wiki decision: no wiki source change required; this preserves rebalance intent behavior and
   improves internal trade-suppression maintainability only.
+
+## BACKEND-REVIEW-20260602-510: Target solver dependency loader helper
+
+- Date: 2026-06-02
+- Scope: `src/core/target_generation.py`,
+  `tests/unit/core/test_target_generation_solver_fallbacks.py`, generated quality reports, and this
+  ledger.
+- Finding: `generate_targets_solver` mixed solver dependency detection and import failure handling
+  with sell-only redistribution, constraint construction, fallback solving, infeasibility hints, and
+  target trace construction.
+- Action: extracted `_load_solver_modules` so solver dependency/import readiness is directly
+  testable and the solver path can keep optimization orchestration separate from environment
+  readiness handling. Added direct tests for missing solver dependencies and import failure
+  warning behavior.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/target_generation.py
+  tests/unit/core/test_target_generation_solver_fallbacks.py`, `python -m ruff format
+  src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m mypy --config-file mypy.ini src/core/target_generation.py`, `python -m pytest
+  tests/unit/core/test_target_generation_solver_fallbacks.py
+  tests/unit/dpm/engine/test_engine_solver_behavior.py
+  tests/unit/dpm/engine/test_engine_target_generation.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report reduces `generate_targets_solver` from
+  complexity 17 / 109 lines to complexity 16 / 102 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `summarize_enrichment_posture`, `_example_from_schema`, `validate_search_item_metadata`, or a
+  further solver constraint-construction extraction.
+- Wiki decision: no wiki source change required; this preserves target-solver behavior and improves
+  internal solver resilience maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12343,3 +12343,35 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `_example_from_schema`.
 - Wiki decision: no wiki source change required; this preserves valuation behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-503: Rebalance projected-cash FX helper
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/execution.py`,
+  `tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`, generated quality reports, and
+  this ledger.
+- Finding: `generate_fx_and_simulate` mixed projected-cash FX intent assembly, missing-FX
+  diagnostics, dependency-map preparation, settlement checks, portfolio mutation, valuation, rule
+  evaluation, and reconciliation in one orchestration function.
+- Action: extracted `_append_projected_cash_fx_intents` so projected-cash FX generation and
+  missing-FX blocking are directly testable while `generate_fx_and_simulate` keeps the orchestration
+  sequence. Added helper tests for funding and sweep FX intent creation, funding dependency-map
+  capture, base-currency skip behavior, and block-on-missing-FX diagnostics.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/execution.py
+  tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`, `python -m ruff format
+  src/core/rebalance/execution.py
+  tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`, `python -m mypy --config-file
+  mypy.ini src/core/rebalance/execution.py`, `python -m pytest
+  tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+  tests/unit/dpm/engine/test_engine_simulation_shared.py
+  tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `generate_fx_and_simulate` out of the
+  top-ten current source functions after it previously ranked first at complexity 19 / 137 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `validate_search_page_metadata`, `generate_targets_heuristic`, `_example_from_schema`, or
+  `_ensure_request_and_response_examples`.
+- Wiki decision: no wiki source change required; this preserves rebalance execution behavior and
+  improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12223,3 +12223,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_targets_solver`, or `_example_from_schema`.
 - Wiki decision: no wiki source change required; this preserves API-enrichment behavior while
   improving generated example semantics and maintainability only.
+
+## BACKEND-REVIEW-20260602-499: Construction enrichment tax and FX posture helpers
+
+- Date: 2026-06-02
+- Scope: `src/core/construction/enrichment.py`,
+  `tests/unit/dpm/construction/test_enrichment.py`, generated quality reports, and this ledger.
+- Finding: `summarize_enrichment_posture` mixed tax-readiness and FX-source posture decisions with
+  liquidity, cost, turnover, risk, and performance enrichment aggregation.
+- Action: extracted `_tax_enrichment_status` and `_fx_enrichment_status`, then routed enrichment
+  summary aggregation through them. Added direct tests for required tax blocking, optional tax
+  degradation, available tax readiness, missing FX blocking, and ready FX posture.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/construction/enrichment.py
+  tests/unit/dpm/construction/test_enrichment.py`, `python -m ruff format
+  src/core/construction/enrichment.py tests/unit/dpm/construction/test_enrichment.py`,
+  `python -m mypy --config-file mypy.ini src/core/construction/enrichment.py`, `python -m pytest
+  tests/unit/dpm/construction/test_enrichment.py
+  tests/unit/dpm/construction/test_method_readiness.py
+  tests/unit/dpm/construction/test_supportability_application.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `summarize_enrichment_posture` out of
+  the top-ten current source functions after it previously ranked first at complexity 21 / 89 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `_proof_pack_governance_section_payload`, `generate_targets_solver`, `generate_fx_and_simulate`,
+  or `build_simulated_state`.
+- Wiki decision: no wiki source change required; this preserves construction enrichment behavior
+  and improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11586,3 +11586,34 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   tax/drift/rule sections, with direct helper tests.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-476: Proof-pack policy section payload helper and source complexity ranking fix
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`, `scripts/engineering_health_report.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `tests/unit/test_engineering_health_report.py`, generated quality reports, and this ledger.
+- Finding: `_section_payload` still carried drift, tax, and rule-result policy branches, and the
+  complexity report's source/test split was derived only from the combined top-ten list. Once source
+  complexity dropped below the combined top ten, the source ranking went empty and stopped being
+  useful evidence.
+- Action: extracted `_run_policy_section_payload` for drift, tax, and rule-result sections; added
+  direct helper tests for direct-run drift fallback and missing tax posture; changed the quality
+  report snapshot to compute source and test complexity rankings independently from all functions.
+- Status: hardened
+- Evidence: `python -m ruff check scripts/engineering_health_report.py
+  tests/unit/test_engineering_health_report.py src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py
+  scripts/engineering_health_report.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py tests/unit/test_engineering_health_report.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows `_section_payload` at complexity 64 /
+  318 lines and preserves an independent populated source-complexity top-ten table.
+- Follow-up: continue extracting remaining proof-pack approval, timeline, lineage, and supportability
+  section families, then consider a table-driven dispatcher.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability and quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12607,4 +12607,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `validate_search_item_metadata`, `compile_mandate_digital_twin_from_core`, or
   `resolve_core_dpm_portfolio_universe_candidates`.
 - Wiki decision: no wiki source change required; this preserves construction enrichment behavior
-  and improves internal transaction-cost source posture maintainability only.
+and improves internal transaction-cost source posture maintainability only.
+
+## BACKEND-REVIEW-20260602-512: OpenAPI collection schema example helper
+
+- Date: 2026-06-02
+- Scope: `src/api/openapi_enrichment.py`,
+  `tests/unit/api/test_openapi_enrichment_helpers.py`, generated quality reports, and this ledger.
+- Finding: `_example_from_schema` mixed explicit schema example selection, ref/composite resolution,
+  object-property recursion, array examples, map examples, and inference fallback in one place.
+- Action: extracted `_collection_example_from_schema` so property/object/array/map traversal is directly
+  testable and separated from reference/composite selection. Added direct tests for object properties,
+  arrays with typed and non-typed items, object maps, object defaults, and collection miss cases.
+- Status: hardened
+- Evidence: `python -m ruff check src/api/openapi_enrichment.py
+  tests/unit/api/test_openapi_enrichment_helpers.py`, `python -m ruff format
+  src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`, `python -m pytest
+  tests/unit/api/test_openapi_enrichment_helpers.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`, and service leakage scan passed. The refreshed complexity report should reduce
+  `_example_from_schema` from 17 / 64 lines and move it further down the top hotspot list.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `_ensure_request_and_response_examples`, `validate_search_item_metadata`, or
+  `compile_mandate_digital_twin_from_core`.
+- Wiki decision: no wiki source change required; this preserves generated OpenAPI behavior and
+  improves internal API-governance maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12405,3 +12405,34 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `evaluate`.
 - Wiki decision: no wiki source change required; this preserves portfolio-memory search API
   behavior and improves internal validation maintainability only.
+
+## BACKEND-REVIEW-20260602-505: Heuristic target total-weight cap helper
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/targets.py`,
+  `tests/unit/dpm/engine/coverage/test_engine_target_generation.py`, generated quality reports, and
+  this ledger.
+- Finding: `generate_targets_heuristic` mixed sell-only redistribution, group constraints,
+  total-weight capping, single-position caps, cash-buffer scaling, and trace construction in one
+  target allocation path.
+- Action: extracted `_cap_tradeable_targets_to_available_weight` so the total-weight cap for
+  tradeable buy targets is directly testable and separate from the rest of heuristic target
+  orchestration. Added helper tests for balanced no-op targets, proportional tradeable scaling, and
+  locked exposure above 100% forcing pending-review posture.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/targets.py
+  tests/unit/dpm/engine/coverage/test_engine_target_generation.py`, `python -m ruff format
+  src/core/rebalance/targets.py tests/unit/dpm/engine/coverage/test_engine_target_generation.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/targets.py`, `python -m pytest
+  tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+  tests/unit/dpm/engine/test_engine_target_generation.py
+  tests/unit/dpm/engine/test_engine_solver_behavior.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `generate_targets_heuristic` out of
+  the top-ten current source functions after it previously ranked first at complexity 19 / 71
+  lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `_example_from_schema`,
+  `_ensure_request_and_response_examples`, `evaluate`, or `generate_intents`.
+- Wiki decision: no wiki source change required; this preserves heuristic target-generation
+  behavior and improves internal allocation maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12079,3 +12079,33 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_intents`.
 - Wiki decision: no wiki source change required; this preserves rebalance intent behavior and
   improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-494: Rebalance FX intent and dependency helpers
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/execution.py`,
+  `tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`, generated quality reports, and
+  this ledger.
+- Finding: `generate_fx_and_simulate` still mixed FX funding/sweep intent construction and
+  dependency-linking defaults with simulation orchestration, keeping direction-specific cash math
+  and dependency policy harder to test directly.
+- Action: extracted `_fx_intent_for_projected_cash_balance` and `_link_execution_dependencies`,
+  then routed FX generation through them. Added direct tests for funding intent construction, sweep
+  intent construction, zero-balance suppression, default same-currency sell dependency linking, and
+  explicit same-currency sell opt-out.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/execution.py
+  tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`, `python -m ruff format
+  src/core/rebalance/execution.py tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/execution.py`, `python -m pytest
+  tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py
+  tests/unit/dpm/engine/test_engine_settlement_awareness.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows `generate_fx_and_simulate` reduced
+  from complexity 22 / 160 lines to complexity 19 / 137 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `generate_intents`,
+  `_section_payload`, `generate_targets_heuristic`, or `_infer_example`.
+- Wiki decision: no wiki source change required; this preserves rebalance execution behavior and
+  improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12491,3 +12491,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_intents`, `generate_targets_solver`, or `summarize_enrichment_posture`.
 - Wiki decision: no wiki source change required; this preserves generated OpenAPI example behavior
   and improves internal API-governance maintainability only.
+
+## BACKEND-REVIEW-20260602-508: Compliance cash-band rule helper
+
+- Date: 2026-06-02
+- Scope: `src/core/compliance.py`, `tests/unit/core/test_common_edge_coverage.py`, generated
+  quality reports, and this ledger.
+- Finding: `RuleEngine.evaluate` mixed cash-band policy evaluation with concentration, data
+  quality, minimum-trade, no-shorting, and insufficient-cash rules in one method.
+- Action: extracted `_cash_band_rule_result` so portfolio cash-band policy evidence is directly
+  testable and the rule engine can keep sequencing independent rule families. Added direct tests
+  for cash inside the policy band and cash breaching the configured maximum band.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/compliance.py
+  tests/unit/core/test_common_edge_coverage.py`, `python -m ruff format src/core/compliance.py
+  tests/unit/core/test_common_edge_coverage.py`, `python -m mypy --config-file mypy.ini
+  src/core/compliance.py`, `python -m pytest tests/unit/core/test_common_edge_coverage.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py
+  tests/unit/dpm/engine/coverage/test_engine_status_blocking.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `evaluate` out of the top-ten current
+  source functions after it previously ranked first at complexity 17 / 199 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `generate_intents`,
+  `generate_targets_solver`, `summarize_enrichment_posture`, or `_example_from_schema`.
+- Wiki decision: no wiki source change required; this preserves compliance-rule behavior and
+  improves internal rule-engine maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11617,3 +11617,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   section families, then consider a table-driven dispatcher.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability and quality evidence.
+
+## BACKEND-REVIEW-20260602-477: Proof-pack governance section payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still carried proof-pack governance sections for approval
+  requirements, operations handoff, decision timeline, lineage, and supportability.
+- Action: extracted `_proof_pack_governance_section_payload` for the cohesive governance section
+  family. Added direct tests for deterministic workflow-decision ordering and lineage source-ref
+  metrics.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 64 / 318 lines to complexity 45 / 278
+  lines, moving `generate_intents` to the top source hotspot.
+- Follow-up: continue source-complexity reduction from the refreshed ranking, starting with
+  `src/core/rebalance/intents.py::generate_intents` or the remaining proof-pack dispatcher branches.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11748,3 +11748,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   eligibility/restriction payloads, with direct tests.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-482: Proof-pack selected alternative payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still assembled selected construction alternative facts, comparison
+  metrics, and not-ready reason codes inline, keeping the dispatcher responsible for section-specific
+  supportability projection.
+- Action: extracted `_selected_alternative_section_payload` and delegated the
+  `selected_alternative` branch through it. Added direct helper tests for the missing-selection
+  degraded state and the ready selected-alternative method trace projection.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 41 / 224 lines to complexity 36 / 192
+  lines.
+- Follow-up: continue extracting remaining proof-pack sections, especially source-readiness,
+  turnover/cost, and eligibility/restriction payloads, before returning to the
+  `external_treasury_currency_overlay_context` source hotspot.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12683,3 +12683,23 @@ and improves internal transaction-cost source posture maintainability only.
   behavior branches.
 - Wiki decision: no wiki source change required; this preserves mandate twin construction behavior and
   improves internal construction maintainability only.
+
+## BACKEND-REVIEW-20260604-515: Core portfolio-universe discovery service boundary
+
+- Date: 2026-06-04
+- Scope: `src/api/services/wave_core_portfolio_universe_resolution.py`, `src/api/routers/wave_core_portfolio_universe_resolution.py`,
+  `src/api/services/wave_errors.py`, `tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`.
+- Finding: `resolve_core_dpm_portfolio_universe_candidates` lived in a router module and mixed source paging logic, source-reference assembly, and HTTP dependency mapping.
+- Action: extracted discovery orchestration into a dedicated service, introduced service dependency errors
+  (`DpmWaveDependencyError`, `DpmWaveDependencyUnavailableError`, `DpmWaveDependencyFailedError`),
+  and left a thin router adapter to map domain failures into API responses.
+- Status: hardened
+- Evidence: `python -m ruff check src/api/services/wave_core_portfolio_universe_resolution.py
+  src/api/services/wave_errors.py src/api/routers/wave_core_portfolio_universe_resolution.py
+  tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`, `python -m ruff format
+  --check` on touched files, `python -m mypy --config-file mypy.ini src/api/services/wave_core_portfolio_universe_resolution.py
+  src/api/services/wave_errors.py`, targeted pytest (`tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`,
+  `tests/unit/dpm/api/test_waves_api.py -k core_universe`), `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `rg` service leakage scan (`from src.api.routers|HTTPException|status.HTTP` in `src/api/services`).
+- Wiki decision: no wiki source change required; this is an internal service-boundary improvement only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11801,3 +11801,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   turnover/cost and eligibility/restriction, then return to top-ranked source hotspots.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-484: Proof-pack turnover and cost payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still mixed turnover/cost proof-pack projection with dispatcher flow,
+  including selected-alternative comparison metrics, missing-metrics degradation, and source-owned
+  transaction-cost evidence merging.
+- Action: extracted `_turnover_and_cost_section_payload` and delegated the `turnover_and_cost`
+  branch through it. Added direct helper tests for missing selected metrics and merging
+  source-owned `TransactionCostCurve` facts and metrics.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 32 / 178 lines to complexity 27 / 154
+  lines.
+- Follow-up: extract eligibility/restriction payload projection or shift to the refreshed top source
+  hotspots: `external_treasury_currency_overlay_context` and `generate_intents`.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12517,3 +12517,33 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_targets_solver`, `summarize_enrichment_posture`, or `_example_from_schema`.
 - Wiki decision: no wiki source change required; this preserves compliance-rule behavior and
   improves internal rule-engine maintainability only.
+
+## BACKEND-REVIEW-20260602-509: Rebalance dust-trade suppression helper
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`, generated quality reports, and this ledger.
+- Finding: `generate_intents` mixed market context resolution, sell clamping, tax-budget limiting,
+  minimum-notional dust suppression, security intent construction, and tax-impact summarization in
+  one path.
+- Action: extracted `_suppress_dust_trade` so below-minimum-notional suppression and
+  `SuppressedIntent` construction are directly testable while `generate_intents` keeps trade-loop
+  orchestration. Added tests for suppressed below-threshold trades and supported notionals that
+  remain unsuppressed.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/intents.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py`, `python -m ruff format
+  src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`, `python -m pytest
+  tests/unit/dpm/engine/test_engine_safety_rules.py
+  tests/unit/dpm/engine/test_engine_core_flows.py
+  tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `generate_intents` out of the top-ten
+  current source functions after it previously ranked first at complexity 17 / 145 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `generate_targets_solver`, `summarize_enrichment_posture`, `_example_from_schema`, or
+  `validate_search_item_metadata`.
+- Wiki decision: no wiki source change required; this preserves rebalance intent behavior and
+  improves internal trade-suppression maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12281,3 +12281,36 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `validate_search_page_metadata`.
 - Wiki decision: no wiki source change required; this preserves proof-pack approval evidence
   behavior and improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-501: Shared target redistribution helper
+
+- Date: 2026-06-02
+- Scope: `src/core/common/target_redistribution.py`, `src/core/rebalance/targets.py`,
+  `src/core/target_generation.py`,
+  `tests/unit/dpm/engine/coverage/test_engine_target_generation.py`, generated quality reports, and
+  this ledger.
+- Finding: `generate_targets_solver` duplicated sell-only excess redistribution logic already
+  extracted for heuristic target generation, leaving solver and heuristic target paths with
+  parallel behavior that could drift.
+- Action: introduced shared `redistribute_sell_only_excess`, routed both heuristic and solver target
+  generation through it, and updated direct redistribution tests to exercise the common helper.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/common/target_redistribution.py
+  src/core/rebalance/targets.py src/core/target_generation.py
+  tests/unit/dpm/engine/coverage/test_engine_target_generation.py`, `python -m ruff format
+  src/core/common/target_redistribution.py src/core/rebalance/targets.py
+  src/core/target_generation.py tests/unit/dpm/engine/coverage/test_engine_target_generation.py`,
+  `python -m mypy --config-file mypy.ini src/core/common/target_redistribution.py
+  src/core/rebalance/targets.py src/core/target_generation.py`, `python -m pytest
+  tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+  tests/unit/dpm/engine/test_engine_target_generation.py
+  tests/unit/dpm/engine/test_engine_solver_behavior.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `generate_targets_solver` reduced from complexity 20 / 113 lines to complexity 17 /
+  109 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `generate_fx_and_simulate`, `build_simulated_state`, `validate_search_page_metadata`, or
+  `generate_targets_heuristic`.
+- Wiki decision: no wiki source change required; this preserves target-generation behavior and
+  improves shared target allocation maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12165,3 +12165,33 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `_infer_example`, `summarize_enrichment_posture`, or `_proof_pack_governance_section_payload`.
 - Wiki decision: no wiki source change required; this preserves rebalance intent behavior and
   improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-497: Proof-pack pre-run section dispatcher helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` mixed pre-run section routing for decision summaries, source
+  readiness, selected alternatives, source analytics, and adapter references with run-required
+  proof-pack sections and missing-run handling.
+- Action: extracted `_pre_run_section_payload` and routed `_section_payload` through it. Added
+  direct tests for degraded decision-summary evidence when actor rationale is missing and for
+  ignoring run-required sections so they remain handled by the run-backed dispatcher path.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_markdown.py
+  tests/unit/dpm/proof_packs/test_proof_pack_repository.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `_section_payload` out of the top-ten
+  current source functions after it previously ranked first at complexity 22 / 130 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `_infer_example`,
+  `summarize_enrichment_posture`, `_proof_pack_governance_section_payload`, or
+  `generate_targets_solver`.
+- Wiki decision: no wiki source change required; this preserves proof-pack section evidence
+  behavior and improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11378,3 +11378,32 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   observability checks.
 - Wiki decision: no wiki source change required yet; this is internal engineering-health evidence
   and does not change route behavior, product feature truth, or operator procedure.
+
+## BACKEND-REVIEW-20260602-468: Report-only quality governance baseline artifacts
+
+- Date: 2026-06-02
+- Scope: `scripts/engineering_health_report.py`, `quality/baseline_report.md`,
+  `quality/quality_scorecard.md`, `quality/architecture_rules.md`,
+  `quality/api_governance_rules.md`, `quality/refactor_health_report.md`,
+  `tests/unit/test_engineering_health_report.py`, and this ledger.
+- Finding: the branch had a useful refactor health report, but the enterprise-readiness objective
+  also needs durable baseline, scorecard, architecture-rule, and API-governance artifacts before
+  richer tools can be introduced as progressive gates.
+- Action: extended the dependency-free health report generator to write the baseline report,
+  quality scorecard, architecture rules, and API governance rules alongside the existing refactor
+  report; added renderer tests proving the artifacts remain report-only and distinguish active
+  gates from planned instrumentation.
+- Status: hardened
+- Evidence: `python -m ruff check scripts/engineering_health_report.py
+  tests/unit/test_engineering_health_report.py docs/architecture/CODEBASE-REVIEW-LEDGER.md`,
+  `python -m ruff format --check scripts/engineering_health_report.py
+  tests/unit/test_engineering_health_report.py`, `python -m mypy --config-file mypy.ini
+  scripts/engineering_health_report.py`, `python -m pytest
+  tests/unit/test_engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, service
+  leakage scan, and generated-artifact sanity scan passed.
+- Follow-up: optimize baseline loading before CI integration, then add report-only optional-tool
+  collectors for complexity, dead code, dependency architecture, security depth, documentation gaps,
+  and observability gaps before enforcing thresholds.
+- Wiki decision: no wiki source change required yet; this is internal quality-governance evidence
+  and does not change route behavior, product feature truth, or operator procedure.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12052,3 +12052,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_fx_and_simulate`, `_section_payload`, or `generate_targets_heuristic`.
 - Wiki decision: no wiki source change required; this preserves rebalance execution behavior and
   improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-493: Rebalance intent market context helper
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`, generated quality reports, and this ledger.
+- Finding: `generate_intents` still mixed target-loop orchestration with source-market lookup,
+  FX conversion, current-position lookup, and data-quality logging for missing price or FX evidence.
+- Action: extracted `_intent_market_context` and routed intent generation through the helper. Added
+  direct helper tests for successful price/FX/position resolution and missing price/FX logging.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/intents.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py`, `python -m ruff format
+  src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`, `python -m pytest
+  tests/unit/dpm/engine/test_engine_safety_rules.py
+  tests/unit/dpm/engine/test_engine_tax_awareness.py
+  tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows `generate_intents` reduced from
+  complexity 24 / 149 lines to complexity 23 / 149 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `generate_fx_and_simulate`, `_section_payload`, `generate_targets_heuristic`, or
+  `generate_intents`.
+- Wiki decision: no wiki source change required; this preserves rebalance intent behavior and
+  improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11942,3 +11942,30 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   behavior-preserving.
 - Wiki decision: no wiki source change required; this preserves source-product mapping behavior and
   improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-489: Campaign definition lifecycle validation helpers
+
+- Date: 2026-06-02
+- Scope: `src/core/waves/campaign_definitions.py`,
+  `tests/unit/dpm/waves/test_campaign_definition_repository.py`, generated quality reports, and
+  this ledger.
+- Finding: `DpmBulkReviewCampaignDefinition.validate_definition` was the top source hotspot after
+  prior reductions because it mixed active, retired, and superseded lifecycle validation branches
+  with structural checks and content-hash assignment.
+- Action: extracted `_validate_active_lifecycle`, `_validate_retired_lifecycle`, and
+  `_validate_superseded_lifecycle`, then routed the Pydantic validator through the status-specific
+  helpers. Added direct helper tests proving the preserved lifecycle reason codes.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/waves/campaign_definitions.py
+  tests/unit/dpm/waves/test_campaign_definition_repository.py`, `python -m ruff format
+  src/core/waves/campaign_definitions.py tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_definitions.py`, `python -m pytest
+  tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `validate_definition` out of the
+  top-ten current source functions after it previously ranked at complexity 30 / 69 lines.
+- Follow-up: continue reducing the refreshed top source hotspots, starting with
+  `build_search_row`, `compile_mandate_digital_twin_from_core`, or `generate_fx_and_simulate`.
+- Wiki decision: no wiki source change required; this preserves campaign-definition lifecycle
+  behavior and improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11482,3 +11482,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   signal that oversized tests also need maintenance work.
 - Wiki decision: no wiki source change required; this is internal quality-governance evidence and
   does not change route behavior, product feature truth, or operator procedure.
+
+## BACKEND-REVIEW-20260602-472: Proof-pack source analytics section payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `quality/complexity_report.md` identified `_section_payload` as the top source-code
+  complexity hotspot; four source-analytics sections repeated the same context-present/fallback
+  branch pattern.
+- Action: extracted `_source_analytics_section_payload` and routed risk, performance,
+  sustainability, and scenario/regime sections through it while preserving the scenario reason-code
+  sorting behavior. Added direct helper tests for missing-context fallback and sorted reason-code
+  projection.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 85 / 465 lines to complexity 81 / 426
+  lines.
+- Follow-up: continue extracting cohesive section families from `_section_payload` with direct
+  behavior tests until source complexity is no longer concentrated in the dispatcher.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12195,3 +12195,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_targets_solver`.
 - Wiki decision: no wiki source change required; this preserves proof-pack section evidence
   behavior and improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-498: OpenAPI semantic example helper extraction
+
+- Date: 2026-06-02
+- Scope: `src/api/openapi_enrichment.py`,
+  `tests/unit/api/test_openapi_enrichment_helpers.py`, generated quality reports, and this ledger.
+- Finding: `_infer_example` mixed schema-type dispatch with semantic number examples and semantic
+  string examples, including ambiguous date/timestamp key handling in generated OpenAPI examples.
+- Action: extracted `_number_example_for_key` and `_semantic_string_example_for_key`, then routed
+  example inference through them. Added direct tests for weight, price/rate, quantity, fallback
+  numeric examples, identifier, currency, date, time/timestamp, status, string fallback, and
+  unknown-schema fallback examples. The timestamp check now takes precedence over generic `date`
+  substrings so keys such as `updated_timestamp` receive date-time examples.
+- Status: hardened
+- Evidence: `python -m ruff check src/api/openapi_enrichment.py
+  tests/unit/api/test_openapi_enrichment_helpers.py`, `python -m ruff format
+  src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`, `python -m pytest
+  tests/unit/api/test_openapi_enrichment_helpers.py tests/unit/test_openapi_quality_gate.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `_infer_example` out of the top-ten
+  current source functions after it previously ranked first at complexity 22 / 48 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `summarize_enrichment_posture`, `_proof_pack_governance_section_payload`,
+  `generate_targets_solver`, or `_example_from_schema`.
+- Wiki decision: no wiki source change required; this preserves API-enrichment behavior while
+  improving generated example semantics and maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12023,3 +12023,32 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_fx_and_simulate`, `generate_intents`, or `_section_payload`.
 - Wiki decision: no wiki source change required; this preserves mandate twin behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-492: Rebalance execution projected cash helper
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/execution.py`,
+  `tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`, generated quality reports, and
+  this ledger.
+- Finding: `generate_fx_and_simulate` was the top source hotspot after mandate compiler reduction
+  and still calculated projected cash balances from security trades inline before FX funding and
+  sweep intent generation.
+- Action: extracted `_project_cash_after_security_trades` and routed FX generation through the
+  helper. Added direct tests proving buy/sell cash projection and skipped incomplete security
+  intents without notional evidence.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/execution.py
+  tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`, `python -m ruff format
+  src/core/rebalance/execution.py tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/execution.py`, `python -m pytest
+  tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py
+  tests/unit/dpm/engine/test_engine_settlement_awareness.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows `generate_fx_and_simulate` reduced
+  from complexity 26 / 167 lines to complexity 22 / 160 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with `generate_intents`,
+  `generate_fx_and_simulate`, `_section_payload`, or `generate_targets_heuristic`.
+- Wiki decision: no wiki source change required; this preserves rebalance execution behavior and
+  improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12375,3 +12375,33 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `_ensure_request_and_response_examples`.
 - Wiki decision: no wiki source change required; this preserves rebalance execution behavior and
   improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-504: Portfolio-memory search pagination validator
+
+- Date: 2026-06-02
+- Scope: `src/core/portfolio_memory/models.py`,
+  `tests/unit/dpm/portfolio_memory/test_search_page.py`, generated quality reports, and this
+  ledger.
+- Finding: `validate_search_page_metadata` mixed pagination posture validation with aggregate
+  supportability, source-system, and matching-event count validation, making the bounded search API
+  pagination contract harder to test directly.
+- Action: extracted `_validate_search_page_pagination` and routed search-page model validation
+  through it. Added direct tests for valid advancing pages, returned-count mismatches, incorrect
+  `has_more` posture, and invalid terminal-page `next_offset`.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/portfolio_memory/models.py
+  tests/unit/dpm/portfolio_memory/test_search_page.py`, `python -m ruff format
+  src/core/portfolio_memory/models.py tests/unit/dpm/portfolio_memory/test_search_page.py`,
+  `python -m mypy --config-file mypy.ini src/core/portfolio_memory/models.py`, `python -m pytest
+  tests/unit/dpm/portfolio_memory/test_search_page.py
+  tests/unit/dpm/api/test_portfolio_memory_api.py -k "search_page or search_indexes or
+  search_counts or search_facets"`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report moves `validate_search_page_metadata` out of the top-ten current source functions after it
+  previously ranked first at complexity 19 / 79 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `generate_targets_heuristic`, `_example_from_schema`, `_ensure_request_and_response_examples`, or
+  `evaluate`.
+- Wiki decision: no wiki source change required; this preserves portfolio-memory search API
+  behavior and improves internal validation maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11828,3 +11828,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   hotspots: `external_treasury_currency_overlay_context` and `generate_intents`.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-485: Proof-pack eligibility and restriction payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still assembled eligibility and client-restriction proof-pack payloads
+  inline, including universe-exclusion fallback state, source-owned restriction facts, and combined
+  reason-code projection.
+- Action: extracted `_eligibility_and_restrictions_section_payload` and delegated the
+  `eligibility_and_restrictions` branch through it. Added direct helper tests for universe-exclusion
+  fallback and source-owned `ClientRestrictionProfile` evidence merged with exclusions.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 27 / 154 lines to complexity 22 / 130
+  lines.
+- Follow-up: `_section_payload` is no longer a top-five source hotspot; continue with
+  `external_treasury_currency_overlay_context` or `generate_intents` based on the refreshed
+  complexity ranking.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12658,3 +12658,28 @@ and improves internal transaction-cost source posture maintainability only.
   `validate_search_page_metadata`.
 - Wiki decision: no wiki source change required; this preserves portfolio-memory search contract behavior and
   improves internal model governance maintainability only.
+
+## BACKEND-REVIEW-20260602-514: Mandate twin source-lineage helper
+
+- Date: 2026-06-02
+- Scope: `src/core/mandates.py`, `tests/unit/dpm/core/test_mandate_health.py`, generated
+  quality reports, and this ledger.
+- Finding: `compile_mandate_digital_twin_from_core` combined core-product lineage construction,
+  mandate/model source evidence assembly, and twin model construction in one function.
+- Action: extracted `_build_digital_twin_source_lineage` so source lineage assembly for mandate twin
+  construction is directly testable, isolated, and reusable. Added direct tests for required-only and
+  fully-populated lineage inputs.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/mandates.py
+  tests/unit/dpm/core/test_mandate_health.py`, `python -m ruff format
+  src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py`,
+  `python -m mypy --config-file mypy.ini src/core/mandates.py`, `python -m pytest
+  tests/unit/dpm/core/test_mandate_health.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`, and service leakage scan passed. The refreshed complexity report should reduce
+  `compile_mandate_digital_twin_from_core` from 16 / 173 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `resolve_core_dpm_portfolio_universe_candidates` or `compile_mandate_digital_twin_from_core` remaining
+  behavior branches.
+- Wiki decision: no wiki source change required; this preserves mandate twin construction behavior and
+  improves internal construction maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11696,3 +11696,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_intents`, preserving tax-aware behavior.
 - Wiki decision: no wiki source change required; this preserves engine behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-480: Rebalance intent threshold and constraint helpers
+
+- Date: 2026-06-02
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`, generated quality reports, and this ledger.
+- Finding: `generate_intents` still resolved option/shelf minimum-notional thresholds and assembled
+  applied constraint labels inline, adding branching to the target loop.
+- Action: extracted `_trade_notional_threshold` and `_security_intent_constraints`; added direct
+  tests for option-over-shelf threshold precedence and combined sell-safety/tax-budget labels.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/rebalance/intents.py
+  tests/unit/dpm/engine/test_engine_safety_rules.py`, `python -m ruff format
+  src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`, `python -m pytest
+  tests/unit/dpm/engine/test_engine_safety_rules.py tests/unit/dpm/engine/test_engine_tax_awareness.py
+  tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report shows `generate_intents` reduced from
+  complexity 48 / 210 lines to complexity 38 / 207 lines.
+- Follow-up: `quality/complexity_report.md` now puts `_section_payload` back at the top source
+  hotspot; continue branch-reducing proof-pack dispatcher extraction or finish trade-construction
+  extraction in `generate_intents`.
+- Wiki decision: no wiki source change required; this preserves engine behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11969,3 +11969,31 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `build_search_row`, `compile_mandate_digital_twin_from_core`, or `generate_fx_and_simulate`.
 - Wiki decision: no wiki source change required; this preserves campaign-definition lifecycle
   behavior and improves internal maintainability only.
+
+## BACKEND-REVIEW-20260602-490: Portfolio-memory search row helper extraction
+
+- Date: 2026-06-02
+- Scope: `src/core/portfolio_memory/search_page.py`,
+  `tests/unit/dpm/portfolio_memory/test_search_page.py`, generated quality reports, and this ledger.
+- Finding: `build_search_row` was the top source hotspot after prior reductions because it mixed
+  summary-level filtering, event-level filter matching, and search-item projection in one function.
+- Action: extracted `_memory_passes_search_summary_filters`, `_filters_require_matching_events`,
+  and `_portfolio_memory_search_item`, then routed `build_search_row` through them. Added direct
+  helper tests for summary filter rejection, event-level filter detection, and latest matching-event
+  projection.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/portfolio_memory/search_page.py
+  tests/unit/dpm/portfolio_memory/test_search_page.py`, `python -m ruff format
+  src/core/portfolio_memory/search_page.py tests/unit/dpm/portfolio_memory/test_search_page.py`,
+  `python -m mypy --config-file mypy.ini src/core/portfolio_memory/search_page.py`, `python -m pytest
+  tests/unit/dpm/portfolio_memory/test_search_page.py
+  tests/unit/dpm/portfolio_memory/test_search_filters.py
+  tests/unit/dpm/portfolio_memory/test_search_facets.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `build_search_row` out of the top-ten
+  current source functions after it previously ranked at complexity 28 / 86 lines.
+- Follow-up: continue reducing the refreshed top source hotspots, starting with
+  `compile_mandate_digital_twin_from_core`, `generate_fx_and_simulate`, or `generate_intents`.
+- Wiki decision: no wiki source change required; this preserves portfolio-memory search behavior
+  and improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11561,3 +11561,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   dispatcher should become table-driven once helper boundaries are stable.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-475: Proof-pack run diagnostics section payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still owned diagnostic section branches for liquidity, FX funding, and
+  currency overlay, keeping proof-pack evidence assembly concentrated in one dispatcher.
+- Action: extracted `_run_diagnostics_section_payload` for the cohesive diagnostics section family
+  and added direct helper tests for ready liquidity posture and currency-overlay fallback posture.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 75 / 383 lines to complexity 69 / 353
+  lines.
+- Follow-up: continue extracting remaining source section families, especially approval/lineage and
+  tax/drift/rule sections, with direct helper tests.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12633,3 +12633,28 @@ and improves internal transaction-cost source posture maintainability only.
   `compile_mandate_digital_twin_from_core`.
 - Wiki decision: no wiki source change required; this preserves generated OpenAPI behavior and
   improves internal API-governance maintainability only.
+
+## BACKEND-REVIEW-20260602-513: Portfolio-memory search-item metadata validation helper
+
+- Date: 2026-06-02
+- Scope: `src/core/portfolio_memory/models.py`,
+  `tests/unit/dpm/portfolio_memory/test_search_page.py`, generated quality reports, and this ledger.
+- Finding: `validate_search_item_metadata` mixed event-count consistency, sorting/uniqueness checks, empty
+  versus non-empty posture checks, and matching-event metadata enforcement in one validator.
+- Action: extracted `_validate_search_item_metadata` so cross-field search-item metadata rules are directly
+  testable independent of model instantiation internals. Added direct tests for empty search posture,
+  aggregate/ordering mismatches, and stale versus required matching metadata errors.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/portfolio_memory/models.py
+  tests/unit/dpm/portfolio_memory/test_search_page.py`, `python -m ruff format
+  src/core/portfolio_memory/models.py tests/unit/dpm/portfolio_memory/test_search_page.py`,
+  `python -m mypy --config-file mypy.ini src/core/portfolio_memory/models.py`, `python -m pytest
+  tests/unit/dpm/portfolio_memory/test_search_page.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`, and service leakage scan passed. The refreshed complexity report should reduce
+  `validate_search_item_metadata` from 17 / 52 lines and move it further down the top hotspot list.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `compile_mandate_digital_twin_from_core`, `resolve_core_dpm_portfolio_universe_candidates`, or
+  `validate_search_page_metadata`.
+- Wiki decision: no wiki source change required; this preserves portfolio-memory search contract behavior and
+  improves internal model governance maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12314,3 +12314,32 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `generate_targets_heuristic`.
 - Wiki decision: no wiki source change required; this preserves target-generation behavior and
   improves shared target allocation maintainability only.
+
+## BACKEND-REVIEW-20260602-502: Valuation cash base-value helper
+
+- Date: 2026-06-02
+- Scope: `src/core/valuation.py`, `tests/unit/dpm/engine/test_engine_valuation_service.py`,
+  generated quality reports, and this ledger.
+- Finding: `build_simulated_state` duplicated base-currency and foreign-currency cash valuation
+  across total-value and cash allocation paths, making missing-FX diagnostic behavior harder to
+  keep consistent.
+- Action: extracted `_cash_value_in_base` and routed both total-value cash valuation and asset-class
+  cash allocation through it. Added direct helper tests for base cash, FX conversion, missing-FX
+  logging, and the allocation path where no missing-FX log is requested.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/valuation.py
+  tests/unit/dpm/engine/test_engine_valuation_service.py`, `python -m ruff format
+  src/core/valuation.py tests/unit/dpm/engine/test_engine_valuation_service.py`,
+  `python -m mypy --config-file mypy.ini src/core/valuation.py`, `python -m pytest
+  tests/unit/dpm/engine/test_engine_valuation_service.py
+  tests/unit/dpm/engine/test_engine_simulation_shared.py
+  tests/unit/dpm/engine/coverage/test_engine_universe_data_quality.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves `build_simulated_state` out of the
+  top-ten current source functions after it previously ranked second at complexity 19 / 123 lines.
+- Follow-up: continue reducing refreshed top source hotspots, starting with
+  `generate_fx_and_simulate`, `validate_search_page_metadata`, `generate_targets_heuristic`, or
+  `_example_from_schema`.
+- Wiki decision: no wiki source change required; this preserves valuation behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11722,3 +11722,29 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   extraction in `generate_intents`.
 - Wiki decision: no wiki source change required; this preserves engine behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-481: Proof-pack mandate context payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still carried the mandate-context supportability ladder inline,
+  including missing mandate identity, missing twin evidence, missing health evidence, and complete
+  health-backed projection.
+- Action: extracted `_mandate_context_section_payload` and delegated the `mandate_context` branch
+  through it. Added direct helper tests for missing identity and full mandate-health projection.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 45 / 278 lines to complexity 41 / 224
+  lines.
+- Follow-up: continue extracting remaining proof-pack sections, especially selected-alternative and
+  eligibility/restriction payloads, with direct tests.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11912,3 +11912,33 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `external_treasury_currency_overlay_context`, `validate_definition`, and `build_search_row`.
 - Wiki decision: no wiki source change required; this preserves engine behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-488: Treasury overlay source identity projection helper
+
+- Date: 2026-06-02
+- Scope: `src/api/services/construction_treasury_source_context.py`,
+  `tests/unit/dpm/construction/test_treasury_source_context.py`, generated quality reports, and
+  this ledger.
+- Finding: after the first treasury overlay extraction, `external_treasury_currency_overlay_context`
+  still repeated the same source-product identity projection fields for each external treasury
+  source family.
+- Action: extracted `_source_identity_fields` and used it for external currency exposure, hedge
+  policy, eligible hedge instruments, and FX forward curve source identity projection. Added direct
+  helper tests for populated and absent source identities.
+- Status: hardened
+- Evidence: `python -m ruff check src/api/services/construction_treasury_source_context.py
+  tests/unit/dpm/construction/test_treasury_source_context.py`, `python -m ruff format
+  src/api/services/construction_treasury_source_context.py
+  tests/unit/dpm/construction/test_treasury_source_context.py`, `python -m mypy --config-file
+  mypy.ini src/api/services/construction_treasury_source_context.py`, `python -m pytest
+  tests/unit/dpm/construction/test_treasury_source_context.py`,
+  `python scripts/engineering_health_report.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `git diff --check`, and service
+  leakage scan passed. The refreshed complexity report moves
+  `external_treasury_currency_overlay_context` out of the top-ten current source functions after it
+  previously ranked at complexity 30 / 164 lines.
+- Follow-up: continue reducing the refreshed top source hotspots, starting with
+  `validate_definition`, `build_search_row`, or another narrow source-boundary mapper if it remains
+  behavior-preserving.
+- Wiki decision: no wiki source change required; this preserves source-product mapping behavior and
+  improves internal maintainability only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -11776,3 +11776,28 @@ This ledger records cleanup and structural review evidence for RFC-0036.
   `external_treasury_currency_overlay_context` source hotspot.
 - Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
   internal maintainability only.
+
+## BACKEND-REVIEW-20260602-483: Proof-pack source readiness payload helper
+
+- Date: 2026-06-02
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, generated quality reports, and this
+  ledger.
+- Finding: `_section_payload` still carried source-run readiness projection inline, mixing the
+  dispatcher with lineage supportability state handling and missing-run failure behavior.
+- Action: extracted `_source_readiness_section_payload` and delegated the `source_readiness` branch
+  through it. Added direct helper tests for missing source runs and degraded lineage supportability.
+- Status: hardened
+- Evidence: `python -m ruff check src/core/proof_packs/builder.py
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python -m ruff format
+  src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`, `python -m pytest
+  tests/unit/dpm/proof_packs/test_proof_pack_builder.py`, `python scripts/engineering_health_report.py`,
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py
+  --validate-only`, `git diff --check`, and service leakage scan passed. The refreshed complexity
+  report shows `_section_payload` reduced from complexity 36 / 192 lines to complexity 32 / 178
+  lines.
+- Follow-up: continue extracting the remaining proof-pack section payloads, especially
+  turnover/cost and eligibility/restriction, then return to top-ranked source hotspots.
+- Wiki decision: no wiki source change required; this preserves proof-pack behavior and improves
+  internal maintainability only.

--- a/quality/api_governance_rules.md
+++ b/quality/api_governance_rules.md
@@ -1,0 +1,22 @@
+# lotus-manage API Governance Rules
+
+These rules define the report-only API-governance baseline for the enterprise-readiness refactor.
+
+## OpenAPI Contract
+
+1. Every endpoint should have a summary, description, tags, stable operation ID, request/response model, examples, and standard errors.
+2. Error responses should use consistent platform problem-details semantics where applicable.
+3. Public and internal endpoints should remain clearly separated.
+4. Health, readiness, liveness, metrics, internal, and public endpoints should be documented as distinct operational surfaces.
+
+## API Behavior
+
+1. Pagination, filtering, sorting, versioning, and deprecation should be consistent across list/read APIs.
+2. Correlation IDs should be accepted or generated and propagated to downstream calls.
+3. Idempotent mutations should document idempotency key behavior, replay behavior, and conflict behavior.
+4. Downstream unavailable/degraded states should be exposed as bounded supportability posture rather than hidden behind generic success.
+
+## Current Gate Phase
+
+OpenAPI and API vocabulary checks are active repo-native gates. The broader rule set is phase
+1/report-only until each detector has a stable baseline and agreed thresholds.

--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -1,0 +1,25 @@
+# lotus-manage Architecture Rules
+
+These rules define the report-only architecture baseline for the enterprise-readiness refactor.
+They are explicit so later validators can enforce them without changing their meaning.
+
+## Layering
+
+1. Routers call application services or use-case functions only.
+2. Routers must not call repositories, database clients, HTTP clients, Kafka, Redis, or downstream adapters directly.
+3. Middleware stays thin, cross-cutting, and business-logic-free.
+4. Domain and application code must not depend on FastAPI, framework objects, infrastructure clients, or persistence models.
+5. Infrastructure sits behind explicit ports/adapters.
+6. DTOs and persistence models must not leak into domain logic.
+
+## Reliability And Auditability
+
+1. Downstream failures map to consistent platform errors.
+2. Every request must support and propagate a correlation identifier.
+3. Relevant mutations must be auditable.
+4. Idempotent operations must define replay/conflict behavior.
+5. Logs must be structured and must not leak sensitive data.
+
+## Current Gate Phase
+
+These rules are in phase 1/report-only except for checks already covered by repo-native gates.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:41:48+00:00`
+- Generated at: `2026-06-02T00:44:53+00:00`
 
-- Baseline commit: `002ca59`
+- Baseline commit: `ca69123`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147219 |
-| Test functions | 1886 |
+| Total Python LOC | 147332 |
+| Test functions | 1888 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:29:49+00:00`
+- Generated at: `2026-06-02T00:32:37+00:00`
 
-- Baseline commit: `5e0ab2e`
+- Baseline commit: `db3a6d0`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146971 |
-| Test functions | 1878 |
+| Total Python LOC | 147023 |
+| Test functions | 1880 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-01T23:57:48+00:00`
+- Generated at: `2026-06-01T23:59:43+00:00`
 
-- Baseline commit: `158f534`
+- Baseline commit: `380eab9`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146222 |
-| Test functions | 1858 |
+| Total Python LOC | 146281 |
+| Test functions | 1859 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:10:08+00:00`
+- Generated at: `2026-06-02T00:12:06+00:00`
 
-- Baseline commit: `9e39058`
+- Baseline commit: `100cbfe`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146500 |
-| Test functions | 1863 |
+| Total Python LOC | 146521 |
+| Test functions | 1864 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:49:11+00:00`
+- Generated at: `2026-06-02T04:52:14+00:00`
 
-- Baseline commit: `3a56e2c`
+- Baseline commit: `f608a30`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148785 |
-| Test functions | 1942 |
+| Total Python LOC | 148809 |
+| Test functions | 1944 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:01:00+00:00`
+- Generated at: `2026-06-02T04:04:36+00:00`
 
-- Baseline commit: `f35ae8e`
+- Baseline commit: `790358a`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 148039 |
-| Test functions | 1911 |
+| Total Python LOC | 148100 |
+| Test functions | 1915 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:22:22+00:00`
+- Generated at: `2026-06-02T04:27:25+00:00`
 
-- Baseline commit: `cb2441e`
+- Baseline commit: `c4167c4`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148331 |
-| Test functions | 1923 |
+| Total Python LOC | 148395 |
+| Test functions | 1927 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:19:18+00:00`
+- Generated at: `2026-06-02T00:22:27+00:00`
 
-- Baseline commit: `6d19e17`
+- Baseline commit: `45afeb5`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146651 |
-| Test functions | 1870 |
+| Total Python LOC | 146736 |
+| Test functions | 1872 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:51:17+00:00`
+- Generated at: `2026-06-02T00:53:57+00:00`
 
-- Baseline commit: `3b665fa`
+- Baseline commit: `96164d2`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147479 |
-| Test functions | 1892 |
+| Total Python LOC | 147477 |
+| Test functions | 1894 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:16:05+00:00`
+- Generated at: `2026-06-02T00:19:18+00:00`
 
-- Baseline commit: `f80fd82`
+- Baseline commit: `6d19e17`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146597 |
-| Test functions | 1868 |
+| Total Python LOC | 146651 |
+| Test functions | 1870 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T01:06:40+00:00`
+- Generated at: `2026-06-02T03:52:45+00:00`
 
-- Baseline commit: `5138bdd`
+- Baseline commit: `fa38cd7`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147751 |
-| Test functions | 1901 |
+| Total Python LOC | 147841 |
+| Test functions | 1903 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:15:36+00:00`
+- Generated at: `2026-06-02T04:18:32+00:00`
 
-- Baseline commit: `aedd311`
+- Baseline commit: `1ade148`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 148266 |
-| Test functions | 1921 |
+| Total Python LOC | 148331 |
+| Test functions | 1923 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-04T04:18:26+00:00`
+- Generated at: `2026-06-04T04:20:12+00:00`
 
-- Baseline commit: `860862d`
+- Baseline commit: `fafa839`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148930 |
-| Test functions | 1946 |
+| Total Python LOC | 149079 |
+| Test functions | 1950 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:27:34+00:00`
+- Generated at: `2026-06-02T00:29:49+00:00`
 
-- Baseline commit: `4e3fecd`
+- Baseline commit: `5e0ab2e`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146907 |
-| Test functions | 1876 |
+| Total Python LOC | 146971 |
+| Test functions | 1878 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:44:53+00:00`
+- Generated at: `2026-06-02T00:47:32+00:00`
 
-- Baseline commit: `ca69123`
+- Baseline commit: `3ef0c62`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147332 |
-| Test functions | 1888 |
+| Total Python LOC | 147393 |
+| Test functions | 1890 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:55:04+00:00`
+- Generated at: `2026-06-04T04:18:26+00:00`
 
-- Baseline commit: `c65fc5a`
+- Baseline commit: `860862d`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148853 |
-| Test functions | 1945 |
+| Total Python LOC | 148930 |
+| Test functions | 1946 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:18:32+00:00`
+- Generated at: `2026-06-02T04:22:22+00:00`
 
-- Baseline commit: `1ade148`
+- Baseline commit: `cb2441e`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -10,7 +10,7 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 769 |
+| Python files | 770 |
 | Total Python LOC | 148331 |
 | Test functions | 1923 |
 | Service boundary findings | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,0 +1,48 @@
+# lotus-manage Baseline Quality Report
+
+- Generated at: `2026-06-01T23:57:48+00:00`
+
+- Baseline commit: `158f534`
+
+- Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
+
+## Current Code Size
+
+| Metric | Value |
+| --- | --- |
+| Python files | 769 |
+| Total Python LOC | 146222 |
+| Test functions | 1858 |
+| Service boundary findings | 0 |
+| Router infrastructure imports | 18 |
+
+## Current OpenAPI Completeness
+
+| Metric | Value |
+| --- | --- |
+| Operations | 135 |
+| Missing summary | 0 |
+| Missing description | 0 |
+| Missing tags | 0 |
+| Missing 4xx/5xx response | 3 |
+| Missing examples marker | 0 |
+
+## Report-Only Coverage Map
+
+| Quality area | Current evidence | Gate phase |
+| --- | --- | --- |
+| Code size | `scripts/engineering_health_report.py` | 1 - baseline |
+| Largest files/functions | `quality/refactor_health_report.md` | 1 - baseline |
+| OpenAPI completeness | `scripts/openapi_quality_gate.py` plus this report | 2 - active/new-regression |
+| Service boundary leakage | service leakage scan plus this report | 2 - active/new-regression |
+| Router infrastructure imports | reported as known baseline debt | 1 - baseline |
+| Complexity/maintainability | not instrumented yet | planned |
+| Dead code | not instrumented yet | planned |
+| Dependency hygiene | `pip check`/security audit in repo gates; richer deptry planned | 2 - active/new-regression |
+| Security | `make security-audit`; richer bandit/pip-audit scorecard planned | 2 - active/new-regression |
+| Documentation gaps | current docs tests plus planned docs scorecard | planned |
+| Observability gaps | `scripts/validate_observability_contracts.py`; richer runtime gap report planned | 2 - active/new-regression |
+
+## Notes
+
+- Future slices should add optional-tool measurements without converting unstable baselines into blocking gates prematurely.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:05:18+00:00`
+- Generated at: `2026-06-02T00:06:52+00:00`
 
-- Baseline commit: `bc3b74c`
+- Baseline commit: `ca90120`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,7 +11,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146441 |
+| Total Python LOC | 146461 |
 | Test functions | 1861 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:32:37+00:00`
+- Generated at: `2026-06-02T00:35:30+00:00`
 
-- Baseline commit: `db3a6d0`
+- Baseline commit: `3d1caf1`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147023 |
-| Test functions | 1880 |
+| Total Python LOC | 147084 |
+| Test functions | 1882 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:11:42+00:00`
+- Generated at: `2026-06-02T04:15:36+00:00`
 
-- Baseline commit: `ffb330d`
+- Baseline commit: `aedd311`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 148221 |
-| Test functions | 1919 |
+| Total Python LOC | 148266 |
+| Test functions | 1921 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:04:36+00:00`
+- Generated at: `2026-06-02T04:07:55+00:00`
 
-- Baseline commit: `790358a`
+- Baseline commit: `7637ee8`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 148100 |
-| Test functions | 1915 |
+| Total Python LOC | 148187 |
+| Test functions | 1917 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:12:06+00:00`
+- Generated at: `2026-06-02T00:14:09+00:00`
 
-- Baseline commit: `100cbfe`
+- Baseline commit: `bb02b2b`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146521 |
-| Test functions | 1864 |
+| Total Python LOC | 146557 |
+| Test functions | 1866 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:33:58+00:00`
+- Generated at: `2026-06-02T04:37:47+00:00`
 
-- Baseline commit: `ded5058`
+- Baseline commit: `9e5d22c`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148535 |
-| Test functions | 1933 |
+| Total Python LOC | 148595 |
+| Test functions | 1936 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:46:13+00:00`
+- Generated at: `2026-06-02T04:49:11+00:00`
 
-- Baseline commit: `5e7e52b`
+- Baseline commit: `3a56e2c`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148725 |
-| Test functions | 1940 |
+| Total Python LOC | 148785 |
+| Test functions | 1942 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T03:58:22+00:00`
+- Generated at: `2026-06-02T04:01:00+00:00`
 
-- Baseline commit: `34a303d`
+- Baseline commit: `f35ae8e`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147976 |
-| Test functions | 1908 |
+| Total Python LOC | 148039 |
+| Test functions | 1911 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:35:30+00:00`
+- Generated at: `2026-06-02T00:39:11+00:00`
 
-- Baseline commit: `3d1caf1`
+- Baseline commit: `5131008`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147084 |
-| Test functions | 1882 |
+| Total Python LOC | 147135 |
+| Test functions | 1884 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:39:11+00:00`
+- Generated at: `2026-06-02T00:41:48+00:00`
 
-- Baseline commit: `5131008`
+- Baseline commit: `002ca59`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147135 |
-| Test functions | 1884 |
+| Total Python LOC | 147219 |
+| Test functions | 1886 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:52:14+00:00`
+- Generated at: `2026-06-02T04:55:04+00:00`
 
-- Baseline commit: `f608a30`
+- Baseline commit: `c65fc5a`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148809 |
-| Test functions | 1944 |
+| Total Python LOC | 148853 |
+| Test functions | 1945 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T01:00:51+00:00`
+- Generated at: `2026-06-02T01:04:15+00:00`
 
-- Baseline commit: `f456945`
+- Baseline commit: `c6f49d9`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147631 |
-| Test functions | 1898 |
+| Total Python LOC | 147699 |
+| Test functions | 1900 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:07:55+00:00`
+- Generated at: `2026-06-02T04:11:42+00:00`
 
-- Baseline commit: `7637ee8`
+- Baseline commit: `ffb330d`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 148187 |
-| Test functions | 1917 |
+| Total Python LOC | 148221 |
+| Test functions | 1919 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T01:04:15+00:00`
+- Generated at: `2026-06-02T01:06:40+00:00`
 
-- Baseline commit: `c6f49d9`
+- Baseline commit: `5138bdd`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147699 |
-| Test functions | 1900 |
+| Total Python LOC | 147751 |
+| Test functions | 1901 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:27:25+00:00`
+- Generated at: `2026-06-02T04:30:46+00:00`
 
-- Baseline commit: `c4167c4`
+- Baseline commit: `be6f7b0`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148395 |
-| Test functions | 1927 |
+| Total Python LOC | 148466 |
+| Test functions | 1929 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:53:57+00:00`
+- Generated at: `2026-06-02T00:57:14+00:00`
 
-- Baseline commit: `96164d2`
+- Baseline commit: `06a20f2`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147477 |
-| Test functions | 1894 |
+| Total Python LOC | 147527 |
+| Test functions | 1895 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:22:27+00:00`
+- Generated at: `2026-06-02T00:25:15+00:00`
 
-- Baseline commit: `45afeb5`
+- Baseline commit: `e500690`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146736 |
-| Test functions | 1872 |
+| Total Python LOC | 146830 |
+| Test functions | 1874 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:25:15+00:00`
+- Generated at: `2026-06-02T00:27:34+00:00`
 
-- Baseline commit: `e500690`
+- Baseline commit: `4e3fecd`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146830 |
-| Test functions | 1874 |
+| Total Python LOC | 146907 |
+| Test functions | 1876 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:37:47+00:00`
+- Generated at: `2026-06-02T04:40:35+00:00`
 
-- Baseline commit: `9e5d22c`
+- Baseline commit: `18e2477`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148595 |
-| Test functions | 1936 |
+| Total Python LOC | 148613 |
+| Test functions | 1937 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:43:29+00:00`
+- Generated at: `2026-06-02T04:46:13+00:00`
 
-- Baseline commit: `a010107`
+- Baseline commit: `5e7e52b`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148663 |
-| Test functions | 1938 |
+| Total Python LOC | 148725 |
+| Test functions | 1940 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:14:09+00:00`
+- Generated at: `2026-06-02T00:16:05+00:00`
 
-- Baseline commit: `bb02b2b`
+- Baseline commit: `f80fd82`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146557 |
-| Test functions | 1866 |
+| Total Python LOC | 146597 |
+| Test functions | 1868 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:30:46+00:00`
+- Generated at: `2026-06-02T04:33:58+00:00`
 
-- Baseline commit: `be6f7b0`
+- Baseline commit: `ded5058`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148466 |
-| Test functions | 1929 |
+| Total Python LOC | 148535 |
+| Test functions | 1933 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:47:32+00:00`
+- Generated at: `2026-06-02T00:51:17+00:00`
 
-- Baseline commit: `3ef0c62`
+- Baseline commit: `3b665fa`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147393 |
-| Test functions | 1890 |
+| Total Python LOC | 147479 |
+| Test functions | 1892 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:57:14+00:00`
+- Generated at: `2026-06-02T01:00:51+00:00`
 
-- Baseline commit: `06a20f2`
+- Baseline commit: `f456945`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147527 |
-| Test functions | 1895 |
+| Total Python LOC | 147631 |
+| Test functions | 1898 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T03:52:45+00:00`
+- Generated at: `2026-06-02T03:58:22+00:00`
 
-- Baseline commit: `fa38cd7`
+- Baseline commit: `34a303d`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 147841 |
-| Test functions | 1903 |
+| Total Python LOC | 147976 |
+| Test functions | 1908 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-01T23:59:43+00:00`
+- Generated at: `2026-06-02T00:05:18+00:00`
 
-- Baseline commit: `380eab9`
+- Baseline commit: `bc3b74c`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146281 |
-| Test functions | 1859 |
+| Total Python LOC | 146441 |
+| Test functions | 1861 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 
@@ -36,7 +36,7 @@
 | OpenAPI completeness | `scripts/openapi_quality_gate.py` plus this report | 2 - active/new-regression |
 | Service boundary leakage | service leakage scan plus this report | 2 - active/new-regression |
 | Router infrastructure imports | reported as known baseline debt | 1 - baseline |
-| Complexity/maintainability | not instrumented yet | planned |
+| Complexity/maintainability | `quality/complexity_report.md` | 1 - baseline |
 | Dead code | not instrumented yet | planned |
 | Dependency hygiene | `pip check`/security audit in repo gates; richer deptry planned | 2 - active/new-regression |
 | Security | `make security-audit`; richer bandit/pip-audit scorecard planned | 2 - active/new-regression |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T04:40:35+00:00`
+- Generated at: `2026-06-02T04:43:29+00:00`
 
-- Baseline commit: `18e2477`
+- Baseline commit: `a010107`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 770 |
-| Total Python LOC | 148613 |
-| Test functions | 1937 |
+| Total Python LOC | 148663 |
+| Test functions | 1938 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-02T00:06:52+00:00`
+- Generated at: `2026-06-02T00:10:08+00:00`
 
-- Baseline commit: `ca90120`
+- Baseline commit: `9e39058`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 769 |
-| Total Python LOC | 146461 |
-| Test functions | 1861 |
+| Total Python LOC | 146500 |
+| Test functions | 1863 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 18 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:04:36+00:00`
+- Generated at: `2026-06-02T04:07:55+00:00`
 
-- Current ref: `790358a`
+- Current ref: `7637ee8`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
-| 2 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 3 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 4 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 5 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
-| 6 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 7 | build_simulated_state | src/core/valuation.py | 19 | 123 |
-| 8 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 9 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 10 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 1 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 2 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 3 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 4 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 5 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
+| 6 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 7 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 9 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 10 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:44:53+00:00`
+- Generated at: `2026-06-02T00:47:32+00:00`
 
-- Current ref: `ca69123`
+- Current ref: `3ef0c62`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,8 +32,8 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
-| 2 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
+| 2 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 30 | 164 |
 | 3 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
 | 4 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
 | 5 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:39:11+00:00`
+- Generated at: `2026-06-02T00:41:48+00:00`
 
-- Current ref: `5131008`
+- Current ref: `002ca59`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -34,9 +34,9 @@
 | --- | --- | --- | --- | --- |
 | 1 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
 | 2 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 32 | 178 |
-| 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
-| 5 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
+| 3 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
+| 4 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
+| 5 | _section_payload | src/core/proof_packs/builder.py | 27 | 154 |
 | 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
 | 7 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
 | 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T03:52:45+00:00`
+- Generated at: `2026-06-02T03:58:22+00:00`
 
-- Current ref: `fa38cd7`
+- Current ref: `34a303d`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -33,13 +33,13 @@
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
 | 1 | generate_intents | src/core/rebalance/intents.py | 23 | 149 |
-| 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 22 | 160 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
-| 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
-| 5 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 6 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 7 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 8 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 2 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
+| 3 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
+| 4 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 5 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 6 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 7 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 8 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
 | 9 | build_simulated_state | src/core/valuation.py | 19 | 123 |
 | 10 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:12:06+00:00`
+- Generated at: `2026-06-02T00:14:09+00:00`
 
-- Current ref: `100cbfe`
+- Current ref: `bb02b2b`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -23,8 +23,8 @@
 | 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
-| 7 | _section_payload | src/core/proof_packs/builder.py | 81 | 420 |
-| 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 8 | _section_payload | src/core/proof_packs/builder.py | 75 | 383 |
 | 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
 
@@ -32,7 +32,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 81 | 420 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 75 | 383 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:16:05+00:00`
+- Generated at: `2026-06-02T00:19:18+00:00`
 
-- Current ref: `f80fd82`
+- Current ref: `6d19e17`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -26,13 +26,22 @@
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 9 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
-| 10 | _section_payload | src/core/proof_packs/builder.py | 69 | 353 |
+| 10 | test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_posture | tests/unit/dpm/api/test_waves_api.py | 66 | 220 |
 
 ### Most Complex Current Source Functions
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 69 | 353 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 64 | 318 |
+| 2 | generate_intents | src/core/rebalance/intents.py | 58 | 236 |
+| 3 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
+| 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
+| 5 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
+| 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
+| 7 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
+| 9 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 10 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
 
 ### Most Complex Current Test Functions
 
@@ -47,6 +56,7 @@
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 9 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+| 10 | test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_posture | tests/unit/dpm/api/test_waves_api.py | 66 | 220 |
 
 ## Gate Posture
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:06:52+00:00`
+- Generated at: `2026-06-02T00:10:08+00:00`
 
-- Current ref: `ca90120`
+- Current ref: `9e39058`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -23,7 +23,7 @@
 | 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
-| 7 | _section_payload | src/core/proof_packs/builder.py | 85 | 465 |
+| 7 | _section_payload | src/core/proof_packs/builder.py | 81 | 426 |
 | 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
@@ -32,7 +32,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 85 | 465 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 81 | 426 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:41:48+00:00`
+- Generated at: `2026-06-02T00:44:53+00:00`
 
-- Current ref: `002ca59`
+- Current ref: `ca69123`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -36,9 +36,9 @@
 | 2 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
 | 3 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
 | 4 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
-| 5 | _section_payload | src/core/proof_packs/builder.py | 27 | 154 |
-| 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
-| 7 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 5 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
+| 6 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 7 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
 | 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
 | 9 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
 | 10 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:52:14+00:00`
+- Generated at: `2026-06-02T04:55:04+00:00`
 
-- Current ref: `f608a30`
+- Current ref: `c65fc5a`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
-| 2 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
-| 3 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
-| 4 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
-| 5 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
-| 6 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
-| 7 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
-| 8 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
-| 9 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
-| 10 | _ensure_operation_documentation | src/api/openapi_enrichment.py | 16 | 33 |
+| 1 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
+| 2 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 3 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 4 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 5 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
+| 6 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
+| 7 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
+| 8 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
+| 9 | _ensure_operation_documentation | src/api/openapi_enrichment.py | 16 | 33 |
+| 10 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:14:09+00:00`
+- Generated at: `2026-06-02T00:16:05+00:00`
 
-- Current ref: `bb02b2b`
+- Current ref: `f80fd82`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -24,15 +24,15 @@
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
-| 8 | _section_payload | src/core/proof_packs/builder.py | 75 | 383 |
-| 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
-| 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+| 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
+| 9 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+| 10 | _section_payload | src/core/proof_packs/builder.py | 69 | 353 |
 
 ### Most Complex Current Source Functions
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 75 | 383 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 69 | 353 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:47:32+00:00`
+- Generated at: `2026-06-02T00:51:17+00:00`
 
-- Current ref: `3ef0c62`
+- Current ref: `3b665fa`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,12 +32,12 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
-| 2 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 30 | 164 |
-| 3 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
-| 4 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
-| 5 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
-| 6 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 1 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 30 | 164 |
+| 2 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
+| 3 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
+| 4 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
+| 5 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 6 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
 | 7 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
 | 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
 | 9 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:37:47+00:00`
+- Generated at: `2026-06-02T04:40:35+00:00`
 
-- Current ref: `9e5d22c`
+- Current ref: `18e2477`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,12 +32,12 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 2 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 3 | evaluate | src/core/compliance.py | 17 | 199 |
-| 4 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
-| 5 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 6 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 1 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 2 | evaluate | src/core/compliance.py | 17 | 199 |
+| 3 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 4 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
+| 5 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 6 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
 | 7 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
 | 8 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
 | 9 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T04:18:26+00:00`
+- Generated at: `2026-06-04T04:20:12+00:00`
 
-- Current ref: `860862d`
+- Current ref: `fafa839`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,7 +32,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 1 | _validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 68 |
 | 2 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
 | 3 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
 | 4 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:49:11+00:00`
+- Generated at: `2026-06-02T04:52:14+00:00`
 
-- Current ref: `3a56e2c`
+- Current ref: `f608a30`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,12 +32,12 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 2 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
-| 3 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
-| 4 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
-| 5 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
-| 6 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 1 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 2 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
+| 3 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 4 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 5 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 6 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
 | 7 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
 | 8 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
 | 9 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T01:06:40+00:00`
+- Generated at: `2026-06-02T03:52:45+00:00`
 
-- Current ref: `5138bdd`
+- Current ref: `fa38cd7`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,7 +32,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 23 | 149 |
 | 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 22 | 160 |
 | 3 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
 | 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:05:18+00:00`
+- Generated at: `2026-06-02T00:06:52+00:00`
 
-- Current ref: `bc3b74c`
+- Current ref: `ca90120`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -27,6 +27,26 @@
 | 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+
+### Most Complex Current Source Functions
+
+| Rank | Function | File | Complexity | Lines |
+| --- | --- | --- | --- | --- |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 85 | 465 |
+
+### Most Complex Current Test Functions
+
+| Rank | Function | File | Complexity | Lines |
+| --- | --- | --- | --- | --- |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1063 | 1546 |
+| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 274 | 754 |
+| 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 376 |
+| 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
+| 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
+| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
+| 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
+| 9 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
 
 ## Gate Posture
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:33:58+00:00`
+- Generated at: `2026-06-02T04:37:47+00:00`
 
-- Current ref: `ded5058`
+- Current ref: `9e5d22c`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 2 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 3 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 4 | evaluate | src/core/compliance.py | 17 | 199 |
-| 5 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
-| 6 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 7 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
-| 8 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
-| 9 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
-| 10 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 1 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 2 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 3 | evaluate | src/core/compliance.py | 17 | 199 |
+| 4 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 5 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
+| 6 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 7 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 8 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 9 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 10 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:27:25+00:00`
+- Generated at: `2026-06-02T04:30:46+00:00`
 
-- Current ref: `c4167c4`
+- Current ref: `be6f7b0`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 2 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 3 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 4 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 5 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 6 | evaluate | src/core/compliance.py | 17 | 199 |
-| 7 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
-| 8 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 9 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
-| 10 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 1 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 2 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 3 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 4 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 5 | evaluate | src/core/compliance.py | 17 | 199 |
+| 6 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 7 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
+| 8 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 9 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 10 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:57:14+00:00`
+- Generated at: `2026-06-02T01:00:51+00:00`
 
-- Current ref: `06a20f2`
+- Current ref: `f456945`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
-| 2 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
-| 3 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
-| 4 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
-| 5 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
-| 6 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
-| 7 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 8 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 9 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 10 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 1 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
+| 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 3 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
+| 4 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
+| 5 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
+| 6 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 7 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 8 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 9 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 10 | build_simulated_state | src/core/valuation.py | 19 | 123 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:40:35+00:00`
+- Generated at: `2026-06-02T04:43:29+00:00`
 
-- Current ref: `18e2477`
+- Current ref: `a010107`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 2 | evaluate | src/core/compliance.py | 17 | 199 |
-| 3 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
-| 4 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 5 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
-| 6 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
-| 7 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
-| 8 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
-| 9 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
-| 10 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
+| 1 | evaluate | src/core/compliance.py | 17 | 199 |
+| 2 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 3 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
+| 4 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 5 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
+| 6 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 7 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 8 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 9 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
+| 10 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:43:29+00:00`
+- Generated at: `2026-06-02T04:46:13+00:00`
 
-- Current ref: `a010107`
+- Current ref: `5e7e52b`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | evaluate | src/core/compliance.py | 17 | 199 |
-| 2 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
-| 3 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 4 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
-| 5 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
-| 6 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
-| 7 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
-| 8 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
-| 9 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
-| 10 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 2 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
+| 3 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 4 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
+| 5 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 7 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 8 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
+| 9 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
+| 10 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:22:22+00:00`
+- Generated at: `2026-06-02T04:27:25+00:00`
 
-- Current ref: `cb2441e`
+- Current ref: `c4167c4`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -33,15 +33,15 @@
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
 | 1 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 2 | build_simulated_state | src/core/valuation.py | 19 | 123 |
-| 3 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 5 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 6 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 7 | evaluate | src/core/compliance.py | 17 | 199 |
-| 8 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
-| 9 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 10 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 2 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 3 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 4 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 5 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 6 | evaluate | src/core/compliance.py | 17 | 199 |
+| 7 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 8 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
+| 9 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 10 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:35:30+00:00`
+- Generated at: `2026-06-02T00:39:11+00:00`
 
-- Current ref: `3d1caf1`
+- Current ref: `5131008`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -34,7 +34,7 @@
 | --- | --- | --- | --- | --- |
 | 1 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
 | 2 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 36 | 192 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 32 | 178 |
 | 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
 | 5 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
 | 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:30:46+00:00`
+- Generated at: `2026-06-02T04:33:58+00:00`
 
-- Current ref: `be6f7b0`
+- Current ref: `ded5058`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 2 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 3 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 4 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 5 | evaluate | src/core/compliance.py | 17 | 199 |
-| 6 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
-| 7 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 8 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
-| 9 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
-| 10 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 1 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 2 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 3 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 4 | evaluate | src/core/compliance.py | 17 | 199 |
+| 5 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 6 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
+| 7 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 8 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 9 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 10 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:25:15+00:00`
+- Generated at: `2026-06-02T00:27:34+00:00`
 
-- Current ref: `e500690`
+- Current ref: `4e3fecd`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,7 +32,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 52 | 217 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 48 | 210 |
 | 2 | _section_payload | src/core/proof_packs/builder.py | 45 | 278 |
 | 3 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
 | 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:19:18+00:00`
+- Generated at: `2026-06-02T00:22:27+00:00`
 
-- Current ref: `6d19e17`
+- Current ref: `45afeb5`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,8 +32,8 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 64 | 318 |
-| 2 | generate_intents | src/core/rebalance/intents.py | 58 | 236 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 58 | 236 |
+| 2 | _section_payload | src/core/proof_packs/builder.py | 45 | 278 |
 | 3 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
 | 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
 | 5 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:46:13+00:00`
+- Generated at: `2026-06-02T04:49:11+00:00`
 
-- Current ref: `5e7e52b`
+- Current ref: `3a56e2c`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
-| 2 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
-| 3 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
-| 4 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
-| 5 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
-| 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
-| 7 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
-| 8 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
-| 9 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
-| 10 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
+| 1 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
+| 2 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
+| 3 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
+| 4 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 5 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 6 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 7 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
+| 8 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
+| 9 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
+| 10 | _ensure_operation_documentation | src/api/openapi_enrichment.py | 16 | 33 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,0 +1,33 @@
+# lotus-manage Complexity Report
+
+- Generated at: `2026-06-02T00:05:18+00:00`
+
+- Current ref: `bc3b74c`
+
+- Mode: report-only maintainability baseline using dependency-free AST branch counting.
+
+## Summary
+
+| Metric | origin/main | current branch | Delta |
+| --- | --- | --- | --- |
+| Reported top functions | 10 | 10 | +0 |
+| Highest complexity | 1063 | 1063 | +0 |
+
+### Most Complex Current Functions
+
+| Rank | Function | File | Complexity | Lines |
+| --- | --- | --- | --- | --- |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1063 | 1546 |
+| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 274 | 754 |
+| 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 376 |
+| 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
+| 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
+| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
+| 7 | _section_payload | src/core/proof_packs/builder.py | 85 | 465 |
+| 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
+| 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+
+## Gate Posture
+
+- This report is phase 1/report-only. It intentionally does not fail builds until the baseline is reviewed and thresholds are agreed.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:32:37+00:00`
+- Generated at: `2026-06-02T00:35:30+00:00`
 
-- Current ref: `db3a6d0`
+- Current ref: `3d1caf1`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,9 +32,9 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 41 | 224 |
-| 2 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
-| 3 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
+| 1 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
+| 2 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 36 | 192 |
 | 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
 | 5 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
 | 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:55:04+00:00`
+- Generated at: `2026-06-04T04:18:26+00:00`
 
-- Current ref: `c65fc5a`
+- Current ref: `860862d`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _example_from_schema | src/api/openapi_enrichment.py | 17 | 64 |
-| 2 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
-| 3 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
-| 4 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
-| 5 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
-| 6 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
-| 7 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
-| 8 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
-| 9 | _ensure_operation_documentation | src/api/openapi_enrichment.py | 16 | 33 |
-| 10 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
+| 1 | validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 52 |
+| 2 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
+| 3 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
+| 4 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
+| 5 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
+| 6 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
+| 7 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
+| 8 | _ensure_operation_documentation | src/api/openapi_enrichment.py | 16 | 33 |
+| 9 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
+| 10 | evaluate | src/core/compliance.py | 15 | 171 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:10:08+00:00`
+- Generated at: `2026-06-02T00:12:06+00:00`
 
-- Current ref: `9e39058`
+- Current ref: `100cbfe`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -23,7 +23,7 @@
 | 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
-| 7 | _section_payload | src/core/proof_packs/builder.py | 81 | 426 |
+| 7 | _section_payload | src/core/proof_packs/builder.py | 81 | 420 |
 | 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
@@ -32,7 +32,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 81 | 426 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 81 | 420 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:15:36+00:00`
+- Generated at: `2026-06-02T04:18:32+00:00`
 
-- Current ref: `aedd311`
+- Current ref: `1ade148`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 2 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
-| 3 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 4 | build_simulated_state | src/core/valuation.py | 19 | 123 |
-| 5 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 6 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 7 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 8 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 9 | evaluate | src/core/compliance.py | 17 | 199 |
-| 10 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 1 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
+| 3 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 4 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 5 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 6 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 7 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 8 | evaluate | src/core/compliance.py | 17 | 199 |
+| 9 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 10 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T01:04:15+00:00`
+- Generated at: `2026-06-02T01:06:40+00:00`
 
-- Current ref: `c6f49d9`
+- Current ref: `5138bdd`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,8 +32,8 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
-| 2 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
+| 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 22 | 160 |
 | 3 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
 | 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
 | 5 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T03:58:22+00:00`
+- Generated at: `2026-06-02T04:01:00+00:00`
 
-- Current ref: `34a303d`
+- Current ref: `f35ae8e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -34,14 +34,14 @@
 | --- | --- | --- | --- | --- |
 | 1 | generate_intents | src/core/rebalance/intents.py | 23 | 149 |
 | 2 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
-| 3 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
-| 4 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 5 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 6 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 7 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
-| 8 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 9 | build_simulated_state | src/core/valuation.py | 19 | 123 |
-| 10 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 3 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 4 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 5 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 6 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 7 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
+| 8 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 9 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 10 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:18:32+00:00`
+- Generated at: `2026-06-02T04:22:22+00:00`
 
-- Current ref: `1ade148`
+- Current ref: `cb2441e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,15 +32,15 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
-| 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 3 | build_simulated_state | src/core/valuation.py | 19 | 123 |
-| 4 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 5 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 6 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 7 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 8 | evaluate | src/core/compliance.py | 17 | 199 |
-| 9 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 1 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
+| 2 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 3 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 5 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 6 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 7 | evaluate | src/core/compliance.py | 17 | 199 |
+| 8 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
+| 9 | generate_targets_solver | src/core/target_generation.py | 17 | 109 |
 | 10 | summarize_enrichment_posture | src/core/construction/enrichment.py | 17 | 87 |
 
 ### Most Complex Current Test Functions

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:01:00+00:00`
+- Generated at: `2026-06-02T04:04:36+00:00`
 
-- Current ref: `f35ae8e`
+- Current ref: `790358a`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 23 | 149 |
-| 2 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
-| 3 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 4 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 5 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 6 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
-| 7 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 8 | build_simulated_state | src/core/valuation.py | 19 | 123 |
-| 9 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 10 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
+| 2 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 3 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 4 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 5 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 6 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
+| 7 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 8 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 9 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 10 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:29:49+00:00`
+- Generated at: `2026-06-02T00:32:37+00:00`
 
-- Current ref: `5e0ab2e`
+- Current ref: `db3a6d0`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,7 +32,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 45 | 278 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 41 | 224 |
 | 2 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
 | 3 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
 | 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:53:57+00:00`
+- Generated at: `2026-06-02T00:57:14+00:00`
 
-- Current ref: `96164d2`
+- Current ref: `06a20f2`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
-| 2 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
-| 3 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
-| 4 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
-| 5 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
-| 6 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
-| 7 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
-| 8 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 9 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 10 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 1 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
+| 2 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
+| 3 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 4 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
+| 5 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
+| 6 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
+| 7 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 8 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 9 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 10 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T01:00:51+00:00`
+- Generated at: `2026-06-02T01:04:15+00:00`
 
-- Current ref: `f456945`
+- Current ref: `c6f49d9`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
-| 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
-| 3 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
-| 4 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
-| 5 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
-| 6 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 7 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 8 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 9 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
-| 10 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 1 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 2 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
+| 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
+| 5 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 6 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 7 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 8 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 9 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 10 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:07:55+00:00`
+- Generated at: `2026-06-02T04:11:42+00:00`
 
-- Current ref: `7637ee8`
+- Current ref: `ffb330d`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 2 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 3 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 4 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
-| 5 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 6 | build_simulated_state | src/core/valuation.py | 19 | 123 |
-| 7 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 9 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 10 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 1 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 2 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 3 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 4 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
+| 5 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 6 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 7 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 8 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 9 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 10 | evaluate | src/core/compliance.py | 17 | 199 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T04:11:42+00:00`
+- Generated at: `2026-06-02T04:15:36+00:00`
 
-- Current ref: `ffb330d`
+- Current ref: `aedd311`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
-| 2 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
-| 3 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
-| 4 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
-| 5 | build_simulated_state | src/core/valuation.py | 19 | 123 |
-| 6 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
-| 7 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
-| 8 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
-| 9 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
-| 10 | evaluate | src/core/compliance.py | 17 | 199 |
+| 1 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
+| 2 | generate_targets_solver | src/core/target_generation.py | 20 | 113 |
+| 3 | generate_fx_and_simulate | src/core/rebalance/execution.py | 19 | 137 |
+| 4 | build_simulated_state | src/core/valuation.py | 19 | 123 |
+| 5 | validate_search_page_metadata | src/core/portfolio_memory/models.py | 19 | 79 |
+| 6 | generate_targets_heuristic | src/core/rebalance/targets.py | 19 | 71 |
+| 7 | _example_from_schema | src/api/openapi_enrichment.py | 19 | 66 |
+| 8 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 18 | 75 |
+| 9 | evaluate | src/core/compliance.py | 17 | 199 |
+| 10 | generate_intents | src/core/rebalance/intents.py | 17 | 145 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:51:17+00:00`
+- Generated at: `2026-06-02T00:53:57+00:00`
 
-- Current ref: `3b665fa`
+- Current ref: `96164d2`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 30 | 164 |
-| 2 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
-| 3 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
-| 4 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
-| 5 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
-| 6 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
-| 7 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
-| 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
-| 9 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
-| 10 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 1 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
+| 2 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
+| 3 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |
+| 4 | generate_fx_and_simulate | src/core/rebalance/execution.py | 26 | 167 |
+| 5 | generate_intents | src/core/rebalance/intents.py | 24 | 149 |
+| 6 | _section_payload | src/core/proof_packs/builder.py | 22 | 130 |
+| 7 | generate_targets_heuristic | src/core/rebalance/targets.py | 22 | 74 |
+| 8 | _infer_example | src/api/openapi_enrichment.py | 22 | 48 |
+| 9 | summarize_enrichment_posture | src/core/construction/enrichment.py | 21 | 89 |
+| 10 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 21 | 60 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:22:27+00:00`
+- Generated at: `2026-06-02T00:25:15+00:00`
 
-- Current ref: `45afeb5`
+- Current ref: `e500690`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,7 +32,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 58 | 236 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 52 | 217 |
 | 2 | _section_payload | src/core/proof_packs/builder.py | 45 | 278 |
 | 3 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
 | 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-02T00:27:34+00:00`
+- Generated at: `2026-06-02T00:29:49+00:00`
 
-- Current ref: `4e3fecd`
+- Current ref: `5e0ab2e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,9 +32,9 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 48 | 210 |
-| 2 | _section_payload | src/core/proof_packs/builder.py | 45 | 278 |
-| 3 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 45 | 278 |
+| 2 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 39 | 189 |
+| 3 | generate_intents | src/core/rebalance/intents.py | 38 | 207 |
 | 4 | validate_definition | src/core/waves/campaign_definitions.py | 30 | 69 |
 | 5 | build_search_row | src/core/portfolio_memory/search_page.py | 28 | 86 |
 | 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 26 | 182 |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T01:04:15+00:00`
+- Generated at: `2026-06-02T01:06:40+00:00`
 
-- Current ref: `c6f49d9`
+- Current ref: `5138bdd`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:18:32+00:00`
+- Generated at: `2026-06-02T04:22:22+00:00`
 
-- Current ref: `1ade148`
+- Current ref: `cb2441e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:05:18+00:00`
+- Generated at: `2026-06-02T00:06:52+00:00`
 
-- Current ref: `bc3b74c`
+- Current ref: `ca90120`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:40:35+00:00`
+- Generated at: `2026-06-02T04:43:29+00:00`
 
-- Current ref: `18e2477`
+- Current ref: `a010107`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:10:08+00:00`
+- Generated at: `2026-06-02T00:12:06+00:00`
 
-- Current ref: `9e39058`
+- Current ref: `100cbfe`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:32:37+00:00`
+- Generated at: `2026-06-02T00:35:30+00:00`
 
-- Current ref: `db3a6d0`
+- Current ref: `3d1caf1`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:22:27+00:00`
+- Generated at: `2026-06-02T00:25:15+00:00`
 
-- Current ref: `45afeb5`
+- Current ref: `e500690`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:46:13+00:00`
+- Generated at: `2026-06-02T04:49:11+00:00`
 
-- Current ref: `5e7e52b`
+- Current ref: `3a56e2c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:43:29+00:00`
+- Generated at: `2026-06-02T04:46:13+00:00`
 
-- Current ref: `a010107`
+- Current ref: `5e7e52b`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-01T23:59:43+00:00`
+- Generated at: `2026-06-02T00:05:18+00:00`
 
-- Current ref: `380eab9`
+- Current ref: `bc3b74c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 
@@ -16,7 +16,7 @@
 | Service boundary leakage | Report plus focused scans | Current service boundary findings: 0. |
 | Router infrastructure imports | Baseline debt | Current router infra imports: 18. |
 | OpenAPI 4xx/5xx response markers | Baseline debt | Current missing markers: 3. |
-| Complexity | Not yet instrumented | Add radon/xenon report-only baseline before thresholds. |
+| Complexity | Report-only baseline | `quality/complexity_report.md`; add thresholds after baseline review. |
 | Dead code | Not yet instrumented | Add vulture report-only baseline before thresholds. |
 | Dependency architecture | Not yet instrumented | Add import-linter/deptry report-only baseline before thresholds. |
 | Security depth | Partially active | Security audit is active; add bandit/pip-audit detail scorecard. |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:19:18+00:00`
+- Generated at: `2026-06-02T00:22:27+00:00`
 
-- Current ref: `6d19e17`
+- Current ref: `45afeb5`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:29:49+00:00`
+- Generated at: `2026-06-02T00:32:37+00:00`
 
-- Current ref: `5e0ab2e`
+- Current ref: `db3a6d0`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:39:11+00:00`
+- Generated at: `2026-06-02T00:41:48+00:00`
 
-- Current ref: `5131008`
+- Current ref: `002ca59`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T03:52:45+00:00`
+- Generated at: `2026-06-02T03:58:22+00:00`
 
-- Current ref: `fa38cd7`
+- Current ref: `34a303d`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T01:00:51+00:00`
+- Generated at: `2026-06-02T01:04:15+00:00`
 
-- Current ref: `f456945`
+- Current ref: `c6f49d9`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:01:00+00:00`
+- Generated at: `2026-06-02T04:04:36+00:00`
 
-- Current ref: `f35ae8e`
+- Current ref: `790358a`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:15:36+00:00`
+- Generated at: `2026-06-02T04:18:32+00:00`
 
-- Current ref: `aedd311`
+- Current ref: `1ade148`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:49:11+00:00`
+- Generated at: `2026-06-02T04:52:14+00:00`
 
-- Current ref: `3a56e2c`
+- Current ref: `f608a30`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:51:17+00:00`
+- Generated at: `2026-06-02T00:53:57+00:00`
 
-- Current ref: `3b665fa`
+- Current ref: `96164d2`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:25:15+00:00`
+- Generated at: `2026-06-02T00:27:34+00:00`
 
-- Current ref: `e500690`
+- Current ref: `4e3fecd`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:41:48+00:00`
+- Generated at: `2026-06-02T00:44:53+00:00`
 
-- Current ref: `002ca59`
+- Current ref: `ca69123`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T03:58:22+00:00`
+- Generated at: `2026-06-02T04:01:00+00:00`
 
-- Current ref: `34a303d`
+- Current ref: `f35ae8e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:52:14+00:00`
+- Generated at: `2026-06-02T04:55:04+00:00`
 
-- Current ref: `f608a30`
+- Current ref: `c65fc5a`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:53:57+00:00`
+- Generated at: `2026-06-02T00:57:14+00:00`
 
-- Current ref: `96164d2`
+- Current ref: `06a20f2`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T04:18:26+00:00`
+- Generated at: `2026-06-04T04:20:12+00:00`
 
-- Current ref: `860862d`
+- Current ref: `fafa839`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:14:09+00:00`
+- Generated at: `2026-06-02T00:16:05+00:00`
 
-- Current ref: `bb02b2b`
+- Current ref: `f80fd82`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:30:46+00:00`
+- Generated at: `2026-06-02T04:33:58+00:00`
 
-- Current ref: `be6f7b0`
+- Current ref: `ded5058`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-01T23:57:48+00:00`
+- Generated at: `2026-06-01T23:59:43+00:00`
 
-- Current ref: `158f534`
+- Current ref: `380eab9`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:07:55+00:00`
+- Generated at: `2026-06-02T04:11:42+00:00`
 
-- Current ref: `7637ee8`
+- Current ref: `ffb330d`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:47:32+00:00`
+- Generated at: `2026-06-02T00:51:17+00:00`
 
-- Current ref: `3ef0c62`
+- Current ref: `3b665fa`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:57:14+00:00`
+- Generated at: `2026-06-02T01:00:51+00:00`
 
-- Current ref: `06a20f2`
+- Current ref: `f456945`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:27:34+00:00`
+- Generated at: `2026-06-02T00:29:49+00:00`
 
-- Current ref: `4e3fecd`
+- Current ref: `5e0ab2e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:37:47+00:00`
+- Generated at: `2026-06-02T04:40:35+00:00`
 
-- Current ref: `9e5d22c`
+- Current ref: `18e2477`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,0 +1,33 @@
+# lotus-manage Quality Scorecard
+
+- Generated at: `2026-06-01T23:57:48+00:00`
+
+- Current ref: `158f534`
+
+- Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
+
+| Area | Status | Evidence / next gate |
+| --- | --- | --- |
+| Lint and formatting | Active gate | `make check` runs Ruff check and format check. |
+| Type checking | Active gate | `make check` runs mypy over source files. |
+| Unit tests | Active gate | `make check` runs `tests/unit`. |
+| OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |
+| API vocabulary | Active gate | `scripts/api_vocabulary_inventory.py --validate-only`. |
+| Service boundary leakage | Report plus focused scans | Current service boundary findings: 0. |
+| Router infrastructure imports | Baseline debt | Current router infra imports: 18. |
+| OpenAPI 4xx/5xx response markers | Baseline debt | Current missing markers: 3. |
+| Complexity | Not yet instrumented | Add radon/xenon report-only baseline before thresholds. |
+| Dead code | Not yet instrumented | Add vulture report-only baseline before thresholds. |
+| Dependency architecture | Not yet instrumented | Add import-linter/deptry report-only baseline before thresholds. |
+| Security depth | Partially active | Security audit is active; add bandit/pip-audit detail scorecard. |
+| Documentation coverage | Partially active | Docs current-state tests exist; add docs-gap scoring later. |
+| Observability | Partially active | Observability contract validator exists; add runtime posture scoring later. |
+
+## Progressive Gate Policy
+
+| Phase | Meaning | Current posture |
+| --- | --- | --- |
+| 1 - baseline/report-only | Measure current posture without failing builds. | Active for refactor health and baseline report. |
+| 2 - fail new regressions | Block newly introduced violations once the detector is stable. | Active for existing repo-native gates; planned for richer quality tools. |
+| 3 - enforce thresholds | Require agreed numeric thresholds. | Not active for new quality tools yet. |
+| 4 - enterprise-readiness gates | Block release on full readiness posture. | Target state, not yet complete. |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:04:36+00:00`
+- Generated at: `2026-06-02T04:07:55+00:00`
 
-- Current ref: `790358a`
+- Current ref: `7637ee8`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:12:06+00:00`
+- Generated at: `2026-06-02T00:14:09+00:00`
 
-- Current ref: `100cbfe`
+- Current ref: `bb02b2b`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:33:58+00:00`
+- Generated at: `2026-06-02T04:37:47+00:00`
 
-- Current ref: `ded5058`
+- Current ref: `9e5d22c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:06:52+00:00`
+- Generated at: `2026-06-02T00:10:08+00:00`
 
-- Current ref: `ca90120`
+- Current ref: `9e39058`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:11:42+00:00`
+- Generated at: `2026-06-02T04:15:36+00:00`
 
-- Current ref: `ffb330d`
+- Current ref: `aedd311`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:27:25+00:00`
+- Generated at: `2026-06-02T04:30:46+00:00`
 
-- Current ref: `c4167c4`
+- Current ref: `be6f7b0`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:22:22+00:00`
+- Generated at: `2026-06-02T04:27:25+00:00`
 
-- Current ref: `cb2441e`
+- Current ref: `c4167c4`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:35:30+00:00`
+- Generated at: `2026-06-02T00:39:11+00:00`
 
-- Current ref: `3d1caf1`
+- Current ref: `5131008`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:44:53+00:00`
+- Generated at: `2026-06-02T00:47:32+00:00`
 
-- Current ref: `ca69123`
+- Current ref: `3ef0c62`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T04:55:04+00:00`
+- Generated at: `2026-06-04T04:18:26+00:00`
 
-- Current ref: `c65fc5a`
+- Current ref: `860862d`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T01:06:40+00:00`
+- Generated at: `2026-06-02T03:52:45+00:00`
 
-- Current ref: `5138bdd`
+- Current ref: `fa38cd7`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-02T00:16:05+00:00`
+- Generated at: `2026-06-02T00:19:18+00:00`
 
-- Current ref: `f80fd82`
+- Current ref: `6d19e17`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-01T23:57:48+00:00`
+- Generated at: `2026-06-01T23:59:43+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `158f534`
+- Current ref: `380eab9`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146222 | +348 |
-| Test functions | 1855 | 1858 | +3 |
+| Total Python LOC | 145874 | 146281 | +407 |
+| Test functions | 1855 | 1859 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:47:32+00:00`
+- Generated at: `2026-06-02T00:51:17+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `3ef0c62`
+- Current ref: `3b665fa`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147393 | +1519 |
-| Test functions | 1855 | 1890 | +35 |
+| Total Python LOC | 145874 | 147479 | +1605 |
+| Test functions | 1855 | 1892 | +37 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:37:47+00:00`
+- Generated at: `2026-06-02T04:40:35+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `9e5d22c`
+- Current ref: `18e2477`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148595 | +2721 |
-| Test functions | 1855 | 1936 | +81 |
+| Total Python LOC | 145874 | 148613 | +2739 |
+| Test functions | 1855 | 1937 | +82 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:35:30+00:00`
+- Generated at: `2026-06-02T00:39:11+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `3d1caf1`
+- Current ref: `5131008`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147084 | +1210 |
-| Test functions | 1855 | 1882 | +27 |
+| Total Python LOC | 145874 | 147135 | +1261 |
+| Test functions | 1855 | 1884 | +29 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:10:08+00:00`
+- Generated at: `2026-06-02T00:12:06+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `9e39058`
+- Current ref: `100cbfe`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146500 | +626 |
-| Test functions | 1855 | 1863 | +8 |
+| Total Python LOC | 145874 | 146521 | +647 |
+| Test functions | 1855 | 1864 | +9 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -84,7 +84,7 @@
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1546 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 754 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 426 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 420 |
 | 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
 | 5 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
 | 6 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
@@ -120,7 +120,7 @@
 | 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
-| 7 | _section_payload | src/core/proof_packs/builder.py | 81 | 426 |
+| 7 | _section_payload | src/core/proof_packs/builder.py | 81 | 420 |
 | 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:22:27+00:00`
+- Generated at: `2026-06-02T00:25:15+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `45afeb5`
+- Current ref: `e500690`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146736 | +862 |
-| Test functions | 1855 | 1872 | +17 |
+| Total Python LOC | 145874 | 146830 | +956 |
+| Test functions | 1855 | 1874 | +19 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -91,7 +91,7 @@
 | 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
 | 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
 | 9 | _section_payload | src/core/proof_packs/builder.py | 278 |
-| 10 | generate_intents | src/core/rebalance/intents.py | 236 |
+| 10 | test_source_context_lifts_external_hedge_readiness_as_fail_closed_currency_context | tests/unit/dpm/construction/test_enrichment.py | 235 |
 
 ## Most Complex Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T01:00:51+00:00`
+- Generated at: `2026-06-02T01:04:15+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f456945`
+- Current ref: `c6f49d9`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147631 | +1757 |
-| Test functions | 1855 | 1898 | +43 |
+| Total Python LOC | 145874 | 147699 | +1825 |
+| Test functions | 1855 | 1900 | +45 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:11:42+00:00`
+- Generated at: `2026-06-02T04:15:36+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `ffb330d`
+- Current ref: `aedd311`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 148221 | +2347 |
-| Test functions | 1855 | 1919 | +64 |
+| Total Python LOC | 145874 | 148266 | +2392 |
+| Test functions | 1855 | 1921 | +66 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:19:18+00:00`
+- Generated at: `2026-06-02T00:22:27+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `6d19e17`
+- Current ref: `45afeb5`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146651 | +777 |
-| Test functions | 1855 | 1870 | +15 |
+| Total Python LOC | 145874 | 146736 | +862 |
+| Test functions | 1855 | 1872 | +17 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -89,8 +89,8 @@
 | 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
 | 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
 | 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
-| 8 | _section_payload | src/core/proof_packs/builder.py | 318 |
-| 9 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
+| 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
+| 9 | _section_payload | src/core/proof_packs/builder.py | 278 |
 | 10 | generate_intents | src/core/rebalance/intents.py | 236 |
 
 ## Most Complex Functions

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T01:06:40+00:00`
+- Generated at: `2026-06-02T03:52:45+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `5138bdd`
+- Current ref: `fa38cd7`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147751 | +1877 |
-| Test functions | 1855 | 1901 | +46 |
+| Total Python LOC | 145874 | 147841 | +1967 |
+| Test functions | 1855 | 1903 | +48 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:25:15+00:00`
+- Generated at: `2026-06-02T00:27:34+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `e500690`
+- Current ref: `4e3fecd`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146830 | +956 |
-| Test functions | 1855 | 1874 | +19 |
+| Total Python LOC | 145874 | 146907 | +1033 |
+| Test functions | 1855 | 1876 | +21 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-01T23:39:43+00:00`
+- Generated at: `2026-06-01T23:57:48+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `8dc39c9`
+- Current ref: `158f534`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 754 | 768 | +14 |
-| Total Python LOC | 144347 | 145874 | +1527 |
-| Test functions | 1834 | 1855 | +21 |
+| Python files | 768 | 769 | +1 |
+| Total Python LOC | 145874 | 146222 | +348 |
+| Test functions | 1855 | 1858 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -35,7 +35,7 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 6399 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 6402 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:15:36+00:00`
+- Generated at: `2026-06-02T04:18:32+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `aedd311`
+- Current ref: `1ade148`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 148266 | +2392 |
-| Test functions | 1855 | 1921 | +66 |
+| Total Python LOC | 145874 | 148331 | +2457 |
+| Test functions | 1855 | 1923 | +68 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -58,7 +58,7 @@
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2140 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
 | 8 | src/core/dpm_source_context.py | 1878 |
-| 9 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 1673 |
+| 9 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 1727 |
 | 10 | tests/unit/dpm/api/test_construction_api.py | 1667 |
 
 ## Largest Functions

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:18:32+00:00`
+- Generated at: `2026-06-02T04:22:22+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `1ade148`
+- Current ref: `cb2441e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,7 +12,7 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 768 | 769 | +1 |
+| Python files | 768 | 770 | +2 |
 | Total Python LOC | 145874 | 148331 | +2457 |
 | Test functions | 1855 | 1923 | +68 |
 | Service boundary findings | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T04:18:26+00:00`
+- Generated at: `2026-06-04T04:20:12+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `860862d`
+- Current ref: `fafa839`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148930 | +3056 |
-| Test functions | 1855 | 1946 | +91 |
+| Total Python LOC | 145874 | 149079 | +3205 |
+| Test functions | 1855 | 1950 | +95 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:01:00+00:00`
+- Generated at: `2026-06-02T04:04:36+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f35ae8e`
+- Current ref: `790358a`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 148039 | +2165 |
-| Test functions | 1855 | 1911 | +56 |
+| Total Python LOC | 145874 | 148100 | +2226 |
+| Test functions | 1855 | 1915 | +60 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:22:22+00:00`
+- Generated at: `2026-06-02T04:27:25+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `cb2441e`
+- Current ref: `c4167c4`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148331 | +2457 |
-| Test functions | 1855 | 1923 | +68 |
+| Total Python LOC | 145874 | 148395 | +2521 |
+| Test functions | 1855 | 1927 | +72 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:14:09+00:00`
+- Generated at: `2026-06-02T00:16:05+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `bb02b2b`
+- Current ref: `f80fd82`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146557 | +683 |
-| Test functions | 1855 | 1866 | +11 |
+| Total Python LOC | 145874 | 146597 | +723 |
+| Test functions | 1855 | 1868 | +13 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -84,10 +84,10 @@
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1546 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 754 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 383 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
-| 5 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
-| 6 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
+| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
+| 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
+| 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
+| 6 | _section_payload | src/core/proof_packs/builder.py | 353 |
 | 7 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
 | 8 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
 | 9 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
@@ -121,9 +121,9 @@
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
-| 8 | _section_payload | src/core/proof_packs/builder.py | 75 | 383 |
-| 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
-| 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+| 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
+| 9 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+| 10 | _section_payload | src/core/proof_packs/builder.py | 69 | 353 |
 
 ## Boundary Findings
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T03:58:22+00:00`
+- Generated at: `2026-06-02T04:01:00+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `34a303d`
+- Current ref: `f35ae8e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147976 | +2102 |
-| Test functions | 1855 | 1908 | +53 |
+| Total Python LOC | 145874 | 148039 | +2165 |
+| Test functions | 1855 | 1911 | +56 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:04:36+00:00`
+- Generated at: `2026-06-02T04:07:55+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `790358a`
+- Current ref: `7637ee8`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 148100 | +2226 |
-| Test functions | 1855 | 1915 | +60 |
+| Total Python LOC | 145874 | 148187 | +2313 |
+| Test functions | 1855 | 1917 | +62 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -58,8 +58,8 @@
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2140 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
 | 8 | src/core/dpm_source_context.py | 1878 |
-| 9 | tests/unit/dpm/api/test_construction_api.py | 1667 |
-| 10 | src/infrastructure/core_sourcing/client.py | 1639 |
+| 9 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 1673 |
+| 10 | tests/unit/dpm/api/test_construction_api.py | 1667 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-01T23:59:43+00:00`
+- Generated at: `2026-06-02T00:05:18+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `380eab9`
+- Current ref: `bc3b74c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146281 | +407 |
-| Test functions | 1855 | 1859 | +4 |
+| Total Python LOC | 145874 | 146441 | +567 |
+| Test functions | 1855 | 1861 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -92,6 +92,38 @@
 | 8 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
 | 9 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
 | 10 | generate_intents | src/core/rebalance/intents.py | 236 |
+
+## Most Complex Functions
+
+### origin/main
+
+| Rank | Function | File | Complexity | Lines |
+| --- | --- | --- | --- | --- |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1063 | 1546 |
+| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 274 | 754 |
+| 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 376 |
+| 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
+| 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
+| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
+| 7 | _section_payload | src/core/proof_packs/builder.py | 85 | 465 |
+| 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
+| 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+
+### current branch
+
+| Rank | Function | File | Complexity | Lines |
+| --- | --- | --- | --- | --- |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1063 | 1546 |
+| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 274 | 754 |
+| 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 376 |
+| 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
+| 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
+| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
+| 7 | _section_payload | src/core/proof_packs/builder.py | 85 | 465 |
+| 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
+| 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
 
 ## Boundary Findings
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:30:46+00:00`
+- Generated at: `2026-06-02T04:33:58+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `be6f7b0`
+- Current ref: `ded5058`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148466 | +2592 |
-| Test functions | 1855 | 1929 | +74 |
+| Total Python LOC | 145874 | 148535 | +2661 |
+| Test functions | 1855 | 1933 | +78 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:55:04+00:00`
+- Generated at: `2026-06-04T04:18:26+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `c65fc5a`
+- Current ref: `860862d`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148853 | +2979 |
-| Test functions | 1855 | 1945 | +90 |
+| Total Python LOC | 145874 | 148930 | +3056 |
+| Test functions | 1855 | 1946 | +91 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T03:52:45+00:00`
+- Generated at: `2026-06-02T03:58:22+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `fa38cd7`
+- Current ref: `34a303d`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147841 | +1967 |
-| Test functions | 1855 | 1903 | +48 |
+| Total Python LOC | 145874 | 147976 | +2102 |
+| Test functions | 1855 | 1908 | +53 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:41:48+00:00`
+- Generated at: `2026-06-02T00:44:53+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `002ca59`
+- Current ref: `ca69123`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147219 | +1345 |
-| Test functions | 1855 | 1886 | +31 |
+| Total Python LOC | 145874 | 147332 | +1458 |
+| Test functions | 1855 | 1888 | +33 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:27:25+00:00`
+- Generated at: `2026-06-02T04:30:46+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `c4167c4`
+- Current ref: `be6f7b0`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148395 | +2521 |
-| Test functions | 1855 | 1927 | +72 |
+| Total Python LOC | 145874 | 148466 | +2592 |
+| Test functions | 1855 | 1929 | +74 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:40:35+00:00`
+- Generated at: `2026-06-02T04:43:29+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `18e2477`
+- Current ref: `a010107`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148613 | +2739 |
-| Test functions | 1855 | 1937 | +82 |
+| Total Python LOC | 145874 | 148663 | +2789 |
+| Test functions | 1855 | 1938 | +83 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:51:17+00:00`
+- Generated at: `2026-06-02T00:53:57+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `3b665fa`
+- Current ref: `96164d2`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147479 | +1605 |
-| Test functions | 1855 | 1892 | +37 |
+| Total Python LOC | 145874 | 147477 | +1603 |
+| Test functions | 1855 | 1894 | +39 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:05:18+00:00`
+- Generated at: `2026-06-02T00:06:52+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `bc3b74c`
+- Current ref: `ca90120`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146441 | +567 |
+| Total Python LOC | 145874 | 146461 | +587 |
 | Test functions | 1855 | 1861 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:06:52+00:00`
+- Generated at: `2026-06-02T00:10:08+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `ca90120`
+- Current ref: `9e39058`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146461 | +587 |
-| Test functions | 1855 | 1861 | +6 |
+| Total Python LOC | 145874 | 146500 | +626 |
+| Test functions | 1855 | 1863 | +8 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -84,7 +84,7 @@
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1546 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 754 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 465 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 426 |
 | 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
 | 5 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
 | 6 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
@@ -120,7 +120,7 @@
 | 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
-| 7 | _section_payload | src/core/proof_packs/builder.py | 85 | 465 |
+| 7 | _section_payload | src/core/proof_packs/builder.py | 81 | 426 |
 | 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:39:11+00:00`
+- Generated at: `2026-06-02T00:41:48+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `5131008`
+- Current ref: `002ca59`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147135 | +1261 |
-| Test functions | 1855 | 1884 | +29 |
+| Total Python LOC | 145874 | 147219 | +1345 |
+| Test functions | 1855 | 1886 | +31 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:33:58+00:00`
+- Generated at: `2026-06-02T04:37:47+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `ded5058`
+- Current ref: `9e5d22c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148535 | +2661 |
-| Test functions | 1855 | 1933 | +78 |
+| Total Python LOC | 145874 | 148595 | +2721 |
+| Test functions | 1855 | 1936 | +81 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:49:11+00:00`
+- Generated at: `2026-06-02T04:52:14+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `3a56e2c`
+- Current ref: `f608a30`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148785 | +2911 |
-| Test functions | 1855 | 1942 | +87 |
+| Total Python LOC | 145874 | 148809 | +2935 |
+| Test functions | 1855 | 1944 | +89 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:57:14+00:00`
+- Generated at: `2026-06-02T01:00:51+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `06a20f2`
+- Current ref: `f456945`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147527 | +1653 |
-| Test functions | 1855 | 1895 | +40 |
+| Total Python LOC | 145874 | 147631 | +1757 |
+| Test functions | 1855 | 1898 | +43 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:44:53+00:00`
+- Generated at: `2026-06-02T00:47:32+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `ca69123`
+- Current ref: `3ef0c62`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147332 | +1458 |
-| Test functions | 1855 | 1888 | +33 |
+| Total Python LOC | 145874 | 147393 | +1519 |
+| Test functions | 1855 | 1890 | +35 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:53:57+00:00`
+- Generated at: `2026-06-02T00:57:14+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `96164d2`
+- Current ref: `06a20f2`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147477 | +1603 |
-| Test functions | 1855 | 1894 | +39 |
+| Total Python LOC | 145874 | 147527 | +1653 |
+| Test functions | 1855 | 1895 | +40 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -55,7 +55,7 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2099 |
+| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2140 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
 | 8 | src/core/dpm_source_context.py | 1878 |
 | 9 | tests/unit/dpm/api/test_construction_api.py | 1667 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:32:37+00:00`
+- Generated at: `2026-06-02T00:35:30+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `db3a6d0`
+- Current ref: `3d1caf1`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147023 | +1149 |
-| Test functions | 1855 | 1880 | +25 |
+| Total Python LOC | 145874 | 147084 | +1210 |
+| Test functions | 1855 | 1882 | +27 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:07:55+00:00`
+- Generated at: `2026-06-02T04:11:42+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `7637ee8`
+- Current ref: `ffb330d`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 148187 | +2313 |
-| Test functions | 1855 | 1917 | +62 |
+| Total Python LOC | 145874 | 148221 | +2347 |
+| Test functions | 1855 | 1919 | +64 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:43:29+00:00`
+- Generated at: `2026-06-02T04:46:13+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `a010107`
+- Current ref: `5e7e52b`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148663 | +2789 |
-| Test functions | 1855 | 1938 | +83 |
+| Total Python LOC | 145874 | 148725 | +2851 |
+| Test functions | 1855 | 1940 | +85 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:16:05+00:00`
+- Generated at: `2026-06-02T00:19:18+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f80fd82`
+- Current ref: `6d19e17`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146597 | +723 |
-| Test functions | 1855 | 1868 | +13 |
+| Total Python LOC | 145874 | 146651 | +777 |
+| Test functions | 1855 | 1870 | +15 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -87,9 +87,9 @@
 | 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
 | 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
 | 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
-| 6 | _section_payload | src/core/proof_packs/builder.py | 353 |
-| 7 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
-| 8 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
+| 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
+| 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
+| 8 | _section_payload | src/core/proof_packs/builder.py | 318 |
 | 9 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
 | 10 | generate_intents | src/core/rebalance/intents.py | 236 |
 
@@ -123,7 +123,7 @@
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 9 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
-| 10 | _section_payload | src/core/proof_packs/builder.py | 69 | 353 |
+| 10 | test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_posture | tests/unit/dpm/api/test_waves_api.py | 66 | 220 |
 
 ## Boundary Findings
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:46:13+00:00`
+- Generated at: `2026-06-02T04:49:11+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `5e7e52b`
+- Current ref: `3a56e2c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148725 | +2851 |
-| Test functions | 1855 | 1940 | +85 |
+| Total Python LOC | 145874 | 148785 | +2911 |
+| Test functions | 1855 | 1942 | +87 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T04:52:14+00:00`
+- Generated at: `2026-06-02T04:55:04+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f608a30`
+- Current ref: `c65fc5a`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 148809 | +2935 |
-| Test functions | 1855 | 1944 | +89 |
+| Total Python LOC | 145874 | 148853 | +2979 |
+| Test functions | 1855 | 1945 | +90 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T01:04:15+00:00`
+- Generated at: `2026-06-02T01:06:40+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `c6f49d9`
+- Current ref: `5138bdd`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 147699 | +1825 |
-| Test functions | 1855 | 1900 | +45 |
+| Total Python LOC | 145874 | 147751 | +1877 |
+| Test functions | 1855 | 1901 | +46 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:27:34+00:00`
+- Generated at: `2026-06-02T00:29:49+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `4e3fecd`
+- Current ref: `5e0ab2e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146907 | +1033 |
-| Test functions | 1855 | 1876 | +21 |
+| Total Python LOC | 145874 | 146971 | +1097 |
+| Test functions | 1855 | 1878 | +23 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:29:49+00:00`
+- Generated at: `2026-06-02T00:32:37+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `5e0ab2e`
+- Current ref: `db3a6d0`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146971 | +1097 |
-| Test functions | 1855 | 1878 | +23 |
+| Total Python LOC | 145874 | 147023 | +1149 |
+| Test functions | 1855 | 1880 | +25 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -90,8 +90,8 @@
 | 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
 | 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
 | 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
-| 9 | _section_payload | src/core/proof_packs/builder.py | 278 |
-| 10 | test_source_context_lifts_external_hedge_readiness_as_fail_closed_currency_context | tests/unit/dpm/construction/test_enrichment.py | 235 |
+| 9 | test_source_context_lifts_external_hedge_readiness_as_fail_closed_currency_context | tests/unit/dpm/construction/test_enrichment.py | 235 |
+| 10 | test_dpm_supportability_and_async_schemas_have_descriptions_and_examples | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 234 |
 
 ## Most Complex Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-02T00:12:06+00:00`
+- Generated at: `2026-06-02T00:14:09+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `100cbfe`
+- Current ref: `bb02b2b`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 768 | 769 | +1 |
-| Total Python LOC | 145874 | 146521 | +647 |
-| Test functions | 1855 | 1864 | +9 |
+| Total Python LOC | 145874 | 146557 | +683 |
+| Test functions | 1855 | 1866 | +11 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 18 | 18 | +0 |
 
@@ -84,7 +84,7 @@
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1546 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 754 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 420 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 383 |
 | 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
 | 5 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
 | 6 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
@@ -120,8 +120,8 @@
 | 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
-| 7 | _section_payload | src/core/proof_packs/builder.py | 81 | 420 |
-| 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 8 | _section_payload | src/core/proof_packs/builder.py | 75 | 383 |
 | 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
 | 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -65,6 +65,8 @@ class SnapshotMetrics:
     largest_files: list[FileMetric]
     largest_functions: list[FunctionMetric]
     most_complex_functions: list[ComplexityMetric]
+    most_complex_source_functions: list[ComplexityMetric]
+    most_complex_test_functions: list[ComplexityMetric]
     service_boundary_violations: list[str]
     router_infra_imports: list[str]
 
@@ -228,6 +230,11 @@ def _snapshot_metrics(label: str, paths: list[str], reader: Any) -> SnapshotMetr
             )
         if path.startswith("src/api/routers/"):
             router_infra_imports.extend(_matching_lines(path, text, ROUTER_INFRA_PATTERNS))
+    sorted_complexity = sorted(
+        complexity_functions,
+        key=lambda item: (item.complexity, item.lines),
+        reverse=True,
+    )
     return SnapshotMetrics(
         label=label,
         python_file_count=len(paths),
@@ -235,11 +242,13 @@ def _snapshot_metrics(label: str, paths: list[str], reader: Any) -> SnapshotMetr
         test_count=test_count,
         largest_files=sorted(files, key=lambda item: item.lines, reverse=True)[:10],
         largest_functions=sorted(functions, key=lambda item: item.lines, reverse=True)[:10],
-        most_complex_functions=sorted(
-            complexity_functions,
-            key=lambda item: (item.complexity, item.lines),
-            reverse=True,
-        )[:10],
+        most_complex_functions=sorted_complexity[:10],
+        most_complex_source_functions=[
+            item for item in sorted_complexity if item.path.startswith("src/")
+        ][:10],
+        most_complex_test_functions=[
+            item for item in sorted_complexity if item.path.startswith("tests/")
+        ][:10],
         service_boundary_violations=service_boundary_violations,
         router_infra_imports=router_infra_imports,
     )
@@ -329,13 +338,6 @@ def _top_complexity_table(title: str, functions: list[ComplexityMetric]) -> str:
             for index, item in enumerate(functions, start=1)
         ],
     )
-
-
-def _complexity_by_path_prefix(
-    functions: list[ComplexityMetric],
-    prefix: str,
-) -> list[ComplexityMetric]:
-    return [item for item in functions if item.path.startswith(prefix)]
 
 
 def _openapi_metrics() -> dict[str, int]:
@@ -683,11 +685,11 @@ def build_complexity_report(context: HealthReportContext) -> str:
         ),
         _top_complexity_table(
             "Most Complex Current Source Functions",
-            _complexity_by_path_prefix(current.most_complex_functions, "src/"),
+            current.most_complex_source_functions,
         ),
         _top_complexity_table(
             "Most Complex Current Test Functions",
-            _complexity_by_path_prefix(current.most_complex_functions, "tests/"),
+            current.most_complex_test_functions,
         ),
         "## Gate Posture",
         "- This report is phase 1/report-only. It intentionally does not fail builds until the "

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -21,6 +21,7 @@ DEFAULT_BASELINE_OUTPUT = REPO_ROOT / "quality" / "baseline_report.md"
 DEFAULT_SCORECARD_OUTPUT = REPO_ROOT / "quality" / "quality_scorecard.md"
 DEFAULT_ARCHITECTURE_RULES_OUTPUT = REPO_ROOT / "quality" / "architecture_rules.md"
 DEFAULT_API_GOVERNANCE_RULES_OUTPUT = REPO_ROOT / "quality" / "api_governance_rules.md"
+DEFAULT_COMPLEXITY_OUTPUT = REPO_ROOT / "quality" / "complexity_report.md"
 PYTHON_ROOTS = ("src", "tests", "scripts")
 SERVICE_LEAKAGE_PATTERNS = (
     "from src.api.routers",
@@ -48,6 +49,14 @@ class FunctionMetric:
 
 
 @dataclass(frozen=True)
+class ComplexityMetric:
+    path: str
+    name: str
+    complexity: int
+    lines: int
+
+
+@dataclass(frozen=True)
 class SnapshotMetrics:
     label: str
     python_file_count: int
@@ -55,6 +64,7 @@ class SnapshotMetrics:
     test_count: int
     largest_files: list[FileMetric]
     largest_functions: list[FunctionMetric]
+    most_complex_functions: list[ComplexityMetric]
     service_boundary_violations: list[str]
     router_infra_imports: list[str]
 
@@ -133,6 +143,47 @@ def _function_metrics(path: str, text: str) -> list[FunctionMetric]:
     return metrics
 
 
+def _complexity_score(node: ast.FunctionDef | ast.AsyncFunctionDef) -> int:
+    score = 1
+    for child in ast.walk(node):
+        if isinstance(
+            child,
+            ast.If
+            | ast.For
+            | ast.AsyncFor
+            | ast.While
+            | ast.IfExp
+            | ast.ExceptHandler
+            | ast.Assert,
+        ):
+            score += 1
+        elif isinstance(child, ast.BoolOp):
+            score += max(0, len(child.values) - 1)
+        elif isinstance(child, ast.Match):
+            score += len(child.cases)
+    return score
+
+
+def _complexity_metrics(path: str, text: str) -> list[ComplexityMetric]:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+    metrics: list[ComplexityMetric] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            end_lineno = getattr(node, "end_lineno", node.lineno)
+            metrics.append(
+                ComplexityMetric(
+                    path=path,
+                    name=node.name,
+                    complexity=_complexity_score(node),
+                    lines=end_lineno - node.lineno + 1,
+                )
+            )
+    return metrics
+
+
 def _test_count(text: str) -> int:
     try:
         tree = ast.parse(text)
@@ -157,6 +208,7 @@ def _matching_lines(path: str, text: str, patterns: Iterable[str]) -> list[str]:
 def _snapshot_metrics(label: str, paths: list[str], reader: Any) -> SnapshotMetrics:
     files: list[FileMetric] = []
     functions: list[FunctionMetric] = []
+    complexity_functions: list[ComplexityMetric] = []
     service_boundary_violations: list[str] = []
     router_infra_imports: list[str] = []
     total_loc = 0
@@ -167,6 +219,7 @@ def _snapshot_metrics(label: str, paths: list[str], reader: Any) -> SnapshotMetr
         total_loc += lines
         files.append(FileMetric(path=path, lines=lines))
         functions.extend(_function_metrics(path, text))
+        complexity_functions.extend(_complexity_metrics(path, text))
         if path.startswith("tests/"):
             test_count += _test_count(text)
         if path.startswith("src/api/services/"):
@@ -182,6 +235,11 @@ def _snapshot_metrics(label: str, paths: list[str], reader: Any) -> SnapshotMetr
         test_count=test_count,
         largest_files=sorted(files, key=lambda item: item.lines, reverse=True)[:10],
         largest_functions=sorted(functions, key=lambda item: item.lines, reverse=True)[:10],
+        most_complex_functions=sorted(
+            complexity_functions,
+            key=lambda item: (item.complexity, item.lines),
+            reverse=True,
+        )[:10],
         service_boundary_violations=service_boundary_violations,
         router_infra_imports=router_infra_imports,
     )
@@ -258,6 +316,16 @@ def _top_function_table(title: str, functions: list[FunctionMetric]) -> str:
         ["Rank", "Function", "File", "Lines"],
         [
             [str(index), item.name, item.path, str(item.lines)]
+            for index, item in enumerate(functions, start=1)
+        ],
+    )
+
+
+def _top_complexity_table(title: str, functions: list[ComplexityMetric]) -> str:
+    return f"### {title}\n\n" + _table(
+        ["Rank", "Function", "File", "Complexity", "Lines"],
+        [
+            [str(index), item.name, item.path, str(item.complexity), str(item.lines)]
             for index, item in enumerate(functions, start=1)
         ],
     )
@@ -369,6 +437,9 @@ def build_refactor_report(context: HealthReportContext) -> str:
         "## Largest Functions",
         _top_function_table(f"{base.label}", base.largest_functions),
         _top_function_table(f"{current.label}", current.largest_functions),
+        "## Most Complex Functions",
+        _top_complexity_table(f"{base.label}", base.most_complex_functions),
+        _top_complexity_table(f"{current.label}", current.most_complex_functions),
         "## Boundary Findings",
         _bounded_findings(
             f"Service boundary findings ({base.label})", base.service_boundary_violations
@@ -445,7 +516,11 @@ def build_baseline_report(context: HealthReportContext) -> str:
                     "reported as known baseline debt",
                     "1 - baseline",
                 ],
-                ["Complexity/maintainability", "not instrumented yet", "planned"],
+                [
+                    "Complexity/maintainability",
+                    "`quality/complexity_report.md`",
+                    "1 - baseline",
+                ],
                 ["Dead code", "not instrumented yet", "planned"],
                 [
                     "Dependency hygiene",
@@ -496,8 +571,8 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
         ],
         [
             "Complexity",
-            "Not yet instrumented",
-            "Add radon/xenon report-only baseline before thresholds.",
+            "Report-only baseline",
+            "`quality/complexity_report.md`; add thresholds after baseline review.",
         ],
         [
             "Dead code",
@@ -562,6 +637,50 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
     return "\n\n".join(sections) + "\n"
 
 
+def build_complexity_report(context: HealthReportContext) -> str:
+    base = context.base
+    current = context.current
+    base_highest = base.most_complex_functions[0].complexity if base.most_complex_functions else 0
+    current_highest = (
+        current.most_complex_functions[0].complexity if current.most_complex_functions else 0
+    )
+    sections = [
+        "# lotus-manage Complexity Report",
+        f"- Generated at: `{context.generated_at}`",
+        f"- Current ref: `{context.current_ref}`",
+        "- Mode: report-only maintainability baseline using dependency-free AST branch counting.",
+        "## Summary",
+        _table(
+            ["Metric", context.base_ref, "current branch", "Delta"],
+            [
+                [
+                    "Reported top functions",
+                    str(len(base.most_complex_functions)),
+                    str(len(current.most_complex_functions)),
+                    _delta(
+                        len(current.most_complex_functions),
+                        len(base.most_complex_functions),
+                    ),
+                ],
+                [
+                    "Highest complexity",
+                    str(base_highest),
+                    str(current_highest),
+                    _delta(current_highest, base_highest),
+                ],
+            ],
+        ),
+        _top_complexity_table(
+            "Most Complex Current Functions",
+            current.most_complex_functions,
+        ),
+        "## Gate Posture",
+        "- This report is phase 1/report-only. It intentionally does not fail builds until the "
+        "baseline is reviewed and thresholds are agreed.",
+    ]
+    return "\n\n".join(sections) + "\n"
+
+
 def build_architecture_rules() -> str:
     return """# lotus-manage Architecture Rules
 
@@ -622,6 +741,7 @@ def write_reports(context: HealthReportContext) -> None:
         DEFAULT_OUTPUT: build_refactor_report(context),
         DEFAULT_BASELINE_OUTPUT: build_baseline_report(context),
         DEFAULT_SCORECARD_OUTPUT: build_quality_scorecard(context),
+        DEFAULT_COMPLEXITY_OUTPUT: build_complexity_report(context),
         DEFAULT_ARCHITECTURE_RULES_OUTPUT: build_architecture_rules(),
         DEFAULT_API_GOVERNANCE_RULES_OUTPUT: build_api_governance_rules(),
     }
@@ -637,6 +757,7 @@ def main() -> None:
         DEFAULT_OUTPUT,
         DEFAULT_BASELINE_OUTPUT,
         DEFAULT_SCORECARD_OUTPUT,
+        DEFAULT_COMPLEXITY_OUTPUT,
         DEFAULT_ARCHITECTURE_RULES_OUTPUT,
         DEFAULT_API_GOVERNANCE_RULES_OUTPUT,
     ):

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import ast
+import io
 import subprocess
 import sys
+import tarfile
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -79,15 +81,6 @@ def _git(*args: str) -> str:
     return completed.stdout
 
 
-def _python_paths_from_git(ref: str) -> list[str]:
-    paths = _git("ls-tree", "-r", "--name-only", ref).splitlines()
-    return [
-        path
-        for path in paths
-        if path.endswith(".py") and path.startswith(tuple(f"{root}/" for root in PYTHON_ROOTS))
-    ]
-
-
 def _python_paths_from_worktree() -> list[str]:
     paths: list[str] = []
     for root in PYTHON_ROOTS:
@@ -98,8 +91,27 @@ def _python_paths_from_worktree() -> list[str]:
     return sorted(paths)
 
 
-def _text_from_git(ref: str, path: str) -> str:
-    return _git("show", f"{ref}:{path}")
+def _python_texts_from_git(ref: str) -> dict[str, str]:
+    completed = subprocess.run(
+        ["git", "archive", "--format=tar", ref, "--", *PYTHON_ROOTS],
+        cwd=REPO_ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    texts: dict[str, str] = {}
+    with tarfile.open(fileobj=io.BytesIO(completed.stdout), mode="r:") as archive:
+        for member in archive.getmembers():
+            path = member.name.replace("\\", "/")
+            if not member.isfile() or not path.endswith(".py"):
+                continue
+            if not path.startswith(tuple(f"{root}/" for root in PYTHON_ROOTS)):
+                continue
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                continue
+            texts[path] = extracted.read().decode("utf-8")
+    return dict(sorted(texts.items()))
 
 
 def _text_from_worktree(path: str) -> str:
@@ -172,6 +184,14 @@ def _snapshot_metrics(label: str, paths: list[str], reader: Any) -> SnapshotMetr
         largest_functions=sorted(functions, key=lambda item: item.lines, reverse=True)[:10],
         service_boundary_violations=service_boundary_violations,
         router_infra_imports=router_infra_imports,
+    )
+
+
+def _snapshot_metrics_from_texts(label: str, texts: dict[str, str]) -> SnapshotMetrics:
+    return _snapshot_metrics(
+        label=label,
+        paths=list(texts),
+        reader=texts.__getitem__,
     )
 
 
@@ -301,13 +321,9 @@ def _bounded_findings(title: str, findings: list[str]) -> str:
 
 
 def _report_context(base_ref: str = DEFAULT_BASE_REF) -> HealthReportContext:
-    base_paths = _python_paths_from_git(base_ref)
+    base_texts = _python_texts_from_git(base_ref)
     current_paths = _python_paths_from_worktree()
-    base = _snapshot_metrics(
-        label=base_ref,
-        paths=base_paths,
-        reader=lambda path: _text_from_git(base_ref, path),
-    )
+    base = _snapshot_metrics_from_texts(label=base_ref, texts=base_texts)
     current = _snapshot_metrics(
         label="current branch",
         paths=current_paths,

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -15,6 +15,10 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 DEFAULT_BASE_REF = "origin/main"
 DEFAULT_OUTPUT = REPO_ROOT / "quality" / "refactor_health_report.md"
+DEFAULT_BASELINE_OUTPUT = REPO_ROOT / "quality" / "baseline_report.md"
+DEFAULT_SCORECARD_OUTPUT = REPO_ROOT / "quality" / "quality_scorecard.md"
+DEFAULT_ARCHITECTURE_RULES_OUTPUT = REPO_ROOT / "quality" / "architecture_rules.md"
+DEFAULT_API_GOVERNANCE_RULES_OUTPUT = REPO_ROOT / "quality" / "api_governance_rules.md"
 PYTHON_ROOTS = ("src", "tests", "scripts")
 SERVICE_LEAKAGE_PATTERNS = (
     "from src.api.routers",
@@ -51,6 +55,16 @@ class SnapshotMetrics:
     largest_functions: list[FunctionMetric]
     service_boundary_violations: list[str]
     router_infra_imports: list[str]
+
+
+@dataclass(frozen=True)
+class HealthReportContext:
+    generated_at: str
+    base_ref: str
+    current_ref: str
+    base: SnapshotMetrics
+    current: SnapshotMetrics
+    openapi: dict[str, int]
 
 
 def _git(*args: str) -> str:
@@ -286,7 +300,7 @@ def _bounded_findings(title: str, findings: list[str]) -> str:
     return f"### {title}\n\n" + "\n".join(f"- `{item}`" for item in shown) + suffix + "\n"
 
 
-def build_report(base_ref: str = DEFAULT_BASE_REF) -> str:
+def _report_context(base_ref: str = DEFAULT_BASE_REF) -> HealthReportContext:
     base_paths = _python_paths_from_git(base_ref)
     current_paths = _python_paths_from_worktree()
     base = _snapshot_metrics(
@@ -299,13 +313,25 @@ def build_report(base_ref: str = DEFAULT_BASE_REF) -> str:
         paths=current_paths,
         reader=_text_from_worktree,
     )
-    openapi = _openapi_metrics()
-    generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    return HealthReportContext(
+        generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        base_ref=base_ref,
+        current_ref=_git("rev-parse", "--short", "HEAD").strip(),
+        base=base,
+        current=current,
+        openapi=_openapi_metrics(),
+    )
+
+
+def build_refactor_report(context: HealthReportContext) -> str:
+    base = context.base
+    current = context.current
+    openapi = context.openapi
     sections = [
         "# lotus-manage Refactor Health Report",
-        f"- Generated at: `{generated_at}`",
-        f"- Baseline ref: `{base_ref}`",
-        f"- Current ref: `{_git('rev-parse', '--short', 'HEAD').strip()}`",
+        f"- Generated at: `{context.generated_at}`",
+        f"- Baseline ref: `{context.base_ref}`",
+        f"- Current ref: `{context.current_ref}`",
         "- Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.",
         "## Scorecard",
         _metric_summary(base, current),
@@ -347,11 +373,258 @@ def build_report(base_ref: str = DEFAULT_BASE_REF) -> str:
     return "\n\n".join(sections) + "\n"
 
 
+def build_report(base_ref: str = DEFAULT_BASE_REF) -> str:
+    return build_refactor_report(_report_context(base_ref))
+
+
+def build_baseline_report(context: HealthReportContext) -> str:
+    current = context.current
+    sections = [
+        "# lotus-manage Baseline Quality Report",
+        f"- Generated at: `{context.generated_at}`",
+        f"- Baseline commit: `{context.current_ref}`",
+        "- Mode: report-only baseline. This records current posture; it does not enforce "
+        "thresholds by itself.",
+        "## Current Code Size",
+        _table(
+            ["Metric", "Value"],
+            [
+                ["Python files", str(current.python_file_count)],
+                ["Total Python LOC", str(current.total_loc)],
+                ["Test functions", str(current.test_count)],
+                ["Service boundary findings", str(len(current.service_boundary_violations))],
+                ["Router infrastructure imports", str(len(current.router_infra_imports))],
+            ],
+        ),
+        "## Current OpenAPI Completeness",
+        _table(
+            ["Metric", "Value"],
+            [
+                ["Operations", str(context.openapi["operations"])],
+                ["Missing summary", str(context.openapi["missing_summary"])],
+                ["Missing description", str(context.openapi["missing_description"])],
+                ["Missing tags", str(context.openapi["missing_tags"])],
+                ["Missing 4xx/5xx response", str(context.openapi["missing_error_response"])],
+                ["Missing examples marker", str(context.openapi["missing_examples"])],
+            ],
+        ),
+        "## Report-Only Coverage Map",
+        _table(
+            ["Quality area", "Current evidence", "Gate phase"],
+            [
+                ["Code size", "`scripts/engineering_health_report.py`", "1 - baseline"],
+                ["Largest files/functions", "`quality/refactor_health_report.md`", "1 - baseline"],
+                [
+                    "OpenAPI completeness",
+                    "`scripts/openapi_quality_gate.py` plus this report",
+                    "2 - active/new-regression",
+                ],
+                [
+                    "Service boundary leakage",
+                    "service leakage scan plus this report",
+                    "2 - active/new-regression",
+                ],
+                [
+                    "Router infrastructure imports",
+                    "reported as known baseline debt",
+                    "1 - baseline",
+                ],
+                ["Complexity/maintainability", "not instrumented yet", "planned"],
+                ["Dead code", "not instrumented yet", "planned"],
+                [
+                    "Dependency hygiene",
+                    "`pip check`/security audit in repo gates; richer deptry planned",
+                    "2 - active/new-regression",
+                ],
+                [
+                    "Security",
+                    "`make security-audit`; richer bandit/pip-audit scorecard planned",
+                    "2 - active/new-regression",
+                ],
+                ["Documentation gaps", "current docs tests plus planned docs scorecard", "planned"],
+                [
+                    "Observability gaps",
+                    "`scripts/validate_observability_contracts.py`; richer runtime gap report planned",
+                    "2 - active/new-regression",
+                ],
+            ],
+        ),
+        "## Notes",
+        "- Future slices should add optional-tool measurements without converting unstable baselines "
+        "into blocking gates prematurely.",
+    ]
+    return "\n\n".join(sections) + "\n"
+
+
+def build_quality_scorecard(context: HealthReportContext) -> str:
+    rows = [
+        ["Lint and formatting", "Active gate", "`make check` runs Ruff check and format check."],
+        ["Type checking", "Active gate", "`make check` runs mypy over source files."],
+        ["Unit tests", "Active gate", "`make check` runs `tests/unit`."],
+        ["OpenAPI governance", "Active gate", "`scripts/openapi_quality_gate.py`."],
+        ["API vocabulary", "Active gate", "`scripts/api_vocabulary_inventory.py --validate-only`."],
+        [
+            "Service boundary leakage",
+            "Report plus focused scans",
+            "Current service boundary findings: 0.",
+        ],
+        [
+            "Router infrastructure imports",
+            "Baseline debt",
+            f"Current router infra imports: {len(context.current.router_infra_imports)}.",
+        ],
+        [
+            "OpenAPI 4xx/5xx response markers",
+            "Baseline debt",
+            f"Current missing markers: {context.openapi['missing_error_response']}.",
+        ],
+        [
+            "Complexity",
+            "Not yet instrumented",
+            "Add radon/xenon report-only baseline before thresholds.",
+        ],
+        [
+            "Dead code",
+            "Not yet instrumented",
+            "Add vulture report-only baseline before thresholds.",
+        ],
+        [
+            "Dependency architecture",
+            "Not yet instrumented",
+            "Add import-linter/deptry report-only baseline before thresholds.",
+        ],
+        [
+            "Security depth",
+            "Partially active",
+            "Security audit is active; add bandit/pip-audit detail scorecard.",
+        ],
+        [
+            "Documentation coverage",
+            "Partially active",
+            "Docs current-state tests exist; add docs-gap scoring later.",
+        ],
+        [
+            "Observability",
+            "Partially active",
+            "Observability contract validator exists; add runtime posture scoring later.",
+        ],
+    ]
+    sections = [
+        "# lotus-manage Quality Scorecard",
+        f"- Generated at: `{context.generated_at}`",
+        f"- Current ref: `{context.current_ref}`",
+        "- Purpose: make enterprise-readiness progress measurable without pretending report-only "
+        "baselines are mature enforcement gates.",
+        _table(["Area", "Status", "Evidence / next gate"], rows),
+        "## Progressive Gate Policy",
+        _table(
+            ["Phase", "Meaning", "Current posture"],
+            [
+                [
+                    "1 - baseline/report-only",
+                    "Measure current posture without failing builds.",
+                    "Active for refactor health and baseline report.",
+                ],
+                [
+                    "2 - fail new regressions",
+                    "Block newly introduced violations once the detector is stable.",
+                    "Active for existing repo-native gates; planned for richer quality tools.",
+                ],
+                [
+                    "3 - enforce thresholds",
+                    "Require agreed numeric thresholds.",
+                    "Not active for new quality tools yet.",
+                ],
+                [
+                    "4 - enterprise-readiness gates",
+                    "Block release on full readiness posture.",
+                    "Target state, not yet complete.",
+                ],
+            ],
+        ),
+    ]
+    return "\n\n".join(sections) + "\n"
+
+
+def build_architecture_rules() -> str:
+    return """# lotus-manage Architecture Rules
+
+These rules define the report-only architecture baseline for the enterprise-readiness refactor.
+They are explicit so later validators can enforce them without changing their meaning.
+
+## Layering
+
+1. Routers call application services or use-case functions only.
+2. Routers must not call repositories, database clients, HTTP clients, Kafka, Redis, or downstream adapters directly.
+3. Middleware stays thin, cross-cutting, and business-logic-free.
+4. Domain and application code must not depend on FastAPI, framework objects, infrastructure clients, or persistence models.
+5. Infrastructure sits behind explicit ports/adapters.
+6. DTOs and persistence models must not leak into domain logic.
+
+## Reliability And Auditability
+
+1. Downstream failures map to consistent platform errors.
+2. Every request must support and propagate a correlation identifier.
+3. Relevant mutations must be auditable.
+4. Idempotent operations must define replay/conflict behavior.
+5. Logs must be structured and must not leak sensitive data.
+
+## Current Gate Phase
+
+These rules are in phase 1/report-only except for checks already covered by repo-native gates.
+"""
+
+
+def build_api_governance_rules() -> str:
+    return """# lotus-manage API Governance Rules
+
+These rules define the report-only API-governance baseline for the enterprise-readiness refactor.
+
+## OpenAPI Contract
+
+1. Every endpoint should have a summary, description, tags, stable operation ID, request/response model, examples, and standard errors.
+2. Error responses should use consistent platform problem-details semantics where applicable.
+3. Public and internal endpoints should remain clearly separated.
+4. Health, readiness, liveness, metrics, internal, and public endpoints should be documented as distinct operational surfaces.
+
+## API Behavior
+
+1. Pagination, filtering, sorting, versioning, and deprecation should be consistent across list/read APIs.
+2. Correlation IDs should be accepted or generated and propagated to downstream calls.
+3. Idempotent mutations should document idempotency key behavior, replay behavior, and conflict behavior.
+4. Downstream unavailable/degraded states should be exposed as bounded supportability posture rather than hidden behind generic success.
+
+## Current Gate Phase
+
+OpenAPI and API vocabulary checks are active repo-native gates. The broader rule set is phase
+1/report-only until each detector has a stable baseline and agreed thresholds.
+"""
+
+
+def write_reports(context: HealthReportContext) -> None:
+    outputs = {
+        DEFAULT_OUTPUT: build_refactor_report(context),
+        DEFAULT_BASELINE_OUTPUT: build_baseline_report(context),
+        DEFAULT_SCORECARD_OUTPUT: build_quality_scorecard(context),
+        DEFAULT_ARCHITECTURE_RULES_OUTPUT: build_architecture_rules(),
+        DEFAULT_API_GOVERNANCE_RULES_OUTPUT: build_api_governance_rules(),
+    }
+    for path, content in outputs.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
 def main() -> None:
-    report = build_report()
-    DEFAULT_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
-    DEFAULT_OUTPUT.write_text(report, encoding="utf-8")
-    print(f"Wrote {DEFAULT_OUTPUT.relative_to(REPO_ROOT).as_posix()}")
+    context = _report_context()
+    write_reports(context)
+    for path in (
+        DEFAULT_OUTPUT,
+        DEFAULT_BASELINE_OUTPUT,
+        DEFAULT_SCORECARD_OUTPUT,
+        DEFAULT_ARCHITECTURE_RULES_OUTPUT,
+        DEFAULT_API_GOVERNANCE_RULES_OUTPUT,
+    ):
+        print(f"Wrote {path.relative_to(REPO_ROOT).as_posix()}")
 
 
 if __name__ == "__main__":

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -331,6 +331,13 @@ def _top_complexity_table(title: str, functions: list[ComplexityMetric]) -> str:
     )
 
 
+def _complexity_by_path_prefix(
+    functions: list[ComplexityMetric],
+    prefix: str,
+) -> list[ComplexityMetric]:
+    return [item for item in functions if item.path.startswith(prefix)]
+
+
 def _openapi_metrics() -> dict[str, int]:
     try:
         from src.api.main import app
@@ -673,6 +680,14 @@ def build_complexity_report(context: HealthReportContext) -> str:
         _top_complexity_table(
             "Most Complex Current Functions",
             current.most_complex_functions,
+        ),
+        _top_complexity_table(
+            "Most Complex Current Source Functions",
+            _complexity_by_path_prefix(current.most_complex_functions, "src/"),
+        ),
+        _top_complexity_table(
+            "Most Complex Current Test Functions",
+            _complexity_by_path_prefix(current.most_complex_functions, "tests/"),
         ),
         "## Gate Posture",
         "- This report is phase 1/report-only. It intentionally does not fail builds until the "

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -273,6 +273,41 @@ def _ensure_error_response_content(
         )
 
 
+def _ensure_operation_examples(
+    *,
+    method: str,
+    path: str,
+    operation: dict[str, Any],
+    schemas: dict[str, Any],
+) -> None:
+    request_content = operation.get("requestBody", {}).get("content", {}).get(_JSON_MEDIA_TYPE)
+    if isinstance(request_content, dict):
+        _ensure_json_content_example(
+            content=request_content,
+            schemas=schemas,
+            name=f"{method}_{path}_request",
+            summary="Example request payload.",
+        )
+
+    for status_code, response in operation.get("responses", {}).items():
+        if not isinstance(response, dict):
+            continue
+        normalized_status_code = str(status_code)
+        if normalized_status_code.startswith(("4", "5")) or normalized_status_code == "default":
+            _ensure_error_response_content(
+                response=response,
+                status_code=normalized_status_code,
+            )
+        response_content = response.get("content", {}).get(_JSON_MEDIA_TYPE)
+        if isinstance(response_content, dict):
+            _ensure_json_content_example(
+                content=response_content,
+                schemas=schemas,
+                name=f"{method}_{path}_{status_code}_response",
+                summary="Example response payload.",
+            )
+
+
 def _ensure_request_and_response_examples(schema: dict[str, Any]) -> None:
     schemas = schema.get("components", {}).get("schemas", {})
     if not isinstance(schemas, dict):
@@ -318,36 +353,12 @@ def _ensure_request_and_response_examples(schema: dict[str, Any]) -> None:
             if not isinstance(operation, dict):
                 continue
 
-            request_content = (
-                operation.get("requestBody", {}).get("content", {}).get(_JSON_MEDIA_TYPE)
+            _ensure_operation_examples(
+                method=method,
+                path=path,
+                operation=operation,
+                schemas=schemas,
             )
-            if isinstance(request_content, dict):
-                _ensure_json_content_example(
-                    content=request_content,
-                    schemas=schemas,
-                    name=f"{method}_{path}_request",
-                    summary="Example request payload.",
-                )
-
-            for status_code, response in operation.get("responses", {}).items():
-                if not isinstance(response, dict):
-                    continue
-                normalized_status_code = str(status_code)
-                if normalized_status_code.startswith(("4", "5")) or (
-                    normalized_status_code == "default"
-                ):
-                    _ensure_error_response_content(
-                        response=response,
-                        status_code=normalized_status_code,
-                    )
-                response_content = response.get("content", {}).get(_JSON_MEDIA_TYPE)
-                if isinstance(response_content, dict):
-                    _ensure_json_content_example(
-                        content=response_content,
-                        schemas=schemas,
-                        name=f"{method}_{path}_{status_code}_response",
-                        summary="Example response payload.",
-                    )
 
 
 def _ensure_operation_documentation(schema: dict[str, Any], service_name: str) -> None:

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -136,6 +136,49 @@ def _schema_declared_example(prop_schema: dict[str, Any]) -> tuple[bool, Any]:
     return False, None
 
 
+def _collection_example_from_schema(
+    prop_name: str,
+    prop_schema: dict[str, Any],
+    schemas: dict[str, Any],
+    seen_refs: set[str],
+) -> tuple[bool, Any]:
+    properties = prop_schema.get("properties")
+    if isinstance(properties, dict):
+        return True, {
+            child_name: _example_from_schema(
+                child_name,
+                child_schema,
+                schemas,
+                seen_refs,
+            )
+            for child_name, child_schema in properties.items()
+            if isinstance(child_schema, dict)
+        }
+
+    schema_type = prop_schema.get("type")
+    if schema_type == "array":
+        item_schema = prop_schema.get("items", {})
+        if isinstance(item_schema, dict):
+            return True, [
+                _example_from_schema(f"{prop_name}_item", item_schema, schemas, seen_refs)
+            ]
+        return True, []
+    if schema_type == "object":
+        additional_properties = prop_schema.get("additionalProperties")
+        if isinstance(additional_properties, dict):
+            return True, {
+                "sample_key": _example_from_schema(
+                    f"{prop_name}_value",
+                    additional_properties,
+                    schemas,
+                    seen_refs,
+                )
+            }
+        return True, {"sample_key": "sample_value"}
+
+    return False, None
+
+
 def _example_from_schema(
     prop_name: str,
     prop_schema: dict[str, Any],
@@ -172,32 +215,14 @@ def _example_from_schema(
             if isinstance(option, dict) and option.get("type") != "null":
                 return _example_from_schema(prop_name, option, schemas, seen_refs)
 
-    properties = prop_schema.get("properties")
-    if isinstance(properties, dict):
-        return {
-            child_name: _example_from_schema(child_name, child_schema, schemas, seen_refs)
-            for child_name, child_schema in properties.items()
-            if isinstance(child_schema, dict)
-        }
-
-    schema_type = prop_schema.get("type")
-    if schema_type == "array":
-        item_schema = prop_schema.get("items", {})
-        if isinstance(item_schema, dict):
-            return [_example_from_schema(f"{prop_name}_item", item_schema, schemas, seen_refs)]
-        return []
-    if schema_type == "object":
-        additional_properties = prop_schema.get("additionalProperties")
-        if isinstance(additional_properties, dict):
-            return {
-                "sample_key": _example_from_schema(
-                    f"{prop_name}_value",
-                    additional_properties,
-                    schemas,
-                    seen_refs,
-                )
-            }
-        return {"sample_key": "sample_value"}
+    has_collection_example, collection_example = _collection_example_from_schema(
+        prop_name=prop_name,
+        prop_schema=prop_schema,
+        schemas=schemas,
+        seen_refs=seen_refs,
+    )
+    if has_collection_example:
+        return collection_example
 
     return _infer_example(prop_name, prop_schema)
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -39,6 +39,33 @@ def _humanize(key: str) -> str:
     return _to_snake_case(key).replace("_", " ").strip()
 
 
+def _number_example_for_key(key: str) -> float:
+    if "weight" in key:
+        return 0.125
+    if "price" in key or "rate" in key:
+        return 1.2345
+    if "quantity" in key:
+        return 100.0
+    return 10.5
+
+
+def _semantic_string_example_for_key(key: str, schema_type: Any) -> str | None:
+    if key.endswith("_id"):
+        entity = key[: -len("_id")]
+        return f"{entity.upper()}_001"
+    if "currency" in key:
+        return "USD"
+    if "time" in key or "timestamp" in key:
+        return "2026-03-02T10:30:00Z"
+    if "date" in key:
+        return "2026-03-02"
+    if "status" in key:
+        return "READY"
+    if schema_type == "string":
+        return f"sample_{key}"
+    return None
+
+
 def _infer_example(prop_name: str, prop_schema: dict[str, Any]) -> Any:
     key = _to_snake_case(prop_name)
     if key in _EXAMPLE_BY_KEY:
@@ -60,32 +87,16 @@ def _infer_example(prop_name: str, prop_schema: dict[str, Any]) -> Any:
     if schema_type == "integer":
         return 10
     if schema_type == "number":
-        if "weight" in key:
-            return 0.125
-        if "price" in key or "rate" in key:
-            return 1.2345
-        if "quantity" in key:
-            return 100.0
-        return 10.5
+        return _number_example_for_key(key)
 
     if schema_format == "date":
         return "2026-03-02"
     if schema_format == "date-time":
         return "2026-03-02T10:30:00Z"
 
-    if key.endswith("_id"):
-        entity = key[: -len("_id")]
-        return f"{entity.upper()}_001"
-    if "currency" in key:
-        return "USD"
-    if "date" in key:
-        return "2026-03-02"
-    if "time" in key or "timestamp" in key:
-        return "2026-03-02T10:30:00Z"
-    if "status" in key:
-        return "READY"
-    if schema_type == "string":
-        return f"sample_{key}"
+    semantic_string = _semantic_string_example_for_key(key, schema_type)
+    if semantic_string is not None:
+        return semantic_string
     return f"{key}_example"
 
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -127,6 +127,15 @@ def _schema_ref_name(ref: str) -> str:
     return ref.rsplit("/", 1)[-1]
 
 
+def _schema_declared_example(prop_schema: dict[str, Any]) -> tuple[bool, Any]:
+    if "example" in prop_schema:
+        return True, prop_schema["example"]
+    examples = prop_schema.get("examples")
+    if isinstance(examples, list) and examples:
+        return True, examples[0]
+    return False, None
+
+
 def _example_from_schema(
     prop_name: str,
     prop_schema: dict[str, Any],
@@ -137,11 +146,9 @@ def _example_from_schema(
     if not isinstance(prop_schema, dict):
         return _infer_example(prop_name, {})
 
-    if "example" in prop_schema:
-        return prop_schema["example"]
-    examples = prop_schema.get("examples")
-    if isinstance(examples, list) and examples:
-        return examples[0]
+    has_declared_example, declared_example = _schema_declared_example(prop_schema)
+    if has_declared_example:
+        return declared_example
 
     schema_ref = prop_schema.get("$ref")
     if isinstance(schema_ref, str):

--- a/src/api/routers/wave_campaign_candidate_selection.py
+++ b/src/api/routers/wave_campaign_candidate_selection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, Sequence
+from collections.abc import Collection, Iterable, Mapping, Sequence
+from typing import cast
 from dataclasses import dataclass
 from typing import Generic, Protocol, TypeVar
 
@@ -14,6 +15,15 @@ class BulkReviewCampaignCandidate(Protocol):
 
     @property
     def source_refs(self) -> Sequence[object]: ...
+
+
+def _candidate_attribute(candidate: object, name: str) -> object | None:
+    if isinstance(candidate, Mapping):
+        if name in candidate:
+            value = candidate[name]
+            return cast(object | None, value)
+        return None
+    return cast(object | None, getattr(candidate, name, None))
 
 
 T = TypeVar("T", bound=BulkReviewCampaignCandidate)
@@ -33,8 +43,14 @@ def select_bulk_review_campaign_candidates(
     included_candidates: list[T] = []
     excluded_count = 0
     for candidate in candidates:
+        portfolio_type_value = _candidate_attribute(candidate, "portfolio_type")
+        if portfolio_type_value is not None and not isinstance(portfolio_type_value, str):
+            raise wave_service.DpmWaveValidationError(
+                "BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_INVALID",
+                "BULK_REVIEW_CAMPAIGN candidate portfolio_type must be a string.",
+            )
         portfolio_type = normalize_required_portfolio_type(
-            candidate.portfolio_type,
+            portfolio_type_value,
             required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_REQUIRED",
             required_message=(
                 "BULK_REVIEW_CAMPAIGN candidate portfolios require source-owned portfolio_type."
@@ -43,7 +59,13 @@ def select_bulk_review_campaign_candidates(
         if portfolio_type not in eligible_portfolio_types:
             excluded_count += 1
             continue
-        if not candidate.source_refs:
+        source_refs = _candidate_attribute(candidate, "source_refs")
+        if source_refs is not None and not isinstance(source_refs, Sequence):
+            raise wave_service.DpmWaveValidationError(
+                "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_INVALID",
+                "BULK_REVIEW_CAMPAIGN candidate source_refs must be a sequence.",
+            )
+        if not source_refs:
             raise wave_service.DpmWaveValidationError(
                 "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_REQUIRED",
                 "BULK_REVIEW_CAMPAIGN candidate portfolios require source_refs.",

--- a/src/api/routers/wave_campaign_source_resolution.py
+++ b/src/api/routers/wave_campaign_source_resolution.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
+from typing import cast
 
 from fastapi import HTTPException, status
 
@@ -12,6 +13,7 @@ from src.api.routers.wave_campaign_governance_resolution import (
     resolve_bulk_review_campaign_governance,
 )
 from src.api.routers.wave_campaign_hashing import campaign_membership_hash
+from src.core.waves import DpmWaveSourceRef
 from src.api.routers.wave_core_portfolio_universe_resolution import (
     resolve_core_dpm_portfolio_universe_candidates,
 )
@@ -85,45 +87,62 @@ def resolve_bulk_review_campaign_portfolios(
             },
         )
 
+    def _candidate_payload(candidate: object) -> dict[str, object]:
+        if hasattr(candidate, "model_dump"):
+            payload = candidate.model_dump(mode="json")
+            if not isinstance(payload, dict):
+                raise TypeError("Candidate payload from model_dump() must be a dictionary.")
+            return cast(dict[str, object], payload)
+        if isinstance(candidate, Mapping):
+            payload = dict(candidate)
+            return cast(dict[str, object], payload)
+        raise TypeError(
+            "Bulk review campaign candidates must expose model_dump() or mapping semantics."
+        )
+
+    candidate_payloads = [_candidate_payload(candidate) for candidate in included_candidates]
     membership_hash = campaign_membership_hash(
         trigger_id=request.trigger_id,
         as_of_date=campaign_as_of_date,
         portfolio_types=sorted(eligible_portfolio_types),
-        portfolios=[candidate.model_dump(mode="json") for candidate in included_candidates],
+        portfolios=candidate_payloads,
     )
     membership_ref = bulk_review_campaign_membership_ref(
         trigger_id=request.trigger_id,
         campaign_as_of_date=campaign_as_of_date,
         membership_hash=membership_hash,
     )
-    return [
-        {
-            "portfolio_id": candidate.portfolio_id,
-            "mandate_id": candidate.mandate_id,
-            "source_refs": [
-                membership_ref,
-                *governance_refs,
-                bulk_review_campaign_member_ref(
-                    trigger_id=request.trigger_id,
-                    portfolio_id=candidate.portfolio_id,
-                    campaign_as_of_date=campaign_as_of_date,
-                    membership_hash=membership_hash,
-                ),
-                *source_refs_payload(candidate.source_refs),
-            ],
-            "diagnostics": {
-                "source_owner": "lotus-manage",
-                "source_product": "BulkReviewCampaignMembership:v1",
-                "campaign_id": request.trigger_id,
-                "campaign_as_of_date": campaign_as_of_date.isoformat(),
-                "portfolio_type": candidate.portfolio_type.strip().upper()
-                if candidate.portfolio_type
-                else None,
-                "eligible_portfolio_types": sorted(eligible_portfolio_types),
-                "excluded_candidate_count": selection.excluded_count,
-                "membership_supportability_state": "READY",
-                **governance_diagnostics,
-            },
-        }
-        for candidate in included_candidates
-    ]
+    output: list[dict[str, object]] = []
+    for payload in candidate_payloads:
+        portfolio_type = cast("str | None", payload["portfolio_type"])
+        output.append(
+            {
+                "portfolio_id": cast("str", payload["portfolio_id"]),
+                "mandate_id": cast("str | None", payload["mandate_id"]),
+                "source_refs": [
+                    membership_ref,
+                    *governance_refs,
+                    bulk_review_campaign_member_ref(
+                        trigger_id=request.trigger_id,
+                        portfolio_id=cast("str", payload["portfolio_id"]),
+                        campaign_as_of_date=campaign_as_of_date,
+                        membership_hash=membership_hash,
+                    ),
+                    *source_refs_payload(
+                        cast(Sequence[DpmWaveSourceRef], payload["source_refs"]),
+                    ),
+                ],
+                "diagnostics": {
+                    "source_owner": "lotus-manage",
+                    "source_product": "BulkReviewCampaignMembership:v1",
+                    "campaign_id": request.trigger_id,
+                    "campaign_as_of_date": campaign_as_of_date.isoformat(),
+                    "portfolio_type": portfolio_type.strip().upper() if portfolio_type else None,
+                    "eligible_portfolio_types": sorted(eligible_portfolio_types),
+                    "excluded_candidate_count": selection.excluded_count,
+                    "membership_supportability_state": "READY",
+                    **governance_diagnostics,
+                },
+            }
+        )
+    return output

--- a/src/api/routers/wave_core_portfolio_universe_resolution.py
+++ b/src/api/routers/wave_core_portfolio_universe_resolution.py
@@ -4,21 +4,17 @@ from collections.abc import Callable
 from typing import Any
 
 from src.api.routers.wave_date_validation import parse_wave_as_of_date
-from src.api.routers.wave_request_models import DpmWavePortfolioInput, DpmWavePreviewRequest
 from src.api.routers.wave_source_dependency_http import (
     source_dependency_failed_http_exception,
-    upstream_dependency_failed_http_exception,
     upstream_unavailable_http_exception,
 )
-from src.api.routers.wave_source_refs import (
-    dpm_portfolio_universe_candidate_ref,
-    dpm_portfolio_universe_ref,
-)
 from src.api.services import wave_service
-from src.core.waves import DpmWaveSourceRef
-from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
-
-MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES = 10
+from src.api.services.wave_core_portfolio_universe_resolution import (
+    resolve_core_dpm_portfolio_universe_candidates as _resolve_core_dpm_portfolio_universe_candidates,
+)
+from src.api.services.wave_errors import DpmWaveDependencyError
+from src.api.services.wave_errors import DpmWaveDependencyUnavailableError
+from src.api.routers.wave_request_models import DpmWavePreviewRequest
 
 
 def resolve_core_dpm_portfolio_universe_candidates(
@@ -26,114 +22,28 @@ def resolve_core_dpm_portfolio_universe_candidates(
     request: DpmWavePreviewRequest,
     correlation_id: str,
     core_resolver_factory: Callable[[], Any],
-) -> list[DpmWavePortfolioInput]:
+) -> list[dict[str, object]]:
     if request.portfolios:
         raise wave_service.DpmWaveValidationError(
             "BULK_REVIEW_CAMPAIGN_CORE_UNIVERSE_REJECTS_CALLER_PORTFOLIOS",
             "Core DPM portfolio-universe discovery supplies the candidate portfolio set.",
         )
     as_of_date = parse_wave_as_of_date(request.as_of_date)
-    resolver = core_resolver_factory()
-    candidate_pages: list[Any] = []
-    next_page_token: str | None = None
-    seen_page_tokens: set[str] = set()
     try:
-        for _ in range(MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES):
-            candidate_page = resolver.resolve_dpm_portfolio_universe_candidates(
-                as_of_date=as_of_date,
-                tenant_id=request.tenant_id,
-                booking_center_code=request.booking_center_code,
-                model_portfolio_ids=request.model_portfolio_ids,
-                include_inactive_mandates=request.include_inactive_mandates,
-                page_size=request.campaign_candidate_page_size,
-                page_token=next_page_token,
-                correlation_id=correlation_id,
-            )
-            candidate_pages.append(candidate_page)
-            if candidate_page.supportability.state != "READY":
-                break
-            next_page_token = candidate_page.page.next_page_token
-            if not next_page_token:
-                break
-            if next_page_token in seen_page_tokens:
-                raise DpmCoreResolverError("DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING")
-            seen_page_tokens.add(next_page_token)
-        else:
-            raise DpmCoreResolverError("DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING")
-    except DpmCoreResolverUnavailableError as exc:
-        raise upstream_unavailable_http_exception(
-            exc,
-            default_code="DPM_CORE_PORTFOLIO_UNIVERSE_UNAVAILABLE",
-        ) from exc
-    except DpmCoreResolverError as exc:
-        raise upstream_dependency_failed_http_exception(
-            exc,
-            default_code="DPM_CORE_PORTFOLIO_UNIVERSE_INCOMPLETE",
-        ) from exc
+        return _resolve_core_dpm_portfolio_universe_candidates(
+            as_of_date=as_of_date,
+            tenant_id=request.tenant_id,
+            booking_center_code=request.booking_center_code,
+            model_portfolio_ids=request.model_portfolio_ids,
+            include_inactive_mandates=request.include_inactive_mandates,
+            campaign_candidate_page_size=request.campaign_candidate_page_size,
+            correlation_id=correlation_id,
+            core_resolver_factory=core_resolver_factory,
+        )
+    except DpmWaveDependencyUnavailableError as exc:
+        raise upstream_unavailable_http_exception(exc, default_code=exc.code) from exc
+    except DpmWaveDependencyError as exc:
+        raise source_dependency_failed_http_exception(code=exc.code, message=exc.message) from exc
 
-    candidate_page = candidate_pages[-1]
-    if candidate_page.supportability.state != "READY":
-        raise source_dependency_failed_http_exception(
-            code=candidate_page.supportability.reason,
-            message="Core DPM portfolio-universe candidates are not source-ready.",
-        )
-    if next_page_token or candidate_page.supportability.page_truncated:
-        raise source_dependency_failed_http_exception(
-            code="DPM_CORE_PORTFOLIO_UNIVERSE_PAGE_PARTIAL",
-            message=(
-                "Core DPM portfolio-universe candidates could not be exhausted within the "
-                "bounded Manage consumer guard; refine filters before creating a campaign wave."
-            ),
-        )
-    candidates = [candidate for page in candidate_pages for candidate in page.candidates]
-    if not candidates:
-        raise source_dependency_failed_http_exception(
-            code="DPM_CORE_PORTFOLIO_UNIVERSE_EMPTY",
-            message="Core DPM portfolio-universe discovery returned no candidate portfolios.",
-        )
-    candidate_keys: set[tuple[str, str | None, str | None]] = set()
-    for candidate in candidates:
-        candidate_key = (
-            candidate.portfolio_id,
-            candidate.mandate_id,
-            candidate.source_record_id,
-        )
-        if candidate_key in candidate_keys:
-            raise source_dependency_failed_http_exception(
-                code="DPM_CORE_PORTFOLIO_UNIVERSE_DUPLICATE_CANDIDATE",
-                message="Core DPM portfolio-universe discovery returned duplicate candidate rows.",
-            )
-        candidate_keys.add(candidate_key)
 
-    first_page = candidate_pages[0]
-    selection_basis = (
-        first_page.selection_basis.model_dump(mode="json")
-        if first_page.selection_basis is not None
-        else None
-    )
-    universe_ref = dpm_portfolio_universe_ref(
-        source_id=first_page.snapshot_id or first_page.page.request_scope_fingerprint,
-        product_version=first_page.product_version,
-        supportability_state=first_page.supportability.state,
-        content_hash=first_page.source_batch_fingerprint,
-    )
-    return [
-        DpmWavePortfolioInput(
-            portfolio_id=candidate.portfolio_id,
-            mandate_id=candidate.mandate_id,
-            portfolio_type="DISCRETIONARY",
-            source_refs=[
-                DpmWaveSourceRef.model_validate(universe_ref),
-                DpmWaveSourceRef.model_validate(
-                    dpm_portfolio_universe_candidate_ref(
-                        source_record_id=candidate.source_record_id,
-                        portfolio_id=candidate.portfolio_id,
-                        mandate_id=candidate.mandate_id,
-                        binding_version=candidate.binding_version,
-                        selection_basis=selection_basis,
-                    )
-                ),
-            ],
-        )
-        for candidate in candidates
-    ]
+__all__ = ["resolve_core_dpm_portfolio_universe_candidates"]

--- a/src/api/routers/wave_source_refs.py
+++ b/src/api/routers/wave_source_refs.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import date
+from typing import cast
 
 from src.core.waves import DpmWaveSourceRef
 
 
 def source_refs_payload(refs: Iterable[DpmWaveSourceRef]) -> list[dict[str, object]]:
-    return [ref.model_dump(mode="json") for ref in refs]
+    def _ref_payload(ref: DpmWaveSourceRef | Mapping[str, object]) -> dict[str, object]:
+        if hasattr(ref, "model_dump"):
+            payload = ref.model_dump(mode="json")
+            if isinstance(payload, dict):
+                return cast(dict[str, object], payload)
+        if isinstance(ref, Mapping):
+            return cast(dict[str, object], dict(ref))
+        raise TypeError("DpmWaveSourceRef payload must be a model or mapping.")
+
+    return [_ref_payload(ref) for ref in refs]
 
 
 def source_ref_payload(

--- a/src/api/services/construction_treasury_source_context.py
+++ b/src/api/services/construction_treasury_source_context.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import TypeAlias
+from typing import NamedTuple, TypeAlias
 
 from src.api.services.construction_source_product_status import source_status_to_method_status
 from src.api.services.construction_source_identity import (
@@ -29,6 +29,23 @@ _TreasurySourceResponse: TypeAlias = (
 
 def _optional_source_payload(response: _TreasurySourceResponse | None) -> JsonPayload | None:
     return source_payload(response) if response is not None else None
+
+
+def _treasury_source_payloads(
+    *,
+    hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
+    currency_exposure: DpmCoreExternalCurrencyExposureResponse | None,
+    hedge_policy: DpmCoreExternalHedgePolicyResponse | None,
+    eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None,
+    fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None,
+) -> dict[str, JsonPayload | None]:
+    return {
+        "external_hedge_execution_readiness": _optional_source_payload(hedge_readiness),
+        "external_currency_exposure": _optional_source_payload(currency_exposure),
+        "external_hedge_policy": _optional_source_payload(hedge_policy),
+        "external_eligible_hedge_instruments": _optional_source_payload(eligible_hedge_instruments),
+        "external_fx_forward_curve": _optional_source_payload(fx_forward_curve),
+    }
 
 
 def _optional_source_identity(
@@ -87,6 +104,36 @@ def _fail_closed_reason_codes(
     return reason_codes
 
 
+class _PrimaryTreasurySupportability(NamedTuple):
+    state: str
+    reason: str
+    exposure_currencies: list[str]
+
+
+def _primary_treasury_supportability(
+    *,
+    hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
+    currency_exposure: DpmCoreExternalCurrencyExposureResponse | None,
+    hedge_policy: DpmCoreExternalHedgePolicyResponse | None,
+    eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None,
+    fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None,
+) -> _PrimaryTreasurySupportability | None:
+    for response in (
+        hedge_readiness,
+        currency_exposure,
+        hedge_policy,
+        eligible_hedge_instruments,
+        fx_forward_curve,
+    ):
+        if response is not None:
+            return _PrimaryTreasurySupportability(
+                state=response.supportability.state,
+                reason=response.supportability.reason,
+                exposure_currencies=response.exposure_currencies,
+            )
+    return None
+
+
 def external_treasury_currency_overlay_context(
     *,
     hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
@@ -95,50 +142,25 @@ def external_treasury_currency_overlay_context(
     eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None,
     fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None,
 ) -> AuthoritativeCurrencyOverlayContext | None:
-    if (
-        hedge_readiness is None
-        and currency_exposure is None
-        and hedge_policy is None
-        and eligible_hedge_instruments is None
-        and fx_forward_curve is None
-    ):
+    primary_supportability = _primary_treasury_supportability(
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=hedge_policy,
+        eligible_hedge_instruments=eligible_hedge_instruments,
+        fx_forward_curve=fx_forward_curve,
+    )
+    if primary_supportability is None:
         return None
 
-    readiness_payload = _optional_source_payload(hedge_readiness)
-    exposure_payload = _optional_source_payload(currency_exposure)
-    hedge_policy_payload = _optional_source_payload(hedge_policy)
-    eligible_hedge_instruments_payload = _optional_source_payload(eligible_hedge_instruments)
-    fx_forward_curve_payload = _optional_source_payload(fx_forward_curve)
     source_hash = hash_canonical_payload(
-        {
-            "external_hedge_execution_readiness": readiness_payload,
-            "external_currency_exposure": exposure_payload,
-            "external_hedge_policy": hedge_policy_payload,
-            "external_eligible_hedge_instruments": eligible_hedge_instruments_payload,
-            "external_fx_forward_curve": fx_forward_curve_payload,
-        }
+        _treasury_source_payloads(
+            hedge_readiness=hedge_readiness,
+            currency_exposure=currency_exposure,
+            hedge_policy=hedge_policy,
+            eligible_hedge_instruments=eligible_hedge_instruments,
+            fx_forward_curve=fx_forward_curve,
+        )
     )
-    if hedge_readiness is not None:
-        supportability_state = hedge_readiness.supportability.state
-        supportability_reason = hedge_readiness.supportability.reason
-        exposure_currencies = hedge_readiness.exposure_currencies
-    elif currency_exposure is not None:
-        supportability_state = currency_exposure.supportability.state
-        supportability_reason = currency_exposure.supportability.reason
-        exposure_currencies = currency_exposure.exposure_currencies
-    elif hedge_policy is not None:
-        supportability_state = hedge_policy.supportability.state
-        supportability_reason = hedge_policy.supportability.reason
-        exposure_currencies = hedge_policy.exposure_currencies
-    elif eligible_hedge_instruments is not None:
-        supportability_state = eligible_hedge_instruments.supportability.state
-        supportability_reason = eligible_hedge_instruments.supportability.reason
-        exposure_currencies = eligible_hedge_instruments.exposure_currencies
-    else:
-        assert fx_forward_curve is not None
-        supportability_state = fx_forward_curve.supportability.state
-        supportability_reason = fx_forward_curve.supportability.reason
-        exposure_currencies = fx_forward_curve.exposure_currencies
 
     readiness_identity = _optional_source_identity(hedge_readiness, source_hash)
     exposure_identity = _optional_source_identity(currency_exposure)
@@ -146,7 +168,7 @@ def external_treasury_currency_overlay_context(
     eligible_hedge_instruments_identity = _optional_source_identity(eligible_hedge_instruments)
     fx_forward_curve_identity = _optional_source_identity(fx_forward_curve)
     reason_codes = _fail_closed_reason_codes(
-        primary_reason=supportability_reason,
+        primary_reason=primary_supportability.reason,
         hedge_readiness=hedge_readiness,
         currency_exposure=currency_exposure,
         hedge_policy=hedge_policy,
@@ -155,12 +177,12 @@ def external_treasury_currency_overlay_context(
     )
 
     return AuthoritativeCurrencyOverlayContext(
-        supportability_status=source_status_to_method_status(supportability_state),
+        supportability_status=source_status_to_method_status(primary_supportability.state),
         source_system="lotus-core",
         policy_id="external-hedge-execution-readiness.v1",
         hedge_ratio_min=Decimal("0.00"),
         hedge_ratio_max=Decimal("0.00"),
-        eligible_currencies=exposure_currencies,
+        eligible_currencies=primary_supportability.exposure_currencies,
         source_product_name=(
             readiness_identity.source_product_name if readiness_identity is not None else None
         ),

--- a/src/api/services/construction_treasury_source_context.py
+++ b/src/api/services/construction_treasury_source_context.py
@@ -57,6 +57,23 @@ def _optional_source_identity(
     return source_product_identity(response, fallback_source_id=fallback_source_id)
 
 
+def _source_identity_fields(
+    *,
+    prefix: str,
+    identity: SourceProductIdentity | None,
+) -> dict[str, str | None]:
+    return {
+        f"{prefix}_source_product_name": (
+            identity.source_product_name if identity is not None else None
+        ),
+        f"{prefix}_source_product_version": (
+            identity.source_product_version if identity is not None else None
+        ),
+        f"{prefix}_source_id": identity.source_id if identity is not None else None,
+        f"{prefix}_content_hash": identity.content_hash if identity is not None else None,
+    }
+
+
 def _missing_data_families(response: _TreasurySourceResponse | None) -> list[str]:
     return response.supportability.missing_data_families if response is not None else []
 
@@ -206,17 +223,9 @@ def external_treasury_currency_overlay_context(
             fx_forward_curve,
         ),
         readiness_checks=hedge_readiness.readiness_checks if hedge_readiness is not None else [],
-        external_currency_exposure_source_product_name=(
-            exposure_identity.source_product_name if exposure_identity is not None else None
-        ),
-        external_currency_exposure_source_product_version=(
-            exposure_identity.source_product_version if exposure_identity is not None else None
-        ),
-        external_currency_exposure_source_id=(
-            exposure_identity.source_id if exposure_identity is not None else None
-        ),
-        external_currency_exposure_content_hash=(
-            exposure_identity.content_hash if exposure_identity is not None else None
+        **_source_identity_fields(
+            prefix="external_currency_exposure",
+            identity=exposure_identity,
         ),
         external_currency_exposure_count=(
             currency_exposure.supportability.exposure_count if currency_exposure is not None else 0
@@ -224,43 +233,17 @@ def external_treasury_currency_overlay_context(
         external_currency_exposure_rows=(
             currency_exposure.exposures if currency_exposure is not None else []
         ),
-        external_hedge_policy_source_product_name=(
-            hedge_policy_identity.source_product_name if hedge_policy_identity is not None else None
-        ),
-        external_hedge_policy_source_product_version=(
-            hedge_policy_identity.source_product_version
-            if hedge_policy_identity is not None
-            else None
-        ),
-        external_hedge_policy_source_id=(
-            hedge_policy_identity.source_id if hedge_policy_identity is not None else None
-        ),
-        external_hedge_policy_content_hash=(
-            hedge_policy_identity.content_hash if hedge_policy_identity is not None else None
+        **_source_identity_fields(
+            prefix="external_hedge_policy",
+            identity=hedge_policy_identity,
         ),
         external_hedge_policy_rule_count=(
             hedge_policy.supportability.policy_rule_count if hedge_policy is not None else 0
         ),
         external_hedge_policy_rules=(hedge_policy.policy_rules if hedge_policy is not None else []),
-        external_eligible_hedge_instrument_source_product_name=(
-            eligible_hedge_instruments_identity.source_product_name
-            if eligible_hedge_instruments_identity is not None
-            else None
-        ),
-        external_eligible_hedge_instrument_source_product_version=(
-            eligible_hedge_instruments_identity.source_product_version
-            if eligible_hedge_instruments_identity is not None
-            else None
-        ),
-        external_eligible_hedge_instrument_source_id=(
-            eligible_hedge_instruments_identity.source_id
-            if eligible_hedge_instruments_identity is not None
-            else None
-        ),
-        external_eligible_hedge_instrument_content_hash=(
-            eligible_hedge_instruments_identity.content_hash
-            if eligible_hedge_instruments_identity is not None
-            else None
+        **_source_identity_fields(
+            prefix="external_eligible_hedge_instrument",
+            identity=eligible_hedge_instruments_identity,
         ),
         external_eligible_hedge_instrument_count=(
             eligible_hedge_instruments.supportability.instrument_count
@@ -272,23 +255,9 @@ def external_treasury_currency_overlay_context(
             if eligible_hedge_instruments is not None
             else []
         ),
-        external_fx_forward_curve_source_product_name=(
-            fx_forward_curve_identity.source_product_name
-            if fx_forward_curve_identity is not None
-            else None
-        ),
-        external_fx_forward_curve_source_product_version=(
-            fx_forward_curve_identity.source_product_version
-            if fx_forward_curve_identity is not None
-            else None
-        ),
-        external_fx_forward_curve_source_id=(
-            fx_forward_curve_identity.source_id if fx_forward_curve_identity is not None else None
-        ),
-        external_fx_forward_curve_content_hash=(
-            fx_forward_curve_identity.content_hash
-            if fx_forward_curve_identity is not None
-            else None
+        **_source_identity_fields(
+            prefix="external_fx_forward_curve",
+            identity=fx_forward_curve_identity,
         ),
         external_fx_forward_curve_point_count=(
             fx_forward_curve.supportability.curve_point_count if fx_forward_curve is not None else 0

--- a/src/api/services/wave_core_portfolio_universe_resolution.py
+++ b/src/api/services/wave_core_portfolio_universe_resolution.py
@@ -150,6 +150,7 @@ def resolve_core_dpm_portfolio_universe_candidates(
             {
                 "portfolio_id": candidate.portfolio_id,
                 "mandate_id": candidate.mandate_id,
+                "portfolio_type": "DISCRETIONARY",
                 "source_refs": [
                     universe_ref,
                     _portfolio_universe_candidate_ref(

--- a/src/api/services/wave_core_portfolio_universe_resolution.py
+++ b/src/api/services/wave_core_portfolio_universe_resolution.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date
+from typing import Any
+
+from src.api.services.wave_errors import (
+    DpmWaveDependencyFailedError,
+    DpmWaveDependencyUnavailableError,
+)
+from src.core.dpm_source_context import (
+    DpmCorePortfolioUniverseCandidate,
+    DpmCorePortfolioUniverseCandidateResponse,
+)
+from src.core.waves import DpmWaveSourceRef
+from src.infrastructure.core_sourcing import (
+    DpmCoreResolverError,
+    DpmCoreResolverUnavailableError,
+)
+
+CoreResolverFactory = Callable[[], Any]
+
+MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES = 10
+
+
+def _selection_basis_payload(
+    page: DpmCorePortfolioUniverseCandidateResponse,
+) -> dict[str, object] | None:
+    if page.selection_basis is None:
+        return None
+    return page.selection_basis.model_dump(mode="json")
+
+
+def _portfolio_universe_candidate_ref(
+    *,
+    candidate: DpmCorePortfolioUniverseCandidate,
+    selection_basis: dict[str, object] | None,
+) -> dict[str, object]:
+    return DpmWaveSourceRef(
+        source_system="lotus-core",
+        source_type="DPM_PORTFOLIO_UNIVERSE_CANDIDATE",
+        source_id=candidate.source_record_id or f"{candidate.portfolio_id}:{candidate.mandate_id}",
+        source_version=str(candidate.binding_version),
+        supportability_state="READY",
+        selection_basis=selection_basis,
+    ).model_dump(mode="json")
+
+
+def _portfolio_universe_candidate_page_ref(
+    *, page: DpmCorePortfolioUniverseCandidateResponse
+) -> dict[str, object]:
+    return DpmWaveSourceRef(
+        source_system="lotus-core",
+        source_type="DpmPortfolioUniverseCandidate",
+        source_id=page.snapshot_id or page.page.request_scope_fingerprint,
+        source_version=page.product_version,
+        supportability_state=page.supportability.state,
+        content_hash=page.source_batch_fingerprint,
+    ).model_dump(mode="json")
+
+
+def resolve_core_dpm_portfolio_universe_candidates(
+    *,
+    as_of_date: date,
+    tenant_id: str | None,
+    booking_center_code: str | None,
+    model_portfolio_ids: list[str],
+    include_inactive_mandates: bool,
+    campaign_candidate_page_size: int,
+    correlation_id: str,
+    core_resolver_factory: CoreResolverFactory,
+) -> list[dict[str, object]]:
+    resolver = core_resolver_factory()
+    candidate_pages: list[DpmCorePortfolioUniverseCandidateResponse] = []
+    next_page_token: str | None = None
+    seen_page_tokens: set[str] = set()
+
+    try:
+        for _ in range(MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES):
+            candidate_page = resolver.resolve_dpm_portfolio_universe_candidates(
+                as_of_date=as_of_date,
+                tenant_id=tenant_id,
+                booking_center_code=booking_center_code,
+                model_portfolio_ids=model_portfolio_ids,
+                include_inactive_mandates=include_inactive_mandates,
+                page_size=campaign_candidate_page_size,
+                page_token=next_page_token,
+                correlation_id=correlation_id,
+            )
+            candidate_pages.append(candidate_page)
+            if candidate_page.supportability.state != "READY":
+                break
+            next_page_token = candidate_page.page.next_page_token
+            if not next_page_token:
+                break
+            if next_page_token in seen_page_tokens:
+                raise DpmCoreResolverError("DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING")
+            seen_page_tokens.add(next_page_token)
+        else:
+            raise DpmCoreResolverError("DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING")
+    except DpmCoreResolverUnavailableError as exc:
+        raise DpmWaveDependencyUnavailableError(
+            code=str(exc) or "DPM_CORE_PORTFOLIO_UNIVERSE_UNAVAILABLE"
+        ) from exc
+    except DpmCoreResolverError as exc:
+        raise DpmWaveDependencyFailedError(
+            code=str(exc) or "DPM_CORE_PORTFOLIO_UNIVERSE_INCOMPLETE"
+        ) from exc
+
+    candidate_page = candidate_pages[-1]
+    if candidate_page.supportability.state != "READY":
+        raise DpmWaveDependencyFailedError(
+            code=candidate_page.supportability.reason,
+            message="Core DPM portfolio-universe candidates are not source-ready.",
+        )
+    if next_page_token or candidate_page.supportability.page_truncated:
+        raise DpmWaveDependencyFailedError(
+            code="DPM_CORE_PORTFOLIO_UNIVERSE_PAGE_PARTIAL",
+            message=(
+                "Core DPM portfolio-universe candidates could not be exhausted within the "
+                "bounded Manage consumer guard; refine filters before creating a campaign wave."
+            ),
+        )
+
+    candidates = [candidate for page in candidate_pages for candidate in page.candidates]
+    if not candidates:
+        raise DpmWaveDependencyFailedError(
+            code="DPM_CORE_PORTFOLIO_UNIVERSE_EMPTY",
+            message="Core DPM portfolio-universe discovery returned no candidate portfolios.",
+        )
+    candidate_keys: set[tuple[str, str | None, str | None]] = set()
+    first_page = candidate_pages[0]
+    selection_basis = _selection_basis_payload(first_page)
+    universe_ref = _portfolio_universe_candidate_page_ref(page=first_page)
+    portfolios: list[dict[str, object]] = []
+
+    for candidate in candidates:
+        candidate_key = (
+            candidate.portfolio_id,
+            candidate.mandate_id,
+            candidate.source_record_id,
+        )
+        if candidate_key in candidate_keys:
+            raise DpmWaveDependencyFailedError(
+                code="DPM_CORE_PORTFOLIO_UNIVERSE_DUPLICATE_CANDIDATE",
+                message="Core DPM portfolio-universe discovery returned duplicate candidate rows.",
+            )
+        candidate_keys.add(candidate_key)
+        portfolios.append(
+            {
+                "portfolio_id": candidate.portfolio_id,
+                "mandate_id": candidate.mandate_id,
+                "source_refs": [
+                    universe_ref,
+                    _portfolio_universe_candidate_ref(
+                        candidate=candidate, selection_basis=selection_basis
+                    ),
+                ],
+            }
+        )
+    return portfolios
+
+
+__all__ = [
+    "resolve_core_dpm_portfolio_universe_candidates",
+    "MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES",
+]

--- a/src/api/services/wave_errors.py
+++ b/src/api/services/wave_errors.py
@@ -12,4 +12,33 @@ class DpmWaveLookupError(LookupError):
         self.message = message
 
 
-__all__ = ["DpmWaveLookupError", "DpmWaveValidationError"]
+class DpmWaveDependencyError(ValueError):
+    status_code: int
+
+    def __init__(self, *, code: str, message: str | None = None, status_code: int) -> None:
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        super().__init__(code)
+
+    def __str__(self) -> str:
+        return self.code
+
+
+class DpmWaveDependencyUnavailableError(DpmWaveDependencyError):
+    def __init__(self, *, code: str, message: str | None = None) -> None:
+        super().__init__(code=code, message=message, status_code=503)
+
+
+class DpmWaveDependencyFailedError(DpmWaveDependencyError):
+    def __init__(self, *, code: str, message: str | None = None) -> None:
+        super().__init__(code=code, message=message, status_code=424)
+
+
+__all__ = [
+    "DpmWaveDependencyError",
+    "DpmWaveDependencyFailedError",
+    "DpmWaveDependencyUnavailableError",
+    "DpmWaveLookupError",
+    "DpmWaveValidationError",
+]

--- a/src/core/common/target_redistribution.py
+++ b/src/core/common/target_redistribution.py
@@ -1,0 +1,23 @@
+from decimal import Decimal
+from typing import Literal
+
+
+def redistribute_sell_only_excess(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+    sell_only_excess: Decimal,
+) -> Literal["READY", "PENDING_REVIEW"]:
+    if sell_only_excess <= Decimal("0.0"):
+        return "READY"
+
+    recipients = {k: v for k, v in eligible_targets.items() if k in buy_set}
+    total_recipient_weight = sum(recipients.values())
+    if total_recipient_weight <= Decimal("0.0"):
+        return "PENDING_REVIEW"
+
+    for instrument_id, weight in recipients.items():
+        eligible_targets[instrument_id] = weight + (
+            sell_only_excess * (weight / total_recipient_weight)
+        )
+    return "READY"

--- a/src/core/compliance.py
+++ b/src/core/compliance.py
@@ -9,6 +9,38 @@ from typing import List
 from src.core.models import DiagnosticsData, EngineOptions, RuleResult, SimulatedState
 
 
+def _cash_band_rule_result(
+    *,
+    state: SimulatedState,
+    options: EngineOptions,
+) -> RuleResult:
+    cash_weight = next(
+        (a.weight for a in state.allocation_by_asset_class if a.key == "CASH"), Decimal("0")
+    )
+    min_w = options.cash_band_min_weight
+    max_w = options.cash_band_max_weight
+
+    if cash_weight < min_w or cash_weight > max_w:
+        return RuleResult(
+            rule_id="CASH_BAND",
+            severity="SOFT",
+            status="FAIL",
+            measured=cash_weight,
+            threshold={"min": min_w, "max": max_w},
+            reason_code="THRESHOLD_BREACH",
+            remediation_hint="Portfolio cash is outside policy bands.",
+        )
+
+    return RuleResult(
+        rule_id="CASH_BAND",
+        severity="SOFT",
+        status="PASS",
+        measured=cash_weight,
+        threshold={"min": min_w, "max": max_w},
+        reason_code="OK",
+    )
+
+
 class RuleEngine:
     """
     Evaluates business rules against the simulated after-state.
@@ -22,35 +54,7 @@ class RuleEngine:
     ) -> List[RuleResult]:
         results = []
 
-        cash_weight = next(
-            (a.weight for a in state.allocation_by_asset_class if a.key == "CASH"), Decimal("0")
-        )
-        min_w = options.cash_band_min_weight
-        max_w = options.cash_band_max_weight
-
-        if cash_weight < min_w or cash_weight > max_w:
-            results.append(
-                RuleResult(
-                    rule_id="CASH_BAND",
-                    severity="SOFT",
-                    status="FAIL",
-                    measured=cash_weight,
-                    threshold={"min": min_w, "max": max_w},
-                    reason_code="THRESHOLD_BREACH",
-                    remediation_hint="Portfolio cash is outside policy bands.",
-                )
-            )
-        else:
-            results.append(
-                RuleResult(
-                    rule_id="CASH_BAND",
-                    severity="SOFT",
-                    status="PASS",
-                    measured=cash_weight,
-                    threshold={"min": min_w, "max": max_w},
-                    reason_code="OK",
-                )
-            )
+        results.append(_cash_band_rule_result(state=state, options=options))
 
         limit_w = options.single_position_max_weight
         if limit_w is not None:

--- a/src/core/construction/enrichment.py
+++ b/src/core/construction/enrichment.py
@@ -39,6 +39,26 @@ def estimate_transaction_cost(
     return Money(amount=cost, currency=result.before.total_value.currency)
 
 
+def _tax_enrichment_status(
+    *,
+    tax_required: bool,
+    tax_impact_available: bool,
+) -> tuple[ConstructionMethodStatus, list[str]]:
+    if tax_impact_available:
+        return ConstructionMethodStatus.READY, []
+    if tax_required:
+        return ConstructionMethodStatus.BLOCKED, ["TAX_LOTS_REQUIRED_BUT_NO_TAX_IMPACT"]
+    return ConstructionMethodStatus.DEGRADED, ["TAX_ENRICHMENT_NOT_REQUESTED_OR_UNAVAILABLE"]
+
+
+def _fx_enrichment_status(
+    *, missing_fx_pairs: object
+) -> tuple[ConstructionMethodStatus, list[str]]:
+    if missing_fx_pairs:
+        return ConstructionMethodStatus.BLOCKED, ["FX_SOURCE_MISSING"]
+    return ConstructionMethodStatus.READY, []
+
+
 def summarize_enrichment_posture(
     *,
     result: RebalanceResult,
@@ -54,18 +74,16 @@ def summarize_enrichment_posture(
     """Summarize source-aware enrichment readiness without hiding degraded inputs."""
 
     reason_codes: list[str] = []
-    tax_status = ConstructionMethodStatus.READY
-    if tax_required and result.tax_impact is None:
-        tax_status = ConstructionMethodStatus.BLOCKED
-        reason_codes.append("TAX_LOTS_REQUIRED_BUT_NO_TAX_IMPACT")
-    elif result.tax_impact is None:
-        tax_status = ConstructionMethodStatus.DEGRADED
-        reason_codes.append("TAX_ENRICHMENT_NOT_REQUESTED_OR_UNAVAILABLE")
+    tax_status, tax_reason_codes = _tax_enrichment_status(
+        tax_required=tax_required,
+        tax_impact_available=result.tax_impact is not None,
+    )
+    reason_codes.extend(tax_reason_codes)
 
-    fx_status = ConstructionMethodStatus.READY
-    if result.diagnostics.missing_fx_pairs:
-        fx_status = ConstructionMethodStatus.BLOCKED
-        reason_codes.append("FX_SOURCE_MISSING")
+    fx_status, fx_reason_codes = _fx_enrichment_status(
+        missing_fx_pairs=result.diagnostics.missing_fx_pairs
+    )
+    reason_codes.extend(fx_reason_codes)
 
     liquidity_status = ConstructionMethodStatus.READY
     if _cash_weight(result.after_simulated) is None:

--- a/src/core/construction/enrichment.py
+++ b/src/core/construction/enrichment.py
@@ -59,6 +59,20 @@ def _fx_enrichment_status(
     return ConstructionMethodStatus.READY, []
 
 
+def _cost_enrichment_status(
+    *,
+    authoritative_cost_available: bool,
+    transaction_cost_context: AuthoritativeTransactionCostContext | None,
+) -> tuple[ConstructionMethodStatus, list[str]]:
+    if transaction_cost_context is not None:
+        return transaction_cost_context.supportability_status, list(
+            transaction_cost_context.reason_codes
+        )
+    if not authoritative_cost_available:
+        return ConstructionMethodStatus.DEGRADED, ["AUTHORITATIVE_TRANSACTION_COST_UNAVAILABLE"]
+    return ConstructionMethodStatus.READY, []
+
+
 def summarize_enrichment_posture(
     *,
     result: RebalanceResult,
@@ -102,15 +116,11 @@ def summarize_enrichment_posture(
             ]
         )
 
-    cost_context_status = (
-        transaction_cost_context.supportability_status if transaction_cost_context else None
+    cost_status, cost_reason_codes = _cost_enrichment_status(
+        authoritative_cost_available=authoritative_cost_available,
+        transaction_cost_context=transaction_cost_context,
     )
-    cost_status = cost_context_status or ConstructionMethodStatus.READY
-    if not authoritative_cost_available and transaction_cost_context is None:
-        cost_status = ConstructionMethodStatus.DEGRADED
-        reason_codes.append("AUTHORITATIVE_TRANSACTION_COST_UNAVAILABLE")
-    elif transaction_cost_context is not None:
-        reason_codes.extend(transaction_cost_context.reason_codes)
+    reason_codes.extend(cost_reason_codes)
 
     turnover_status = ConstructionMethodStatus.READY
     if result.diagnostics.dropped_intents:

--- a/src/core/mandates.py
+++ b/src/core/mandates.py
@@ -574,24 +574,17 @@ class DpmCommandCenterSummary(BaseModel):
     )
 
 
-def compile_mandate_digital_twin_from_core(
+def _mandate_twin_field_gap_codes(
     *,
     mandate: DpmCoreMandateBindingResponse,
-    model_targets: DpmCoreModelPortfolioTargetResponse,
-    as_of_date: date,
-    reference_currency: Optional[str] = None,
-    client_restriction_profile: Optional[DpmCoreClientRestrictionProfileResponse] = None,
-    sustainability_preference_profile: Optional[
-        DpmCoreSustainabilityPreferenceProfileResponse
-    ] = None,
-    portfolio_cashflow_projection: Optional[DpmCorePortfolioCashflowProjectionResponse] = None,
-    client_income_needs_schedule: Optional[DpmCoreClientIncomeNeedsScheduleResponse] = None,
-    liquidity_reserve_requirement: Optional[DpmCoreLiquidityReserveRequirementResponse] = None,
-    planned_withdrawal_schedule: Optional[DpmCorePlannedWithdrawalScheduleResponse] = None,
-    benchmark_assignment: Optional[DpmCoreBenchmarkAssignmentResponse] = None,
-) -> DpmMandateDigitalTwin:
-    """Compile the minimum viable mandate twin from current RFC-087 core products."""
-
+    client_restriction_profile: Optional[DpmCoreClientRestrictionProfileResponse],
+    sustainability_preference_profile: Optional[DpmCoreSustainabilityPreferenceProfileResponse],
+    portfolio_cashflow_projection: Optional[DpmCorePortfolioCashflowProjectionResponse],
+    client_income_needs_schedule: Optional[DpmCoreClientIncomeNeedsScheduleResponse],
+    liquidity_reserve_requirement: Optional[DpmCoreLiquidityReserveRequirementResponse],
+    planned_withdrawal_schedule: Optional[DpmCorePlannedWithdrawalScheduleResponse],
+    benchmark_assignment: Optional[DpmCoreBenchmarkAssignmentResponse],
+) -> list[str]:
     field_gaps = []
     if client_income_needs_schedule is None:
         field_gaps.append("CLIENT_INCOME_NEED_PROFILE_NOT_YET_SOURCED")
@@ -611,6 +604,37 @@ def compile_mandate_digital_twin_from_core(
         field_gaps.append("PORTFOLIO_CASHFLOW_PROJECTION_NOT_YET_SOURCED")
     if benchmark_assignment is None:
         field_gaps.append("BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED")
+    return field_gaps
+
+
+def compile_mandate_digital_twin_from_core(
+    *,
+    mandate: DpmCoreMandateBindingResponse,
+    model_targets: DpmCoreModelPortfolioTargetResponse,
+    as_of_date: date,
+    reference_currency: Optional[str] = None,
+    client_restriction_profile: Optional[DpmCoreClientRestrictionProfileResponse] = None,
+    sustainability_preference_profile: Optional[
+        DpmCoreSustainabilityPreferenceProfileResponse
+    ] = None,
+    portfolio_cashflow_projection: Optional[DpmCorePortfolioCashflowProjectionResponse] = None,
+    client_income_needs_schedule: Optional[DpmCoreClientIncomeNeedsScheduleResponse] = None,
+    liquidity_reserve_requirement: Optional[DpmCoreLiquidityReserveRequirementResponse] = None,
+    planned_withdrawal_schedule: Optional[DpmCorePlannedWithdrawalScheduleResponse] = None,
+    benchmark_assignment: Optional[DpmCoreBenchmarkAssignmentResponse] = None,
+) -> DpmMandateDigitalTwin:
+    """Compile the minimum viable mandate twin from current RFC-087 core products."""
+
+    field_gaps = _mandate_twin_field_gap_codes(
+        mandate=mandate,
+        client_restriction_profile=client_restriction_profile,
+        sustainability_preference_profile=sustainability_preference_profile,
+        portfolio_cashflow_projection=portfolio_cashflow_projection,
+        client_income_needs_schedule=client_income_needs_schedule,
+        liquidity_reserve_requirement=liquidity_reserve_requirement,
+        planned_withdrawal_schedule=planned_withdrawal_schedule,
+        benchmark_assignment=benchmark_assignment,
+    )
     cash_reserve_weight = mandate.rebalance_bands.cash_reserve_weight or Decimal("0")
     constraints = DpmMandateConstraintSet(
         cash_band_min_weight=cash_reserve_weight,

--- a/src/core/mandates.py
+++ b/src/core/mandates.py
@@ -607,12 +607,10 @@ def _mandate_twin_field_gap_codes(
     return field_gaps
 
 
-def compile_mandate_digital_twin_from_core(
+def _build_digital_twin_source_lineage(
     *,
     mandate: DpmCoreMandateBindingResponse,
     model_targets: DpmCoreModelPortfolioTargetResponse,
-    as_of_date: date,
-    reference_currency: Optional[str] = None,
     client_restriction_profile: Optional[DpmCoreClientRestrictionProfileResponse] = None,
     sustainability_preference_profile: Optional[
         DpmCoreSustainabilityPreferenceProfileResponse
@@ -622,44 +620,7 @@ def compile_mandate_digital_twin_from_core(
     liquidity_reserve_requirement: Optional[DpmCoreLiquidityReserveRequirementResponse] = None,
     planned_withdrawal_schedule: Optional[DpmCorePlannedWithdrawalScheduleResponse] = None,
     benchmark_assignment: Optional[DpmCoreBenchmarkAssignmentResponse] = None,
-) -> DpmMandateDigitalTwin:
-    """Compile the minimum viable mandate twin from current RFC-087 core products."""
-
-    field_gaps = _mandate_twin_field_gap_codes(
-        mandate=mandate,
-        client_restriction_profile=client_restriction_profile,
-        sustainability_preference_profile=sustainability_preference_profile,
-        portfolio_cashflow_projection=portfolio_cashflow_projection,
-        client_income_needs_schedule=client_income_needs_schedule,
-        liquidity_reserve_requirement=liquidity_reserve_requirement,
-        planned_withdrawal_schedule=planned_withdrawal_schedule,
-        benchmark_assignment=benchmark_assignment,
-    )
-    cash_reserve_weight = mandate.rebalance_bands.cash_reserve_weight or Decimal("0")
-    constraints = DpmMandateConstraintSet(
-        cash_band_min_weight=cash_reserve_weight,
-        cash_band_max_weight=max(cash_reserve_weight, Decimal("0.10")),
-        turnover_budget=Decimal("0.15"),
-    )
-    if client_restriction_profile is not None:
-        constraints.restricted_instruments = sorted(
-            {
-                instrument_id
-                for restriction in client_restriction_profile.restrictions
-                if restriction.restriction_status.upper() == "ACTIVE"
-                for instrument_id in restriction.instrument_ids
-            }
-        )
-    preferences = DpmMandatePreferences()
-    if sustainability_preference_profile is not None:
-        preferences.sustainability_strategy = _sustainability_strategy(
-            sustainability_preference_profile
-        )
-        preferences.bespoke_notes = [
-            preference.preference_code
-            for preference in sustainability_preference_profile.preferences
-            if preference.preference_status.upper() == "ACTIVE"
-        ]
+) -> list[DpmSourceProductLineage]:
     source_lineage = [
         _lineage_from_core_product(
             product_name=mandate.product_name,
@@ -755,6 +716,73 @@ def compile_mandate_digital_twin_from_core(
                 lineage={"contract_version": benchmark_assignment.contract_version},
             )
         )
+    return source_lineage
+
+
+def compile_mandate_digital_twin_from_core(
+    *,
+    mandate: DpmCoreMandateBindingResponse,
+    model_targets: DpmCoreModelPortfolioTargetResponse,
+    as_of_date: date,
+    reference_currency: Optional[str] = None,
+    client_restriction_profile: Optional[DpmCoreClientRestrictionProfileResponse] = None,
+    sustainability_preference_profile: Optional[
+        DpmCoreSustainabilityPreferenceProfileResponse
+    ] = None,
+    portfolio_cashflow_projection: Optional[DpmCorePortfolioCashflowProjectionResponse] = None,
+    client_income_needs_schedule: Optional[DpmCoreClientIncomeNeedsScheduleResponse] = None,
+    liquidity_reserve_requirement: Optional[DpmCoreLiquidityReserveRequirementResponse] = None,
+    planned_withdrawal_schedule: Optional[DpmCorePlannedWithdrawalScheduleResponse] = None,
+    benchmark_assignment: Optional[DpmCoreBenchmarkAssignmentResponse] = None,
+) -> DpmMandateDigitalTwin:
+    """Compile the minimum viable mandate twin from current RFC-087 core products."""
+
+    field_gaps = _mandate_twin_field_gap_codes(
+        mandate=mandate,
+        client_restriction_profile=client_restriction_profile,
+        sustainability_preference_profile=sustainability_preference_profile,
+        portfolio_cashflow_projection=portfolio_cashflow_projection,
+        client_income_needs_schedule=client_income_needs_schedule,
+        liquidity_reserve_requirement=liquidity_reserve_requirement,
+        planned_withdrawal_schedule=planned_withdrawal_schedule,
+        benchmark_assignment=benchmark_assignment,
+    )
+    cash_reserve_weight = mandate.rebalance_bands.cash_reserve_weight or Decimal("0")
+    constraints = DpmMandateConstraintSet(
+        cash_band_min_weight=cash_reserve_weight,
+        cash_band_max_weight=max(cash_reserve_weight, Decimal("0.10")),
+        turnover_budget=Decimal("0.15"),
+    )
+    if client_restriction_profile is not None:
+        constraints.restricted_instruments = sorted(
+            {
+                instrument_id
+                for restriction in client_restriction_profile.restrictions
+                if restriction.restriction_status.upper() == "ACTIVE"
+                for instrument_id in restriction.instrument_ids
+            }
+        )
+    preferences = DpmMandatePreferences()
+    if sustainability_preference_profile is not None:
+        preferences.sustainability_strategy = _sustainability_strategy(
+            sustainability_preference_profile
+        )
+        preferences.bespoke_notes = [
+            preference.preference_code
+            for preference in sustainability_preference_profile.preferences
+            if preference.preference_status.upper() == "ACTIVE"
+        ]
+    source_lineage = _build_digital_twin_source_lineage(
+        mandate=mandate,
+        model_targets=model_targets,
+        client_restriction_profile=client_restriction_profile,
+        sustainability_preference_profile=sustainability_preference_profile,
+        portfolio_cashflow_projection=portfolio_cashflow_projection,
+        client_income_needs_schedule=client_income_needs_schedule,
+        liquidity_reserve_requirement=liquidity_reserve_requirement,
+        planned_withdrawal_schedule=planned_withdrawal_schedule,
+        benchmark_assignment=benchmark_assignment,
+    )
     return DpmMandateDigitalTwin(
         mandate_id=mandate.mandate_id,
         portfolio_id=mandate.portfolio_id,

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -531,57 +531,96 @@ class DpmPortfolioMemorySearchItem(BaseModel):
 
     @model_validator(mode="after")
     def validate_search_item_metadata(self) -> "DpmPortfolioMemorySearchItem":
-        expected_event_count = sum(self.event_type_counts.values())
-        if self.event_count != expected_event_count:
-            raise ValueError("event_count must equal the sum of event_type_counts.")
-
-        if self.matching_event_count > self.event_count:
-            raise ValueError("matching_event_count must not exceed event_count.")
-
-        if self.source_systems != sorted(set(self.source_systems)):
-            raise ValueError("source_systems must be sorted and unique.")
-
-        if self.reason_codes != sorted(set(self.reason_codes)):
-            raise ValueError("reason_codes must be sorted and unique.")
-
-        latest_event_fields = [self.latest_event_time, self.latest_event_type]
-        if self.event_count == 0:
-            if self.supportability_state != "EMPTY":
-                raise ValueError("empty search items must use EMPTY supportability_state.")
-            if self.event_type_counts or self.source_systems or self.reason_codes:
-                raise ValueError("empty search items must not carry aggregate event metadata.")
-            if any(value is not None for value in latest_event_fields):
-                raise ValueError("empty search items must not carry latest event metadata.")
-        else:
-            if self.supportability_state == "EMPTY":
-                raise ValueError("non-empty search items must not use EMPTY supportability_state.")
-            if any(value is None for value in latest_event_fields):
-                raise ValueError("non-empty search items must carry latest event metadata.")
-
-        latest_matching_fields = [
-            self.latest_matching_event_time,
-            self.latest_matching_event_type,
-            self.latest_matching_event_id,
-            self.latest_matching_event_identity,
-            self.latest_matching_event_source_system,
-            self.latest_matching_event_source_type,
-            self.latest_matching_event_source_id,
-        ]
-        if self.matching_event_count == 0:
-            if any(value is not None for value in latest_matching_fields):
-                raise ValueError(
-                    "search items with no matching events must not carry latest matching event metadata."
-                )
-            if self.latest_matching_event_content_hash is not None:
-                raise ValueError(
-                    "search items with no matching events must not carry latest matching event content hash."
-                )
-        elif any(value is None for value in latest_matching_fields):
-            raise ValueError(
-                "search items with matching events must carry latest matching event metadata."
-            )
+        _validate_search_item_metadata(
+            event_count=self.event_count,
+            event_type_counts=self.event_type_counts,
+            source_systems=self.source_systems,
+            reason_codes=self.reason_codes,
+            supportability_state=self.supportability_state,
+            matching_event_count=self.matching_event_count,
+            latest_event_time=self.latest_event_time,
+            latest_event_type=self.latest_event_type,
+            latest_matching_event_time=self.latest_matching_event_time,
+            latest_matching_event_type=self.latest_matching_event_type,
+            latest_matching_event_id=self.latest_matching_event_id,
+            latest_matching_event_identity=self.latest_matching_event_identity,
+            latest_matching_event_source_system=self.latest_matching_event_source_system,
+            latest_matching_event_source_type=self.latest_matching_event_source_type,
+            latest_matching_event_source_id=self.latest_matching_event_source_id,
+            latest_matching_event_content_hash=self.latest_matching_event_content_hash,
+        )
 
         return self
+
+
+def _validate_search_item_metadata(
+    *,
+    event_count: int,
+    event_type_counts: dict[str, int],
+    source_systems: list[str],
+    reason_codes: list[str],
+    supportability_state: PortfolioMemorySupportabilityState,
+    matching_event_count: int,
+    latest_event_time: str | None,
+    latest_event_type: PortfolioMemoryEventType | None,
+    latest_matching_event_time: str | None,
+    latest_matching_event_type: PortfolioMemoryEventType | None,
+    latest_matching_event_id: str | None,
+    latest_matching_event_identity: str | None,
+    latest_matching_event_source_system: str | None,
+    latest_matching_event_source_type: str | None,
+    latest_matching_event_source_id: str | None,
+    latest_matching_event_content_hash: str | None,
+) -> None:
+    expected_event_count = sum(event_type_counts.values())
+    if event_count != expected_event_count:
+        raise ValueError("event_count must equal the sum of event_type_counts.")
+
+    if matching_event_count > event_count:
+        raise ValueError("matching_event_count must not exceed event_count.")
+
+    if source_systems != sorted(set(source_systems)):
+        raise ValueError("source_systems must be sorted and unique.")
+
+    if reason_codes != sorted(set(reason_codes)):
+        raise ValueError("reason_codes must be sorted and unique.")
+
+    latest_event_fields = [latest_event_time, latest_event_type]
+    if event_count == 0:
+        if supportability_state != "EMPTY":
+            raise ValueError("empty search items must use EMPTY supportability_state.")
+        if event_type_counts or source_systems or reason_codes:
+            raise ValueError("empty search items must not carry aggregate event metadata.")
+        if any(value is not None for value in latest_event_fields):
+            raise ValueError("empty search items must not carry latest event metadata.")
+    else:
+        if supportability_state == "EMPTY":
+            raise ValueError("non-empty search items must not use EMPTY supportability_state.")
+        if any(value is None for value in latest_event_fields):
+            raise ValueError("non-empty search items must carry latest event metadata.")
+
+    latest_matching_fields = [
+        latest_matching_event_time,
+        latest_matching_event_type,
+        latest_matching_event_id,
+        latest_matching_event_identity,
+        latest_matching_event_source_system,
+        latest_matching_event_source_type,
+        latest_matching_event_source_id,
+    ]
+    if matching_event_count == 0:
+        if any(value is not None for value in latest_matching_fields):
+            raise ValueError(
+                "search items with no matching events must not carry latest matching event metadata."
+            )
+        if latest_matching_event_content_hash is not None:
+            raise ValueError(
+                "search items with no matching events must not carry latest matching event content hash."
+            )
+    elif any(value is None for value in latest_matching_fields):
+        raise ValueError(
+            "search items with matching events must carry latest matching event metadata."
+        )
 
 
 class DpmPortfolioMemorySearchAppliedFilters(BaseModel):

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -762,24 +762,14 @@ class DpmPortfolioMemorySearchPage(BaseModel):
 
     @model_validator(mode="after")
     def validate_search_page_metadata(self) -> "DpmPortfolioMemorySearchPage":
-        if self.returned_count != len(self.items):
-            raise ValueError("returned_count must equal the number of items.")
-
-        if self.returned_count > self.total_count:
-            raise ValueError("returned_count must not exceed total_count.")
-
-        expected_has_more = self.offset + self.returned_count < self.total_count
-        if self.has_more != expected_has_more:
-            raise ValueError("has_more must match pagination posture.")
-
-        if self.has_more:
-            expected_next_offset = self.offset + self.returned_count
-            if self.next_offset != expected_next_offset:
-                raise ValueError("next_offset must equal offset plus returned_count.")
-            if self.next_offset <= self.offset:
-                raise ValueError("next_offset must advance when has_more is true.")
-        elif self.next_offset is not None:
-            raise ValueError("next_offset must be null when has_more is false.")
+        _validate_search_page_pagination(
+            returned_count=self.returned_count,
+            item_count=len(self.items),
+            total_count=self.total_count,
+            offset=self.offset,
+            has_more=self.has_more,
+            next_offset=self.next_offset,
+        )
 
         _validate_non_negative_counts(
             label="supportability_state_counts", counts=self.supportability_state_counts
@@ -840,6 +830,35 @@ class DpmPortfolioMemorySearchPage(BaseModel):
                 )
 
         return self
+
+
+def _validate_search_page_pagination(
+    *,
+    returned_count: int,
+    item_count: int,
+    total_count: int,
+    offset: int,
+    has_more: bool,
+    next_offset: int | None,
+) -> None:
+    if returned_count != item_count:
+        raise ValueError("returned_count must equal the number of items.")
+
+    if returned_count > total_count:
+        raise ValueError("returned_count must not exceed total_count.")
+
+    expected_has_more = offset + returned_count < total_count
+    if has_more != expected_has_more:
+        raise ValueError("has_more must match pagination posture.")
+
+    if has_more:
+        expected_next_offset = offset + returned_count
+        if next_offset is None or next_offset != expected_next_offset:
+            raise ValueError("next_offset must equal offset plus returned_count.")
+        if next_offset <= offset:
+            raise ValueError("next_offset must advance when has_more is true.")
+    elif next_offset is not None:
+        raise ValueError("next_offset must be null when has_more is false.")
 
 
 def _counts(values: Iterable[str]) -> dict[str, int]:

--- a/src/core/portfolio_memory/search_page.py
+++ b/src/core/portfolio_memory/search_page.py
@@ -42,26 +42,95 @@ class PortfolioMemorySearchFilters:
 SearchRow = tuple[DpmPortfolioMemorySearchItem, list[DpmPortfolioMemoryEvent]]
 
 
+def _memory_passes_search_summary_filters(
+    *,
+    memory: DpmPortfolioMemory,
+    filters: PortfolioMemorySearchFilters,
+    explicit_candidate_ids: set[str],
+) -> bool:
+    if memory.event_count == 0:
+        if (
+            filters.supportability_state != "EMPTY"
+            or memory.portfolio_id not in explicit_candidate_ids
+        ):
+            return False
+    if filters.event_type is not None and filters.event_type not in memory.event_type_counts:
+        return False
+    if (
+        filters.supportability_state is not None
+        and memory.supportability_state != filters.supportability_state
+    ):
+        return False
+    if filters.source_system is not None and filters.source_system not in memory.source_systems:
+        return False
+    return True
+
+
+def _filters_require_matching_events(filters: PortfolioMemorySearchFilters) -> bool:
+    return (
+        filters.event_type is not None
+        or filters.source_system is not None
+        or filters.source_type is not None
+        or filters.supportability_state is not None
+    )
+
+
+def _portfolio_memory_search_item(
+    *,
+    memory: DpmPortfolioMemory,
+    matching_events: list[DpmPortfolioMemoryEvent],
+) -> DpmPortfolioMemorySearchItem:
+    latest_event = memory.events[0] if memory.events else None
+    latest_matching_event = matching_events[0] if matching_events else None
+    return DpmPortfolioMemorySearchItem(
+        portfolio_id=memory.portfolio_id,
+        event_count=memory.event_count,
+        supportability_state=memory.supportability_state,
+        event_type_counts=memory.event_type_counts,
+        source_systems=memory.source_systems,
+        reason_codes=memory.reason_codes,
+        latest_event_time=latest_event.event_time if latest_event else None,
+        latest_event_type=latest_event.event_type if latest_event else None,
+        matching_event_count=len(matching_events),
+        latest_matching_event_time=(
+            latest_matching_event.event_time if latest_matching_event else None
+        ),
+        latest_matching_event_type=(
+            latest_matching_event.event_type if latest_matching_event else None
+        ),
+        latest_matching_event_id=(
+            latest_matching_event.event_id if latest_matching_event else None
+        ),
+        latest_matching_event_identity=(
+            latest_matching_event.event_identity if latest_matching_event else None
+        ),
+        latest_matching_event_source_system=(
+            latest_matching_event.source_system if latest_matching_event else None
+        ),
+        latest_matching_event_source_type=(
+            latest_matching_event.source_type if latest_matching_event else None
+        ),
+        latest_matching_event_source_id=(
+            latest_matching_event.source_id if latest_matching_event else None
+        ),
+        latest_matching_event_content_hash=(
+            latest_matching_event.content_hash if latest_matching_event else None
+        ),
+        content_hash=memory.content_hash,
+    )
+
+
 def build_search_row(
     *,
     memory: DpmPortfolioMemory,
     filters: PortfolioMemorySearchFilters,
     explicit_candidate_ids: set[str],
 ) -> SearchRow | None:
-    if memory.event_count == 0:
-        if (
-            filters.supportability_state != "EMPTY"
-            or memory.portfolio_id not in explicit_candidate_ids
-        ):
-            return None
-    if filters.event_type is not None and filters.event_type not in memory.event_type_counts:
-        return None
-    if (
-        filters.supportability_state is not None
-        and memory.supportability_state != filters.supportability_state
+    if not _memory_passes_search_summary_filters(
+        memory=memory,
+        filters=filters,
+        explicit_candidate_ids=explicit_candidate_ids,
     ):
-        return None
-    if filters.source_system is not None and filters.source_system not in memory.source_systems:
         return None
 
     matching_events = [
@@ -76,56 +145,14 @@ def build_search_row(
         )
     ]
     if (
-        (
-            filters.event_type is not None
-            or filters.source_system is not None
-            or filters.source_type is not None
-            or filters.supportability_state is not None
-        )
+        _filters_require_matching_events(filters)
         and filters.supportability_state != "EMPTY"
         and not matching_events
     ):
         return None
 
-    latest_event = memory.events[0] if memory.events else None
-    latest_matching_event = matching_events[0] if matching_events else None
     return (
-        DpmPortfolioMemorySearchItem(
-            portfolio_id=memory.portfolio_id,
-            event_count=memory.event_count,
-            supportability_state=memory.supportability_state,
-            event_type_counts=memory.event_type_counts,
-            source_systems=memory.source_systems,
-            reason_codes=memory.reason_codes,
-            latest_event_time=latest_event.event_time if latest_event else None,
-            latest_event_type=latest_event.event_type if latest_event else None,
-            matching_event_count=len(matching_events),
-            latest_matching_event_time=(
-                latest_matching_event.event_time if latest_matching_event else None
-            ),
-            latest_matching_event_type=(
-                latest_matching_event.event_type if latest_matching_event else None
-            ),
-            latest_matching_event_id=(
-                latest_matching_event.event_id if latest_matching_event else None
-            ),
-            latest_matching_event_identity=(
-                latest_matching_event.event_identity if latest_matching_event else None
-            ),
-            latest_matching_event_source_system=(
-                latest_matching_event.source_system if latest_matching_event else None
-            ),
-            latest_matching_event_source_type=(
-                latest_matching_event.source_type if latest_matching_event else None
-            ),
-            latest_matching_event_source_id=(
-                latest_matching_event.source_id if latest_matching_event else None
-            ),
-            latest_matching_event_content_hash=(
-                latest_matching_event.content_hash if latest_matching_event else None
-            ),
-            content_hash=memory.content_hash,
-        ),
+        _portfolio_memory_search_item(memory=memory, matching_events=matching_events),
         matching_events,
     )
 

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -377,6 +377,29 @@ def _build_section(
     return DpmProofPackSection.model_validate(payload)
 
 
+def _source_analytics_section_payload(
+    *,
+    source_analytics: dict[str, ProofPackSourceAnalytics],
+    family: ProofPackAnalyticsFamily,
+    missing_summary: str,
+    missing_reason_code: str,
+    sort_reason_codes: bool = False,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    analytics = source_analytics.get(family)
+    if analytics is None:
+        return ("DEGRADED", missing_summary, {}, {}, [missing_reason_code])
+    reason_codes = list(analytics.reason_codes)
+    if sort_reason_codes:
+        reason_codes = sorted(set(reason_codes))
+    return (
+        analytics.state,
+        analytics.summary,
+        analytics.facts,
+        analytics.metrics,
+        reason_codes,
+    )
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -530,55 +553,25 @@ def _section_payload(
             else ["DPM_SELECTED_METHOD_NOT_READY"],
         )
     if section_type == "risk_impact":
-        risk_context = source_analytics.get("risk")
-        if risk_context is not None:
-            return (
-                risk_context.state,
-                risk_context.summary,
-                risk_context.facts,
-                risk_context.metrics,
-                risk_context.reason_codes,
-            )
-        return (
-            "DEGRADED",
-            "No risk-authoritative enrichment is attached to this first-wave proof pack.",
-            {},
-            {},
-            ["DPM_RISK_AUTHORITY_CONTEXT_MISSING"],
+        return _source_analytics_section_payload(
+            source_analytics=source_analytics,
+            family="risk",
+            missing_summary="No risk-authoritative enrichment is attached to this first-wave proof pack.",
+            missing_reason_code="DPM_RISK_AUTHORITY_CONTEXT_MISSING",
         )
     if section_type == "performance_context":
-        performance_context = source_analytics.get("performance")
-        if performance_context is not None:
-            return (
-                performance_context.state,
-                performance_context.summary,
-                performance_context.facts,
-                performance_context.metrics,
-                performance_context.reason_codes,
-            )
-        return (
-            "DEGRADED",
-            "No performance-authoritative benchmark context is attached.",
-            {},
-            {},
-            ["DPM_PERFORMANCE_CONTEXT_MISSING"],
+        return _source_analytics_section_payload(
+            source_analytics=source_analytics,
+            family="performance",
+            missing_summary="No performance-authoritative benchmark context is attached.",
+            missing_reason_code="DPM_PERFORMANCE_CONTEXT_MISSING",
         )
     if section_type == "sustainability_controls":
-        sustainability_context = source_analytics.get("sustainability_preference")
-        if sustainability_context is not None:
-            return (
-                sustainability_context.state,
-                sustainability_context.summary,
-                sustainability_context.facts,
-                sustainability_context.metrics,
-                sustainability_context.reason_codes,
-            )
-        return (
-            "DEGRADED",
-            "Sustainability preference authority context is not attached.",
-            {},
-            {},
-            ["DPM_SUSTAINABILITY_PREFERENCE_CONTEXT_MISSING"],
+        return _source_analytics_section_payload(
+            source_analytics=source_analytics,
+            family="sustainability_preference",
+            missing_summary="Sustainability preference authority context is not attached.",
+            missing_reason_code="DPM_SUSTAINABILITY_PREFERENCE_CONTEXT_MISSING",
         )
     if section_type == "reporting_refs":
         return (
@@ -737,21 +730,12 @@ def _section_payload(
             ["DPM_CURRENCY_OVERLAY_CONTEXT_MISSING"],
         )
     if section_type == "scenario_and_regime_evidence":
-        regime_context = source_analytics.get("regime_stress")
-        if regime_context is not None:
-            return (
-                regime_context.state,
-                regime_context.summary,
-                regime_context.facts,
-                regime_context.metrics,
-                sorted(set(regime_context.reason_codes)),
-            )
-        return (
-            "DEGRADED",
-            "Scenario/regime authority context is not attached.",
-            {},
-            {},
-            ["DPM_SCENARIO_CONTEXT_MISSING"],
+        return _source_analytics_section_payload(
+            source_analytics=source_analytics,
+            family="regime_stress",
+            missing_summary="Scenario/regime authority context is not attached.",
+            missing_reason_code="DPM_SCENARIO_CONTEXT_MISSING",
+            sort_reason_codes=True,
         )
     if section_type == "eligibility_and_restrictions":
         restriction_context = source_analytics.get("client_restriction")

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -753,6 +753,43 @@ def _source_readiness_section_payload(
     )
 
 
+def _turnover_and_cost_section_payload(
+    *,
+    selected_alternative: ConstructionAlternative | None,
+    source_analytics: dict[str, ProofPackSourceAnalytics],
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    transaction_cost_context = source_analytics.get("transaction_cost")
+    metrics = (
+        selected_alternative.comparison_metrics.model_dump(mode="json")
+        if selected_alternative
+        else {}
+    )
+    facts: dict[str, Any] = {}
+    reason_codes = [] if metrics else ["DPM_TURNOVER_COST_METRICS_MISSING"]
+    state: ProofPackSectionState = "READY" if metrics else "DEGRADED"
+    summary = "Turnover and cost evidence captured when construction metrics are available."
+
+    if transaction_cost_context is not None:
+        facts = transaction_cost_context.facts
+        metrics = {**metrics, **transaction_cost_context.metrics}
+        reason_codes.extend(transaction_cost_context.reason_codes)
+        state = _lowest_section_state([state, transaction_cost_context.state])
+        summary = (
+            "Turnover metrics and source-owned observed transaction-cost evidence are attached."
+        )
+    elif metrics:
+        reason_codes.append("DPM_TRANSACTION_COST_AUTHORITY_CONTEXT_MISSING")
+        state = "DEGRADED"
+
+    return (
+        state,
+        summary,
+        facts,
+        metrics,
+        sorted(set(reason_codes)),
+    )
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -849,33 +886,9 @@ def _section_payload(
     if run_policy_payload is not None:
         return run_policy_payload
     if section_type == "turnover_and_cost":
-        transaction_cost_context = source_analytics.get("transaction_cost")
-        metrics = (
-            selected_alternative.comparison_metrics.model_dump(mode="json")
-            if selected_alternative
-            else {}
-        )
-        facts: dict[str, Any] = {}
-        reason_codes = [] if metrics else ["DPM_TURNOVER_COST_METRICS_MISSING"]
-        state: ProofPackSectionState = "READY" if metrics else "DEGRADED"
-        summary = "Turnover and cost evidence captured when construction metrics are available."
-        if transaction_cost_context is not None:
-            facts = transaction_cost_context.facts
-            metrics = {**metrics, **transaction_cost_context.metrics}
-            reason_codes.extend(transaction_cost_context.reason_codes)
-            state = _lowest_section_state([state, transaction_cost_context.state])
-            summary = (
-                "Turnover metrics and source-owned observed transaction-cost evidence are attached."
-            )
-        elif metrics:
-            reason_codes.append("DPM_TRANSACTION_COST_AUTHORITY_CONTEXT_MISSING")
-            state = "DEGRADED"
-        return (
-            state,
-            summary,
-            facts,
-            metrics,
-            sorted(set(reason_codes)),
+        return _turnover_and_cost_section_payload(
+            selected_alternative=selected_alternative,
+            source_analytics=source_analytics,
         )
     run_diagnostics_payload = _run_diagnostics_section_payload(
         section_type=section_type,

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -570,25 +570,9 @@ def _proof_pack_governance_section_payload(
     workflow_decisions: list[DpmRunWorkflowDecisionRecord],
 ) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]] | None:
     if section_type == "approval_requirements":
-        gate = result.gate_decision
-        workflow_facts = [
-            decision.model_dump(mode="json")
-            for decision in sorted(workflow_decisions, key=lambda item: item.decided_at)
-        ]
-        approval_state: ProofPackSectionState = "READY"
-        if result.status == "PENDING_REVIEW" or (gate and gate.gate.endswith("REQUIRED")):
-            approval_state = "PENDING_REVIEW"
-        if result.status == "BLOCKED" or (gate and gate.gate == "BLOCKED"):
-            approval_state = "BLOCKED"
-        return (
-            approval_state,
-            "Approval posture captured from run status and gate decision.",
-            {
-                "gate_decision": gate.model_dump(mode="json") if gate else None,
-                "workflow_decisions": workflow_facts,
-            },
-            {"workflow_decision_count": len(workflow_facts)},
-            [reason.reason_code for reason in gate.reasons] if gate else [],
+        return _approval_requirements_section_payload(
+            result=result,
+            workflow_decisions=workflow_decisions,
         )
     if section_type == "operations_handoff":
         return (
@@ -620,6 +604,33 @@ def _proof_pack_governance_section_payload(
     if section_type == "supportability":
         return ("READY", "Supportability summary is generated for every proof pack.", {}, {}, [])
     return None
+
+
+def _approval_requirements_section_payload(
+    *,
+    result: RebalanceResult,
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
+) -> _SectionPayload:
+    gate = result.gate_decision
+    workflow_facts = [
+        decision.model_dump(mode="json")
+        for decision in sorted(workflow_decisions, key=lambda item: item.decided_at)
+    ]
+    approval_state: ProofPackSectionState = "READY"
+    if result.status == "PENDING_REVIEW" or (gate and gate.gate.endswith("REQUIRED")):
+        approval_state = "PENDING_REVIEW"
+    if result.status == "BLOCKED" or (gate and gate.gate == "BLOCKED"):
+        approval_state = "BLOCKED"
+    return (
+        approval_state,
+        "Approval posture captured from run status and gate decision.",
+        {
+            "gate_decision": gate.model_dump(mode="json") if gate else None,
+            "workflow_decisions": workflow_facts,
+        },
+        {"workflow_decision_count": len(workflow_facts)},
+        [reason.reason_code for reason in gate.reasons] if gate else [],
+    )
 
 
 def _mandate_context_section_payload(

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -790,6 +790,42 @@ def _turnover_and_cost_section_payload(
     )
 
 
+def _eligibility_and_restrictions_section_payload(
+    *,
+    result: RebalanceResult,
+    source_analytics: dict[str, ProofPackSourceAnalytics],
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    restriction_context = source_analytics.get("client_restriction")
+    excluded = result.universe.excluded
+    if restriction_context is not None:
+        reason_codes = list(restriction_context.reason_codes)
+        if excluded:
+            reason_codes.append("DPM_UNIVERSE_EXCLUSIONS_PRESENT")
+        return (
+            _lowest_section_state(
+                [
+                    restriction_context.state,
+                    "PENDING_REVIEW" if excluded else "READY",
+                ]
+            ),
+            "Eligibility evidence and source-owned client restriction profile are attached.",
+            {
+                **restriction_context.facts,
+                "excluded": [item.model_dump(mode="json") for item in excluded],
+            },
+            {**restriction_context.metrics, "excluded_count": len(excluded)},
+            sorted(set(reason_codes)),
+        )
+
+    return (
+        "READY" if not excluded else "PENDING_REVIEW",
+        "Eligibility and restriction evidence captured from source run universe.",
+        {"excluded": [item.model_dump(mode="json") for item in excluded]},
+        {"excluded_count": len(excluded)},
+        ["DPM_UNIVERSE_EXCLUSIONS_PRESENT"] if excluded else [],
+    )
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -905,33 +941,9 @@ def _section_payload(
             sort_reason_codes=True,
         )
     if section_type == "eligibility_and_restrictions":
-        restriction_context = source_analytics.get("client_restriction")
-        excluded = result.universe.excluded
-        if restriction_context is not None:
-            reason_codes = list(restriction_context.reason_codes)
-            if excluded:
-                reason_codes.append("DPM_UNIVERSE_EXCLUSIONS_PRESENT")
-            return (
-                _lowest_section_state(
-                    [
-                        restriction_context.state,
-                        "PENDING_REVIEW" if excluded else "READY",
-                    ]
-                ),
-                "Eligibility evidence and source-owned client restriction profile are attached.",
-                {
-                    **restriction_context.facts,
-                    "excluded": [item.model_dump(mode="json") for item in excluded],
-                },
-                {**restriction_context.metrics, "excluded_count": len(excluded)},
-                sorted(set(reason_codes)),
-            )
-        return (
-            "READY" if not excluded else "PENDING_REVIEW",
-            "Eligibility and restriction evidence captured from source run universe.",
-            {"excluded": [item.model_dump(mode="json") for item in excluded]},
-            {"excluded_count": len(excluded)},
-            ["DPM_UNIVERSE_EXCLUSIONS_PRESENT"] if excluded else [],
+        return _eligibility_and_restrictions_section_payload(
+            result=result,
+            source_analytics=source_analytics,
         )
     governance_payload = _proof_pack_governance_section_payload(
         section_type=section_type,

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -729,6 +729,30 @@ def _selected_alternative_section_payload(
     )
 
 
+def _source_readiness_section_payload(
+    *,
+    result: RebalanceResult | None,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    if result is None:
+        return ("BLOCKED", "No source run is available.", {}, {}, ["DPM_SOURCE_RUN_MISSING"])
+
+    source_state = result.lineage.source_supportability_state
+    reason_codes = (
+        [] if source_state in {None, "READY", "ready"} else ["DPM_SOURCE_READINESS_DEGRADED"]
+    )
+    return (
+        "READY" if not reason_codes else "DEGRADED",
+        "Source readiness captured from run lineage.",
+        {
+            "input_mode": result.lineage.input_mode,
+            "source_system": result.lineage.source_system,
+            "source_supportability_state": source_state,
+        },
+        {},
+        reason_codes,
+    )
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -772,22 +796,8 @@ def _section_payload(
             mandate_evidence_gap_codes=mandate_evidence_gap_codes,
         )
     if section_type == "source_readiness":
-        source_state = result.lineage.source_supportability_state if result is not None else None
-        if result is None:
-            return ("BLOCKED", "No source run is available.", {}, {}, ["DPM_SOURCE_RUN_MISSING"])
-        reason_codes = (
-            [] if source_state in {None, "READY", "ready"} else ["DPM_SOURCE_READINESS_DEGRADED"]
-        )
-        return (
-            "READY" if not reason_codes else "DEGRADED",
-            "Source readiness captured from run lineage.",
-            {
-                "input_mode": result.lineage.input_mode,
-                "source_system": result.lineage.source_system,
-                "source_supportability_state": source_state,
-            },
-            {},
-            reason_codes,
+        return _source_readiness_section_payload(
+            result=result,
         )
     if section_type == "selected_alternative":
         return _selected_alternative_section_payload(

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -506,6 +506,57 @@ def _run_diagnostics_section_payload(
     return None
 
 
+def _run_policy_section_payload(
+    *,
+    section_type: ProofPackSectionType,
+    result: RebalanceResult,
+    selected_alternative: ConstructionAlternative | None,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]] | None:
+    if section_type == "drift_impact":
+        if selected_alternative is not None:
+            metrics = selected_alternative.comparison_metrics.model_dump(mode="json")
+            return (
+                "READY",
+                "Drift impact captured from construction comparison metrics.",
+                {},
+                metrics,
+                [],
+            )
+        return (
+            "DEGRADED",
+            "Direct-run proof has no construction comparison drift trace.",
+            {},
+            {},
+            ["DPM_DRIFT_COMPARISON_UNAVAILABLE"],
+        )
+    if section_type == "tax_impact":
+        if result.tax_impact is None:
+            return (
+                "DEGRADED",
+                "Tax impact is not available for this run.",
+                {},
+                {},
+                ["DPM_TAX_IMPACT_MISSING"],
+            )
+        return (
+            "READY",
+            "Tax impact captured from manage tax-aware simulation.",
+            result.tax_impact.model_dump(mode="json"),
+            {},
+            [],
+        )
+    if section_type == "rule_results":
+        failed = [rule for rule in result.rule_results if rule.status == "FAIL"]
+        return (
+            "BLOCKED" if any(rule.severity == "HARD" for rule in failed) else "READY",
+            "Rule results captured from manage policy engine.",
+            {"rule_results": [rule.model_dump(mode="json") for rule in result.rule_results]},
+            {"fail_count": len(failed)},
+            [rule.reason_code for rule in failed],
+        )
+    return None
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -694,39 +745,13 @@ def _section_payload(
     run_state_payload = _run_state_section_payload(section_type=section_type, result=result)
     if run_state_payload is not None:
         return run_state_payload
-    if section_type == "drift_impact":
-        if selected_alternative is not None:
-            metrics = selected_alternative.comparison_metrics.model_dump(mode="json")
-            return (
-                "READY",
-                "Drift impact captured from construction comparison metrics.",
-                {},
-                metrics,
-                [],
-            )
-        return (
-            "DEGRADED",
-            "Direct-run proof has no construction comparison drift trace.",
-            {},
-            {},
-            ["DPM_DRIFT_COMPARISON_UNAVAILABLE"],
-        )
-    if section_type == "tax_impact":
-        if result.tax_impact is None:
-            return (
-                "DEGRADED",
-                "Tax impact is not available for this run.",
-                {},
-                {},
-                ["DPM_TAX_IMPACT_MISSING"],
-            )
-        return (
-            "READY",
-            "Tax impact captured from manage tax-aware simulation.",
-            result.tax_impact.model_dump(mode="json"),
-            {},
-            [],
-        )
+    run_policy_payload = _run_policy_section_payload(
+        section_type=section_type,
+        result=result,
+        selected_alternative=selected_alternative,
+    )
+    if run_policy_payload is not None:
+        return run_policy_payload
     if section_type == "turnover_and_cost":
         transaction_cost_context = source_analytics.get("transaction_cost")
         metrics = (
@@ -798,15 +823,6 @@ def _section_payload(
             {"excluded": [item.model_dump(mode="json") for item in excluded]},
             {"excluded_count": len(excluded)},
             ["DPM_UNIVERSE_EXCLUSIONS_PRESENT"] if excluded else [],
-        )
-    if section_type == "rule_results":
-        failed = [rule for rule in result.rule_results if rule.status == "FAIL"]
-        return (
-            "BLOCKED" if any(rule.severity == "HARD" for rule in failed) else "READY",
-            "Rule results captured from manage policy engine.",
-            {"rule_results": [rule.model_dump(mode="json") for rule in result.rule_results]},
-            {"fail_count": len(failed)},
-            [rule.reason_code for rule in failed],
         )
     if section_type == "approval_requirements":
         gate = result.gate_decision

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -462,6 +462,50 @@ def _run_state_section_payload(
     return None
 
 
+def _run_diagnostics_section_payload(
+    *,
+    section_type: ProofPackSectionType,
+    result: RebalanceResult,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]] | None:
+    if section_type == "liquidity_and_cash":
+        breaches = result.diagnostics.cash_ladder_breaches
+        return (
+            "BLOCKED" if breaches else "READY",
+            "Liquidity and cash posture captured from run diagnostics.",
+            {
+                "cash_ladder": [
+                    item.model_dump(mode="json") for item in result.diagnostics.cash_ladder
+                ],
+                "cash_ladder_breaches": [item.model_dump(mode="json") for item in breaches],
+            },
+            {"breach_count": len(breaches)},
+            ["DPM_CASH_LADDER_BREACH"] if breaches else [],
+        )
+    if section_type == "fx_funding_plan":
+        missing_pairs = result.diagnostics.missing_fx_pairs
+        return (
+            "BLOCKED" if missing_pairs else "READY",
+            "FX funding posture captured from run diagnostics.",
+            {
+                "funding_plan": [
+                    item.model_dump(mode="json") for item in result.diagnostics.funding_plan
+                ],
+                "missing_fx_pairs": missing_pairs,
+            },
+            {"missing_fx_pair_count": len(missing_pairs)},
+            ["DPM_REQUIRED_FX_PAIR_MISSING"] if missing_pairs else [],
+        )
+    if section_type == "currency_overlay_evidence":
+        return (
+            "DEGRADED",
+            "Currency-overlay authority context is not attached.",
+            {},
+            {},
+            ["DPM_CURRENCY_OVERLAY_CONTEXT_MISSING"],
+        )
+    return None
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -712,42 +756,12 @@ def _section_payload(
             metrics,
             sorted(set(reason_codes)),
         )
-    if section_type == "liquidity_and_cash":
-        breaches = result.diagnostics.cash_ladder_breaches
-        return (
-            "BLOCKED" if breaches else "READY",
-            "Liquidity and cash posture captured from run diagnostics.",
-            {
-                "cash_ladder": [
-                    item.model_dump(mode="json") for item in result.diagnostics.cash_ladder
-                ],
-                "cash_ladder_breaches": [item.model_dump(mode="json") for item in breaches],
-            },
-            {"breach_count": len(breaches)},
-            ["DPM_CASH_LADDER_BREACH"] if breaches else [],
-        )
-    if section_type == "fx_funding_plan":
-        missing_pairs = result.diagnostics.missing_fx_pairs
-        return (
-            "BLOCKED" if missing_pairs else "READY",
-            "FX funding posture captured from run diagnostics.",
-            {
-                "funding_plan": [
-                    item.model_dump(mode="json") for item in result.diagnostics.funding_plan
-                ],
-                "missing_fx_pairs": missing_pairs,
-            },
-            {"missing_fx_pair_count": len(missing_pairs)},
-            ["DPM_REQUIRED_FX_PAIR_MISSING"] if missing_pairs else [],
-        )
-    if section_type == "currency_overlay_evidence":
-        return (
-            "DEGRADED",
-            "Currency-overlay authority context is not attached.",
-            {},
-            {},
-            ["DPM_CURRENCY_OVERLAY_CONTEXT_MISSING"],
-        )
+    run_diagnostics_payload = _run_diagnostics_section_payload(
+        section_type=section_type,
+        result=result,
+    )
+    if run_diagnostics_payload is not None:
+        return run_diagnostics_payload
     if section_type == "scenario_and_regime_evidence":
         return _source_analytics_section_payload(
             source_analytics=source_analytics,

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -414,6 +414,54 @@ def _adapter_section_payload(
     )
 
 
+def _run_state_section_payload(
+    *,
+    section_type: ProofPackSectionType,
+    result: RebalanceResult,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]] | None:
+    if section_type == "before_state":
+        return (
+            "READY",
+            "Before-state summary captured from source run artifact.",
+            {"before_summary": result.before.model_dump(mode="json")},
+            {"position_count": len(result.before.positions)},
+            [],
+        )
+    if section_type == "target_state":
+        return (
+            "READY",
+            "Target state captured from source run target trace.",
+            {"target_id": result.target.target_id},
+            {"target_count": len(result.target.targets)},
+            [],
+        )
+    if section_type == "trade_intents":
+        if not result.intents:
+            return (
+                "BLOCKED",
+                "No trade intents are available for pre-trade proof.",
+                {"intent_ids": []},
+                {"trade_count": 0},
+                ["DPM_TRADE_INTENTS_MISSING"],
+            )
+        return (
+            "READY",
+            "Trade intents captured from source run.",
+            {"intent_ids": [intent.intent_id for intent in result.intents]},
+            {"trade_count": len(result.intents)},
+            [],
+        )
+    if section_type == "after_state":
+        return (
+            "READY" if result.status != "BLOCKED" else "BLOCKED",
+            "After-state simulation summary captured from source run.",
+            {"after_summary": result.after_simulated.model_dump(mode="json")},
+            {"position_count": len(result.after_simulated.positions)},
+            [] if result.status != "BLOCKED" else ["DPM_AFTER_STATE_BLOCKED"],
+        )
+    return None
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -599,46 +647,9 @@ def _section_payload(
         )
     if result is None:
         return ("BLOCKED", "Source rebalance run is missing.", {}, {}, ["DPM_SOURCE_RUN_MISSING"])
-    if section_type == "before_state":
-        return (
-            "READY",
-            "Before-state summary captured from source run artifact.",
-            {"before_summary": result.before.model_dump(mode="json")},
-            {"position_count": len(result.before.positions)},
-            [],
-        )
-    if section_type == "target_state":
-        return (
-            "READY",
-            "Target state captured from source run target trace.",
-            {"target_id": result.target.target_id},
-            {"target_count": len(result.target.targets)},
-            [],
-        )
-    if section_type == "trade_intents":
-        if not result.intents:
-            return (
-                "BLOCKED",
-                "No trade intents are available for pre-trade proof.",
-                {"intent_ids": []},
-                {"trade_count": 0},
-                ["DPM_TRADE_INTENTS_MISSING"],
-            )
-        return (
-            "READY",
-            "Trade intents captured from source run.",
-            {"intent_ids": [intent.intent_id for intent in result.intents]},
-            {"trade_count": len(result.intents)},
-            [],
-        )
-    if section_type == "after_state":
-        return (
-            "READY" if result.status != "BLOCKED" else "BLOCKED",
-            "After-state simulation summary captured from source run.",
-            {"after_summary": result.after_simulated.model_dump(mode="json")},
-            {"position_count": len(result.after_simulated.positions)},
-            [] if result.status != "BLOCKED" else ["DPM_AFTER_STATE_BLOCKED"],
-        )
+    run_state_payload = _run_state_section_payload(section_type=section_type, result=result)
+    if run_state_payload is not None:
+        return run_state_payload
     if section_type == "drift_impact":
         if selected_alternative is not None:
             metrics = selected_alternative.comparison_metrics.model_dump(mode="json")

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -688,6 +688,47 @@ def _mandate_context_section_payload(
     )
 
 
+def _selected_alternative_section_payload(
+    *,
+    alternative_set: ConstructionAlternativeSet | None,
+    selected_alternative: ConstructionAlternative | None,
+    selection: ConstructionAlternativeSelection | None,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    if selected_alternative is None:
+        return (
+            "DEGRADED",
+            "Direct-run proof pack has no selected construction alternative.",
+            {},
+            {},
+            ["DPM_DIRECT_RUN_NO_SELECTED_ALTERNATIVE"],
+        )
+    selected_state = (
+        "READY"
+        if selected_alternative.method_status == "READY"
+        else cast(ProofPackSectionState, str(selected_alternative.method_status))
+    )
+    return (
+        selected_state,
+        "Selected construction alternative captured with method and trace evidence.",
+        {
+            "alternative_set_id": alternative_set.alternative_set_id if alternative_set else None,
+            "selected_alternative_id": selected_alternative.alternative_id,
+            "selection_id": selection.selection_id if selection else None,
+            "method": selected_alternative.method,
+            "method_status": selected_alternative.method_status,
+            "summary": selected_alternative.summary,
+            "objective_trace": [
+                item.model_dump(mode="json") for item in selected_alternative.objective_trace
+            ],
+            "constraint_trace": [
+                item.model_dump(mode="json") for item in selected_alternative.constraint_trace
+            ],
+        },
+        selected_alternative.comparison_metrics.model_dump(mode="json"),
+        [] if selected_alternative.method_status == "READY" else ["DPM_SELECTED_METHOD_NOT_READY"],
+    )
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -749,42 +790,10 @@ def _section_payload(
             reason_codes,
         )
     if section_type == "selected_alternative":
-        if selected_alternative is None:
-            return (
-                "DEGRADED",
-                "Direct-run proof pack has no selected construction alternative.",
-                {},
-                {},
-                ["DPM_DIRECT_RUN_NO_SELECTED_ALTERNATIVE"],
-            )
-        selected_state = (
-            "READY"
-            if selected_alternative.method_status == "READY"
-            else cast(ProofPackSectionState, str(selected_alternative.method_status))
-        )
-        return (
-            selected_state,
-            "Selected construction alternative captured with method and trace evidence.",
-            {
-                "alternative_set_id": alternative_set.alternative_set_id
-                if alternative_set
-                else None,
-                "selected_alternative_id": selected_alternative.alternative_id,
-                "selection_id": selection.selection_id if selection else None,
-                "method": selected_alternative.method,
-                "method_status": selected_alternative.method_status,
-                "summary": selected_alternative.summary,
-                "objective_trace": [
-                    item.model_dump(mode="json") for item in selected_alternative.objective_trace
-                ],
-                "constraint_trace": [
-                    item.model_dump(mode="json") for item in selected_alternative.constraint_trace
-                ],
-            },
-            selected_alternative.comparison_metrics.model_dump(mode="json"),
-            []
-            if selected_alternative.method_status == "READY"
-            else ["DPM_SELECTED_METHOD_NOT_READY"],
+        return _selected_alternative_section_payload(
+            alternative_set=alternative_set,
+            selected_alternative=selected_alternative,
+            selection=selection,
         )
     if section_type == "risk_impact":
         return _source_analytics_section_payload(

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -619,6 +619,75 @@ def _proof_pack_governance_section_payload(
     return None
 
 
+def _mandate_context_section_payload(
+    *,
+    mandate_id: str | None,
+    mandate_twin: DpmMandateDigitalTwin | None,
+    mandate_health: DpmMandateHealthSnapshot | None,
+    mandate_evidence_gap_codes: list[str],
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    if not mandate_id:
+        return (
+            "BLOCKED",
+            "Mandate identity is required before proof-pack promotion.",
+            {"mandate_id": None},
+            {},
+            ["DPM_PROOF_PACK_MANDATE_ID_MISSING"],
+        )
+    if mandate_twin is None:
+        reason_codes = mandate_evidence_gap_codes or ["DPM_MANDATE_TWIN_EVIDENCE_MISSING"]
+        return (
+            "DEGRADED",
+            "Mandate identity is present, but no persisted mandate digital-twin evidence is attached.",
+            {"mandate_id": mandate_id},
+            {},
+            reason_codes,
+        )
+    if mandate_health is None:
+        return (
+            "DEGRADED",
+            "Mandate digital-twin evidence is attached, but latest mandate-health evidence is missing.",
+            {
+                "mandate_id": mandate_twin.mandate_id,
+                "mandate_version": mandate_twin.mandate_version,
+                "portfolio_id": mandate_twin.portfolio_id,
+                "as_of_date": mandate_twin.as_of_date.isoformat(),
+                "risk_profile": mandate_twin.risk_profile,
+                "model_portfolio_id": mandate_twin.model_portfolio_id,
+                "field_gap_codes": mandate_twin.field_gap_codes,
+            },
+            {},
+            ["DPM_MANDATE_HEALTH_EVIDENCE_MISSING", *mandate_twin.field_gap_codes],
+        )
+    mandate_state = _mandate_health_state(mandate_health)
+    reason_codes = [reason.reason_code for reason in mandate_health.top_reasons]
+    return (
+        mandate_state,
+        "Mandate digital-twin and health evidence are attached from persisted RFC-0038 truth.",
+        {
+            "mandate_id": mandate_twin.mandate_id,
+            "mandate_version": mandate_twin.mandate_version,
+            "portfolio_id": mandate_twin.portfolio_id,
+            "as_of_date": mandate_twin.as_of_date.isoformat(),
+            "risk_profile": mandate_twin.risk_profile,
+            "investment_objective": mandate_twin.investment_objective,
+            "model_portfolio_id": mandate_twin.model_portfolio_id,
+            "model_portfolio_version": mandate_twin.model_portfolio_version,
+            "health_snapshot_id": mandate_health.health_snapshot_id,
+            "health_state": mandate_health.health_state.value,
+            "source_readiness_state": mandate_health.source_readiness_state,
+            "field_gap_codes": mandate_twin.field_gap_codes,
+        },
+        {
+            "health_score": mandate_health.health_score,
+            "dimension_count": len(mandate_health.dimension_scores),
+            "top_reason_count": len(mandate_health.top_reasons),
+            "source_lineage_count": len(mandate_twin.source_lineage),
+        },
+        [*reason_codes, *mandate_twin.field_gap_codes],
+    )
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -655,65 +724,11 @@ def _section_payload(
             reason_codes,
         )
     if section_type == "mandate_context":
-        if not mandate_id:
-            return (
-                "BLOCKED",
-                "Mandate identity is required before proof-pack promotion.",
-                {"mandate_id": None},
-                {},
-                ["DPM_PROOF_PACK_MANDATE_ID_MISSING"],
-            )
-        if mandate_twin is None:
-            reason_codes = mandate_evidence_gap_codes or ["DPM_MANDATE_TWIN_EVIDENCE_MISSING"]
-            return (
-                "DEGRADED",
-                "Mandate identity is present, but no persisted mandate digital-twin evidence is attached.",
-                {"mandate_id": mandate_id},
-                {},
-                reason_codes,
-            )
-        if mandate_health is None:
-            return (
-                "DEGRADED",
-                "Mandate digital-twin evidence is attached, but latest mandate-health evidence is missing.",
-                {
-                    "mandate_id": mandate_twin.mandate_id,
-                    "mandate_version": mandate_twin.mandate_version,
-                    "portfolio_id": mandate_twin.portfolio_id,
-                    "as_of_date": mandate_twin.as_of_date.isoformat(),
-                    "risk_profile": mandate_twin.risk_profile,
-                    "model_portfolio_id": mandate_twin.model_portfolio_id,
-                    "field_gap_codes": mandate_twin.field_gap_codes,
-                },
-                {},
-                ["DPM_MANDATE_HEALTH_EVIDENCE_MISSING", *mandate_twin.field_gap_codes],
-            )
-        mandate_state = _mandate_health_state(mandate_health)
-        reason_codes = [reason.reason_code for reason in mandate_health.top_reasons]
-        return (
-            mandate_state,
-            "Mandate digital-twin and health evidence are attached from persisted RFC-0038 truth.",
-            {
-                "mandate_id": mandate_twin.mandate_id,
-                "mandate_version": mandate_twin.mandate_version,
-                "portfolio_id": mandate_twin.portfolio_id,
-                "as_of_date": mandate_twin.as_of_date.isoformat(),
-                "risk_profile": mandate_twin.risk_profile,
-                "investment_objective": mandate_twin.investment_objective,
-                "model_portfolio_id": mandate_twin.model_portfolio_id,
-                "model_portfolio_version": mandate_twin.model_portfolio_version,
-                "health_snapshot_id": mandate_health.health_snapshot_id,
-                "health_state": mandate_health.health_state.value,
-                "source_readiness_state": mandate_health.source_readiness_state,
-                "field_gap_codes": mandate_twin.field_gap_codes,
-            },
-            {
-                "health_score": mandate_health.health_score,
-                "dimension_count": len(mandate_health.dimension_scores),
-                "top_reason_count": len(mandate_health.top_reasons),
-                "source_lineage_count": len(mandate_twin.source_lineage),
-            },
-            [*reason_codes, *mandate_twin.field_gap_codes],
+        return _mandate_context_section_payload(
+            mandate_id=mandate_id,
+            mandate_twin=mandate_twin,
+            mandate_health=mandate_health,
+            mandate_evidence_gap_codes=mandate_evidence_gap_codes,
         )
     if section_type == "source_readiness":
         source_state = result.lineage.source_supportability_state if result is not None else None

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -85,6 +85,9 @@ class ProofPackSourceValidationError(ValueError):
     pass
 
 
+_SectionPayload = tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]
+
+
 def build_proof_pack_from_run(
     *,
     run: DpmRunRecord,
@@ -826,12 +829,10 @@ def _eligibility_and_restrictions_section_payload(
     )
 
 
-def _section_payload(
+def _pre_run_section_payload(
     *,
     section_type: ProofPackSectionType,
     result: RebalanceResult | None,
-    run: DpmRunRecord | None,
-    run_artifact_hash: str | None,
     alternative_set: ConstructionAlternativeSet | None,
     selected_alternative: ConstructionAlternative | None,
     selection: ConstructionAlternativeSelection | None,
@@ -841,10 +842,8 @@ def _section_payload(
     mandate_health: DpmMandateHealthSnapshot | None,
     mandate_evidence_gap_codes: list[str],
     created_by: str,
-    source_ref_count: int,
     source_analytics: dict[str, ProofPackSourceAnalytics],
-    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
-) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+) -> _SectionPayload | None:
     if section_type == "decision_summary":
         reason_codes = [] if reason else ["DPM_PROOF_PACK_REASON_MISSING"]
         return (
@@ -909,6 +908,44 @@ def _section_payload(
             summary="AI evidence input adapter is available with forbidden-action and forbidden-field guardrails.",
             adapter_contract="DpmProofPackAiEvidenceInput",
         )
+    return None
+
+
+def _section_payload(
+    *,
+    section_type: ProofPackSectionType,
+    result: RebalanceResult | None,
+    run: DpmRunRecord | None,
+    run_artifact_hash: str | None,
+    alternative_set: ConstructionAlternativeSet | None,
+    selected_alternative: ConstructionAlternative | None,
+    selection: ConstructionAlternativeSelection | None,
+    reason: str | None,
+    mandate_id: str | None,
+    mandate_twin: DpmMandateDigitalTwin | None,
+    mandate_health: DpmMandateHealthSnapshot | None,
+    mandate_evidence_gap_codes: list[str],
+    created_by: str,
+    source_ref_count: int,
+    source_analytics: dict[str, ProofPackSourceAnalytics],
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    pre_run_payload = _pre_run_section_payload(
+        section_type=section_type,
+        result=result,
+        alternative_set=alternative_set,
+        selected_alternative=selected_alternative,
+        selection=selection,
+        reason=reason,
+        mandate_id=mandate_id,
+        mandate_twin=mandate_twin,
+        mandate_health=mandate_health,
+        mandate_evidence_gap_codes=mandate_evidence_gap_codes,
+        created_by=created_by,
+        source_analytics=source_analytics,
+    )
+    if pre_run_payload is not None:
+        return pre_run_payload
     if result is None:
         return ("BLOCKED", "Source rebalance run is missing.", {}, {}, ["DPM_SOURCE_RUN_MISSING"])
     run_state_payload = _run_state_section_payload(section_type=section_type, result=result)

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -400,6 +400,20 @@ def _source_analytics_section_payload(
     )
 
 
+def _adapter_section_payload(
+    *,
+    summary: str,
+    adapter_contract: str,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    return (
+        "READY",
+        summary,
+        {"adapter_contract": adapter_contract},
+        {},
+        [],
+    )
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -574,20 +588,14 @@ def _section_payload(
             missing_reason_code="DPM_SUSTAINABILITY_PREFERENCE_CONTEXT_MISSING",
         )
     if section_type == "reporting_refs":
-        return (
-            "READY",
-            "Report input adapter is available; generated refs are appended outside the immutable proof-pack body.",
-            {"adapter_contract": "DpmProofPackReportInput"},
-            {},
-            [],
+        return _adapter_section_payload(
+            summary="Report input adapter is available; generated refs are appended outside the immutable proof-pack body.",
+            adapter_contract="DpmProofPackReportInput",
         )
     if section_type == "ai_refs":
-        return (
-            "READY",
-            "AI evidence input adapter is available with forbidden-action and forbidden-field guardrails.",
-            {"adapter_contract": "DpmProofPackAiEvidenceInput"},
-            {},
-            [],
+        return _adapter_section_payload(
+            summary="AI evidence input adapter is available with forbidden-action and forbidden-field guardrails.",
+            adapter_contract="DpmProofPackAiEvidenceInput",
         )
     if result is None:
         return ("BLOCKED", "Source rebalance run is missing.", {}, {}, ["DPM_SOURCE_RUN_MISSING"])

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -557,6 +557,68 @@ def _run_policy_section_payload(
     return None
 
 
+def _proof_pack_governance_section_payload(
+    *,
+    section_type: ProofPackSectionType,
+    result: RebalanceResult,
+    run: DpmRunRecord | None,
+    selection: ConstructionAlternativeSelection | None,
+    source_ref_count: int,
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]] | None:
+    if section_type == "approval_requirements":
+        gate = result.gate_decision
+        workflow_facts = [
+            decision.model_dump(mode="json")
+            for decision in sorted(workflow_decisions, key=lambda item: item.decided_at)
+        ]
+        approval_state: ProofPackSectionState = "READY"
+        if result.status == "PENDING_REVIEW" or (gate and gate.gate.endswith("REQUIRED")):
+            approval_state = "PENDING_REVIEW"
+        if result.status == "BLOCKED" or (gate and gate.gate == "BLOCKED"):
+            approval_state = "BLOCKED"
+        return (
+            approval_state,
+            "Approval posture captured from run status and gate decision.",
+            {
+                "gate_decision": gate.model_dump(mode="json") if gate else None,
+                "workflow_decisions": workflow_facts,
+            },
+            {"workflow_decision_count": len(workflow_facts)},
+            [reason.reason_code for reason in gate.reasons] if gate else [],
+        )
+    if section_type == "operations_handoff":
+        return (
+            "READY" if result.status == "READY" else "PENDING_REVIEW",
+            "Operations handoff reflects current pre-trade readiness.",
+            {"run_status": result.status},
+            {},
+            [] if result.status == "READY" else ["DPM_OPERATIONS_REVIEW_REQUIRED"],
+        )
+    if section_type == "decision_timeline":
+        return (
+            "READY",
+            "Timeline generated from source run, selection, and proof-pack generation events.",
+            {
+                "run_created_at": run.created_at.isoformat() if run else None,
+                "selection_id": selection.selection_id if selection else None,
+            },
+            {},
+            [],
+        )
+    if section_type == "lineage":
+        return (
+            "READY" if run is not None else "BLOCKED",
+            "Lineage identifiers captured from source run and source artifacts.",
+            result.lineage.model_dump(mode="json") if result else {},
+            {"source_ref_count": source_ref_count},
+            [] if run is not None else ["DPM_LINEAGE_RUN_MISSING"],
+        )
+    if section_type == "supportability":
+        return ("READY", "Supportability summary is generated for every proof pack.", {}, {}, [])
+    return None
+
+
 def _section_payload(
     *,
     section_type: ProofPackSectionType,
@@ -824,56 +886,16 @@ def _section_payload(
             {"excluded_count": len(excluded)},
             ["DPM_UNIVERSE_EXCLUSIONS_PRESENT"] if excluded else [],
         )
-    if section_type == "approval_requirements":
-        gate = result.gate_decision
-        workflow_facts = [
-            decision.model_dump(mode="json")
-            for decision in sorted(workflow_decisions, key=lambda item: item.decided_at)
-        ]
-        approval_state: ProofPackSectionState = "READY"
-        if result.status == "PENDING_REVIEW" or (gate and gate.gate.endswith("REQUIRED")):
-            approval_state = "PENDING_REVIEW"
-        if result.status == "BLOCKED" or (gate and gate.gate == "BLOCKED"):
-            approval_state = "BLOCKED"
-        return (
-            approval_state,
-            "Approval posture captured from run status and gate decision.",
-            {
-                "gate_decision": gate.model_dump(mode="json") if gate else None,
-                "workflow_decisions": workflow_facts,
-            },
-            {"workflow_decision_count": len(workflow_facts)},
-            [reason.reason_code for reason in gate.reasons] if gate else [],
-        )
-    if section_type == "operations_handoff":
-        return (
-            "READY" if result.status == "READY" else "PENDING_REVIEW",
-            "Operations handoff reflects current pre-trade readiness.",
-            {"run_status": result.status},
-            {},
-            [] if result.status == "READY" else ["DPM_OPERATIONS_REVIEW_REQUIRED"],
-        )
-    if section_type == "decision_timeline":
-        return (
-            "READY",
-            "Timeline generated from source run, selection, and proof-pack generation events.",
-            {
-                "run_created_at": run.created_at.isoformat() if run else None,
-                "selection_id": selection.selection_id if selection else None,
-            },
-            {},
-            [],
-        )
-    if section_type == "lineage":
-        return (
-            "READY" if run is not None else "BLOCKED",
-            "Lineage identifiers captured from source run and source artifacts.",
-            result.lineage.model_dump(mode="json") if result else {},
-            {"source_ref_count": source_ref_count},
-            [] if run is not None else ["DPM_LINEAGE_RUN_MISSING"],
-        )
-    if section_type == "supportability":
-        return ("READY", "Supportability summary is generated for every proof pack.", {}, {}, [])
+    governance_payload = _proof_pack_governance_section_payload(
+        section_type=section_type,
+        result=result,
+        run=run,
+        selection=selection,
+        source_ref_count=source_ref_count,
+        workflow_decisions=workflow_decisions,
+    )
+    if governance_payload is not None:
+        return governance_payload
     raise AssertionError(f"Unhandled proof-pack section type: {section_type}")
 
 

--- a/src/core/rebalance/execution.py
+++ b/src/core/rebalance/execution.py
@@ -129,6 +129,59 @@ def _project_cash_after_security_trades(
     return projected_cash
 
 
+def _fx_intent_for_projected_cash_balance(
+    *,
+    currency: str,
+    balance: Decimal,
+    base_currency: str,
+    rate_to_base: Decimal,
+    intent_id: str,
+    fx_buffer_pct: Decimal,
+) -> FxSpotIntent | None:
+    if balance < 0:
+        buy_amount = abs(balance) * (Decimal("1.0") + fx_buffer_pct)
+        return FxSpotIntent(
+            intent_id=intent_id,
+            pair=f"{currency}/{base_currency}",
+            buy_currency=currency,
+            buy_amount=buy_amount,
+            sell_currency=base_currency,
+            sell_amount_estimated=buy_amount * rate_to_base,
+            rationale=IntentRationale(code="FUNDING", message="Fund"),
+        )
+    if balance > 0:
+        return FxSpotIntent(
+            intent_id=intent_id,
+            pair=f"{currency}/{base_currency}",
+            buy_currency=base_currency,
+            buy_amount=balance * rate_to_base,
+            sell_currency=currency,
+            sell_amount_estimated=balance,
+            rationale=IntentRationale(code="SWEEP", message="Sweep"),
+        )
+    return None
+
+
+def _link_execution_dependencies(
+    *,
+    intents: list[OrderIntent],
+    fx_intent_id_by_currency: dict[str, str],
+    include_same_currency_sell_dependency: bool | None,
+) -> None:
+    resolved_include_same_currency_sell_dependency = include_same_currency_sell_dependency
+    if resolved_include_same_currency_sell_dependency is None:
+        resolved_include_same_currency_sell_dependency = True
+
+    dependency_intents = [
+        intent for intent in intents if isinstance(intent, (SecurityTradeIntent, FxSpotIntent))
+    ]
+    link_buy_intent_dependencies(
+        dependency_intents,
+        fx_intent_id_by_currency=fx_intent_id_by_currency,
+        include_same_currency_sell_dependency=resolved_include_same_currency_sell_dependency,
+    )
+
+
 def generate_fx_and_simulate(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -162,48 +215,25 @@ def generate_fx_and_simulate(
                 return intents, deepcopy(portfolio), [], "BLOCKED", None
             continue
 
+        fx_id = f"oi_fx_{len(intents) + 1}"
+        fx_intent = _fx_intent_for_projected_cash_balance(
+            currency=ccy,
+            balance=bal,
+            base_currency=portfolio.base_currency,
+            rate_to_base=rate,
+            intent_id=fx_id,
+            fx_buffer_pct=options.fx_buffer_pct,
+        )
+        if fx_intent is None:
+            continue
+        intents.append(fx_intent)
         if bal < 0:
-            buy_amt = abs(bal) * (Decimal("1.0") + options.fx_buffer_pct)
-            sell_amt = buy_amt * rate
-            fx_id = f"oi_fx_{len(intents) + 1}"
             fx_map[ccy] = fx_id
-            intents.append(
-                FxSpotIntent(
-                    intent_id=fx_id,
-                    pair=f"{ccy}/{portfolio.base_currency}",
-                    buy_currency=ccy,
-                    buy_amount=buy_amt,
-                    sell_currency=portfolio.base_currency,
-                    sell_amount_estimated=sell_amt,
-                    rationale=IntentRationale(code="FUNDING", message="Fund"),
-                )
-            )
-        elif bal > 0:
-            buy_amt = bal * rate
-            fx_id = f"oi_fx_{len(intents) + 1}"
-            intents.append(
-                FxSpotIntent(
-                    intent_id=fx_id,
-                    pair=f"{ccy}/{portfolio.base_currency}",
-                    buy_currency=portfolio.base_currency,
-                    buy_amount=buy_amt,
-                    sell_currency=ccy,
-                    sell_amount_estimated=bal,
-                    rationale=IntentRationale(code="SWEEP", message="Sweep"),
-                )
-            )
 
-    include_sell_dependency = options.link_buy_to_same_currency_sell_dependency
-    if include_sell_dependency is None:
-        include_sell_dependency = True
-    dependency_intents: list[SecurityTradeIntent | FxSpotIntent] = []
-    for intent in intents:
-        if isinstance(intent, (SecurityTradeIntent, FxSpotIntent)):
-            dependency_intents.append(intent)
-    link_buy_intent_dependencies(
-        dependency_intents,
+    _link_execution_dependencies(
+        intents=intents,
         fx_intent_id_by_currency=fx_map,
-        include_same_currency_sell_dependency=include_sell_dependency,
+        include_same_currency_sell_dependency=options.link_buy_to_same_currency_sell_dependency,
     )
 
     intents = sort_execution_intents(intents)

--- a/src/core/rebalance/execution.py
+++ b/src/core/rebalance/execution.py
@@ -113,6 +113,22 @@ def build_settlement_ladder(
         diagnostics.warnings.append("SETTLEMENT_OVERDRAFT_UTILIZED")
 
 
+def _project_cash_after_security_trades(
+    *,
+    portfolio: PortfolioSnapshot,
+    intents: list[OrderIntent],
+) -> dict[str, Decimal]:
+    projected_cash = {cash.currency: cash.amount for cash in portfolio.cash_balances}
+    for intent in intents:
+        if intent.intent_type != "SECURITY_TRADE" or intent.notional is None:
+            continue
+        projected_cash[intent.notional.currency] = projected_cash.get(
+            intent.notional.currency,
+            Decimal("0"),
+        ) + (intent.notional.amount if intent.side == "SELL" else -intent.notional.amount)
+    return projected_cash
+
+
 def generate_fx_and_simulate(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -131,14 +147,7 @@ def generate_fx_and_simulate(
     """
     Applies intents, generates FX, checks Safety Guards, and computes Reconciliation.
     """
-    proj = {c.currency: c.amount for c in portfolio.cash_balances}
-    for i in intents:
-        if i.intent_type == "SECURITY_TRADE":
-            if i.notional is None:
-                continue
-            proj[i.notional.currency] = proj.get(i.notional.currency, Decimal("0")) + (
-                i.notional.amount if i.side == "SELL" else -i.notional.amount
-            )
+    proj = _project_cash_after_security_trades(portfolio=portfolio, intents=intents)
 
     fx_map = {}
     for ccy, bal in proj.items():

--- a/src/core/rebalance/execution.py
+++ b/src/core/rebalance/execution.py
@@ -182,6 +182,46 @@ def _link_execution_dependencies(
     )
 
 
+def _append_projected_cash_fx_intents(
+    *,
+    projected_cash: dict[str, Decimal],
+    portfolio: PortfolioSnapshot,
+    market_data: MarketDataSnapshot,
+    intents: list[OrderIntent],
+    options: EngineOptions,
+    diagnostics: DiagnosticsData,
+) -> tuple[bool, dict[str, str]]:
+    fx_intent_id_by_currency: dict[str, str] = {}
+    for ccy, bal in projected_cash.items():
+        if ccy == portfolio.base_currency:
+            continue
+        rate = get_fx_rate(market_data, ccy, portfolio.base_currency)
+        if rate is None:
+            diagnostics.data_quality.setdefault("fx_missing", []).append(
+                f"{ccy}/{portfolio.base_currency}"
+            )
+            if options.block_on_missing_fx:
+                return True, fx_intent_id_by_currency
+            continue
+
+        fx_id = f"oi_fx_{len(intents) + 1}"
+        fx_intent = _fx_intent_for_projected_cash_balance(
+            currency=ccy,
+            balance=bal,
+            base_currency=portfolio.base_currency,
+            rate_to_base=rate,
+            intent_id=fx_id,
+            fx_buffer_pct=options.fx_buffer_pct,
+        )
+        if fx_intent is None:
+            continue
+        intents.append(fx_intent)
+        if bal < 0:
+            fx_intent_id_by_currency[ccy] = fx_id
+
+    return False, fx_intent_id_by_currency
+
+
 def generate_fx_and_simulate(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -202,33 +242,16 @@ def generate_fx_and_simulate(
     """
     proj = _project_cash_after_security_trades(portfolio=portfolio, intents=intents)
 
-    fx_map = {}
-    for ccy, bal in proj.items():
-        if ccy == portfolio.base_currency:
-            continue
-        rate = get_fx_rate(market_data, ccy, portfolio.base_currency)
-        if rate is None:
-            diagnostics.data_quality.setdefault("fx_missing", []).append(
-                f"{ccy}/{portfolio.base_currency}"
-            )
-            if options.block_on_missing_fx:
-                return intents, deepcopy(portfolio), [], "BLOCKED", None
-            continue
-
-        fx_id = f"oi_fx_{len(intents) + 1}"
-        fx_intent = _fx_intent_for_projected_cash_balance(
-            currency=ccy,
-            balance=bal,
-            base_currency=portfolio.base_currency,
-            rate_to_base=rate,
-            intent_id=fx_id,
-            fx_buffer_pct=options.fx_buffer_pct,
-        )
-        if fx_intent is None:
-            continue
-        intents.append(fx_intent)
-        if bal < 0:
-            fx_map[ccy] = fx_id
+    blocked_on_missing_fx, fx_map = _append_projected_cash_fx_intents(
+        projected_cash=proj,
+        portfolio=portfolio,
+        market_data=market_data,
+        intents=intents,
+        options=options,
+        diagnostics=diagnostics,
+    )
+    if blocked_on_missing_fx:
+        return intents, deepcopy(portfolio), [], "BLOCKED", None
 
     _link_execution_dependencies(
         intents=intents,

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -130,6 +130,29 @@ def _security_intent_constraints(
     return applied_constraints
 
 
+def _suppress_dust_trade(
+    *,
+    instrument_id: str,
+    notional: Decimal,
+    notional_currency: str,
+    threshold: Money | None,
+    options: EngineOptions,
+    suppressed: list[SuppressedIntent],
+) -> bool:
+    if not options.suppress_dust_trades or threshold is None or notional >= threshold.amount:
+        return False
+
+    suppressed.append(
+        SuppressedIntent(
+            instrument_id=instrument_id,
+            reason="BELOW_MIN_NOTIONAL",
+            intended_notional=Money(amount=notional, currency=notional_currency),
+            threshold=threshold,
+        )
+    )
+    return True
+
+
 @dataclass
 class _TaxBudgetAccumulator:
     total_realized_gain_base: Decimal
@@ -325,15 +348,14 @@ def generate_intents(
         shelf_ent = next((s for s in shelf if s.instrument_id == i_id), None)
         threshold = _trade_notional_threshold(options=options, shelf_entry=shelf_ent)
 
-        if options.suppress_dust_trades and threshold and notional < threshold.amount:
-            suppressed.append(
-                SuppressedIntent(
-                    instrument_id=i_id,
-                    reason="BELOW_MIN_NOTIONAL",
-                    intended_notional=Money(amount=notional, currency=price_ent.currency),
-                    threshold=threshold,
-                )
-            )
+        if _suppress_dust_trade(
+            instrument_id=i_id,
+            notional=notional,
+            notional_currency=price_ent.currency,
+            threshold=threshold,
+            options=options,
+            suppressed=suppressed,
+        ):
             continue
 
         if quantity > 0:

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -232,6 +232,22 @@ def _intent_market_context(
     return price, rate, position
 
 
+def _current_instrument_value_and_unit_value(
+    *,
+    position: Position | None,
+    price: Price,
+) -> tuple[Decimal, Decimal]:
+    if position is None:
+        return Decimal("0"), price.price
+    if position.market_value is None:
+        return position.quantity * price.price, price.price
+
+    current_value = position.market_value.amount
+    if position.quantity > Decimal("0"):
+        return current_value, current_value / position.quantity
+    return current_value, price.price
+
+
 def generate_intents(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -263,14 +279,10 @@ def generate_intents(
             continue
         price_ent, rate, curr = market_context
 
-        curr_instr_val = (
-            curr.market_value.amount
-            if curr and curr.market_value
-            else (curr.quantity * price_ent.price if curr else Decimal("0"))
+        curr_instr_val, unit_value = _current_instrument_value_and_unit_value(
+            position=curr,
+            price=price_ent,
         )
-        unit_value = price_ent.price
-        if curr and curr.market_value and curr.quantity > Decimal("0"):
-            unit_value = curr.market_value.amount / curr.quantity
 
         target_instr_val = (total_val * target_w) / rate
 

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -10,6 +10,7 @@ from src.core.models import (
     Money,
     PortfolioSnapshot,
     Position,
+    Price,
     SecurityTradeIntent,
     ShelfEntry,
     SuppressedIntent,
@@ -207,6 +208,30 @@ def _tax_budget_limited_sell_quantity(
     return allowed_qty
 
 
+def _intent_market_context(
+    *,
+    instrument_id: str,
+    portfolio: PortfolioSnapshot,
+    market_data: MarketDataSnapshot,
+    dq_log: dict[str, list[str]],
+) -> tuple[Price, Decimal, Position | None] | None:
+    price = next((item for item in market_data.prices if item.instrument_id == instrument_id), None)
+    if price is None:
+        dq_log["price_missing"].append(instrument_id)
+        return None
+
+    rate = get_fx_rate(market_data, price.currency, portfolio.base_currency)
+    if not rate:
+        dq_log["fx_missing"].append(f"{price.currency}/{portfolio.base_currency}")
+        return None
+
+    position = next(
+        (item for item in portfolio.positions if item.instrument_id == instrument_id),
+        None,
+    )
+    return price, rate, position
+
+
 def generate_intents(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -228,16 +253,16 @@ def generate_intents(
 
     target_dict = {t.instrument_id: t.final_weight for t in targets}
     for i_id, target_w in target_dict.items():
-        price_ent = next((p for p in market_data.prices if p.instrument_id == i_id), None)
-        if not price_ent:
-            dq_log["price_missing"].append(i_id)
+        market_context = _intent_market_context(
+            instrument_id=i_id,
+            portfolio=portfolio,
+            market_data=market_data,
+            dq_log=dq_log,
+        )
+        if market_context is None:
             continue
-        rate = get_fx_rate(market_data, price_ent.currency, portfolio.base_currency)
-        if not rate:
-            dq_log["fx_missing"].append(f"{price_ent.currency}/{portfolio.base_currency}")
-            continue
+        price_ent, rate, curr = market_context
 
-        curr = next((p for p in portfolio.positions if p.instrument_id == i_id), None)
         curr_instr_val = (
             curr.market_value.amount
             if curr and curr.market_value

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Literal
 
@@ -128,6 +129,84 @@ def _security_intent_constraints(
     return applied_constraints
 
 
+@dataclass
+class _TaxBudgetAccumulator:
+    total_realized_gain_base: Decimal
+    total_realized_loss_base: Decimal
+    tax_budget_used_base: Decimal
+    tax_budget_limit_base: Decimal | None
+
+
+def _tax_budget_limited_sell_quantity(
+    *,
+    options: EngineOptions,
+    position: Position | None,
+    requested_qty: Decimal,
+    sell_price: Decimal,
+    price_ccy: str,
+    base_rate: Decimal,
+    market_data: MarketDataSnapshot,
+    dq_log: dict[str, list[str]],
+    tax_budget: _TaxBudgetAccumulator,
+) -> Decimal:
+    if not options.enable_tax_awareness:
+        return requested_qty
+
+    sorted_lots = _hifo_sorted_lots(
+        position=position,
+        instrument_ccy=price_ccy,
+        market_data=market_data,
+        dq_log=dq_log,
+    )
+    if not sorted_lots:
+        return requested_qty
+
+    remaining = requested_qty
+    allowed_qty = Decimal("0")
+    for lot, lot_unit_cost in sorted_lots:
+        if remaining <= Decimal("0"):
+            break
+        if lot.quantity <= Decimal("0"):
+            continue
+
+        lot_sell_qty = min(remaining, lot.quantity)
+        per_unit_gain_base = (sell_price - lot_unit_cost) * base_rate
+        allowed_from_lot = lot_sell_qty
+
+        if (
+            tax_budget.tax_budget_limit_base is not None
+            and per_unit_gain_base > Decimal("0")
+            and tax_budget.tax_budget_used_base < tax_budget.tax_budget_limit_base
+        ):
+            remaining_headroom = tax_budget.tax_budget_limit_base - tax_budget.tax_budget_used_base
+            max_qty_headroom = remaining_headroom / per_unit_gain_base
+            allowed_from_lot = min(lot_sell_qty, max_qty_headroom)
+        elif (
+            tax_budget.tax_budget_limit_base is not None
+            and per_unit_gain_base > Decimal("0")
+            and tax_budget.tax_budget_used_base >= tax_budget.tax_budget_limit_base
+        ):
+            allowed_from_lot = Decimal("0")
+
+        if allowed_from_lot <= Decimal("0"):
+            break
+
+        lot_realized_base = per_unit_gain_base * allowed_from_lot
+        if lot_realized_base >= Decimal("0"):
+            tax_budget.total_realized_gain_base += lot_realized_base
+            tax_budget.tax_budget_used_base += lot_realized_base
+        else:
+            tax_budget.total_realized_loss_base += abs(lot_realized_base)
+
+        allowed_qty += allowed_from_lot
+        remaining -= allowed_from_lot
+
+        if allowed_from_lot < lot_sell_qty:
+            break
+
+    return allowed_qty
+
+
 def generate_intents(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -140,76 +219,12 @@ def generate_intents(
     suppressed: list[SuppressedIntent],
 ) -> tuple[list[SecurityTradeIntent], TaxImpact | None]:
     intents: list[SecurityTradeIntent] = []
-    total_realized_gain_base = Decimal("0")
-    total_realized_loss_base = Decimal("0")
-    tax_budget_used_base = Decimal("0")
-    tax_budget_limit_base = options.max_realized_capital_gains
-
-    def apply_tax_budget_sell_limit(
-        position: Position | None,
-        requested_qty: Decimal,
-        sell_price: Decimal,
-        price_ccy: str,
-        base_rate: Decimal,
-    ) -> Decimal:
-        nonlocal total_realized_gain_base, total_realized_loss_base, tax_budget_used_base
-
-        if not options.enable_tax_awareness:
-            return requested_qty
-
-        sorted_lots = _hifo_sorted_lots(
-            position=position,
-            instrument_ccy=price_ccy,
-            market_data=market_data,
-            dq_log=dq_log,
-        )
-        if not sorted_lots:
-            return requested_qty
-
-        remaining = requested_qty
-        allowed_qty = Decimal("0")
-        for lot, lot_unit_cost in sorted_lots:
-            if remaining <= Decimal("0"):
-                break
-            if lot.quantity <= Decimal("0"):
-                continue
-
-            lot_sell_qty = min(remaining, lot.quantity)
-            per_unit_gain_base = (sell_price - lot_unit_cost) * base_rate
-            allowed_from_lot = lot_sell_qty
-
-            if (
-                tax_budget_limit_base is not None
-                and per_unit_gain_base > Decimal("0")
-                and tax_budget_used_base < tax_budget_limit_base
-            ):
-                remaining_headroom = tax_budget_limit_base - tax_budget_used_base
-                max_qty_headroom = remaining_headroom / per_unit_gain_base
-                allowed_from_lot = min(lot_sell_qty, max_qty_headroom)
-            elif (
-                tax_budget_limit_base is not None
-                and per_unit_gain_base > Decimal("0")
-                and tax_budget_used_base >= tax_budget_limit_base
-            ):
-                allowed_from_lot = Decimal("0")
-
-            if allowed_from_lot <= Decimal("0"):
-                break
-
-            lot_realized_base = per_unit_gain_base * allowed_from_lot
-            if lot_realized_base >= Decimal("0"):
-                total_realized_gain_base += lot_realized_base
-                tax_budget_used_base += lot_realized_base
-            else:
-                total_realized_loss_base += abs(lot_realized_base)
-
-            allowed_qty += allowed_from_lot
-            remaining -= allowed_from_lot
-
-            if allowed_from_lot < lot_sell_qty:
-                break
-
-        return allowed_qty
+    tax_budget = _TaxBudgetAccumulator(
+        total_realized_gain_base=Decimal("0"),
+        total_realized_loss_base=Decimal("0"),
+        tax_budget_used_base=Decimal("0"),
+        tax_budget_limit_base=options.max_realized_capital_gains,
+    )
 
     target_dict = {t.instrument_id: t.final_weight for t in targets}
     for i_id, target_w in target_dict.items():
@@ -248,12 +263,16 @@ def generate_intents(
                 diagnostics=diagnostics,
             )
             sell_quantity_before_tax = quantity
-            quantity = apply_tax_budget_sell_limit(
+            quantity = _tax_budget_limited_sell_quantity(
+                options=options,
                 position=curr,
                 requested_qty=sell_quantity_before_tax,
                 sell_price=unit_value,
                 price_ccy=price_ent.currency,
                 base_rate=rate,
+                market_data=market_data,
+                dq_log=dq_log,
+                tax_budget=tax_budget,
             )
             if options.enable_tax_awareness and quantity < sell_quantity_before_tax:
                 _record_tax_budget_limit_reached(
@@ -304,30 +323,32 @@ def generate_intents(
 
     tax_impact = None
     if options.enable_tax_awareness:
-        normalized_budget_used = tax_budget_used_base
-        if tax_budget_limit_base is not None:
-            if abs(tax_budget_limit_base - normalized_budget_used) <= Decimal("0.0000000001"):
-                normalized_budget_used = tax_budget_limit_base
+        normalized_budget_used = tax_budget.tax_budget_used_base
+        if tax_budget.tax_budget_limit_base is not None:
+            if abs(tax_budget.tax_budget_limit_base - normalized_budget_used) <= Decimal(
+                "0.0000000001"
+            ):
+                normalized_budget_used = tax_budget.tax_budget_limit_base
         budget_limit = (
-            Money(amount=tax_budget_limit_base, currency=portfolio.base_currency)
-            if tax_budget_limit_base is not None
+            Money(amount=tax_budget.tax_budget_limit_base, currency=portfolio.base_currency)
+            if tax_budget.tax_budget_limit_base is not None
             else None
         )
         budget_used = (
             Money(
-                amount=min(normalized_budget_used, tax_budget_limit_base),
+                amount=min(normalized_budget_used, tax_budget.tax_budget_limit_base),
                 currency=portfolio.base_currency,
             )
-            if tax_budget_limit_base is not None
+            if tax_budget.tax_budget_limit_base is not None
             else None
         )
         tax_impact = TaxImpact(
             total_realized_gain=Money(
-                amount=total_realized_gain_base,
+                amount=tax_budget.total_realized_gain_base,
                 currency=portfolio.base_currency,
             ),
             total_realized_loss=Money(
-                amount=total_realized_loss_base,
+                amount=tax_budget.total_realized_loss_base,
                 currency=portfolio.base_currency,
             ),
             budget_limit=budget_limit,

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -61,6 +61,39 @@ def _hifo_sorted_lots(
     )
 
 
+def _clamped_sell_quantity(
+    *,
+    requested_qty: Decimal,
+    position: Position | None,
+    diagnostics: DiagnosticsData,
+) -> Decimal:
+    available_qty = position.quantity if position is not None else Decimal("0")
+    if requested_qty <= available_qty:
+        return requested_qty
+    if "SELL_QUANTITY_CLAMPED_TO_AVAILABLE_HOLDING" not in diagnostics.warnings:
+        diagnostics.warnings.append("SELL_QUANTITY_CLAMPED_TO_AVAILABLE_HOLDING")
+    return max(available_qty, Decimal("0"))
+
+
+def _record_tax_budget_limit_reached(
+    *,
+    instrument_id: str,
+    requested_quantity: Decimal,
+    allowed_quantity: Decimal,
+    diagnostics: DiagnosticsData,
+) -> None:
+    if "TAX_BUDGET_LIMIT_REACHED" not in diagnostics.warnings:
+        diagnostics.warnings.append("TAX_BUDGET_LIMIT_REACHED")
+    diagnostics.tax_budget_constraint_events.append(
+        TaxBudgetConstraintEvent(
+            instrument_id=instrument_id,
+            requested_quantity=requested_quantity,
+            allowed_quantity=allowed_quantity,
+            reason_code="TAX_BUDGET_LIMIT_REACHED",
+        )
+    )
+
+
 def generate_intents(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -175,13 +208,11 @@ def generate_intents(
         sell_quantity_before_tax: Decimal | None = None
         if side == "SELL" and qty > 0:
             requested_qty = Decimal(qty)
-            available_qty = curr.quantity if curr is not None else Decimal("0")
-            if requested_qty > available_qty:
-                quantity = max(available_qty, Decimal("0"))
-                if "SELL_QUANTITY_CLAMPED_TO_AVAILABLE_HOLDING" not in diagnostics.warnings:
-                    diagnostics.warnings.append("SELL_QUANTITY_CLAMPED_TO_AVAILABLE_HOLDING")
-            else:
-                quantity = requested_qty
+            quantity = _clamped_sell_quantity(
+                requested_qty=requested_qty,
+                position=curr,
+                diagnostics=diagnostics,
+            )
             sell_quantity_before_tax = quantity
             quantity = apply_tax_budget_sell_limit(
                 position=curr,
@@ -191,16 +222,11 @@ def generate_intents(
                 base_rate=rate,
             )
             if options.enable_tax_awareness and quantity < sell_quantity_before_tax:
-                constraints = [c for c in diagnostics.warnings if c == "TAX_BUDGET_LIMIT_REACHED"]
-                if not constraints:
-                    diagnostics.warnings.append("TAX_BUDGET_LIMIT_REACHED")
-                diagnostics.tax_budget_constraint_events.append(
-                    TaxBudgetConstraintEvent(
-                        instrument_id=i_id,
-                        requested_quantity=sell_quantity_before_tax,
-                        allowed_quantity=quantity,
-                        reason_code="TAX_BUDGET_LIMIT_REACHED",
-                    )
+                _record_tax_budget_limit_reached(
+                    instrument_id=i_id,
+                    requested_quantity=sell_quantity_before_tax,
+                    allowed_quantity=quantity,
+                    diagnostics=diagnostics,
                 )
 
         notional = quantity * unit_value

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -94,6 +94,40 @@ def _record_tax_budget_limit_reached(
     )
 
 
+def _trade_notional_threshold(
+    *,
+    options: EngineOptions,
+    shelf_entry: ShelfEntry | None,
+) -> Money | None:
+    if options.min_trade_notional:
+        return options.min_trade_notional
+    if shelf_entry and shelf_entry.min_notional:
+        return shelf_entry.min_notional
+    return None
+
+
+def _security_intent_constraints(
+    *,
+    threshold: Money | None,
+    side: Literal["BUY", "SELL"],
+    quantity: Decimal,
+    requested_quantity: Decimal,
+    sell_quantity_before_tax: Decimal | None,
+    tax_awareness_enabled: bool,
+) -> list[str]:
+    applied_constraints = ["MIN_NOTIONAL"] if threshold else []
+    if side == "SELL" and quantity < requested_quantity:
+        applied_constraints.append("AVAILABLE_HOLDING")
+    if (
+        side == "SELL"
+        and tax_awareness_enabled
+        and sell_quantity_before_tax is not None
+        and quantity < sell_quantity_before_tax
+    ):
+        applied_constraints.append("TAX_BUDGET")
+    return applied_constraints
+
+
 def generate_intents(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -233,12 +267,7 @@ def generate_intents(
         notional_base = notional * rate
 
         shelf_ent = next((s for s in shelf if s.instrument_id == i_id), None)
-
-        threshold = None
-        if options.min_trade_notional:
-            threshold = options.min_trade_notional
-        elif shelf_ent and shelf_ent.min_notional:
-            threshold = shelf_ent.min_notional
+        threshold = _trade_notional_threshold(options=options, shelf_entry=shelf_ent)
 
         if options.suppress_dust_trades and threshold and notional < threshold.amount:
             suppressed.append(
@@ -252,12 +281,14 @@ def generate_intents(
             continue
 
         if quantity > 0:
-            applied_constraints = ["MIN_NOTIONAL"] if threshold else []
-            if side == "SELL" and quantity < Decimal(qty):
-                applied_constraints.append("AVAILABLE_HOLDING")
-            if side == "SELL" and options.enable_tax_awareness:
-                if sell_quantity_before_tax is not None and quantity < sell_quantity_before_tax:
-                    applied_constraints.append("TAX_BUDGET")
+            applied_constraints = _security_intent_constraints(
+                threshold=threshold,
+                side=side,
+                quantity=quantity,
+                requested_quantity=Decimal(qty),
+                sell_quantity_before_tax=sell_quantity_before_tax,
+                tax_awareness_enabled=options.enable_tax_awareness,
+            )
             intents.append(
                 SecurityTradeIntent(
                     intent_id=f"oi_{len(intents) + 1}",

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -8,6 +8,7 @@ from src.core.models import (
     MarketDataSnapshot,
     Money,
     PortfolioSnapshot,
+    Position,
     SecurityTradeIntent,
     ShelfEntry,
     SuppressedIntent,
@@ -15,6 +16,49 @@ from src.core.models import (
     TaxImpact,
 )
 from src.core.valuation import get_fx_rate
+
+
+def _lot_cost_in_instrument_ccy(
+    *,
+    unit_cost: Money,
+    instrument_ccy: str,
+    market_data: MarketDataSnapshot,
+    dq_log: dict[str, list[str]],
+) -> Decimal | None:
+    if unit_cost.currency == instrument_ccy:
+        return unit_cost.amount
+    fx = get_fx_rate(market_data, unit_cost.currency, instrument_ccy)
+    if fx is None:
+        dq_log["fx_missing"].append(f"{unit_cost.currency}/{instrument_ccy}")
+        return None
+    return unit_cost.amount * fx
+
+
+def _hifo_sorted_lots(
+    *,
+    position: Position | None,
+    instrument_ccy: str,
+    market_data: MarketDataSnapshot,
+    dq_log: dict[str, list[str]],
+) -> list[tuple[Any, Decimal]]:
+    if not position or not position.lots:
+        return []
+    lots_with_cost = []
+    for lot in position.lots:
+        cost = _lot_cost_in_instrument_ccy(
+            unit_cost=lot.unit_cost,
+            instrument_ccy=instrument_ccy,
+            market_data=market_data,
+            dq_log=dq_log,
+        )
+        if cost is None:
+            return []
+        lots_with_cost.append((lot, cost))
+    return sorted(
+        lots_with_cost,
+        key=lambda item: (item[1], item[0].purchase_date, item[0].lot_id),
+        reverse=True,
+    )
 
 
 def generate_intents(
@@ -34,32 +78,8 @@ def generate_intents(
     tax_budget_used_base = Decimal("0")
     tax_budget_limit_base = options.max_realized_capital_gains
 
-    def lot_cost_in_instrument_ccy(unit_cost: Money, instrument_ccy: str) -> Decimal | None:
-        if unit_cost.currency == instrument_ccy:
-            return unit_cost.amount
-        fx = get_fx_rate(market_data, unit_cost.currency, instrument_ccy)
-        if fx is None:
-            dq_log["fx_missing"].append(f"{unit_cost.currency}/{instrument_ccy}")
-            return None
-        return unit_cost.amount * fx
-
-    def hifo_sorted_lots(position: Any, instrument_ccy: str) -> list[tuple[Any, Decimal]]:
-        if not position or not position.lots:
-            return []
-        lots_with_cost = []
-        for lot in position.lots:
-            cost = lot_cost_in_instrument_ccy(lot.unit_cost, instrument_ccy)
-            if cost is None:
-                return []
-            lots_with_cost.append((lot, cost))
-        return sorted(
-            lots_with_cost,
-            key=lambda item: (item[1], item[0].purchase_date, item[0].lot_id),
-            reverse=True,
-        )
-
     def apply_tax_budget_sell_limit(
-        position: Any,
+        position: Position | None,
         requested_qty: Decimal,
         sell_price: Decimal,
         price_ccy: str,
@@ -70,7 +90,12 @@ def generate_intents(
         if not options.enable_tax_awareness:
             return requested_qty
 
-        sorted_lots = hifo_sorted_lots(position, price_ccy)
+        sorted_lots = _hifo_sorted_lots(
+            position=position,
+            instrument_ccy=price_ccy,
+            market_data=market_data,
+            dq_log=dq_log,
+        )
         if not sorted_lots:
             return requested_qty
 

--- a/src/core/rebalance/targets.py
+++ b/src/core/rebalance/targets.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from decimal import Decimal
 from typing import Any, Literal, cast
 
+from src.core.common.target_redistribution import redistribute_sell_only_excess
 from src.core.common.diagnostics import make_diagnostics_data
 from src.core.models import (
     DiagnosticsData,
@@ -215,27 +216,6 @@ def compare_target_generation_methods(
     }
 
 
-def _redistribute_sell_only_excess(
-    *,
-    eligible_targets: dict[str, Decimal],
-    buy_set: set[str],
-    sell_only_excess: Decimal,
-) -> Literal["READY", "PENDING_REVIEW"]:
-    if sell_only_excess <= Decimal("0.0"):
-        return "READY"
-
-    recipients = {k: v for k, v in eligible_targets.items() if k in buy_set}
-    total_recipient_weight = sum(recipients.values())
-    if total_recipient_weight <= Decimal("0.0"):
-        return "PENDING_REVIEW"
-
-    for instrument_id, weight in recipients.items():
-        eligible_targets[instrument_id] = weight + (
-            sell_only_excess * (weight / total_recipient_weight)
-        )
-    return "READY"
-
-
 def generate_targets_heuristic(
     model: ModelPortfolio,
     eligible_targets: dict[str, Decimal],
@@ -250,7 +230,7 @@ def generate_targets_heuristic(
     status = "READY"
     buy_set = set(buy_list)
 
-    status = _redistribute_sell_only_excess(
+    status = redistribute_sell_only_excess(
         eligible_targets=eligible_targets,
         buy_set=buy_set,
         sell_only_excess=sell_only_excess,

--- a/src/core/rebalance/targets.py
+++ b/src/core/rebalance/targets.py
@@ -215,6 +215,27 @@ def compare_target_generation_methods(
     }
 
 
+def _redistribute_sell_only_excess(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+    sell_only_excess: Decimal,
+) -> Literal["READY", "PENDING_REVIEW"]:
+    if sell_only_excess <= Decimal("0.0"):
+        return "READY"
+
+    recipients = {k: v for k, v in eligible_targets.items() if k in buy_set}
+    total_recipient_weight = sum(recipients.values())
+    if total_recipient_weight <= Decimal("0.0"):
+        return "PENDING_REVIEW"
+
+    for instrument_id, weight in recipients.items():
+        eligible_targets[instrument_id] = weight + (
+            sell_only_excess * (weight / total_recipient_weight)
+        )
+    return "READY"
+
+
 def generate_targets_heuristic(
     model: ModelPortfolio,
     eligible_targets: dict[str, Decimal],
@@ -229,14 +250,11 @@ def generate_targets_heuristic(
     status = "READY"
     buy_set = set(buy_list)
 
-    if sell_only_excess > Decimal("0.0"):
-        recs = {k: v for k, v in eligible_targets.items() if k in buy_set}
-        total_rec = sum(recs.values())
-        if total_rec > Decimal("0.0"):
-            for i_id, w in recs.items():
-                eligible_targets[i_id] = w + (sell_only_excess * (w / total_rec))
-        else:
-            status = "PENDING_REVIEW"
+    status = _redistribute_sell_only_excess(
+        eligible_targets=eligible_targets,
+        buy_set=buy_set,
+        sell_only_excess=sell_only_excess,
+    )
 
     group_status = apply_group_constraints(eligible_targets, buy_list, shelf, options, diagnostics)
     if group_status == "BLOCKED":

--- a/src/core/rebalance/targets.py
+++ b/src/core/rebalance/targets.py
@@ -216,6 +216,32 @@ def compare_target_generation_methods(
     }
 
 
+def _cap_tradeable_targets_to_available_weight(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+) -> str:
+    total_w = sum(eligible_targets.values())
+    if total_w <= Decimal("1.0001"):
+        return "READY"
+
+    tradeable_keys = [k for k in eligible_targets if k in buy_set]
+    locked_w = sum(v for k, v in eligible_targets.items() if k not in buy_set)
+    available_space = max(Decimal("0.0"), Decimal("1.0") - locked_w)
+    status = "PENDING_REVIEW" if locked_w > Decimal("1.0") else "READY"
+
+    tradeable_w = sum(eligible_targets[k] for k in tradeable_keys)
+    if tradeable_w <= available_space:
+        return status
+
+    if tradeable_w > Decimal("0.0"):
+        scale = available_space / tradeable_w
+        for k in tradeable_keys:
+            eligible_targets[k] *= scale
+
+    return "PENDING_REVIEW"
+
+
 def generate_targets_heuristic(
     model: ModelPortfolio,
     eligible_targets: dict[str, Decimal],
@@ -240,20 +266,12 @@ def generate_targets_heuristic(
     if group_status == "BLOCKED":
         return [], "BLOCKED"
 
-    total_w = sum(eligible_targets.values())
-    if total_w > Decimal("1.0001"):
-        tradeable_keys = [k for k in eligible_targets if k in buy_set]
-        locked_w = sum(v for k, v in eligible_targets.items() if k not in buy_set)
-        available_space = max(Decimal("0.0"), Decimal("1.0") - locked_w)
-        if locked_w > Decimal("1.0"):
-            status = "PENDING_REVIEW"
-        tradeable_w = sum(eligible_targets[k] for k in tradeable_keys)
-        if tradeable_w > available_space:
-            if tradeable_w > Decimal("0.0"):
-                scale = available_space / tradeable_w
-                for k in tradeable_keys:
-                    eligible_targets[k] *= scale
-            status = "PENDING_REVIEW"
+    cap_status = _cap_tradeable_targets_to_available_weight(
+        eligible_targets=eligible_targets,
+        buy_set=buy_set,
+    )
+    if cap_status == "PENDING_REVIEW":
+        status = "PENDING_REVIEW"
 
     if options.single_position_max_weight is not None:
         max_w = options.single_position_max_weight

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -127,6 +127,19 @@ def _collect_infeasibility_hints(
     return hints
 
 
+def _load_solver_modules(diagnostics: DiagnosticsData) -> tuple[Any, Any] | None:
+    if not has_solver_dependencies():
+        diagnostics.warnings.append("SOLVER_ERROR")
+        return None
+    try:
+        import cvxpy as cp
+        import numpy as np
+    except Exception:
+        diagnostics.warnings.append("SOLVER_ERROR")
+        return None
+    return cp, np
+
+
 def build_target_trace(
     model: Any,
     eligible_targets: dict[str, Decimal],
@@ -182,17 +195,10 @@ def generate_targets_solver(
     base_ccy: str,
     diagnostics: DiagnosticsData,
 ) -> tuple[list[TargetInstrument], str]:
-    if not has_solver_dependencies():
-        diagnostics.warnings.append("SOLVER_ERROR")
+    solver_modules = _load_solver_modules(diagnostics)
+    if solver_modules is None:
         return [], "BLOCKED"
-    try:
-        import cvxpy as _cp
-        import numpy as _np
-    except Exception:
-        diagnostics.warnings.append("SOLVER_ERROR")
-        return [], "BLOCKED"
-    cp: Any = _cp
-    np: Any = _np
+    cp, np = solver_modules
 
     status = redistribute_sell_only_excess(
         eligible_targets=eligible_targets,

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from typing import Any
 
 from src.core.common.capabilities import has_solver_dependencies
+from src.core.common.target_redistribution import redistribute_sell_only_excess
 from src.core.models import DiagnosticsData, EngineOptions, Money, ShelfEntry, TargetInstrument
 
 _SOLVER_STATUS_OPTIMAL = {"optimal", "optimal_inaccurate"}
@@ -193,15 +194,11 @@ def generate_targets_solver(
     cp: Any = _cp
     np: Any = _np
 
-    status = "READY"
-    if sell_only_excess > Decimal("0.0"):
-        recs = {k: v for k, v in eligible_targets.items() if k in buy_list}
-        total_rec = sum(recs.values())
-        if total_rec > Decimal("0.0"):
-            for i_id, rec_weight in recs.items():
-                eligible_targets[i_id] = rec_weight + (sell_only_excess * (rec_weight / total_rec))
-        else:
-            status = "PENDING_REVIEW"
+    status = redistribute_sell_only_excess(
+        eligible_targets=eligible_targets,
+        buy_set=set(buy_list),
+        sell_only_excess=sell_only_excess,
+    )
 
     tradeable_ids = [i_id for i_id in eligible_targets if i_id in buy_list]
     locked_ids = [i_id for i_id in eligible_targets if i_id not in buy_list]

--- a/src/core/valuation.py
+++ b/src/core/valuation.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 
 from src.core.models import (
     AllocationMetric,
+    CashBalance,
     EngineOptions,
     MarketDataSnapshot,
     Money,
@@ -94,6 +95,25 @@ class ValuationService:
         )
 
 
+def _cash_value_in_base(
+    *,
+    cash: CashBalance,
+    market_data: MarketDataSnapshot,
+    base_ccy: str,
+    dq_log: Dict[str, List[str]] | None = None,
+) -> Decimal:
+    if cash.currency == base_ccy:
+        return cash.amount
+
+    rate = get_fx_rate(market_data, cash.currency, base_ccy)
+    if rate:
+        return cash.amount * rate
+
+    if dq_log is not None:
+        dq_log.setdefault("fx_missing", []).append(f"{cash.currency}/{base_ccy}")
+    return Decimal("0")
+
+
 def build_simulated_state(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -130,14 +150,12 @@ def build_simulated_state(
         total_val += summary.value_in_base_ccy.amount
 
     for cash in portfolio.cash_balances:
-        if cash.currency == base_ccy:
-            total_val += cash.amount
-        else:
-            rate = get_fx_rate(market_data, cash.currency, base_ccy)
-            if rate:
-                total_val += cash.amount * rate
-            else:
-                dq_log.setdefault("fx_missing", []).append(f"{cash.currency}/{base_ccy}")
+        total_val += _cash_value_in_base(
+            cash=cash,
+            market_data=market_data,
+            base_ccy=base_ccy,
+            dq_log=dq_log,
+        )
 
     if total_val == 0:
         total_val_safe = Decimal("1")
@@ -174,14 +192,11 @@ def build_simulated_state(
 
     total_cash_val = Decimal("0")
     for cash in portfolio.cash_balances:
-        val = cash.amount
-        if cash.currency != base_ccy:
-            rate = get_fx_rate(market_data, cash.currency, base_ccy)
-            if rate:
-                val = cash.amount * rate
-            else:
-                val = Decimal("0")
-        total_cash_val += val
+        total_cash_val += _cash_value_in_base(
+            cash=cash,
+            market_data=market_data,
+            base_ccy=base_ccy,
+        )
 
     alloc_class_map["CASH"] = alloc_class_map.get("CASH", Decimal("0")) + total_cash_val
 

--- a/src/core/waves/campaign_definitions.py
+++ b/src/core/waves/campaign_definitions.py
@@ -480,67 +480,76 @@ class DpmBulkReviewCampaignDefinition(BaseModel):
     )
     content_hash: str = Field(default="")
 
+    def _validate_active_lifecycle(self) -> None:
+        lifecycle_fields = [
+            self.retired_at,
+            self.retired_by,
+            self.retirement_reason,
+            self.retirement_correlation_id,
+            self.superseded_at,
+            self.superseded_by,
+            self.supersession_reason,
+            self.supersession_correlation_id,
+            self.superseded_by_campaign_id,
+            self.superseded_by_campaign_version,
+            self.superseded_by_content_hash,
+        ]
+        if any(value is not None for value in lifecycle_fields):
+            raise ValueError("BULK_REVIEW_CAMPAIGN_ACTIVE_LIFECYCLE_FIELDS_FORBIDDEN")
+
+    def _validate_retired_lifecycle(self) -> None:
+        if self.retired_at is None:
+            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_TIMESTAMP_REQUIRED")
+        if not (self.retired_by or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_ACTOR_REQUIRED")
+        if not (self.retirement_reason or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_REASON_REQUIRED")
+        if not (self.retirement_correlation_id or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_CORRELATION_REQUIRED")
+        supersession_fields = [
+            self.superseded_at,
+            self.superseded_by,
+            self.supersession_reason,
+            self.supersession_correlation_id,
+            self.superseded_by_campaign_id,
+            self.superseded_by_campaign_version,
+            self.superseded_by_content_hash,
+        ]
+        if any(value is not None for value in supersession_fields):
+            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIRED_SUPERSESSION_FIELDS_FORBIDDEN")
+
+    def _validate_superseded_lifecycle(self) -> None:
+        if self.superseded_at is None:
+            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_TIMESTAMP_REQUIRED")
+        if not (self.superseded_by or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_ACTOR_REQUIRED")
+        if not (self.supersession_reason or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_REASON_REQUIRED")
+        if not (self.supersession_correlation_id or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CORRELATION_REQUIRED")
+        if not (self.superseded_by_campaign_id or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CAMPAIGN_ID_REQUIRED")
+        if not (self.superseded_by_campaign_version or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CAMPAIGN_VERSION_REQUIRED")
+        if not (self.superseded_by_content_hash or "").strip():
+            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CONTENT_HASH_REQUIRED")
+        retirement_fields = [
+            self.retired_at,
+            self.retired_by,
+            self.retirement_reason,
+            self.retirement_correlation_id,
+        ]
+        if any(value is not None for value in retirement_fields):
+            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSEDED_RETIREMENT_FIELDS_FORBIDDEN")
+
     @model_validator(mode="after")
     def validate_definition(self) -> "DpmBulkReviewCampaignDefinition":
         if self.status == "ACTIVE":
-            lifecycle_fields = [
-                self.retired_at,
-                self.retired_by,
-                self.retirement_reason,
-                self.retirement_correlation_id,
-                self.superseded_at,
-                self.superseded_by,
-                self.supersession_reason,
-                self.supersession_correlation_id,
-                self.superseded_by_campaign_id,
-                self.superseded_by_campaign_version,
-                self.superseded_by_content_hash,
-            ]
-            if any(value is not None for value in lifecycle_fields):
-                raise ValueError("BULK_REVIEW_CAMPAIGN_ACTIVE_LIFECYCLE_FIELDS_FORBIDDEN")
+            self._validate_active_lifecycle()
         elif self.status == "RETIRED":
-            if self.retired_at is None:
-                raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_TIMESTAMP_REQUIRED")
-            if not (self.retired_by or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_ACTOR_REQUIRED")
-            if not (self.retirement_reason or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_REASON_REQUIRED")
-            if not (self.retirement_correlation_id or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_CORRELATION_REQUIRED")
-            supersession_fields = [
-                self.superseded_at,
-                self.superseded_by,
-                self.supersession_reason,
-                self.supersession_correlation_id,
-                self.superseded_by_campaign_id,
-                self.superseded_by_campaign_version,
-                self.superseded_by_content_hash,
-            ]
-            if any(value is not None for value in supersession_fields):
-                raise ValueError("BULK_REVIEW_CAMPAIGN_RETIRED_SUPERSESSION_FIELDS_FORBIDDEN")
+            self._validate_retired_lifecycle()
         else:
-            if self.superseded_at is None:
-                raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_TIMESTAMP_REQUIRED")
-            if not (self.superseded_by or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_ACTOR_REQUIRED")
-            if not (self.supersession_reason or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_REASON_REQUIRED")
-            if not (self.supersession_correlation_id or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CORRELATION_REQUIRED")
-            if not (self.superseded_by_campaign_id or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CAMPAIGN_ID_REQUIRED")
-            if not (self.superseded_by_campaign_version or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CAMPAIGN_VERSION_REQUIRED")
-            if not (self.superseded_by_content_hash or "").strip():
-                raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CONTENT_HASH_REQUIRED")
-            retirement_fields = [
-                self.retired_at,
-                self.retired_by,
-                self.retirement_reason,
-                self.retirement_correlation_id,
-            ]
-            if any(value is not None for value in retirement_fields):
-                raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSEDED_RETIREMENT_FIELDS_FORBIDDEN")
+            self._validate_superseded_lifecycle()
         if not [value for value in self.eligible_portfolio_types if value.strip()]:
             raise ValueError("BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPES_REQUIRED")
         if not self.candidates:

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -4,6 +4,7 @@ from src.api.openapi_enrichment import (
     _infer_description,
     _infer_example,
     _number_example_for_key,
+    _collection_example_from_schema,
     _schema_declared_example,
     _semantic_string_example_for_key,
     enrich_openapi_schema,
@@ -74,6 +75,57 @@ def test_openapi_enrichment_prefers_declared_schema_examples() -> None:
     assert _schema_declared_example({"examples": ["first", "second"]}) == (True, "first")
     assert _schema_declared_example({"examples": []}) == (False, None)
     assert _schema_declared_example({"type": "string"}) == (False, None)
+
+
+def test_openapi_enrichment_collects_object_array_and_map_examples() -> None:
+    schemas = {
+        "Leaf": {
+            "type": "object",
+            "properties": {"currency": {"type": "string"}, "amount": {"type": "number"}},
+        }
+    }
+
+    assert _collection_example_from_schema(
+        prop_name="position",
+        prop_schema={
+            "properties": {"id": {"type": "string"}, "leaf": {"$ref": "#/components/schemas/Leaf"}}
+        },
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (True, {"id": "sample_id", "leaf": {"currency": "USD", "amount": 10.5}})
+    assert _collection_example_from_schema(
+        prop_name="items",
+        prop_schema={"type": "array", "items": {"type": "string"}},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (True, ["sample_items_item"])
+    assert _collection_example_from_schema(
+        prop_name="props",
+        prop_schema={"type": "array", "items": "bad"},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (True, [])
+    assert _collection_example_from_schema(
+        prop_name="tags",
+        prop_schema={
+            "type": "object",
+            "additionalProperties": {"type": "boolean"},
+        },
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (True, {"sample_key": True})
+    assert _collection_example_from_schema(
+        prop_name="meta",
+        prop_schema={"type": "object"},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (True, {"sample_key": "sample_value"})
+    assert _collection_example_from_schema(
+        prop_name="value",
+        prop_schema={"type": "string"},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (False, None)
 
 
 def test_openapi_enrichment_builds_examples_from_refs_composites_and_maps() -> None:

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -1,5 +1,6 @@
 from src.api.openapi_enrichment import (
     _example_from_schema,
+    _ensure_operation_examples,
     _infer_description,
     _infer_example,
     _number_example_for_key,
@@ -118,6 +119,44 @@ def test_openapi_enrichment_builds_examples_from_refs_composites_and_maps() -> N
     ) == ["sample_any_of_item"]
     assert _example_from_schema("explicit_examples", {"examples": ["from-list"]}, schemas) == (
         "from-list"
+    )
+
+
+def test_openapi_enrichment_adds_operation_level_examples_and_errors() -> None:
+    operation = {
+        "requestBody": {
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Payload"}}}
+        },
+        "responses": {
+            "200": {"content": {"application/json": {"schema": {"type": "string"}}}},
+            "409": {"description": "Conflict detected."},
+        },
+    }
+
+    _ensure_operation_examples(
+        method="post",
+        path="/api/v1/example",
+        operation=operation,
+        schemas={
+            "Payload": {
+                "type": "object",
+                "properties": {"portfolio_id": {"type": "string"}},
+            }
+        },
+    )
+
+    assert operation["requestBody"]["content"]["application/json"]["examples"]["default"][
+        "value"
+    ] == {"portfolio_id": "DEMO_DPM_EUR_001"}
+    assert (
+        operation["responses"]["200"]["content"]["application/json"]["examples"]["default"]["value"]
+        == "sample_post_/api/v1/example_200_response"
+    )
+    assert (
+        operation["responses"]["409"]["content"]["application/json"]["examples"]["default"][
+            "value"
+        ]["status"]
+        == 409
     )
 
 

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -2,6 +2,8 @@ from src.api.openapi_enrichment import (
     _example_from_schema,
     _infer_description,
     _infer_example,
+    _number_example_for_key,
+    _semantic_string_example_for_key,
     enrich_openapi_schema,
 )
 
@@ -39,6 +41,27 @@ def test_openapi_enrichment_infers_domain_examples_and_descriptions() -> None:
     assert _infer_description("RunModel", "marketPrice", {"type": "number"}) == (
         "Rate/price value for market price."
     )
+
+
+def test_openapi_enrichment_number_examples_follow_domain_semantics() -> None:
+    assert _number_example_for_key("target_weight") == 0.125
+    assert _number_example_for_key("last_price") == 1.2345
+    assert _number_example_for_key("fx_rate") == 1.2345
+    assert _number_example_for_key("quantity") == 100.0
+    assert _number_example_for_key("other_number") == 10.5
+
+
+def test_openapi_enrichment_semantic_string_examples_follow_domain_semantics() -> None:
+    assert _semantic_string_example_for_key("custom_id", "string") == "CUSTOM_001"
+    assert _semantic_string_example_for_key("base_currency", "string") == "USD"
+    assert _semantic_string_example_for_key("as_of_date", "string") == "2026-03-02"
+    assert _semantic_string_example_for_key("run_time", "string") == "2026-03-02T10:30:00Z"
+    assert _semantic_string_example_for_key("updated_timestamp", "string") == (
+        "2026-03-02T10:30:00Z"
+    )
+    assert _semantic_string_example_for_key("workflow_status", "string") == "READY"
+    assert _semantic_string_example_for_key("display_name", "string") == "sample_display_name"
+    assert _semantic_string_example_for_key("unknown", None) is None
 
 
 def test_openapi_enrichment_builds_examples_from_refs_composites_and_maps() -> None:

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -3,6 +3,7 @@ from src.api.openapi_enrichment import (
     _infer_description,
     _infer_example,
     _number_example_for_key,
+    _schema_declared_example,
     _semantic_string_example_for_key,
     enrich_openapi_schema,
 )
@@ -62,6 +63,16 @@ def test_openapi_enrichment_semantic_string_examples_follow_domain_semantics() -
     assert _semantic_string_example_for_key("workflow_status", "string") == "READY"
     assert _semantic_string_example_for_key("display_name", "string") == "sample_display_name"
     assert _semantic_string_example_for_key("unknown", None) is None
+
+
+def test_openapi_enrichment_prefers_declared_schema_examples() -> None:
+    assert _schema_declared_example({"example": {"status": "READY"}}) == (
+        True,
+        {"status": "READY"},
+    )
+    assert _schema_declared_example({"examples": ["first", "second"]}) == (True, "first")
+    assert _schema_declared_example({"examples": []}) == (False, None)
+    assert _schema_declared_example({"type": "string"}) == (False, None)
 
 
 def test_openapi_enrichment_builds_examples_from_refs_composites_and_maps() -> None:

--- a/tests/unit/api/test_wave_source_refs.py
+++ b/tests/unit/api/test_wave_source_refs.py
@@ -40,6 +40,30 @@ def test_source_refs_payload_serializes_refs_with_json_mode() -> None:
     ]
 
 
+def test_source_refs_payload_accepts_mapping_payloads() -> None:
+    refs: list[dict[str, object]] = [
+        {
+            "source_system": "lotus-core",
+            "source_type": "PortfolioManagerBookMembership",
+            "source_id": "pm-book-snapshot-001",
+            "source_version": "v1",
+            "supportability_state": "READY",
+            "content_hash": "sha256:pm-book",
+        }
+    ]
+
+    assert source_refs_payload(refs) == [
+        {
+            "source_system": "lotus-core",
+            "source_type": "PortfolioManagerBookMembership",
+            "source_id": "pm-book-snapshot-001",
+            "source_version": "v1",
+            "supportability_state": "READY",
+            "content_hash": "sha256:pm-book",
+        }
+    ]
+
+
 def test_pm_book_membership_ref_preserves_source_batch_lineage() -> None:
     assert pm_book_membership_ref(
         source_id="pm-book-snapshot-001",

--- a/tests/unit/core/test_common_edge_coverage.py
+++ b/tests/unit/core/test_common_edge_coverage.py
@@ -14,7 +14,7 @@ from src.core.common.simulation_shared import (
     sort_execution_intents,
 )
 from src.core.common.workflow_gates import evaluate_gate_decision
-from src.core.compliance import RuleEngine
+from src.core.compliance import RuleEngine, _cash_band_rule_result
 from src.core.models import (
     AllocationMetric,
     BatchRebalanceRequest,
@@ -366,3 +366,61 @@ def test_rule_engine_flags_single_position_limit_breaches() -> None:
         and result.reason_code == "LIMIT_BREACH"
         for result in results
     )
+
+
+def test_cash_band_rule_result_passes_when_cash_is_inside_policy_band() -> None:
+    state = SimulatedState(
+        total_value=Money(amount=Decimal("100"), currency="USD"),
+        positions=[],
+        cash_balances=[],
+        allocation_by_asset_class=[
+            AllocationMetric(
+                key="CASH",
+                weight=Decimal("0.05"),
+                value=Money(amount=Decimal("5"), currency="USD"),
+            )
+        ],
+        allocation_by_instrument=[],
+    )
+
+    result = _cash_band_rule_result(
+        state=state,
+        options=EngineOptions(
+            cash_band_min_weight=Decimal("0.02"),
+            cash_band_max_weight=Decimal("0.10"),
+        ),
+    )
+
+    assert result.rule_id == "CASH_BAND"
+    assert result.status == "PASS"
+    assert result.reason_code == "OK"
+    assert result.measured == Decimal("0.05")
+
+
+def test_cash_band_rule_result_fails_when_cash_breaches_policy_band() -> None:
+    state = SimulatedState(
+        total_value=Money(amount=Decimal("100"), currency="USD"),
+        positions=[],
+        cash_balances=[],
+        allocation_by_asset_class=[
+            AllocationMetric(
+                key="CASH",
+                weight=Decimal("0.20"),
+                value=Money(amount=Decimal("20"), currency="USD"),
+            )
+        ],
+        allocation_by_instrument=[],
+    )
+
+    result = _cash_band_rule_result(
+        state=state,
+        options=EngineOptions(
+            cash_band_min_weight=Decimal("0.02"),
+            cash_band_max_weight=Decimal("0.10"),
+        ),
+    )
+
+    assert result.rule_id == "CASH_BAND"
+    assert result.status == "FAIL"
+    assert result.reason_code == "THRESHOLD_BREACH"
+    assert result.remediation_hint == "Portfolio cash is outside policy bands."

--- a/tests/unit/core/test_target_generation_solver_fallbacks.py
+++ b/tests/unit/core/test_target_generation_solver_fallbacks.py
@@ -3,6 +3,7 @@ import sys
 
 from src.core.models import DiagnosticsData, EngineOptions, ModelPortfolio, ModelTarget, ShelfEntry
 from src.core.target_generation import (
+    _load_solver_modules,
     _solve_with_fallbacks,
     build_target_trace,
     generate_targets_solver,
@@ -161,6 +162,23 @@ def test_solve_with_fallbacks_skips_uninstalled_solver_and_tries_compatibility_k
     assert solved is True
     assert latest_status == "optimal"
     assert [solver for solver, _ in problem.calls] == ["SCS", "SCS"]
+
+
+def test_load_solver_modules_records_error_when_dependencies_are_absent(monkeypatch) -> None:
+    monkeypatch.setattr("src.core.target_generation.has_solver_dependencies", lambda: False)
+    diagnostics = DiagnosticsData(data_quality={}, suppressed_intents=[], warnings=[])
+
+    assert _load_solver_modules(diagnostics) is None
+    assert diagnostics.warnings == ["SOLVER_ERROR"]
+
+
+def test_load_solver_modules_records_error_when_import_fails(monkeypatch) -> None:
+    monkeypatch.setattr("src.core.target_generation.has_solver_dependencies", lambda: True)
+    monkeypatch.setitem(sys.modules, "cvxpy", None)
+    diagnostics = DiagnosticsData(data_quality={}, suppressed_intents=[], warnings=[])
+
+    assert _load_solver_modules(diagnostics) is None
+    assert diagnostics.warnings == ["SOLVER_ERROR"]
 
 
 def test_generate_targets_solver_reports_pending_review_when_sell_excess_has_no_recipient(

--- a/tests/unit/dpm/construction/test_enrichment.py
+++ b/tests/unit/dpm/construction/test_enrichment.py
@@ -52,6 +52,7 @@ from src.core.construction import (
     summarize_enrichment_posture,
 )
 from src.core.construction.enrichment import _fx_enrichment_status, _tax_enrichment_status
+from src.core.construction.enrichment import _cost_enrichment_status
 from src.core.construction.repository import (
     ConstructionAlternativeSetNotFoundError,
     ConstructionIdempotencyConflictError,
@@ -153,6 +154,39 @@ def test_fx_enrichment_status_blocks_only_when_pairs_are_missing() -> None:
     assert _fx_enrichment_status(missing_fx_pairs=[]) == (
         ConstructionMethodStatus.READY,
         [],
+    )
+
+
+def test_cost_enrichment_status_distinguishes_missing_local_and_source_context() -> None:
+    assert _cost_enrichment_status(
+        authoritative_cost_available=False,
+        transaction_cost_context=None,
+    ) == (
+        ConstructionMethodStatus.DEGRADED,
+        ["AUTHORITATIVE_TRANSACTION_COST_UNAVAILABLE"],
+    )
+    assert _cost_enrichment_status(
+        authoritative_cost_available=True,
+        transaction_cost_context=None,
+    ) == (ConstructionMethodStatus.READY, [])
+
+    context = AuthoritativeTransactionCostContext(
+        supportability_status=ConstructionMethodStatus.PENDING_REVIEW,
+        source_system="lotus-core",
+        as_of_date="2026-05-03",
+        window_start_date="2026-05-01",
+        window_end_date="2026-05-03",
+        returned_curve_point_count=0,
+        missing_security_ids=["EQ_MISSING"],
+        reason_codes=["TRANSACTION_COST_CURVE_MISSING_SECURITIES"],
+    )
+
+    assert _cost_enrichment_status(
+        authoritative_cost_available=False,
+        transaction_cost_context=context,
+    ) == (
+        ConstructionMethodStatus.PENDING_REVIEW,
+        ["TRANSACTION_COST_CURVE_MISSING_SECURITIES"],
     )
 
 

--- a/tests/unit/dpm/construction/test_enrichment.py
+++ b/tests/unit/dpm/construction/test_enrichment.py
@@ -51,6 +51,7 @@ from src.core.construction import (
     estimate_transaction_cost,
     summarize_enrichment_posture,
 )
+from src.core.construction.enrichment import _fx_enrichment_status, _tax_enrichment_status
 from src.core.construction.repository import (
     ConstructionAlternativeSetNotFoundError,
     ConstructionIdempotencyConflictError,
@@ -127,6 +128,32 @@ def test_transaction_cost_estimate_is_labelled_local_and_reconciles_to_turnover_
 
     assert cost.currency == "USD"
     assert cost.amount == Decimal("1.00")
+
+
+def test_tax_enrichment_status_distinguishes_required_optional_and_available_tax() -> None:
+    assert _tax_enrichment_status(tax_required=True, tax_impact_available=False) == (
+        ConstructionMethodStatus.BLOCKED,
+        ["TAX_LOTS_REQUIRED_BUT_NO_TAX_IMPACT"],
+    )
+    assert _tax_enrichment_status(tax_required=False, tax_impact_available=False) == (
+        ConstructionMethodStatus.DEGRADED,
+        ["TAX_ENRICHMENT_NOT_REQUESTED_OR_UNAVAILABLE"],
+    )
+    assert _tax_enrichment_status(tax_required=True, tax_impact_available=True) == (
+        ConstructionMethodStatus.READY,
+        [],
+    )
+
+
+def test_fx_enrichment_status_blocks_only_when_pairs_are_missing() -> None:
+    assert _fx_enrichment_status(missing_fx_pairs=[("USD", "SGD")]) == (
+        ConstructionMethodStatus.BLOCKED,
+        ["FX_SOURCE_MISSING"],
+    )
+    assert _fx_enrichment_status(missing_fx_pairs=[]) == (
+        ConstructionMethodStatus.READY,
+        [],
+    )
 
 
 def test_enrichment_summary_blocks_required_tax_without_tax_impact() -> None:

--- a/tests/unit/dpm/construction/test_treasury_source_context.py
+++ b/tests/unit/dpm/construction/test_treasury_source_context.py
@@ -69,6 +69,35 @@ def test_primary_treasury_supportability_uses_first_available_source_family() ->
     assert primary.exposure_currencies == ["EUR", "JPY"]
 
 
+def test_source_identity_fields_project_prefixed_source_product_identity() -> None:
+    identity = construction_treasury_source_context._optional_source_identity(
+        currency_exposure_response()
+    )
+
+    assert identity is not None
+    assert construction_treasury_source_context._source_identity_fields(
+        prefix="external_currency_exposure",
+        identity=identity,
+    ) == {
+        "external_currency_exposure_source_product_name": "ExternalCurrencyExposure",
+        "external_currency_exposure_source_product_version": "v1",
+        "external_currency_exposure_source_id": "core-currency-exposure",
+        "external_currency_exposure_content_hash": identity.content_hash,
+    }
+
+
+def test_source_identity_fields_project_absent_identity_as_nulls() -> None:
+    assert construction_treasury_source_context._source_identity_fields(
+        prefix="external_currency_exposure",
+        identity=None,
+    ) == {
+        "external_currency_exposure_source_product_name": None,
+        "external_currency_exposure_source_product_version": None,
+        "external_currency_exposure_source_id": None,
+        "external_currency_exposure_content_hash": None,
+    }
+
+
 def test_external_treasury_currency_overlay_context_preserves_fail_closed_readiness() -> None:
     context = external_treasury_currency_overlay_context(
         hedge_readiness=hedge_readiness_response(),

--- a/tests/unit/dpm/construction/test_treasury_source_context.py
+++ b/tests/unit/dpm/construction/test_treasury_source_context.py
@@ -30,6 +30,45 @@ def _without_source_lineage(response: Any) -> Any:
     )
 
 
+def test_treasury_source_payloads_preserve_aggregate_hash_inputs() -> None:
+    hedge_readiness = hedge_readiness_response()
+    currency_exposure = currency_exposure_response()
+
+    payloads = construction_treasury_source_context._treasury_source_payloads(
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=None,
+        eligible_hedge_instruments=None,
+        fx_forward_curve=None,
+    )
+
+    assert payloads["external_hedge_execution_readiness"] == hedge_readiness.model_dump(
+        mode="json",
+        exclude_none=True,
+    )
+    assert payloads["external_currency_exposure"] == currency_exposure.model_dump(
+        mode="json",
+        exclude_none=True,
+    )
+    assert payloads["external_hedge_policy"] is None
+    assert hash_canonical_payload(payloads)
+
+
+def test_primary_treasury_supportability_uses_first_available_source_family() -> None:
+    primary = construction_treasury_source_context._primary_treasury_supportability(
+        hedge_readiness=None,
+        currency_exposure=currency_exposure_response(),
+        hedge_policy=hedge_policy_response(),
+        eligible_hedge_instruments=None,
+        fx_forward_curve=None,
+    )
+
+    assert primary is not None
+    assert primary.state == "UNAVAILABLE"
+    assert primary.reason == "EXTERNAL_TREASURY_SOURCE_NOT_INGESTED"
+    assert primary.exposure_currencies == ["EUR", "JPY"]
+
+
 def test_external_treasury_currency_overlay_context_preserves_fail_closed_readiness() -> None:
     context = external_treasury_currency_overlay_context(
         hedge_readiness=hedge_readiness_response(),

--- a/tests/unit/dpm/core/test_mandate_health.py
+++ b/tests/unit/dpm/core/test_mandate_health.py
@@ -29,6 +29,7 @@ from src.core.mandates import (
     MandateHealthDimension,
     MandateHealthState,
     MandateRecommendedAction,
+    _build_digital_twin_source_lineage,
     _mandate_twin_field_gap_codes,
     calculate_mandate_health,
     build_health_input_from_core_sources,
@@ -549,6 +550,51 @@ def test_mandate_twin_field_gap_codes_clear_when_core_products_are_sourced() -> 
         )
         == []
     )
+
+
+def test_build_digital_twin_source_lineage_includes_all_core_products() -> None:
+    benchmark = _benchmark_assignment()
+    lineage = _build_digital_twin_source_lineage(
+        mandate=_mandate_binding(),
+        model_targets=_model_targets(),
+        client_restriction_profile=_client_restriction_profile(),
+        sustainability_preference_profile=_sustainability_preference_profile(),
+        portfolio_cashflow_projection=_portfolio_cashflow_projection(),
+        client_income_needs_schedule=_client_income_needs_schedule(),
+        liquidity_reserve_requirement=_liquidity_reserve_requirement(),
+        planned_withdrawal_schedule=_planned_withdrawal_schedule(),
+        benchmark_assignment=benchmark,
+    )
+
+    assert [entry.product_name for entry in lineage] == [
+        "DiscretionaryMandateBinding",
+        "DpmModelPortfolioTarget",
+        "ClientRestrictionProfile",
+        "SustainabilityPreferenceProfile",
+        "PortfolioCashflowProjection",
+        "ClientIncomeNeedsSchedule",
+        "LiquidityReserveRequirement",
+        "PlannedWithdrawalSchedule",
+        benchmark.product_name,
+    ]
+    assert lineage[-1].source_record_id == (
+        "PB_SG_GLOBAL_BAL_001:BMK_PB_GLOBAL_BALANCED_60_40:2026-01-01:1"
+    )
+
+
+def test_build_digital_twin_source_lineage_includes_only_required_products_when_optionals_missing() -> (
+    None
+):
+    lineage = _build_digital_twin_source_lineage(
+        mandate=_mandate_binding(),
+        model_targets=_model_targets(),
+    )
+
+    assert [entry.product_name for entry in lineage] == [
+        "DiscretionaryMandateBinding",
+        "DpmModelPortfolioTarget",
+    ]
+    assert all(entry.lineage.get("contract_version") for entry in lineage)
 
 
 def test_compile_mandate_twin_preserves_client_profile_cashflow_and_sustainability_lineage() -> (

--- a/tests/unit/dpm/core/test_mandate_health.py
+++ b/tests/unit/dpm/core/test_mandate_health.py
@@ -29,9 +29,10 @@ from src.core.mandates import (
     MandateHealthDimension,
     MandateHealthState,
     MandateRecommendedAction,
+    _mandate_twin_field_gap_codes,
     calculate_mandate_health,
-    compile_mandate_digital_twin_from_core,
     build_health_input_from_core_sources,
+    compile_mandate_digital_twin_from_core,
     monitoring_exceptions_from_health,
 )
 
@@ -505,6 +506,49 @@ def test_compile_mandate_twin_preserves_explicit_gap_codes_for_missing_profile_f
     assert "MANDATE_OBJECTIVE_PROFILE_NOT_YET_SOURCED" in twin.field_gap_codes
     assert "MANDATE_REVIEW_SCHEDULE_NOT_YET_SOURCED" in twin.field_gap_codes
     assert "BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED" in twin.field_gap_codes
+
+
+def test_mandate_twin_field_gap_codes_project_missing_core_products() -> None:
+    assert _mandate_twin_field_gap_codes(
+        mandate=_mandate_binding(
+            mandate_objective=None,
+            review_cadence=None,
+            next_review_due_date=None,
+        ),
+        client_restriction_profile=None,
+        sustainability_preference_profile=None,
+        portfolio_cashflow_projection=None,
+        client_income_needs_schedule=None,
+        liquidity_reserve_requirement=None,
+        planned_withdrawal_schedule=None,
+        benchmark_assignment=None,
+    ) == [
+        "CLIENT_INCOME_NEED_PROFILE_NOT_YET_SOURCED",
+        "LIQUIDITY_RESERVE_REQUIREMENT_NOT_YET_SOURCED",
+        "PLANNED_WITHDRAWAL_SCHEDULE_NOT_YET_SOURCED",
+        "MANDATE_OBJECTIVE_PROFILE_NOT_YET_SOURCED",
+        "MANDATE_REVIEW_SCHEDULE_NOT_YET_SOURCED",
+        "CLIENT_RESTRICTION_PROFILE_NOT_YET_SOURCED",
+        "SUSTAINABILITY_PREFERENCE_PROFILE_NOT_YET_SOURCED",
+        "PORTFOLIO_CASHFLOW_PROJECTION_NOT_YET_SOURCED",
+        "BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED",
+    ]
+
+
+def test_mandate_twin_field_gap_codes_clear_when_core_products_are_sourced() -> None:
+    assert (
+        _mandate_twin_field_gap_codes(
+            mandate=_mandate_binding(),
+            client_restriction_profile=_client_restriction_profile(),
+            sustainability_preference_profile=_sustainability_preference_profile(),
+            portfolio_cashflow_projection=_portfolio_cashflow_projection(),
+            client_income_needs_schedule=_client_income_needs_schedule(),
+            liquidity_reserve_requirement=_liquidity_reserve_requirement(),
+            planned_withdrawal_schedule=_planned_withdrawal_schedule(),
+            benchmark_assignment=_benchmark_assignment(),
+        )
+        == []
+    )
 
 
 def test_compile_mandate_twin_preserves_client_profile_cashflow_and_sustainability_lineage() -> (

--- a/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 from src.core.rebalance.execution import (
+    _append_projected_cash_fx_intents,
     _fx_intent_for_projected_cash_balance,
     _link_execution_dependencies,
     _project_cash_after_security_trades,
@@ -169,6 +170,53 @@ class TestIntentDependenciesAndSimulation:
         )
 
         assert projected == {"USD": Decimal("900"), "EUR": Decimal("75")}
+
+    def test_append_projected_cash_fx_intents_adds_funding_and_sweep_intents(self):
+        portfolio = portfolio_snapshot(portfolio_id="pf_fx_append", base_currency="USD")
+        diagnostics = empty_diagnostics()
+        intents = []
+
+        blocked, fx_map = _append_projected_cash_fx_intents(
+            projected_cash={"USD": Decimal("1000"), "EUR": Decimal("-100"), "GBP": Decimal("50")},
+            portfolio=portfolio,
+            market_data=market_data_snapshot(
+                fx_rates=[
+                    fx("EUR/USD", "1.2"),
+                    fx("GBP/USD", "1.3"),
+                ]
+            ),
+            intents=intents,
+            options=EngineOptions(fx_buffer_pct=Decimal("0.05")),
+            diagnostics=diagnostics,
+        )
+
+        assert blocked is False
+        assert fx_map == {"EUR": "oi_fx_1"}
+        assert [intent.intent_id for intent in intents] == ["oi_fx_1", "oi_fx_2"]
+        assert intents[0].buy_currency == "EUR"
+        assert intents[0].sell_currency == "USD"
+        assert intents[1].buy_currency == "USD"
+        assert intents[1].sell_currency == "GBP"
+        assert diagnostics.data_quality == {}
+
+    def test_append_projected_cash_fx_intents_blocks_on_missing_fx(self):
+        portfolio = portfolio_snapshot(portfolio_id="pf_fx_missing_append", base_currency="USD")
+        diagnostics = empty_diagnostics()
+        intents = []
+
+        blocked, fx_map = _append_projected_cash_fx_intents(
+            projected_cash={"EUR": Decimal("-100")},
+            portfolio=portfolio,
+            market_data=market_data_snapshot(),
+            intents=intents,
+            options=EngineOptions(block_on_missing_fx=True),
+            diagnostics=diagnostics,
+        )
+
+        assert blocked is True
+        assert fx_map == {}
+        assert intents == []
+        assert diagnostics.data_quality == {"fx_missing": ["EUR/USD"]}
 
     def test_dependency_linking_explicit(self):
         pf = usd_cash_portfolio("dep_test")

--- a/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
@@ -1,6 +1,9 @@
 from decimal import Decimal
 
-from src.core.rebalance.execution import build_settlement_ladder
+from src.core.rebalance.execution import (
+    _project_cash_after_security_trades,
+    build_settlement_ladder,
+)
 from src.core.rebalance.engine import _generate_fx_and_simulate, run_simulation
 from src.core.models import (
     EngineOptions,
@@ -22,6 +25,46 @@ from tests.unit.dpm.engine.coverage.helpers import empty_diagnostics, usd_cash_p
 
 
 class TestIntentDependenciesAndSimulation:
+    def test_project_cash_after_security_trades_applies_buy_sell_and_skips_missing_notional(self):
+        portfolio = portfolio_snapshot(
+            portfolio_id="pf_project_cash",
+            base_currency="USD",
+            cash_balances=[cash("USD", "1000"), cash("EUR", "50")],
+        )
+        intents = [
+            SecurityTradeIntent(
+                intent_id="oi_buy",
+                instrument_id="EQ_US",
+                side="BUY",
+                quantity=Decimal("1"),
+                notional={"amount": Decimal("100"), "currency": "USD"},
+                notional_base={"amount": Decimal("100"), "currency": "USD"},
+            ),
+            SecurityTradeIntent(
+                intent_id="oi_sell",
+                instrument_id="EQ_EU",
+                side="SELL",
+                quantity=Decimal("1"),
+                notional={"amount": Decimal("25"), "currency": "EUR"},
+                notional_base={"amount": Decimal("30"), "currency": "USD"},
+            ),
+            SecurityTradeIntent(
+                intent_id="oi_missing_notional",
+                instrument_id="EQ_SKIP",
+                side="BUY",
+                quantity=Decimal("1"),
+                notional=None,
+                notional_base=None,
+            ),
+        ]
+
+        projected = _project_cash_after_security_trades(
+            portfolio=portfolio,
+            intents=intents,
+        )
+
+        assert projected == {"USD": Decimal("900"), "EUR": Decimal("75")}
+
     def test_dependency_linking_explicit(self):
         pf = usd_cash_portfolio("dep_test")
         mkt = market_data_snapshot(

--- a/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 
 from src.core.rebalance.execution import (
+    _fx_intent_for_projected_cash_balance,
+    _link_execution_dependencies,
     _project_cash_after_security_trades,
     build_settlement_ladder,
 )
@@ -25,6 +27,109 @@ from tests.unit.dpm.engine.coverage.helpers import empty_diagnostics, usd_cash_p
 
 
 class TestIntentDependenciesAndSimulation:
+    def test_fx_intent_for_projected_cash_balance_builds_funding_intent(self):
+        intent = _fx_intent_for_projected_cash_balance(
+            currency="EUR",
+            balance=Decimal("-100"),
+            base_currency="USD",
+            rate_to_base=Decimal("1.2"),
+            intent_id="oi_fx_1",
+            fx_buffer_pct=Decimal("0.05"),
+        )
+
+        assert intent is not None
+        assert intent.intent_id == "oi_fx_1"
+        assert intent.pair == "EUR/USD"
+        assert intent.buy_currency == "EUR"
+        assert intent.buy_amount == Decimal("105.00")
+        assert intent.sell_currency == "USD"
+        assert intent.sell_amount_estimated == Decimal("126.000")
+        assert intent.rationale.code == "FUNDING"
+
+    def test_fx_intent_for_projected_cash_balance_builds_sweep_intent(self):
+        intent = _fx_intent_for_projected_cash_balance(
+            currency="EUR",
+            balance=Decimal("100"),
+            base_currency="USD",
+            rate_to_base=Decimal("1.2"),
+            intent_id="oi_fx_2",
+            fx_buffer_pct=Decimal("0.05"),
+        )
+
+        assert intent is not None
+        assert intent.intent_id == "oi_fx_2"
+        assert intent.pair == "EUR/USD"
+        assert intent.buy_currency == "USD"
+        assert intent.buy_amount == Decimal("120.0")
+        assert intent.sell_currency == "EUR"
+        assert intent.sell_amount_estimated == Decimal("100")
+        assert intent.rationale.code == "SWEEP"
+
+    def test_fx_intent_for_projected_cash_balance_skips_zero_balance(self):
+        assert (
+            _fx_intent_for_projected_cash_balance(
+                currency="EUR",
+                balance=Decimal("0"),
+                base_currency="USD",
+                rate_to_base=Decimal("1.2"),
+                intent_id="oi_fx_3",
+                fx_buffer_pct=Decimal("0.05"),
+            )
+            is None
+        )
+
+    def test_link_execution_dependencies_defaults_to_same_currency_sell_dependency(self):
+        sell = SecurityTradeIntent(
+            intent_id="oi_sell_eur",
+            instrument_id="EQ_EU_SELL",
+            side="SELL",
+            quantity=Decimal("1"),
+            notional={"amount": Decimal("100"), "currency": "EUR"},
+            notional_base={"amount": Decimal("120"), "currency": "USD"},
+        )
+        buy = SecurityTradeIntent(
+            intent_id="oi_buy_eur",
+            instrument_id="EQ_EU_BUY",
+            side="BUY",
+            quantity=Decimal("1"),
+            notional={"amount": Decimal("100"), "currency": "EUR"},
+            notional_base={"amount": Decimal("120"), "currency": "USD"},
+        )
+
+        _link_execution_dependencies(
+            intents=[sell, buy],
+            fx_intent_id_by_currency={"EUR": "oi_fx_eur"},
+            include_same_currency_sell_dependency=None,
+        )
+
+        assert buy.dependencies == ["oi_fx_eur", "oi_sell_eur"]
+
+    def test_link_execution_dependencies_respects_same_currency_sell_opt_out(self):
+        sell = SecurityTradeIntent(
+            intent_id="oi_sell_eur",
+            instrument_id="EQ_EU_SELL",
+            side="SELL",
+            quantity=Decimal("1"),
+            notional={"amount": Decimal("100"), "currency": "EUR"},
+            notional_base={"amount": Decimal("120"), "currency": "USD"},
+        )
+        buy = SecurityTradeIntent(
+            intent_id="oi_buy_eur",
+            instrument_id="EQ_EU_BUY",
+            side="BUY",
+            quantity=Decimal("1"),
+            notional={"amount": Decimal("100"), "currency": "EUR"},
+            notional_base={"amount": Decimal("120"), "currency": "USD"},
+        )
+
+        _link_execution_dependencies(
+            intents=[sell, buy],
+            fx_intent_id_by_currency={"EUR": "oi_fx_eur"},
+            include_same_currency_sell_dependency=False,
+        )
+
+        assert buy.dependencies == ["oi_fx_eur"]
+
     def test_project_cash_after_security_trades_applies_buy_sell_and_skips_missing_notional(self):
         portfolio = portfolio_snapshot(
             portfolio_id="pf_project_cash",

--- a/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 import pytest
 from pydantic import ValidationError
 
+from src.core.rebalance.targets import _redistribute_sell_only_excess
 from src.core.rebalance.engine import _apply_group_constraints, _generate_targets, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, GroupConstraint, ShelfEntry
 from tests.shared.assertions import assert_status
@@ -10,6 +11,50 @@ from tests.shared.factories import model_portfolio, position, target
 
 
 class TestTargetGeneration:
+    def test_redistribute_sell_only_excess_allocates_to_buy_targets_proportionally(self):
+        eligible_targets = {
+            "BUY_A": Decimal("0.30"),
+            "BUY_B": Decimal("0.10"),
+            "LOCKED": Decimal("0.20"),
+        }
+
+        status = _redistribute_sell_only_excess(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A", "BUY_B"},
+            sell_only_excess=Decimal("0.20"),
+        )
+
+        assert status == "READY"
+        assert eligible_targets == {
+            "BUY_A": Decimal("0.45"),
+            "BUY_B": Decimal("0.15"),
+            "LOCKED": Decimal("0.20"),
+        }
+
+    def test_redistribute_sell_only_excess_skips_when_no_excess(self):
+        eligible_targets = {"BUY_A": Decimal("0.30")}
+
+        status = _redistribute_sell_only_excess(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A"},
+            sell_only_excess=Decimal("0.0"),
+        )
+
+        assert status == "READY"
+        assert eligible_targets == {"BUY_A": Decimal("0.30")}
+
+    def test_redistribute_sell_only_excess_marks_pending_without_recipient_weight(self):
+        eligible_targets = {"BUY_A": Decimal("0.0"), "LOCKED": Decimal("0.20")}
+
+        status = _redistribute_sell_only_excess(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A"},
+            sell_only_excess=Decimal("0.20"),
+        )
+
+        assert status == "PENDING_REVIEW"
+        assert eligible_targets == {"BUY_A": Decimal("0.0"), "LOCKED": Decimal("0.20")}
+
     def test_target_locked_over_100(self, base_inputs):
         pf, mkt, model, shelf = base_inputs
         pf.positions = [position("LOCKED_ASSET", "1000")]

--- a/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import pytest
 from pydantic import ValidationError
 
-from src.core.rebalance.targets import _redistribute_sell_only_excess
+from src.core.common.target_redistribution import redistribute_sell_only_excess
 from src.core.rebalance.engine import _apply_group_constraints, _generate_targets, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, GroupConstraint, ShelfEntry
 from tests.shared.assertions import assert_status
@@ -18,7 +18,7 @@ class TestTargetGeneration:
             "LOCKED": Decimal("0.20"),
         }
 
-        status = _redistribute_sell_only_excess(
+        status = redistribute_sell_only_excess(
             eligible_targets=eligible_targets,
             buy_set={"BUY_A", "BUY_B"},
             sell_only_excess=Decimal("0.20"),
@@ -34,7 +34,7 @@ class TestTargetGeneration:
     def test_redistribute_sell_only_excess_skips_when_no_excess(self):
         eligible_targets = {"BUY_A": Decimal("0.30")}
 
-        status = _redistribute_sell_only_excess(
+        status = redistribute_sell_only_excess(
             eligible_targets=eligible_targets,
             buy_set={"BUY_A"},
             sell_only_excess=Decimal("0.0"),
@@ -46,7 +46,7 @@ class TestTargetGeneration:
     def test_redistribute_sell_only_excess_marks_pending_without_recipient_weight(self):
         eligible_targets = {"BUY_A": Decimal("0.0"), "LOCKED": Decimal("0.20")}
 
-        status = _redistribute_sell_only_excess(
+        status = redistribute_sell_only_excess(
             eligible_targets=eligible_targets,
             buy_set={"BUY_A"},
             sell_only_excess=Decimal("0.20"),

--- a/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from src.core.common.target_redistribution import redistribute_sell_only_excess
+from src.core.rebalance.targets import _cap_tradeable_targets_to_available_weight
 from src.core.rebalance.engine import _apply_group_constraints, _generate_targets, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, GroupConstraint, ShelfEntry
 from tests.shared.assertions import assert_status
@@ -54,6 +55,47 @@ class TestTargetGeneration:
 
         assert status == "PENDING_REVIEW"
         assert eligible_targets == {"BUY_A": Decimal("0.0"), "LOCKED": Decimal("0.20")}
+
+    def test_cap_tradeable_targets_to_available_weight_skips_balanced_targets(self):
+        eligible_targets = {"BUY_A": Decimal("0.40"), "LOCKED": Decimal("0.30")}
+
+        status = _cap_tradeable_targets_to_available_weight(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A"},
+        )
+
+        assert status == "READY"
+        assert eligible_targets == {"BUY_A": Decimal("0.40"), "LOCKED": Decimal("0.30")}
+
+    def test_cap_tradeable_targets_to_available_weight_scales_buy_targets(self):
+        eligible_targets = {
+            "BUY_A": Decimal("0.60"),
+            "BUY_B": Decimal("0.30"),
+            "LOCKED": Decimal("0.30"),
+        }
+
+        status = _cap_tradeable_targets_to_available_weight(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A", "BUY_B"},
+        )
+
+        assert status == "PENDING_REVIEW"
+        assert eligible_targets == {
+            "BUY_A": Decimal("0.4666666666666666666666666667"),
+            "BUY_B": Decimal("0.2333333333333333333333333333"),
+            "LOCKED": Decimal("0.30"),
+        }
+
+    def test_cap_tradeable_targets_to_available_weight_marks_locked_overage_pending(self):
+        eligible_targets = {"BUY_A": Decimal("0.20"), "LOCKED": Decimal("1.10")}
+
+        status = _cap_tradeable_targets_to_available_weight(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A"},
+        )
+
+        assert status == "PENDING_REVIEW"
+        assert eligible_targets == {"BUY_A": Decimal("0.00"), "LOCKED": Decimal("1.10")}
 
     def test_target_locked_over_100(self, base_inputs):
         pf, mkt, model, shelf = base_inputs

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -4,6 +4,7 @@ from src.core.rebalance.engine import _generate_fx_and_simulate, run_simulation
 from src.core.rebalance.intents import (
     _TaxBudgetAccumulator,
     _clamped_sell_quantity,
+    _current_instrument_value_and_unit_value,
     _hifo_sorted_lots,
     _intent_market_context,
     _record_tax_budget_limit_reached,
@@ -365,6 +366,54 @@ def test_intent_market_context_records_missing_price_and_fx() -> None:
         is None
     )
     assert dq_log["fx_missing"] == ["USD/SGD"]
+
+
+def test_current_instrument_value_and_unit_value_uses_price_without_position() -> None:
+    current_value, unit_value = _current_instrument_value_and_unit_value(
+        position=None,
+        price=price("EQ_1", "10", "SGD"),
+    )
+
+    assert current_value == Decimal("0")
+    assert unit_value == Decimal("10")
+
+
+def test_current_instrument_value_and_unit_value_uses_quantity_and_price_without_snapshot_value():
+    current_value, unit_value = _current_instrument_value_and_unit_value(
+        position=Position(instrument_id="EQ_1", quantity=Decimal("7")),
+        price=price("EQ_1", "10", "SGD"),
+    )
+
+    assert current_value == Decimal("70")
+    assert unit_value == Decimal("10")
+
+
+def test_current_instrument_value_and_unit_value_uses_trusted_market_value() -> None:
+    current_value, unit_value = _current_instrument_value_and_unit_value(
+        position=Position(
+            instrument_id="EQ_1",
+            quantity=Decimal("5"),
+            market_value=Money(amount=Decimal("125"), currency="SGD"),
+        ),
+        price=price("EQ_1", "10", "SGD"),
+    )
+
+    assert current_value == Decimal("125")
+    assert unit_value == Decimal("25")
+
+
+def test_current_instrument_value_and_unit_value_keeps_price_unit_for_zero_quantity_snapshot():
+    current_value, unit_value = _current_instrument_value_and_unit_value(
+        position=Position(
+            instrument_id="EQ_1",
+            quantity=Decimal("0"),
+            market_value=Money(amount=Decimal("125"), currency="SGD"),
+        ),
+        price=price("EQ_1", "10", "SGD"),
+    )
+
+    assert current_value == Decimal("125")
+    assert unit_value == Decimal("10")
 
 
 def test_trusted_market_value_drives_sell_sizing_and_after_state(base_options):

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -1,7 +1,12 @@
 from decimal import Decimal
 
 from src.core.rebalance.engine import _generate_fx_and_simulate, run_simulation
-from src.core.rebalance.intents import _hifo_sorted_lots, generate_intents
+from src.core.rebalance.intents import (
+    _clamped_sell_quantity,
+    _hifo_sorted_lots,
+    _record_tax_budget_limit_reached,
+    generate_intents,
+)
 from src.core.models import (
     EngineOptions,
     Money,
@@ -151,6 +156,52 @@ def test_hifo_sorted_lots_returns_empty_when_lot_fx_is_missing() -> None:
         == []
     )
     assert dq_log["fx_missing"] == ["EUR/SGD"]
+
+
+def test_clamped_sell_quantity_records_warning_once() -> None:
+    diagnostics = empty_diagnostics()
+    sell_position = Position(instrument_id="EQ_1", quantity=Decimal("10"))
+
+    first = _clamped_sell_quantity(
+        requested_qty=Decimal("20"),
+        position=sell_position,
+        diagnostics=diagnostics,
+    )
+    second = _clamped_sell_quantity(
+        requested_qty=Decimal("15"),
+        position=sell_position,
+        diagnostics=diagnostics,
+    )
+
+    assert first == Decimal("10")
+    assert second == Decimal("10")
+    assert diagnostics.warnings == ["SELL_QUANTITY_CLAMPED_TO_AVAILABLE_HOLDING"]
+
+
+def test_record_tax_budget_limit_reached_appends_event_without_duplicate_warning() -> None:
+    diagnostics = empty_diagnostics()
+
+    _record_tax_budget_limit_reached(
+        instrument_id="EQ_1",
+        requested_quantity=Decimal("20"),
+        allowed_quantity=Decimal("7"),
+        diagnostics=diagnostics,
+    )
+    _record_tax_budget_limit_reached(
+        instrument_id="EQ_2",
+        requested_quantity=Decimal("15"),
+        allowed_quantity=Decimal("0"),
+        diagnostics=diagnostics,
+    )
+
+    assert diagnostics.warnings == ["TAX_BUDGET_LIMIT_REACHED"]
+    assert [
+        (event.instrument_id, event.requested_quantity, event.allowed_quantity)
+        for event in diagnostics.tax_budget_constraint_events
+    ] == [
+        ("EQ_1", Decimal("20"), Decimal("7")),
+        ("EQ_2", Decimal("15"), Decimal("0")),
+    ]
 
 
 def test_trusted_market_value_drives_sell_sizing_and_after_state(base_options):

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -5,6 +5,7 @@ from src.core.rebalance.intents import (
     _TaxBudgetAccumulator,
     _clamped_sell_quantity,
     _hifo_sorted_lots,
+    _intent_market_context,
     _record_tax_budget_limit_reached,
     _security_intent_constraints,
     _tax_budget_limited_sell_quantity,
@@ -300,6 +301,70 @@ def test_tax_budget_limited_sell_quantity_bypasses_when_tax_awareness_disabled()
     assert allowed_quantity == Decimal("10")
     assert tax_budget.total_realized_gain_base == Decimal("0")
     assert tax_budget.tax_budget_used_base == Decimal("0")
+
+
+def test_intent_market_context_resolves_price_fx_and_position() -> None:
+    portfolio = portfolio_snapshot(
+        portfolio_id="pf_market_context",
+        base_currency="SGD",
+        positions=[position("EQ_US", "10")],
+        cash_balances=[cash("SGD", "1000")],
+    )
+    market_data = market_data_snapshot(
+        prices=[price("EQ_US", "100", "USD")],
+        fx_rates=[fx("USD/SGD", "1.35")],
+    )
+    dq_log = {"price_missing": [], "fx_missing": []}
+
+    context = _intent_market_context(
+        instrument_id="EQ_US",
+        portfolio=portfolio,
+        market_data=market_data,
+        dq_log=dq_log,
+    )
+
+    assert context is not None
+    resolved_price, rate, resolved_position = context
+    assert resolved_price.instrument_id == "EQ_US"
+    assert rate == Decimal("1.35")
+    assert resolved_position is not None
+    assert resolved_position.instrument_id == "EQ_US"
+    assert dq_log == {"price_missing": [], "fx_missing": []}
+
+
+def test_intent_market_context_records_missing_price_and_fx() -> None:
+    portfolio = portfolio_snapshot(
+        portfolio_id="pf_market_context_missing",
+        base_currency="SGD",
+        positions=[],
+        cash_balances=[cash("SGD", "1000")],
+    )
+    dq_log = {"price_missing": [], "fx_missing": []}
+
+    assert (
+        _intent_market_context(
+            instrument_id="EQ_MISSING",
+            portfolio=portfolio,
+            market_data=market_data_snapshot(prices=[], fx_rates=[]),
+            dq_log=dq_log,
+        )
+        is None
+    )
+    assert dq_log["price_missing"] == ["EQ_MISSING"]
+
+    assert (
+        _intent_market_context(
+            instrument_id="EQ_US",
+            portfolio=portfolio,
+            market_data=market_data_snapshot(
+                prices=[price("EQ_US", "100", "USD")],
+                fx_rates=[],
+            ),
+            dq_log=dq_log,
+        )
+        is None
+    )
+    assert dq_log["fx_missing"] == ["USD/SGD"]
 
 
 def test_trusted_market_value_drives_sell_sizing_and_after_state(base_options):

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -5,6 +5,8 @@ from src.core.rebalance.intents import (
     _clamped_sell_quantity,
     _hifo_sorted_lots,
     _record_tax_budget_limit_reached,
+    _security_intent_constraints,
+    _trade_notional_threshold,
     generate_intents,
 )
 from src.core.models import (
@@ -202,6 +204,37 @@ def test_record_tax_budget_limit_reached_appends_event_without_duplicate_warning
         ("EQ_1", Decimal("20"), Decimal("7")),
         ("EQ_2", Decimal("15"), Decimal("0")),
     ]
+
+
+def test_trade_notional_threshold_prefers_option_before_shelf_value() -> None:
+    option_threshold = Money(amount=Decimal("100"), currency="SGD")
+    shelf_threshold = Money(amount=Decimal("50"), currency="SGD")
+
+    assert (
+        _trade_notional_threshold(
+            options=EngineOptions(min_trade_notional=option_threshold),
+            shelf_entry=shelf_entry("EQ_1").model_copy(update={"min_notional": shelf_threshold}),
+        )
+        == option_threshold
+    )
+    assert (
+        _trade_notional_threshold(
+            options=EngineOptions(),
+            shelf_entry=shelf_entry("EQ_1").model_copy(update={"min_notional": shelf_threshold}),
+        )
+        == shelf_threshold
+    )
+
+
+def test_security_intent_constraints_include_sell_safety_and_tax_budget_labels() -> None:
+    assert _security_intent_constraints(
+        threshold=Money(amount=Decimal("100"), currency="SGD"),
+        side="SELL",
+        quantity=Decimal("5"),
+        requested_quantity=Decimal("10"),
+        sell_quantity_before_tax=Decimal("8"),
+        tax_awareness_enabled=True,
+    ) == ["MIN_NOTIONAL", "AVAILABLE_HOLDING", "TAX_BUDGET"]
 
 
 def test_trusted_market_value_drives_sell_sizing_and_after_state(base_options):

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -2,10 +2,12 @@ from decimal import Decimal
 
 from src.core.rebalance.engine import _generate_fx_and_simulate, run_simulation
 from src.core.rebalance.intents import (
+    _TaxBudgetAccumulator,
     _clamped_sell_quantity,
     _hifo_sorted_lots,
     _record_tax_budget_limit_reached,
     _security_intent_constraints,
+    _tax_budget_limited_sell_quantity,
     _trade_notional_threshold,
     generate_intents,
 )
@@ -235,6 +237,69 @@ def test_security_intent_constraints_include_sell_safety_and_tax_budget_labels()
         sell_quantity_before_tax=Decimal("8"),
         tax_awareness_enabled=True,
     ) == ["MIN_NOTIONAL", "AVAILABLE_HOLDING", "TAX_BUDGET"]
+
+
+def test_tax_budget_limited_sell_quantity_caps_realized_gain_to_budget() -> None:
+    lot_position = Position(
+        instrument_id="EQ_1",
+        quantity=Decimal("10"),
+        lots=[
+            TaxLot(
+                lot_id="LOT_GAIN",
+                quantity=Decimal("10"),
+                unit_cost=Money(amount=Decimal("90"), currency="SGD"),
+                purchase_date="2024-01-01",
+            )
+        ],
+    )
+    tax_budget = _TaxBudgetAccumulator(
+        total_realized_gain_base=Decimal("0"),
+        total_realized_loss_base=Decimal("0"),
+        tax_budget_used_base=Decimal("0"),
+        tax_budget_limit_base=Decimal("50"),
+    )
+
+    allowed_quantity = _tax_budget_limited_sell_quantity(
+        options=EngineOptions(enable_tax_awareness=True),
+        position=lot_position,
+        requested_qty=Decimal("10"),
+        sell_price=Decimal("100"),
+        price_ccy="SGD",
+        base_rate=Decimal("1"),
+        market_data=market_data_snapshot(),
+        dq_log={"fx_missing": []},
+        tax_budget=tax_budget,
+    )
+
+    assert allowed_quantity == Decimal("5")
+    assert tax_budget.total_realized_gain_base == Decimal("50")
+    assert tax_budget.total_realized_loss_base == Decimal("0")
+    assert tax_budget.tax_budget_used_base == Decimal("50")
+
+
+def test_tax_budget_limited_sell_quantity_bypasses_when_tax_awareness_disabled() -> None:
+    tax_budget = _TaxBudgetAccumulator(
+        total_realized_gain_base=Decimal("0"),
+        total_realized_loss_base=Decimal("0"),
+        tax_budget_used_base=Decimal("0"),
+        tax_budget_limit_base=Decimal("0"),
+    )
+
+    allowed_quantity = _tax_budget_limited_sell_quantity(
+        options=EngineOptions(enable_tax_awareness=False),
+        position=None,
+        requested_qty=Decimal("10"),
+        sell_price=Decimal("100"),
+        price_ccy="SGD",
+        base_rate=Decimal("1"),
+        market_data=market_data_snapshot(),
+        dq_log={"fx_missing": []},
+        tax_budget=tax_budget,
+    )
+
+    assert allowed_quantity == Decimal("10")
+    assert tax_budget.total_realized_gain_base == Decimal("0")
+    assert tax_budget.tax_budget_used_base == Decimal("0")
 
 
 def test_trusted_market_value_drives_sell_sizing_and_after_state(base_options):

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -1,11 +1,13 @@
 from decimal import Decimal
 
 from src.core.rebalance.engine import _generate_fx_and_simulate, run_simulation
-from src.core.rebalance.intents import generate_intents
+from src.core.rebalance.intents import _hifo_sorted_lots, generate_intents
 from src.core.models import (
     EngineOptions,
     Money,
+    Position,
     SecurityTradeIntent,
+    TaxLot,
 )
 from tests.unit.dpm.engine.coverage.helpers import empty_diagnostics
 from tests.shared.factories import (
@@ -82,6 +84,73 @@ def test_sell_intent_generation_defensively_clamps_impossible_target():
     assert intents[0].notional.amount == Decimal("10000.0")
     assert "AVAILABLE_HOLDING" in intents[0].constraints_applied
     assert "SELL_QUANTITY_CLAMPED_TO_AVAILABLE_HOLDING" in diagnostics.warnings
+
+
+def test_hifo_sorted_lots_orders_highest_cost_then_latest_purchase() -> None:
+    lot_position = Position(
+        instrument_id="EQ_1",
+        quantity=Decimal("30"),
+        lots=[
+            TaxLot(
+                lot_id="LOT_LOW",
+                quantity=Decimal("10"),
+                unit_cost=Money(amount=Decimal("80"), currency="SGD"),
+                purchase_date="2024-01-01",
+            ),
+            TaxLot(
+                lot_id="LOT_HIGH_OLD",
+                quantity=Decimal("10"),
+                unit_cost=Money(amount=Decimal("100"), currency="SGD"),
+                purchase_date="2024-02-01",
+            ),
+            TaxLot(
+                lot_id="LOT_HIGH_NEW",
+                quantity=Decimal("10"),
+                unit_cost=Money(amount=Decimal("100"), currency="SGD"),
+                purchase_date="2024-03-01",
+            ),
+        ],
+    )
+
+    sorted_lots = _hifo_sorted_lots(
+        position=lot_position,
+        instrument_ccy="SGD",
+        market_data=market_data_snapshot(),
+        dq_log={"fx_missing": []},
+    )
+
+    assert [lot.lot_id for lot, _cost in sorted_lots] == [
+        "LOT_HIGH_NEW",
+        "LOT_HIGH_OLD",
+        "LOT_LOW",
+    ]
+
+
+def test_hifo_sorted_lots_returns_empty_when_lot_fx_is_missing() -> None:
+    lot_position = Position(
+        instrument_id="EQ_1",
+        quantity=Decimal("10"),
+        lots=[
+            TaxLot(
+                lot_id="LOT_EUR",
+                quantity=Decimal("10"),
+                unit_cost=Money(amount=Decimal("80"), currency="EUR"),
+                purchase_date="2024-01-01",
+            )
+        ],
+    )
+    dq_log = {"fx_missing": []}
+
+    assert (
+        _hifo_sorted_lots(
+            position=lot_position,
+            instrument_ccy="SGD",
+            market_data=market_data_snapshot(),
+            dq_log=dq_log,
+        )
+        == []
+    )
+    assert dq_log["fx_missing"] == ["EUR/SGD"]
 
 
 def test_trusted_market_value_drives_sell_sizing_and_after_state(base_options):

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -9,6 +9,7 @@ from src.core.rebalance.intents import (
     _intent_market_context,
     _record_tax_budget_limit_reached,
     _security_intent_constraints,
+    _suppress_dust_trade,
     _tax_budget_limited_sell_quantity,
     _trade_notional_threshold,
     generate_intents,
@@ -239,6 +240,43 @@ def test_security_intent_constraints_include_sell_safety_and_tax_budget_labels()
         sell_quantity_before_tax=Decimal("8"),
         tax_awareness_enabled=True,
     ) == ["MIN_NOTIONAL", "AVAILABLE_HOLDING", "TAX_BUDGET"]
+
+
+def test_suppress_dust_trade_records_below_min_notional_intent() -> None:
+    suppressed = []
+    threshold = Money(amount=Decimal("100"), currency="SGD")
+
+    suppressed_trade = _suppress_dust_trade(
+        instrument_id="EQ_1",
+        notional=Decimal("75"),
+        notional_currency="SGD",
+        threshold=threshold,
+        options=EngineOptions(suppress_dust_trades=True),
+        suppressed=suppressed,
+    )
+
+    assert suppressed_trade is True
+    assert len(suppressed) == 1
+    assert suppressed[0].instrument_id == "EQ_1"
+    assert suppressed[0].reason == "BELOW_MIN_NOTIONAL"
+    assert suppressed[0].intended_notional == Money(amount=Decimal("75"), currency="SGD")
+    assert suppressed[0].threshold == threshold
+
+
+def test_suppress_dust_trade_keeps_supported_notional_unsuppressed() -> None:
+    suppressed = []
+
+    suppressed_trade = _suppress_dust_trade(
+        instrument_id="EQ_1",
+        notional=Decimal("125"),
+        notional_currency="SGD",
+        threshold=Money(amount=Decimal("100"), currency="SGD"),
+        options=EngineOptions(suppress_dust_trades=True),
+        suppressed=suppressed,
+    )
+
+    assert suppressed_trade is False
+    assert suppressed == []
 
 
 def test_tax_budget_limited_sell_quantity_caps_realized_gain_to_budget() -> None:

--- a/tests/unit/dpm/engine/test_engine_valuation_service.py
+++ b/tests/unit/dpm/engine/test_engine_valuation_service.py
@@ -13,7 +13,56 @@ from src.core.models import (
     Price,
     ShelfEntry,
 )
-from src.core.valuation import build_simulated_state
+from src.core.valuation import _cash_value_in_base, build_simulated_state
+from tests.shared.factories import fx, market_data_snapshot
+
+
+def test_cash_value_in_base_returns_base_cash_without_fx() -> None:
+    dq_log: dict[str, list[str]] = {}
+
+    value = _cash_value_in_base(
+        cash=CashBalance(currency="USD", amount=Decimal("100")),
+        market_data=market_data_snapshot(),
+        base_ccy="USD",
+        dq_log=dq_log,
+    )
+
+    assert value == Decimal("100")
+    assert dq_log == {}
+
+
+def test_cash_value_in_base_converts_foreign_cash_with_fx() -> None:
+    value = _cash_value_in_base(
+        cash=CashBalance(currency="EUR", amount=Decimal("100")),
+        market_data=market_data_snapshot(fx_rates=[fx("EUR/USD", "1.2")]),
+        base_ccy="USD",
+    )
+
+    assert value == Decimal("120.0")
+
+
+def test_cash_value_in_base_records_missing_cash_fx_when_log_provided() -> None:
+    dq_log: dict[str, list[str]] = {}
+
+    value = _cash_value_in_base(
+        cash=CashBalance(currency="EUR", amount=Decimal("100")),
+        market_data=market_data_snapshot(),
+        base_ccy="USD",
+        dq_log=dq_log,
+    )
+
+    assert value == Decimal("0")
+    assert dq_log == {"fx_missing": ["EUR/USD"]}
+
+
+def test_cash_value_in_base_suppresses_missing_cash_fx_log_without_log() -> None:
+    value = _cash_value_in_base(
+        cash=CashBalance(currency="EUR", amount=Decimal("100")),
+        market_data=market_data_snapshot(),
+        base_ccy="USD",
+    )
+
+    assert value == Decimal("0")
 
 
 def test_valuation_service_aggregates_attributes():

--- a/tests/unit/dpm/portfolio_memory/test_search_page.py
+++ b/tests/unit/dpm/portfolio_memory/test_search_page.py
@@ -11,6 +11,9 @@ from src.core.portfolio_memory.models import (
 )
 from src.core.portfolio_memory.search_page import (
     PortfolioMemorySearchFilters,
+    _filters_require_matching_events,
+    _memory_passes_search_summary_filters,
+    _portfolio_memory_search_item,
     build_search_page,
     build_search_row,
 )
@@ -75,6 +78,80 @@ def test_build_search_row_keeps_only_explicit_empty_portfolios() -> None:
         )
         is None
     )
+
+
+def test_memory_passes_search_summary_filters_rejects_unmatched_summary_fields() -> None:
+    memory = _memory(
+        portfolio_id="PB_SEARCH_001",
+        events=[
+            _event(
+                event_id="memory:search:handoff",
+                event_type="WAVE_HANDOFF_READY",
+                event_time="2026-05-31T10:00:00+00:00",
+                source_id="handoff-001",
+                content_hash="sha256:handoff",
+            )
+        ],
+    )
+
+    assert not _memory_passes_search_summary_filters(
+        memory=memory,
+        filters=PortfolioMemorySearchFilters(
+            event_type="OUTCOME_REVIEW_CREATED",
+            supportability_state=None,
+            source_system=None,
+            source_type=None,
+        ),
+        explicit_candidate_ids=set(),
+    )
+    assert not _memory_passes_search_summary_filters(
+        memory=memory,
+        filters=PortfolioMemorySearchFilters(
+            event_type=None,
+            supportability_state=None,
+            source_system="lotus-risk",
+            source_type=None,
+        ),
+        explicit_candidate_ids=set(),
+    )
+
+
+def test_filters_require_matching_events_tracks_event_level_filters() -> None:
+    assert not _filters_require_matching_events(
+        PortfolioMemorySearchFilters(
+            event_type=None,
+            supportability_state=None,
+            source_system=None,
+            source_type=None,
+        )
+    )
+    assert _filters_require_matching_events(
+        PortfolioMemorySearchFilters(
+            event_type=None,
+            supportability_state=None,
+            source_system=None,
+            source_type="PortfolioManagerBookMembership",
+        )
+    )
+
+
+def test_portfolio_memory_search_item_projects_latest_matching_event() -> None:
+    event = _event(
+        event_id="memory:search:handoff",
+        event_type="WAVE_HANDOFF_READY",
+        event_time="2026-05-31T10:00:00+00:00",
+        source_id="handoff-001",
+        content_hash="sha256:handoff",
+    )
+    memory = _memory(portfolio_id="PB_SEARCH_001", events=[event])
+
+    item = _portfolio_memory_search_item(memory=memory, matching_events=[event])
+
+    assert item.portfolio_id == "PB_SEARCH_001"
+    assert item.matching_event_count == 1
+    assert item.latest_matching_event_id == "memory:search:handoff"
+    assert item.latest_matching_event_source_type == "DPM_WAVE_INTERNAL_OPERATIONS_HANDOFF"
+    assert item.latest_matching_event_content_hash == "sha256:handoff"
 
 
 def test_build_search_page_counts_matching_event_facets_and_paginates() -> None:

--- a/tests/unit/dpm/portfolio_memory/test_search_page.py
+++ b/tests/unit/dpm/portfolio_memory/test_search_page.py
@@ -10,6 +10,7 @@ from src.core.portfolio_memory.models import (
     DpmPortfolioMemory,
     DpmPortfolioMemoryEvent,
     DpmPortfolioMemorySourceRef,
+    _validate_search_item_metadata,
     _validate_search_page_pagination,
 )
 from src.core.portfolio_memory.search_page import (
@@ -182,6 +183,115 @@ def test_validate_search_page_pagination_rejects_terminal_next_offset() -> None:
             offset=0,
             has_more=False,
             next_offset=2,
+        )
+
+
+def test_validate_search_item_metadata_accepts_empty_search_item_metadata() -> None:
+    _validate_search_item_metadata(
+        event_count=0,
+        event_type_counts={},
+        source_systems=[],
+        reason_codes=[],
+        supportability_state="EMPTY",
+        matching_event_count=0,
+        latest_event_time=None,
+        latest_event_type=None,
+        latest_matching_event_time=None,
+        latest_matching_event_type=None,
+        latest_matching_event_id=None,
+        latest_matching_event_identity=None,
+        latest_matching_event_source_system=None,
+        latest_matching_event_source_type=None,
+        latest_matching_event_source_id=None,
+        latest_matching_event_content_hash=None,
+    )
+
+
+def test_validate_search_item_metadata_rejects_mismatched_aggregates_and_ordering() -> None:
+    with pytest.raises(ValueError, match="event_count must equal"):
+        _validate_search_item_metadata(
+            event_count=2,
+            event_type_counts={"WAVE_HANDOFF_READY": 1},
+            source_systems=["lotus-manage"],
+            reason_codes=[],
+            supportability_state="READY",
+            matching_event_count=0,
+            latest_event_time="2026-05-31T10:00:00+00:00",
+            latest_event_type="WAVE_HANDOFF_READY",
+            latest_matching_event_time=None,
+            latest_matching_event_type=None,
+            latest_matching_event_id=None,
+            latest_matching_event_identity=None,
+            latest_matching_event_source_system=None,
+            latest_matching_event_source_type=None,
+            latest_matching_event_source_id=None,
+            latest_matching_event_content_hash=None,
+        )
+
+    with pytest.raises(ValueError, match="source_systems must be sorted"):
+        _validate_search_item_metadata(
+            event_count=1,
+            event_type_counts={"WAVE_HANDOFF_READY": 1},
+            source_systems=["b", "a"],
+            reason_codes=["READY_FOR_OPERATIONS_REVIEW"],
+            supportability_state="READY",
+            matching_event_count=0,
+            latest_event_time="2026-05-31T10:00:00+00:00",
+            latest_event_type="WAVE_HANDOFF_READY",
+            latest_matching_event_time=None,
+            latest_matching_event_type=None,
+            latest_matching_event_id=None,
+            latest_matching_event_identity=None,
+            latest_matching_event_source_system=None,
+            latest_matching_event_source_type=None,
+            latest_matching_event_source_id=None,
+            latest_matching_event_content_hash=None,
+        )
+
+
+def test_validate_search_item_metadata_rejects_missing_matching_event_metadata() -> None:
+    with pytest.raises(ValueError, match="matching events must carry latest matching"):
+        _validate_search_item_metadata(
+            event_count=1,
+            event_type_counts={"WAVE_HANDOFF_READY": 1},
+            source_systems=["lotus-manage"],
+            reason_codes=["READY_FOR_OPERATIONS_REVIEW"],
+            supportability_state="READY",
+            matching_event_count=1,
+            latest_event_time="2026-05-31T10:00:00+00:00",
+            latest_event_type="WAVE_HANDOFF_READY",
+            latest_matching_event_time="2026-05-31T10:00:00+00:00",
+            latest_matching_event_type="WAVE_HANDOFF_READY",
+            latest_matching_event_id=None,
+            latest_matching_event_identity="memory:search:handoff",
+            latest_matching_event_source_system="lotus-manage",
+            latest_matching_event_source_type="DPM_WAVE_INTERNAL_OPERATIONS_HANDOFF",
+            latest_matching_event_source_id="handoff-001",
+            latest_matching_event_content_hash="sha256:handoff",
+        )
+
+
+def test_validate_search_item_metadata_rejects_stale_matching_metadata() -> None:
+    with pytest.raises(
+        ValueError, match="no matching events must not carry latest matching event metadata"
+    ):
+        _validate_search_item_metadata(
+            event_count=1,
+            event_type_counts={"WAVE_HANDOFF_READY": 1},
+            source_systems=["lotus-manage"],
+            reason_codes=["READY_FOR_OPERATIONS_REVIEW"],
+            supportability_state="READY",
+            matching_event_count=0,
+            latest_event_time="2026-05-31T10:00:00+00:00",
+            latest_event_type="WAVE_HANDOFF_READY",
+            latest_matching_event_time="2026-05-31T10:00:00+00:00",
+            latest_matching_event_type="WAVE_HANDOFF_READY",
+            latest_matching_event_id="memory:search:handoff",
+            latest_matching_event_identity="memory:search:handoff:id",
+            latest_matching_event_source_system="lotus-manage",
+            latest_matching_event_source_type="DPM_WAVE_INTERNAL_OPERATIONS_HANDOFF",
+            latest_matching_event_source_id="handoff-001",
+            latest_matching_event_content_hash=None,
         )
 
 

--- a/tests/unit/dpm/portfolio_memory/test_search_page.py
+++ b/tests/unit/dpm/portfolio_memory/test_search_page.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.core.portfolio_memory.envelopes import finalize_portfolio_memory
 from src.core.portfolio_memory.governance import (
     client_communication_boundary_evidence,
@@ -8,6 +10,7 @@ from src.core.portfolio_memory.models import (
     DpmPortfolioMemory,
     DpmPortfolioMemoryEvent,
     DpmPortfolioMemorySourceRef,
+    _validate_search_page_pagination,
 )
 from src.core.portfolio_memory.search_page import (
     PortfolioMemorySearchFilters,
@@ -133,6 +136,53 @@ def test_filters_require_matching_events_tracks_event_level_filters() -> None:
             source_type="PortfolioManagerBookMembership",
         )
     )
+
+
+def test_validate_search_page_pagination_accepts_advancing_page() -> None:
+    _validate_search_page_pagination(
+        returned_count=2,
+        item_count=2,
+        total_count=5,
+        offset=0,
+        has_more=True,
+        next_offset=2,
+    )
+
+
+def test_validate_search_page_pagination_rejects_item_count_mismatch() -> None:
+    with pytest.raises(ValueError, match="returned_count must equal"):
+        _validate_search_page_pagination(
+            returned_count=2,
+            item_count=1,
+            total_count=5,
+            offset=0,
+            has_more=True,
+            next_offset=2,
+        )
+
+
+def test_validate_search_page_pagination_rejects_wrong_has_more_posture() -> None:
+    with pytest.raises(ValueError, match="has_more must match"):
+        _validate_search_page_pagination(
+            returned_count=2,
+            item_count=2,
+            total_count=5,
+            offset=0,
+            has_more=False,
+            next_offset=None,
+        )
+
+
+def test_validate_search_page_pagination_rejects_terminal_next_offset() -> None:
+    with pytest.raises(ValueError, match="next_offset must be null"):
+        _validate_search_page_pagination(
+            returned_count=2,
+            item_count=2,
+            total_count=2,
+            offset=0,
+            has_more=False,
+            next_offset=2,
+        )
 
 
 def test_portfolio_memory_search_item_projects_latest_matching_event() -> None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -375,6 +375,58 @@ def test_mandate_context_section_payload_projects_health_evidence() -> None:
     assert reason_codes == [reason.reason_code for reason in mandate_health.top_reasons]
 
 
+def test_selected_alternative_section_payload_degrades_without_selection() -> None:
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._selected_alternative_section_payload(
+            alternative_set=None,
+            selected_alternative=None,
+            selection=None,
+        )
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "Direct-run proof pack has no selected construction alternative."
+    assert facts == {}
+    assert metrics == {}
+    assert reason_codes == ["DPM_DIRECT_RUN_NO_SELECTED_ALTERNATIVE"]
+
+
+def test_selected_alternative_section_payload_projects_method_trace() -> None:
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+    alternative_set = build_alternative_set(
+        alternative_set_id="cas_selected_section",
+        portfolio_id="pf_proof_pack_1",
+        as_of="2026-05-03",
+        alternatives=[alternative],
+    ).model_copy(update={"generated_at": CREATED_AT})
+    selection = ConstructionAlternativeSelection(
+        selection_id="sel_selected_section",
+        alternative_set_id=alternative_set.alternative_set_id,
+        alternative_id=alternative.alternative_id,
+        actor_id="pm_001",
+        reason_code="MODEL_DRIFT_REVIEW",
+    )
+
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._selected_alternative_section_payload(
+            alternative_set=alternative_set,
+            selected_alternative=alternative,
+            selection=selection,
+        )
+    )
+
+    assert state == "READY"
+    assert summary == "Selected construction alternative captured with method and trace evidence."
+    assert facts["alternative_set_id"] == "cas_selected_section"
+    assert facts["selected_alternative_id"] == alternative.alternative_id
+    assert facts["selection_id"] == "sel_selected_section"
+    assert facts["objective_trace"]
+    assert facts["constraint_trace"]
+    assert metrics == alternative.comparison_metrics.model_dump(mode="json")
+    assert reason_codes == []
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -31,8 +31,10 @@ from src.core.proof_packs import (
     build_proof_pack_from_selected_alternative,
 )
 from src.core.proof_packs import builder as builder_module
+from src.core.proof_packs.models import DpmProofPackSourceRef
 from src.core.proof_packs.source_analytics import (
     ProofPackAnalyticsFamily,
+    ProofPackSourceAnalytics,
     source_analytics_for_alternative,
     source_analytics_for_context,
 )
@@ -126,6 +128,59 @@ def _mandate_twin() -> DpmMandateDigitalTwin:
 
 def _section(pack, section_type: str):
     return next(section for section in pack.sections if section.section_type == section_type)
+
+
+def _source_ref() -> DpmProofPackSourceRef:
+    return DpmProofPackSourceRef(
+        source_system="lotus-risk",
+        source_type="RiskMetricsReport",
+        source_id="risk-report:pf_proof_pack_1:2026-05-03",
+        supportability_state="READY",
+        content_hash="sha256:risk-report-proof",
+    )
+
+
+def test_source_analytics_section_payload_returns_degraded_missing_context() -> None:
+    state, summary, facts, metrics, reason_codes = builder_module._source_analytics_section_payload(
+        source_analytics={},
+        family="risk",
+        missing_summary="No risk-authoritative enrichment is attached.",
+        missing_reason_code="DPM_RISK_AUTHORITY_CONTEXT_MISSING",
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "No risk-authoritative enrichment is attached."
+    assert facts == {}
+    assert metrics == {}
+    assert reason_codes == ["DPM_RISK_AUTHORITY_CONTEXT_MISSING"]
+
+
+def test_source_analytics_section_payload_preserves_context_and_can_sort_reason_codes() -> None:
+    analytics = ProofPackSourceAnalytics(
+        family="regime_stress",
+        state="PENDING_REVIEW",
+        summary="Scenario evidence is attached.",
+        facts={"scenario_pack_id": "CIO_REGIME_2026_Q2"},
+        metrics={"worst_case_loss_pct": "0.1800"},
+        reason_codes=["Z_REASON", "A_REASON", "Z_REASON"],
+        source_ref=_source_ref(),
+        source_hash_key="regime_stress_context",
+        content_hash="sha256:regime-stress-context",
+    )
+
+    state, summary, facts, metrics, reason_codes = builder_module._source_analytics_section_payload(
+        source_analytics={"regime_stress": analytics},
+        family="regime_stress",
+        missing_summary="Scenario/regime authority context is not attached.",
+        missing_reason_code="DPM_SCENARIO_CONTEXT_MISSING",
+        sort_reason_codes=True,
+    )
+
+    assert state == "PENDING_REVIEW"
+    assert summary == "Scenario evidence is attached."
+    assert facts == {"scenario_pack_id": "CIO_REGIME_2026_Q2"}
+    assert metrics == {"worst_case_loss_pct": "0.1800"}
+    assert reason_codes == ["A_REASON", "Z_REASON"]
 
 
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -221,6 +221,32 @@ def test_run_state_section_payload_ignores_unrelated_sections() -> None:
     )
 
 
+def test_run_diagnostics_section_payload_returns_ready_liquidity_posture() -> None:
+    state, summary, facts, metrics, reason_codes = builder_module._run_diagnostics_section_payload(
+        section_type="liquidity_and_cash",
+        result=_ready_rebalance_result(),
+    )
+
+    assert state == "READY"
+    assert summary == "Liquidity and cash posture captured from run diagnostics."
+    assert facts["cash_ladder_breaches"] == []
+    assert metrics == {"breach_count": 0}
+    assert reason_codes == []
+
+
+def test_run_diagnostics_section_payload_returns_currency_overlay_fallback() -> None:
+    state, summary, facts, metrics, reason_codes = builder_module._run_diagnostics_section_payload(
+        section_type="currency_overlay_evidence",
+        result=_ready_rebalance_result(),
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "Currency-overlay authority context is not attached."
+    assert facts == {}
+    assert metrics == {}
+    assert reason_codes == ["DPM_CURRENCY_OVERLAY_CONTEXT_MISSING"]
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -427,6 +427,47 @@ def test_selected_alternative_section_payload_projects_method_trace() -> None:
     assert reason_codes == []
 
 
+def test_source_readiness_section_payload_blocks_missing_run() -> None:
+    state, summary, facts, metrics, reason_codes = builder_module._source_readiness_section_payload(
+        result=None
+    )
+
+    assert state == "BLOCKED"
+    assert summary == "No source run is available."
+    assert facts == {}
+    assert metrics == {}
+    assert reason_codes == ["DPM_SOURCE_RUN_MISSING"]
+
+
+def test_source_readiness_section_payload_degrades_on_lineage_state() -> None:
+    result = _ready_rebalance_result()
+    result = result.model_copy(
+        update={
+            "lineage": result.lineage.model_copy(
+                update={
+                    "input_mode": "stateful",
+                    "source_system": "lotus-core",
+                    "source_supportability_state": "DEGRADED",
+                }
+            )
+        }
+    )
+
+    state, summary, facts, metrics, reason_codes = builder_module._source_readiness_section_payload(
+        result=result
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "Source readiness captured from run lineage."
+    assert facts == {
+        "input_mode": "stateful",
+        "source_system": "lotus-core",
+        "source_supportability_state": "DEGRADED",
+    }
+    assert metrics == {}
+    assert reason_codes == ["DPM_SOURCE_READINESS_DEGRADED"]
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -325,6 +325,60 @@ def test_run_policy_section_payload_returns_missing_tax_impact_posture() -> None
     assert reason_codes == ["DPM_TAX_IMPACT_MISSING"]
 
 
+def test_approval_requirements_section_payload_orders_workflow_decisions() -> None:
+    result = _ready_rebalance_result().model_copy(update={"status": "PENDING_REVIEW"})
+    later = DpmRunWorkflowDecisionRecord(
+        decision_id="dwd_later",
+        run_id=result.rebalance_run_id,
+        action="APPROVE",
+        reason_code="LATER",
+        actor_id="pm_002",
+        decided_at=datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc),
+        correlation_id="corr-later",
+    )
+    earlier = DpmRunWorkflowDecisionRecord(
+        decision_id="dwd_earlier",
+        run_id=result.rebalance_run_id,
+        action="REQUEST_CHANGES",
+        reason_code="EARLIER",
+        actor_id="pm_001",
+        decided_at=datetime(2026, 5, 3, 9, 0, tzinfo=timezone.utc),
+        correlation_id="corr-earlier",
+    )
+
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._approval_requirements_section_payload(
+            result=result,
+            workflow_decisions=[later, earlier],
+        )
+    )
+
+    assert state == "PENDING_REVIEW"
+    assert summary == "Approval posture captured from run status and gate decision."
+    assert [decision["decision_id"] for decision in facts["workflow_decisions"]] == [
+        "dwd_earlier",
+        "dwd_later",
+    ]
+    assert metrics == {"workflow_decision_count": 2}
+    assert reason_codes == []
+
+
+def test_approval_requirements_section_payload_blocks_for_blocked_run() -> None:
+    result = _ready_rebalance_result().model_copy(update={"status": "BLOCKED"})
+
+    state, _summary, facts, metrics, reason_codes = (
+        builder_module._approval_requirements_section_payload(
+            result=result,
+            workflow_decisions=[],
+        )
+    )
+
+    assert state == "BLOCKED"
+    assert facts["workflow_decisions"] == []
+    assert metrics == {"workflow_decision_count": 0}
+    assert reason_codes == []
+
+
 def test_proof_pack_governance_section_payload_orders_workflow_decisions() -> None:
     result = _ready_rebalance_result().model_copy(update={"status": "PENDING_REVIEW"})
     later = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -196,6 +196,56 @@ def test_adapter_section_payload_returns_ready_contract_reference() -> None:
     assert reason_codes == []
 
 
+def test_pre_run_section_payload_returns_decision_summary_missing_reason() -> None:
+    result = _ready_rebalance_result()
+
+    state, summary, facts, metrics, reason_codes = builder_module._pre_run_section_payload(
+        section_type="decision_summary",
+        result=result,
+        alternative_set=None,
+        selected_alternative=None,
+        selection=None,
+        reason=None,
+        mandate_id=None,
+        mandate_twin=None,
+        mandate_health=None,
+        mandate_evidence_gap_codes=[],
+        created_by="pm_001",
+        source_analytics={},
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "Decision evidence assembled from manage run and actor rationale."
+    assert facts == {
+        "actor": "pm_001",
+        "reason": None,
+        "source_run_status": result.status,
+        "selected_alternative_id": None,
+    }
+    assert metrics == {}
+    assert reason_codes == ["DPM_PROOF_PACK_REASON_MISSING"]
+
+
+def test_pre_run_section_payload_ignores_run_required_sections() -> None:
+    assert (
+        builder_module._pre_run_section_payload(
+            section_type="trade_intents",
+            result=_ready_rebalance_result(),
+            alternative_set=None,
+            selected_alternative=None,
+            selection=None,
+            reason="Review rebalance.",
+            mandate_id=None,
+            mandate_twin=None,
+            mandate_health=None,
+            mandate_evidence_gap_codes=[],
+            created_by="pm_001",
+            source_analytics={},
+        )
+        is None
+    )
+
+
 def test_run_state_section_payload_blocks_missing_trade_intents() -> None:
     result = _ready_rebalance_result().model_copy(update={"intents": []})
 

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -468,6 +468,77 @@ def test_source_readiness_section_payload_degrades_on_lineage_state() -> None:
     assert reason_codes == ["DPM_SOURCE_READINESS_DEGRADED"]
 
 
+def test_turnover_and_cost_section_payload_degrades_without_selected_metrics() -> None:
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._turnover_and_cost_section_payload(
+            selected_alternative=None,
+            source_analytics={},
+        )
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "Turnover and cost evidence captured when construction metrics are available."
+    assert facts == {}
+    assert metrics == {}
+    assert reason_codes == ["DPM_TURNOVER_COST_METRICS_MISSING"]
+
+
+def test_turnover_and_cost_section_payload_merges_source_cost_context() -> None:
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+    cost_context = AuthoritativeTransactionCostContext(
+        supportability_status="READY",
+        source_system="lotus-core",
+        source_id="transaction-cost-scope-001",
+        content_hash="sha256:transaction-cost-curve-proof",
+        as_of_date="2026-05-03",
+        window_start_date="2026-02-02",
+        window_end_date="2026-05-03",
+        returned_curve_point_count=1,
+        reason_codes=["TRANSACTION_COST_CURVE_READY"],
+        curve_points=[
+            AuthoritativeTransactionCostPoint(
+                security_id="EQ_B",
+                transaction_type="BUY",
+                currency="USD",
+                observation_count=3,
+                total_notional=Decimal("30000"),
+                total_cost=Decimal("15"),
+                average_cost_bps=Decimal("5.0000"),
+                min_cost_bps=Decimal("4.5000"),
+                max_cost_bps=Decimal("5.5000"),
+                first_observed_date="2026-04-01",
+                last_observed_date="2026-05-03",
+            )
+        ],
+    )
+    transaction_cost = source_analytics_for_context(
+        source_context=cost_context.model_dump(mode="json", exclude_none=True),
+        family="transaction_cost",
+    )
+
+    assert transaction_cost is not None
+
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._turnover_and_cost_section_payload(
+            selected_alternative=alternative,
+            source_analytics={"transaction_cost": transaction_cost},
+        )
+    )
+
+    assert state == "READY"
+    assert (
+        summary
+        == "Turnover metrics and source-owned observed transaction-cost evidence are attached."
+    )
+    assert facts["source_system"] == "lotus-core"
+    assert facts["curve_points"][0]["average_cost_bps"] == "5.0000"
+    assert metrics["returned_curve_point_count"] == 1
+    assert metrics["represented_observation_count"] == 3
+    assert metrics["estimated_transaction_cost"] is None
+    assert reason_codes == ["TRANSACTION_COST_CURVE_READY"]
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -18,7 +18,7 @@ from src.core.construction import (
     build_alternative_set,
     build_rebalance_result_alternative,
 )
-from src.core.models import EngineOptions, Money, RebalanceResult, TaxImpact
+from src.core.models import EngineOptions, ExcludedInstrument, Money, RebalanceResult, TaxImpact
 from src.core.mandates import (
     DpmMandateDigitalTwin,
     DpmMandateHealthInput,
@@ -537,6 +537,107 @@ def test_turnover_and_cost_section_payload_merges_source_cost_context() -> None:
     assert metrics["represented_observation_count"] == 3
     assert metrics["estimated_transaction_cost"] is None
     assert reason_codes == ["TRANSACTION_COST_CURVE_READY"]
+
+
+def test_eligibility_and_restrictions_section_payload_reports_universe_exclusions() -> None:
+    result = _ready_rebalance_result()
+    result = result.model_copy(
+        update={
+            "universe": result.universe.model_copy(
+                update={
+                    "excluded": [
+                        ExcludedInstrument(
+                            instrument_id="PRIVATE_CREDIT_FUND",
+                            reason_code="SHELF_NOT_APPROVED",
+                            details="Instrument is outside the approved shelf.",
+                        )
+                    ]
+                }
+            )
+        }
+    )
+
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._eligibility_and_restrictions_section_payload(
+            result=result,
+            source_analytics={},
+        )
+    )
+
+    assert state == "PENDING_REVIEW"
+    assert summary == "Eligibility and restriction evidence captured from source run universe."
+    assert facts["excluded"][0]["instrument_id"] == "PRIVATE_CREDIT_FUND"
+    assert metrics == {"excluded_count": 1}
+    assert reason_codes == ["DPM_UNIVERSE_EXCLUSIONS_PRESENT"]
+
+
+def test_eligibility_and_restrictions_section_payload_merges_restriction_context() -> None:
+    result = _ready_rebalance_result()
+    result = result.model_copy(
+        update={
+            "universe": result.universe.model_copy(
+                update={
+                    "excluded": [
+                        ExcludedInstrument(
+                            instrument_id="PRIVATE_CREDIT_FUND",
+                            reason_code="CLIENT_RESTRICTION",
+                        )
+                    ]
+                }
+            )
+        }
+    )
+    restriction_context = AuthoritativeClientRestrictionContext(
+        supportability_status="READY",
+        source_system="lotus-core",
+        source_id="sha256:client-restrictions",
+        content_hash="sha256:client-restrictions",
+        portfolio_id="pf_proof_pack_1",
+        client_id="client_001",
+        mandate_id="mandate_001",
+        as_of_date="2026-05-03",
+        restriction_count=1,
+        reason_codes=["CLIENT_RESTRICTION_PROFILE_READY"],
+        restrictions=[
+            AuthoritativeClientRestrictionRule(
+                restriction_scope="instrument",
+                restriction_code="NO_PRIVATE_CREDIT_BUY",
+                restriction_status="active",
+                restriction_source="client_mandate",
+                applies_to_buy=True,
+                applies_to_sell=False,
+                instrument_ids=["PRIVATE_CREDIT_FUND"],
+                effective_from="2026-01-01",
+                restriction_version=1,
+            )
+        ],
+    )
+    restriction = source_analytics_for_context(
+        source_context=restriction_context.model_dump(mode="json", exclude_none=True),
+        family="client_restriction",
+    )
+
+    assert restriction is not None
+
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._eligibility_and_restrictions_section_payload(
+            result=result,
+            source_analytics={"client_restriction": restriction},
+        )
+    )
+
+    assert state == "PENDING_REVIEW"
+    assert (
+        summary == "Eligibility evidence and source-owned client restriction profile are attached."
+    )
+    assert facts["source_product_name"] == "ClientRestrictionProfile"
+    assert facts["restrictions"][0]["restriction_code"] == "NO_PRIVATE_CREDIT_BUY"
+    assert facts["excluded"][0]["instrument_id"] == "PRIVATE_CREDIT_FUND"
+    assert metrics == {"restriction_count": 1, "excluded_count": 1}
+    assert reason_codes == [
+        "CLIENT_RESTRICTION_PROFILE_READY",
+        "DPM_UNIVERSE_EXCLUSIONS_PRESENT",
+    ]
 
 
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -275,6 +275,69 @@ def test_run_policy_section_payload_returns_missing_tax_impact_posture() -> None
     assert reason_codes == ["DPM_TAX_IMPACT_MISSING"]
 
 
+def test_proof_pack_governance_section_payload_orders_workflow_decisions() -> None:
+    result = _ready_rebalance_result().model_copy(update={"status": "PENDING_REVIEW"})
+    later = DpmRunWorkflowDecisionRecord(
+        decision_id="dwd_later",
+        run_id=result.rebalance_run_id,
+        action="APPROVE",
+        reason_code="LATER",
+        actor_id="pm_002",
+        decided_at=datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc),
+        correlation_id="corr-later",
+    )
+    earlier = DpmRunWorkflowDecisionRecord(
+        decision_id="dwd_earlier",
+        run_id=result.rebalance_run_id,
+        action="REQUEST_CHANGES",
+        reason_code="EARLIER",
+        actor_id="pm_001",
+        decided_at=datetime(2026, 5, 3, 9, 0, tzinfo=timezone.utc),
+        correlation_id="corr-earlier",
+    )
+
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._proof_pack_governance_section_payload(
+            section_type="approval_requirements",
+            result=result,
+            run=_run_record(result=result),
+            selection=None,
+            source_ref_count=3,
+            workflow_decisions=[later, earlier],
+        )
+    )
+
+    assert state == "PENDING_REVIEW"
+    assert summary == "Approval posture captured from run status and gate decision."
+    assert [decision["decision_id"] for decision in facts["workflow_decisions"]] == [
+        "dwd_earlier",
+        "dwd_later",
+    ]
+    assert metrics == {"workflow_decision_count": 2}
+    assert reason_codes == []
+
+
+def test_proof_pack_governance_section_payload_tracks_lineage_refs() -> None:
+    result = _ready_rebalance_result()
+
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._proof_pack_governance_section_payload(
+            section_type="lineage",
+            result=result,
+            run=_run_record(result=result),
+            selection=None,
+            source_ref_count=7,
+            workflow_decisions=[],
+        )
+    )
+
+    assert state == "READY"
+    assert summary == "Lineage identifiers captured from source run and source artifacts."
+    assert facts["source_system"] == result.lineage.source_system
+    assert metrics == {"source_ref_count": 7}
+    assert reason_codes == []
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -196,6 +196,31 @@ def test_adapter_section_payload_returns_ready_contract_reference() -> None:
     assert reason_codes == []
 
 
+def test_run_state_section_payload_blocks_missing_trade_intents() -> None:
+    result = _ready_rebalance_result().model_copy(update={"intents": []})
+
+    state, summary, facts, metrics, reason_codes = builder_module._run_state_section_payload(
+        section_type="trade_intents",
+        result=result,
+    )
+
+    assert state == "BLOCKED"
+    assert summary == "No trade intents are available for pre-trade proof."
+    assert facts == {"intent_ids": []}
+    assert metrics == {"trade_count": 0}
+    assert reason_codes == ["DPM_TRADE_INTENTS_MISSING"]
+
+
+def test_run_state_section_payload_ignores_unrelated_sections() -> None:
+    assert (
+        builder_module._run_state_section_payload(
+            section_type="tax_impact",
+            result=_ready_rebalance_result(),
+        )
+        is None
+    )
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -183,6 +183,19 @@ def test_source_analytics_section_payload_preserves_context_and_can_sort_reason_
     assert reason_codes == ["A_REASON", "Z_REASON"]
 
 
+def test_adapter_section_payload_returns_ready_contract_reference() -> None:
+    state, summary, facts, metrics, reason_codes = builder_module._adapter_section_payload(
+        summary="Report input adapter is available.",
+        adapter_contract="DpmProofPackReportInput",
+    )
+
+    assert state == "READY"
+    assert summary == "Report input adapter is available."
+    assert facts == {"adapter_contract": "DpmProofPackReportInput"}
+    assert metrics == {}
+    assert reason_codes == []
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -247,6 +247,34 @@ def test_run_diagnostics_section_payload_returns_currency_overlay_fallback() -> 
     assert reason_codes == ["DPM_CURRENCY_OVERLAY_CONTEXT_MISSING"]
 
 
+def test_run_policy_section_payload_returns_direct_run_drift_fallback() -> None:
+    state, summary, facts, metrics, reason_codes = builder_module._run_policy_section_payload(
+        section_type="drift_impact",
+        result=_ready_rebalance_result(),
+        selected_alternative=None,
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "Direct-run proof has no construction comparison drift trace."
+    assert facts == {}
+    assert metrics == {}
+    assert reason_codes == ["DPM_DRIFT_COMPARISON_UNAVAILABLE"]
+
+
+def test_run_policy_section_payload_returns_missing_tax_impact_posture() -> None:
+    state, summary, facts, metrics, reason_codes = builder_module._run_policy_section_payload(
+        section_type="tax_impact",
+        result=_ready_rebalance_result(),
+        selected_alternative=None,
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "Tax impact is not available for this run."
+    assert facts == {}
+    assert metrics == {}
+    assert reason_codes == ["DPM_TAX_IMPACT_MISSING"]
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -338,6 +338,43 @@ def test_proof_pack_governance_section_payload_tracks_lineage_refs() -> None:
     assert reason_codes == []
 
 
+def test_mandate_context_section_payload_blocks_missing_identity() -> None:
+    state, summary, facts, metrics, reason_codes = builder_module._mandate_context_section_payload(
+        mandate_id=None,
+        mandate_twin=None,
+        mandate_health=None,
+        mandate_evidence_gap_codes=[],
+    )
+
+    assert state == "BLOCKED"
+    assert summary == "Mandate identity is required before proof-pack promotion."
+    assert facts == {"mandate_id": None}
+    assert metrics == {}
+    assert reason_codes == ["DPM_PROOF_PACK_MANDATE_ID_MISSING"]
+
+
+def test_mandate_context_section_payload_projects_health_evidence() -> None:
+    mandate_twin = _mandate_twin()
+    mandate_health = calculate_mandate_health(DpmMandateHealthInput(twin=mandate_twin))
+
+    state, summary, facts, metrics, reason_codes = builder_module._mandate_context_section_payload(
+        mandate_id=mandate_twin.mandate_id,
+        mandate_twin=mandate_twin,
+        mandate_health=mandate_health,
+        mandate_evidence_gap_codes=[],
+    )
+
+    assert state == "PENDING_REVIEW"
+    assert summary == (
+        "Mandate digital-twin and health evidence are attached from persisted RFC-0038 truth."
+    )
+    assert facts["mandate_id"] == mandate_twin.mandate_id
+    assert facts["health_snapshot_id"] == mandate_health.health_snapshot_id
+    assert metrics["dimension_count"] == len(mandate_health.dimension_scores)
+    assert metrics["source_lineage_count"] == len(mandate_twin.source_lineage)
+    assert reason_codes == [reason.reason_code for reason in mandate_health.top_reasons]
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/waves/test_campaign_definition_repository.py
+++ b/tests/unit/dpm/waves/test_campaign_definition_repository.py
@@ -226,6 +226,47 @@ def test_campaign_definition_retired_and_superseded_validation_edges() -> None:
         )
 
 
+def test_campaign_definition_lifecycle_helpers_preserve_reason_codes() -> None:
+    definition = _definition()
+
+    with pytest.raises(
+        ValueError,
+        match="BULK_REVIEW_CAMPAIGN_ACTIVE_LIFECYCLE_FIELDS_FORBIDDEN",
+    ):
+        definition.model_copy(update={"retired_by": "ops"})._validate_active_lifecycle()
+
+    with pytest.raises(
+        ValueError,
+        match="BULK_REVIEW_CAMPAIGN_RETIREMENT_TIMESTAMP_REQUIRED",
+    ):
+        definition.model_copy(
+            update={
+                "status": "RETIRED",
+                "retired_by": "ops",
+                "retirement_reason": "Campaign completed.",
+                "retirement_correlation_id": "corr-campaign-definition-retire-001",
+            }
+        )._validate_retired_lifecycle()
+
+    with pytest.raises(
+        ValueError,
+        match="BULK_REVIEW_CAMPAIGN_SUPERSEDED_RETIREMENT_FIELDS_FORBIDDEN",
+    ):
+        definition.model_copy(
+            update={
+                "status": "SUPERSEDED",
+                "superseded_at": datetime(2026, 5, 12, 8, 0, tzinfo=timezone.utc),
+                "superseded_by": "ops",
+                "supersession_reason": "Campaign candidate set refreshed.",
+                "supersession_correlation_id": "corr-campaign-definition-supersede-001",
+                "superseded_by_campaign_id": definition.campaign_id,
+                "superseded_by_campaign_version": "2026.06",
+                "superseded_by_content_hash": "sha256:replacement",
+                "retired_by": "ops",
+            }
+        )._validate_superseded_lifecycle()
+
+
 def test_in_memory_campaign_definition_repository_filters_and_conflicts() -> None:
     repository = InMemoryDpmBulkReviewCampaignDefinitionRepository()
     definition = _definition()

--- a/tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py
+++ b/tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.api.services.wave_core_portfolio_universe_resolution import (
+    resolve_core_dpm_portfolio_universe_candidates,
+)
+from src.api.services.wave_errors import (
+    DpmWaveDependencyFailedError,
+    DpmWaveDependencyUnavailableError,
+)
+from src.core.dpm_source_context import (
+    DpmCorePortfolioUniverseCandidate,
+    DpmCorePortfolioUniverseCandidateResponse,
+    DpmCorePortfolioUniverseCandidateSelectionBasis,
+    DpmCorePortfolioUniverseCandidateSupportability,
+    DpmCorePortfolioUniversePageMetadata,
+)
+from src.infrastructure.core_sourcing import (
+    DpmCoreResolverError,
+    DpmCoreResolverUnavailableError,
+)
+
+
+def _candidate_row(
+    *,
+    portfolio_id: str,
+    mandate_id: str,
+    binding_version: int,
+    source_record_id: str,
+) -> dict[str, object]:
+    return {
+        "portfolio_id": portfolio_id,
+        "mandate_id": mandate_id,
+        "client_id": "CIF_SG_000184",
+        "booking_center_code": "Singapore",
+        "jurisdiction_code": "SG",
+        "discretionary_authority_status": "active",
+        "model_portfolio_id": "MODEL_PB_SG_GLOBAL_BAL_DPM",
+        "policy_pack_id": "POLICY_DPM_SG_BALANCED_V1",
+        "mandate_objective": "Global balanced discretionary mandate.",
+        "risk_profile": "balanced",
+        "investment_horizon": "long_term",
+        "effective_from": "2026-05-01",
+        "effective_to": None,
+        "binding_version": binding_version,
+        "source_record_id": source_record_id,
+    }
+
+
+def _candidate_page(
+    *,
+    supportability_state: str = "READY",
+    next_page_token: str | None = None,
+    returned_candidate_count: int = 1,
+    candidates: list[dict[str, object]] | None = None,
+) -> DpmCorePortfolioUniverseCandidateResponse:
+    resolved_candidates = (
+        [DpmCorePortfolioUniverseCandidate.model_validate(candidate) for candidate in candidates]
+        if candidates is not None
+        else [
+            DpmCorePortfolioUniverseCandidate.model_validate(
+                _candidate_row(
+                    portfolio_id="PB_SG_GLOBAL_BAL_001",
+                    mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+                    binding_version=3,
+                    source_record_id="mandate-binding-001",
+                )
+            )
+        ]
+    )
+    if returned_candidate_count == 0:
+        resolved_candidates = []
+    return DpmCorePortfolioUniverseCandidateResponse(
+        product_name="DpmPortfolioUniverseCandidate",
+        product_version="v1",
+        as_of_date=date(2026, 5, 10),
+        tenant_id="default",
+        candidates=resolved_candidates,
+        page=DpmCorePortfolioUniversePageMetadata(
+            page_size=1000,
+            sort_key="portfolio_id:asc,mandate_id:asc",
+            returned_component_count=returned_candidate_count,
+            request_scope_fingerprint="sha256:dpm-portfolio-universe",
+            next_page_token=next_page_token,
+        ),
+        supportability=DpmCorePortfolioUniverseCandidateSupportability(
+            state=supportability_state,
+            reason=(
+                "DPM_PORTFOLIO_UNIVERSE_READY"
+                if supportability_state == "READY"
+                else "DPM_PORTFOLIO_UNIVERSE_EMPTY"
+                if returned_candidate_count == 0
+                else "DPM_PORTFOLIO_UNIVERSE_PAGE_PARTIAL"
+            ),
+            returned_candidate_count=returned_candidate_count,
+            filters_applied=["as_of_date"],
+            page_truncated=next_page_token is not None,
+        ),
+        selection_basis=DpmCorePortfolioUniverseCandidateSelectionBasis(
+            basis_type="EFFECTIVE_DISCRETIONARY_MANDATE_BINDING",
+            source_table="portfolio_mandate_bindings",
+            included_when=[],
+            downstream_boundary="Candidate membership is not execution authority.",
+        ),
+        lineage={},
+        source_batch_fingerprint="sha256:portfolio-universe",
+        snapshot_id="snapshot-001",
+        data_quality_status="ACCEPTED",
+        latest_evidence_timestamp="2026-05-10T09:00:00Z",
+    )
+
+
+class _UniverseResolver:
+    def __init__(self, pages: list[DpmCorePortfolioUniverseCandidateResponse]) -> None:
+        self.pages = pages
+        self.calls: list[dict[str, object]] = []
+
+    def resolve_dpm_portfolio_universe_candidates(
+        self,
+        **kwargs: object,
+    ) -> DpmCorePortfolioUniverseCandidateResponse:
+        self.calls.append(kwargs)
+        index = min(len(self.calls) - 1, len(self.pages) - 1)
+        return self.pages[index]
+
+
+def _resolve(
+    *,
+    pages: list[DpmCorePortfolioUniverseCandidateResponse],
+    campaign_candidate_page_size: int = 1000,
+) -> tuple[list[dict[str, object]], _UniverseResolver]:
+    resolver = _UniverseResolver(pages)
+    candidates = resolve_core_dpm_portfolio_universe_candidates(
+        as_of_date=date(2026, 5, 10),
+        tenant_id="default",
+        booking_center_code="Singapore",
+        model_portfolio_ids=["MODEL_PB_SG_GLOBAL_BAL_DPM"],
+        include_inactive_mandates=False,
+        campaign_candidate_page_size=campaign_candidate_page_size,
+        correlation_id="corr-universe-001",
+        core_resolver_factory=lambda: resolver,
+    )
+    return candidates, resolver
+
+
+def test_resolve_core_dpm_portfolio_universe_candidates_paginates_and_attaches_selection_basis() -> (
+    None
+):
+    page_0 = _candidate_page(next_page_token="page-2", returned_candidate_count=1)
+    page_1 = _candidate_page(
+        next_page_token=None,
+        returned_candidate_count=1,
+        candidates=[
+            _candidate_row(
+                portfolio_id="PB_SG_GLOBAL_BAL_002",
+                mandate_id="MANDATE_PB_SG_GLOBAL_BAL_002",
+                binding_version=4,
+                source_record_id="mandate-binding-002",
+            )
+        ],
+    )
+
+    candidates, resolver = _resolve(pages=[page_0, page_1], campaign_candidate_page_size=1)
+
+    assert len(candidates) == 2
+    assert resolver.calls[0]["page_token"] is None
+    assert resolver.calls[1]["page_token"] == "page-2"
+    assert candidates[0]["source_refs"][0]["source_type"] == "DpmPortfolioUniverseCandidate"
+    assert candidates[0]["source_refs"][1]["source_type"] == "DPM_PORTFOLIO_UNIVERSE_CANDIDATE"
+
+
+def test_resolve_core_dpm_portfolio_universe_candidates_rejects_duplicate_candidates() -> None:
+    page = _candidate_page(
+        next_page_token=None,
+        returned_candidate_count=2,
+        candidates=[
+            _candidate_row(
+                portfolio_id="PB_SG_GLOBAL_BAL_001",
+                mandate_id="MANDATE_001",
+                binding_version=3,
+                source_record_id="mandate-binding-001",
+            ),
+            _candidate_row(
+                portfolio_id="PB_SG_GLOBAL_BAL_001",
+                mandate_id="MANDATE_001",
+                binding_version=3,
+                source_record_id="mandate-binding-001",
+            ),
+        ],
+    )
+
+    with pytest.raises(DpmWaveDependencyFailedError) as exc_info:
+        _resolve(pages=[page])
+
+    assert exc_info.value.code == "DPM_CORE_PORTFOLIO_UNIVERSE_DUPLICATE_CANDIDATE"
+
+
+def test_resolve_core_dpm_portfolio_universe_candidates_rejects_non_terminating_page_tokens() -> (
+    None
+):
+    first_page = _candidate_page(next_page_token="page-2", returned_candidate_count=1)
+    second_page = _candidate_page(
+        next_page_token="page-2",
+        returned_candidate_count=1,
+        candidates=[
+            _candidate_row(
+                portfolio_id="PB_SG_GLOBAL_BAL_002",
+                mandate_id="MANDATE_002",
+                binding_version=4,
+                source_record_id="mandate-binding-002",
+            )
+        ],
+    )
+
+    with pytest.raises(DpmWaveDependencyFailedError) as exc_info:
+        _resolve(pages=[first_page, second_page])
+
+    assert exc_info.value.code == "DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING"
+
+
+def test_resolve_core_dpm_portfolio_universe_candidates_maps_unavailable_dependency() -> None:
+    with pytest.raises(DpmWaveDependencyUnavailableError) as exc_info:
+        resolve_core_dpm_portfolio_universe_candidates(
+            as_of_date=date(2026, 5, 10),
+            tenant_id="default",
+            booking_center_code="Singapore",
+            model_portfolio_ids=[],
+            include_inactive_mandates=False,
+            campaign_candidate_page_size=1000,
+            correlation_id="corr-universe-unavailable",
+            core_resolver_factory=lambda: _UnavailableCoreResolver(),
+        )
+
+    assert exc_info.value.code == "UNAVAILABLE"
+
+
+class _UnavailableCoreResolver:
+    def resolve_dpm_portfolio_universe_candidates(self, **_kwargs: object) -> None:
+        raise DpmCoreResolverUnavailableError("UNAVAILABLE")
+
+
+def test_resolve_core_dpm_portfolio_universe_candidates_maps_incomplete_dependency() -> None:
+    with pytest.raises(DpmWaveDependencyFailedError) as exc_info:
+        resolve_core_dpm_portfolio_universe_candidates(
+            as_of_date=date(2026, 5, 10),
+            tenant_id="default",
+            booking_center_code="Singapore",
+            model_portfolio_ids=[],
+            include_inactive_mandates=False,
+            campaign_candidate_page_size=1000,
+            correlation_id="corr-universe-incomplete",
+            core_resolver_factory=lambda: _IncompleteCoreResolver(),
+        )
+
+    assert exc_info.value.code == "INCOMPLETE"
+
+
+class _IncompleteCoreResolver:
+    def resolve_dpm_portfolio_universe_candidates(self, **_kwargs: object) -> None:
+        raise DpmCoreResolverError("INCOMPLETE")

--- a/tests/unit/dpm/waves/test_wave_errors.py
+++ b/tests/unit/dpm/waves/test_wave_errors.py
@@ -26,4 +26,10 @@ def test_wave_service_preserves_imported_error_surface() -> None:
 def test_wave_errors_exports_only_wave_error_types() -> None:
     from src.api.services import wave_errors
 
-    assert wave_errors.__all__ == ["DpmWaveLookupError", "DpmWaveValidationError"]
+    assert set(wave_errors.__all__) == {
+        "DpmWaveLookupError",
+        "DpmWaveValidationError",
+        "DpmWaveDependencyError",
+        "DpmWaveDependencyFailedError",
+        "DpmWaveDependencyUnavailableError",
+    }

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -42,6 +42,14 @@ def _snapshot(*, label: str, router_imports: list[str] | None = None) -> Snapsho
             ),
             ComplexityMetric(path="src/api/main.py", name="create_app", complexity=3, lines=12),
         ],
+        most_complex_source_functions=[
+            ComplexityMetric(path="src/api/main.py", name="create_app", complexity=3, lines=12)
+        ],
+        most_complex_test_functions=[
+            ComplexityMetric(
+                path="tests/unit/test_main.py", name="test_create_app", complexity=4, lines=16
+            )
+        ],
         service_boundary_violations=[],
         router_infra_imports=router_imports or [],
     )

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from scripts import engineering_health_report as ehr
 from scripts.engineering_health_report import (
+    ComplexityMetric,
     FileMetric,
     FunctionMetric,
     HealthReportContext,
@@ -11,6 +12,7 @@ from scripts.engineering_health_report import (
     build_api_governance_rules,
     build_architecture_rules,
     build_baseline_report,
+    build_complexity_report,
     build_quality_scorecard,
 )
 
@@ -34,6 +36,9 @@ def _snapshot(*, label: str, router_imports: list[str] | None = None) -> Snapsho
         test_count=4,
         largest_files=[FileMetric(path="src/api/main.py", lines=42)],
         largest_functions=[FunctionMetric(path="src/api/main.py", name="create_app", lines=12)],
+        most_complex_functions=[
+            ComplexityMetric(path="src/api/main.py", name="create_app", complexity=3, lines=12)
+        ],
         service_boundary_violations=[],
         router_infra_imports=router_imports or [],
     )
@@ -93,7 +98,9 @@ def test_baseline_report_declares_report_only_quality_coverage() -> None:
     assert "# lotus-manage Baseline Quality Report" in report
     assert "| Python files | 3 |" in report
     assert "| Router infrastructure imports | 1 |" in report
-    assert "| Complexity/maintainability | not instrumented yet | planned |" in report
+    assert (
+        "| Complexity/maintainability | `quality/complexity_report.md` | 1 - baseline |" in report
+    )
     assert "does not enforce thresholds by itself" in report
 
 
@@ -102,10 +109,42 @@ def test_quality_scorecard_separates_active_gates_from_planned_gates() -> None:
 
     assert "# lotus-manage Quality Scorecard" in scorecard
     assert "| OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |" in scorecard
-    assert "| Complexity | Not yet instrumented |" in scorecard
+    assert "| Complexity | Report-only baseline |" in scorecard
     assert (
         "| 4 - enterprise-readiness gates | Block release on full readiness posture." in scorecard
     )
+
+
+def test_complexity_metrics_count_branching_constructs() -> None:
+    metrics = ehr._complexity_metrics(
+        "src/api/example.py",
+        """
+def evaluate(flag, value):
+    if flag and value:
+        return 1
+    for item in range(2):
+        if item:
+            return item
+    return 0
+""",
+    )
+
+    assert metrics == [
+        ComplexityMetric(
+            path="src/api/example.py",
+            name="evaluate",
+            complexity=5,
+            lines=7,
+        )
+    ]
+
+
+def test_complexity_report_is_report_only() -> None:
+    report = build_complexity_report(_context())
+
+    assert "# lotus-manage Complexity Report" in report
+    assert "| Highest complexity | 3 | 3 | +0 |" in report
+    assert "phase 1/report-only" in report
 
 
 def test_quality_rule_documents_state_report_only_architecture_and_api_rules() -> None:

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -1,3 +1,8 @@
+import io
+import tarfile
+from types import SimpleNamespace
+
+from scripts import engineering_health_report as ehr
 from scripts.engineering_health_report import (
     FileMetric,
     FunctionMetric,
@@ -8,6 +13,17 @@ from scripts.engineering_health_report import (
     build_baseline_report,
     build_quality_scorecard,
 )
+
+
+def _tar_bytes(files: dict[str, str]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        for path, text in files.items():
+            payload = text.encode("utf-8")
+            info = tarfile.TarInfo(path)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return buffer.getvalue()
 
 
 def _snapshot(*, label: str, router_imports: list[str] | None = None) -> SnapshotMetrics:
@@ -21,6 +37,33 @@ def _snapshot(*, label: str, router_imports: list[str] | None = None) -> Snapsho
         service_boundary_violations=[],
         router_infra_imports=router_imports or [],
     )
+
+
+def test_python_texts_from_git_reads_python_files_from_one_archive(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    archive_payload = _tar_bytes(
+        {
+            "src/api/main.py": "def create_app():\n    pass\n",
+            "src/api/ignored.txt": "not python\n",
+            "tests/unit/test_example.py": "def test_example():\n    pass\n",
+        }
+    )
+
+    def fake_run(command: list[str], **kwargs):
+        calls.append(command)
+        return SimpleNamespace(stdout=archive_payload)
+
+    monkeypatch.setattr(ehr.subprocess, "run", fake_run)
+
+    texts = ehr._python_texts_from_git("origin/main")
+
+    assert calls == [
+        ["git", "archive", "--format=tar", "origin/main", "--", "src", "tests", "scripts"]
+    ]
+    assert texts == {
+        "src/api/main.py": "def create_app():\n    pass\n",
+        "tests/unit/test_example.py": "def test_example():\n    pass\n",
+    }
 
 
 def _context() -> HealthReportContext:

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -1,0 +1,75 @@
+from scripts.engineering_health_report import (
+    FileMetric,
+    FunctionMetric,
+    HealthReportContext,
+    SnapshotMetrics,
+    build_api_governance_rules,
+    build_architecture_rules,
+    build_baseline_report,
+    build_quality_scorecard,
+)
+
+
+def _snapshot(*, label: str, router_imports: list[str] | None = None) -> SnapshotMetrics:
+    return SnapshotMetrics(
+        label=label,
+        python_file_count=3,
+        total_loc=120,
+        test_count=4,
+        largest_files=[FileMetric(path="src/api/main.py", lines=42)],
+        largest_functions=[FunctionMetric(path="src/api/main.py", name="create_app", lines=12)],
+        service_boundary_violations=[],
+        router_infra_imports=router_imports or [],
+    )
+
+
+def _context() -> HealthReportContext:
+    return HealthReportContext(
+        generated_at="2026-06-02T00:00:00+00:00",
+        base_ref="origin/main",
+        current_ref="abc1234",
+        base=_snapshot(label="origin/main"),
+        current=_snapshot(
+            label="current branch",
+            router_imports=["src/api/routers/example.py:1: from src.infrastructure.foo import Foo"],
+        ),
+        openapi={
+            "operations": 10,
+            "missing_summary": 0,
+            "missing_description": 0,
+            "missing_tags": 0,
+            "missing_error_response": 2,
+            "missing_examples": 0,
+        },
+    )
+
+
+def test_baseline_report_declares_report_only_quality_coverage() -> None:
+    report = build_baseline_report(_context())
+
+    assert "# lotus-manage Baseline Quality Report" in report
+    assert "| Python files | 3 |" in report
+    assert "| Router infrastructure imports | 1 |" in report
+    assert "| Complexity/maintainability | not instrumented yet | planned |" in report
+    assert "does not enforce thresholds by itself" in report
+
+
+def test_quality_scorecard_separates_active_gates_from_planned_gates() -> None:
+    scorecard = build_quality_scorecard(_context())
+
+    assert "# lotus-manage Quality Scorecard" in scorecard
+    assert "| OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |" in scorecard
+    assert "| Complexity | Not yet instrumented |" in scorecard
+    assert (
+        "| 4 - enterprise-readiness gates | Block release on full readiness posture." in scorecard
+    )
+
+
+def test_quality_rule_documents_state_report_only_architecture_and_api_rules() -> None:
+    architecture_rules = build_architecture_rules()
+    api_rules = build_api_governance_rules()
+
+    assert "Routers call application services or use-case functions only." in architecture_rules
+    assert "Current Gate Phase" in architecture_rules
+    assert "Every endpoint should have a summary" in api_rules
+    assert "OpenAPI and API vocabulary checks are active repo-native gates" in api_rules

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -37,7 +37,10 @@ def _snapshot(*, label: str, router_imports: list[str] | None = None) -> Snapsho
         largest_files=[FileMetric(path="src/api/main.py", lines=42)],
         largest_functions=[FunctionMetric(path="src/api/main.py", name="create_app", lines=12)],
         most_complex_functions=[
-            ComplexityMetric(path="src/api/main.py", name="create_app", complexity=3, lines=12)
+            ComplexityMetric(
+                path="tests/unit/test_main.py", name="test_create_app", complexity=4, lines=16
+            ),
+            ComplexityMetric(path="src/api/main.py", name="create_app", complexity=3, lines=12),
         ],
         service_boundary_violations=[],
         router_infra_imports=router_imports or [],
@@ -143,7 +146,9 @@ def test_complexity_report_is_report_only() -> None:
     report = build_complexity_report(_context())
 
     assert "# lotus-manage Complexity Report" in report
-    assert "| Highest complexity | 3 | 3 | +0 |" in report
+    assert "| Highest complexity | 4 | 4 | +0 |" in report
+    assert "### Most Complex Current Source Functions" in report
+    assert "### Most Complex Current Test Functions" in report
     assert "phase 1/report-only" in report
 
 


### PR DESCRIPTION
## Summary
- Extracted core portfolio-universe candidate paging, validation, and source-reference assembly into `src/api/services/wave_core_portfolio_universe_resolution.py`.
- Kept `src/api/routers/wave_core_portfolio_universe_resolution.py` as a thin adapter (date parsing + HTTP mapping only).
- Added service-level dependency errors in `src/api/services/wave_errors.py` and mapped them in router.
- Added direct service unit tests in `tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`.
- Logged governance review entry `BACKEND-REVIEW-20260604-515` in `docs/architecture/CODEBASE-REVIEW-LEDGER.md`.

## Validation
- `python -m ruff check src/api/services/wave_core_portfolio_universe_resolution.py src/api/services/wave_errors.py src/api/routers/wave_core_portfolio_universe_resolution.py tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`
- `python -m ruff format --check src/api/routers/wave_core_portfolio_universe_resolution.py src/api/services/wave_core_portfolio_universe_resolution.py src/api/services/wave_errors.py tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`
- `python -m mypy --config-file mypy.ini src/api/services/wave_core_portfolio_universe_resolution.py src/api/services/wave_errors.py src/api/routers/wave_core_portfolio_universe_resolution.py`
- `python -m pytest tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py tests/unit/dpm/api/test_waves_api.py -k core_universe`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP" src/api/services -g "*.py"`