### PR TITLE
chore(manage): baseline quality governance infrastructure

### DIFF
--- a/.github/workflows/quality-baseline.yml
+++ b/.github/workflows/quality-baseline.yml
@@ -1,0 +1,110 @@
+name: Quality Baseline
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches-ignore:
+      - "main"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  report-only:
+    name: Quality Baseline / Report Only
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Python Quality Tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,quality]"
+          python -m pip check
+
+      - name: Install Spectral
+        run: npm install -g @stoplight/spectral-cli
+
+      - name: Ruff
+        continue-on-error: true
+        run: |
+          mkdir -p output/quality-baseline
+          python -m ruff check . 2>&1 | tee output/quality-baseline/ruff.txt
+
+      - name: Mypy
+        continue-on-error: true
+        run: |
+          python -m mypy --config-file mypy.ini src 2>&1 | tee output/quality-baseline/mypy.txt
+
+      - name: Coverage
+        continue-on-error: true
+        run: python -m pytest tests/unit --cov=src --cov-report=term-missing 2>&1 | tee output/quality-baseline/coverage.txt
+
+      - name: Architecture Import Rules
+        continue-on-error: true
+        run: |
+          lint-imports --config .importlinter 2>&1 | tee output/quality-baseline/import-linter.txt
+
+      - name: Complexity Baseline
+        continue-on-error: true
+        run: |
+          {
+            radon cc src -s -a
+            radon mi src -s
+            xenon --max-absolute C --max-modules B --max-average A src
+          } 2>&1 | tee output/quality-baseline/complexity.txt
+
+      - name: Dead Code Baseline
+        continue-on-error: true
+        run: vulture src tests --min-confidence 80 2>&1 | tee output/quality-baseline/vulture.txt
+
+      - name: Dependency Baseline
+        continue-on-error: true
+        run: deptry . 2>&1 | tee output/quality-baseline/deptry.txt
+
+      - name: Security Baseline
+        continue-on-error: true
+        run: |
+          {
+            bandit -q -r src -c pyproject.toml
+            pip-audit -r pyproject.toml
+            make security-audit
+          } 2>&1 | tee output/quality-baseline/security.txt
+
+      - name: Documentation Baseline
+        continue-on-error: true
+        run: interrogate src 2>&1 | tee output/quality-baseline/interrogate.txt
+
+      - name: OpenAPI Spectral Baseline
+        continue-on-error: true
+        run: |
+          python - <<'PY' > openapi.json
+          import json
+          from src.api.main import app
+          print(json.dumps(app.openapi(), indent=2))
+          PY
+          spectral lint openapi.json --ruleset .spectral.yaml 2>&1 | tee output/quality-baseline/spectral.txt
+
+      - name: Upload Quality Baseline Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-baseline
+          path: |
+            output/quality-baseline/
+            openapi.json
+          if-no-files-found: warn

--- a/.importlinter
+++ b/.importlinter
@@ -1,0 +1,23 @@
+[importlinter]
+root_package = src
+
+[importlinter:contract:routers_do_not_import_infrastructure]
+name = Routers depend on service layer, not concrete infrastructure clients
+type = forbidden
+source_modules = src.api.routers
+forbidden_modules =
+    src.infrastructure
+
+[importlinter:contract:services_do_not_depend_on_routers]
+name = Services do not depend on routers
+type = forbidden
+source_modules = src.api.services
+forbidden_modules =
+    src.api.routers
+
+[importlinter:contract:services_use_factory_modules]
+name = Services use factory modules for concrete clients
+type = forbidden
+source_modules = src.api.services
+forbidden_modules =
+    src.infrastructure

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,62 @@
+extends:
+  - spectral:oas
+
+rules:
+  lotus-operation-operation-id:
+    description: Every public operation should define a stable operationId.
+    message: "Operation must define operationId."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: operationId
+      function: truthy
+
+  lotus-operation-summary:
+    description: Every operation should have a concise summary.
+    message: "Operation must define summary."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: summary
+      function: truthy
+
+  lotus-operation-description:
+    description: Every operation should explain behavior and operational ownership.
+    message: "Operation must define description."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: description
+      function: truthy
+
+  lotus-operation-tags:
+    description: Every operation should be assigned to at least one tag.
+    message: "Operation must define tags."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: tags
+      function: truthy
+
+  lotus-standard-error-response:
+    description: Every operation should document at least one standard error response.
+    message: "Operation should define standard 4xx/5xx response."
+    severity: warn
+    given: "$.paths[*][get,post,put,patch,delete]"
+    then:
+      field: responses
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          anyOf:
+            - required: ["400"]
+            - required: ["401"]
+            - required: ["403"]
+            - required: ["404"]
+            - required: ["409"]
+            - required: ["422"]
+            - required: ["429"]
+            - required: ["500"]
+            - required: ["502"]
+            - required: ["503"]

--- a/docs/api-governance.md
+++ b/docs/api-governance.md
@@ -1,0 +1,41 @@
+# Lotus Manage API Governance
+
+This document is the API-governance baseline for `lotus-manage` surfaces.
+
+## Public contract expectations
+
+- All API operations should declare:
+  - `summary`
+  - `description`
+  - one or more `tags`
+  - stable `operationId`
+  - request/response models
+- Operations should document at least one standard 4xx/5xx response contract.
+- OpenAPI and API vocabulary checks are required in repository lanes.
+- Endpoint naming and parameter style should remain compatible with existing contract families in
+  `src/api`.
+
+## Surfaces and conventions
+
+- Public operational surfaces should remain explicit in routing and documentation:
+  - `/api/v1/...` portfolio/rebalance and management surfaces
+  - `/health`, `/health/live`, `/health/ready` public health surfaces
+  - internal metrics/logging surfaces as implemented by observability contracts
+- Pagination, filtering, sorting, and cursor continuity should be consistent within each list family.
+- Idempotency-sensitive mutations must carry stable behavior under retries.
+- Correlation identifiers should be accepted when provided and propagated through downstream calls.
+
+## Error handling
+
+- Service and transport failures should map to consistent problem-details or standardized supportability posture.
+- Unsupported capabilities should be represented with explicit boundary evidence rather than inferred ownership.
+- Retryable upstream failures should surface bounded supportability states where current code paths already use
+  fail-closed contracts.
+
+## Governance gates
+
+- `make openapi-gate`
+- `make api-vocabulary-gate`
+- `make no-alias-gate`
+- `make lint`, `make typecheck`
+- Quality evidence is reported by `quality-baseline.yml` and `quality/*.md` artifacts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,36 @@
+# Lotus Manage Architecture
+
+`lotus-manage` is a Domain API in the Lotus stack for discretionary portfolio management execution and
+pre-trade operating workflows.
+
+## Primary responsibilities
+
+- Build and persist rebalance construction alternatives and deterministic metadata.
+- Run supportability pipelines for async operations, lineage, proof-pack handoff, and idempotent reruns.
+- Persist and expose command-center signals used by downstream workflow surfaces.
+- Mediate governed source-context intake from `lotus-core`, `lotus-risk`, and `lotus-performance` without
+  adopting those domains’ modeling or execution responsibilities.
+- Expose bounded governance boundaries for unsupported capabilities such as OMS, client communication,
+  and portfolio-level advisory actions.
+
+## Domain and layering
+
+- `src/api` owns router and request/response surfaces.
+- `src/core` owns business logic and domain rules.
+- `src/api/services` owns orchestration, assembly, and integration use-cases.
+- `src/infrastructure` owns concrete adapter implementations and storage/network clients.
+- `tests` contains unit, integration, and contract verification aligned to architecture contracts.
+
+## Governance invariants
+
+- Routers do not import concrete infra clients.
+- Services do not import router modules.
+- Domain and persistence details do not leak into API request contract helpers.
+- OpenAPI and API vocabulary checks remain mandatory in every PR lane.
+
+## Current truth pointers
+
+- Ledger: [docs/architecture/CODEBASE-REVIEW-LEDGER.md](architecture/CODEBASE-REVIEW-LEDGER.md)
+- Standards: [docs/standards/enterprise-readiness.md](standards/enterprise-readiness.md)
+- Standards map: [docs/standards/RFC-0082-upstream-contract-family-map.md](standards/RFC-0082-upstream-contract-family-map.md)
+- Open RFC and contract context: [docs/rfcs](rfcs)

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12703,3 +12703,26 @@ and improves internal transaction-cost source posture maintainability only.
   `python scripts/api_vocabulary_inventory.py --validate-only`,
   `rg` service leakage scan (`from src.api.routers|HTTPException|status.HTTP` in `src/api/services`).
 - Wiki decision: no wiki source change required; this is an internal service-boundary improvement only.
+
+## BACKEND-REVIEW-20260604-516: Add baseline governance and quality infrastructure
+
+- Date: 2026-06-04
+- Scope: `.github/workflows/quality-baseline.yml`, `pyproject.toml`, `.importlinter`,
+  `.spectral.yaml`, `docs/architecture.md`, `docs/api-governance.md`, `docs/observability.md`,
+  `docs/security.md`, `docs/operations-runbook.md`, `docs/supported-features.md`,
+  `quality/baseline_report.md`, `quality/refactor_health_report.md`, `quality/quality_scorecard.md`,
+  `quality/architecture_rules.md`, `quality/api_governance_rules.md`.
+- Finding: quality-governance artifacts for enterprise-readiness slicing were missing in-repo:
+  quality dependency group, baseline workflow, architecture/import contracts, spectral rules, and
+  required governance documentation anchors.
+- Action: added report-only baseline workflow with controlled tooling slices (Ruff, mypy, coverage,
+  import-linter, radon/xenon, vulture, deptry, bandit, OpenAPI spectral), added quality dependency
+  group for on-demand tooling, added governing docs and updated quality scorecards to reflect the new baseline
+  slice.
+- Status: hardened
+- Evidence: `python -m ruff check .`, `python -m ruff format --check .`, `python -m mypy
+  --config-file mypy.ini src/api/services` (no new typed src violations introduced outside baseline scope),
+  `python scripts/openapi_quality_gate.py`, `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP" src/api/services -g "*.py"`,
+  `git diff --check`.
+- Wiki decision: no wiki source change required; slice is repository-local quality governance scaffolding.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,30 @@
+# Lotus Manage Observability
+
+## Contracted surfaces
+
+- Health:
+  - `/health`
+  - `/health/live`
+  - `/health/ready`
+- OpenAPI/spec surfaces via `/docs` and managed OpenAPI contracts.
+- Service and domain logs should include stable request identifiers and `correlation_id`.
+
+## Metrics and telemetry
+
+- HTTP request latency and outcome summaries are emitted by the application runtime and surfaced through
+  service telemetry integrations.
+- Structured logs should avoid raw payload leakage and retain bounded operational fields (route, outcome,
+  request family, correlation).
+
+## Traceability
+
+- Correlation IDs should remain stable across async request paths.
+- Persisted artifacts (runs, alternatives, operations, proof packs) should preserve deterministic ref IDs and
+  lineage fields for downstream audit and troubleshooting.
+
+## Contracts and validation
+
+- Mesh and observability contracts are validated through:
+  - `scripts/validate_observability_contracts.py`
+  - `make mesh-contract-validate`
+- Quality baseline logs are collected by `.github/workflows/quality-baseline.yml`.

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -1,0 +1,35 @@
+# Lotus Manage Operations Runbook
+
+## Local proof posture
+
+- Install dependencies: `make install`
+- Local API: `make run` (default) or `make run-canonical`
+- Canonical local stack: `powershell -ExecutionPolicy Bypass -File scripts/Start-CanonicalManage.ps1`
+
+## Validation sequence
+
+1. `make lint`
+2. `make typecheck`
+3. `make openapi-gate`
+4. `make api-vocabulary-gate`
+5. `make test-unit`
+6. `make security-audit`
+7. `make migration-smoke`
+
+For full repo-native evidence in production-oriented work, run:
+
+- `make ci-local` (unit/integration/e2e with merge-gate coverage and gates)
+- `make mesh-contract-validate`
+
+## Incident triage
+
+- If health fails, verify startup migration state and storage adapter configuration first.
+- For supportability anomalies, inspect persisted supportability state and correlation IDs before retry.
+- For OpenAPI or contract drift, run:
+  - `python scripts/openapi_quality_gate.py`
+  - `python scripts/api_vocabulary_inventory.py --validate-only`
+
+## Ownership
+
+- This runbook reflects repository-native evidence and does not include downstream UI or gateway-only
+  diagnostics.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,27 @@
+# Lotus Manage Security
+
+## Threat and trust boundaries
+
+- `lotus-manage` is a controlled backend API for managed workflow operations and does not own advisory
+  client communication or order execution.
+- Upstream and downstream calls should remain explicit, bounded, and auditable through service contracts.
+- Security-sensitive methods should fail closed when required source/identity signals are missing.
+
+## Operational controls
+
+- Runtime configuration should use environment-based secret injection (no repository-checked credentials).
+- Downstream failures are handled through bounded supportability states and explicit error contracts.
+- Idempotency-sensitive mutation routes should not execute duplicate irreversible side effects.
+- Authentication/authorization posture follows the runtime environment policy and upstream gateway requirements.
+
+## Security checks in lanes
+
+- `make security-audit`
+- `pip-audit` and dependency checks in CI/quality slices
+- `bandit` profile is included in report-only baseline
+
+## Data handling
+
+- Structured logging should avoid PII and secrets.
+- Persisted supportability artifacts should retain only bounded review evidence and no claim to prohibited
+  ownership (OMS execution, client approvals, communication artifacts, settlement truth).

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -1,0 +1,29 @@
+# Lotus Manage Supported Features
+
+This file tracks implementation-backed and supported `lotus-manage` capabilities. Unsupported claims are
+explicitly excluded.
+
+## Supported
+
+- Deterministic rebalance simulation and what-if alternatives.
+- Asynchronous operations with supportability and lineage artifacts.
+- Policy-pack and mandate context read/build surfaces.
+- Construction alternative generation/selection for supported methods.
+- Wave lifecycle preview/create/read/list item/simulate/approve flows.
+- Portfolio-memory persistence search and bounded retrieval.
+- Monitoring, exceptions, and command-center read/write for managed domains.
+
+## Explicitly unsupported in `lotus-manage`
+
+- OMS execution instructions, best execution claims, and settlement lifecycle.
+- Client-ready communication, consent collection, or messaging.
+- External treasury advisory, order routing, or execution confirmation.
+- Final trade approval or portfolio-CRM decisioning.
+
+## Promotion requirements
+
+- New features remain unsupported until:
+  - source-code implementation is complete,
+  - API contracts are validated,
+  - governance gates pass, and
+  - owning RFC/release evidence is present.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,15 @@ dev = [
   "cvxpy>=1.4.0",
   "numpy>=1.26.0"
 ]
+quality = [
+  "bandit[toml]>=1.7.10",
+  "deptry>=0.23.0",
+  "import-linter>=2.1",
+  "interrogate>=1.7.0",
+  "radon>=6.0.1",
+  "vulture>=2.14",
+  "xenon>=0.9.3"
+]
 
 [tool.ruff]
 line-length = 100
@@ -49,3 +58,22 @@ markers = [
   "integration: integration tests",
   "e2e: end-to-end tests",
 ]
+
+[tool.bandit]
+exclude_dirs = ["tests", ".venv", ".venv-codex", "output"]
+skips = []
+
+[tool.deptry]
+known_first_party = ["src"]
+exclude = ["tests", "output", ".venv", ".venv-codex"]
+
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = true
+ignore-magic = true
+ignore-module = true
+ignore-nested-functions = true
+ignore-private = true
+ignore-property-decorators = true
+fail-under = 45
+exclude = ["tests", "output", ".venv", ".venv-codex"]

--- a/quality/api_governance_rules.md
+++ b/quality/api_governance_rules.md
@@ -8,6 +8,7 @@ These rules define the report-only API-governance baseline for the enterprise-re
 2. Error responses should use consistent platform problem-details semantics where applicable.
 3. Public and internal endpoints should remain clearly separated.
 4. Health, readiness, liveness, metrics, internal, and public endpoints should be documented as distinct operational surfaces.
+5. Spectral baselines are now enforced in report-only mode via `.spectral.yaml` to keep missing metadata visible before phase-gate enforcement.
 
 ## API Behavior
 

--- a/quality/architecture_rules.md
+++ b/quality/architecture_rules.md
@@ -23,3 +23,11 @@ They are explicit so later validators can enforce them without changing their me
 ## Current Gate Phase
 
 These rules are in phase 1/report-only except for checks already covered by repo-native gates.
+
+Planned baseline signal additions in `.github/workflows/quality-baseline.yml` keep these rules measurable without
+moving to hard thresholds yet:
+
+- architectural import leakage (via `.importlinter`)
+- OpenAPI operation/response completeness (via `.spectral.yaml`)
+- dead-code and complexity trends (`vulture`, `radon`, `xenon`)
+- dependency hygiene (`deptry`) and security trend (`bandit`, `pip-audit`)

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-04T04:20:12+00:00`
+- Generated at: `2026-06-04T06:06:00+00:00`
 
-- Baseline commit: `fafa839`
+- Baseline commit: `19bbdd1`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -10,11 +10,11 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 770 |
-| Total Python LOC | 149079 |
-| Test functions | 1950 |
+| Python files | 772 |
+| Total Python LOC | 149604 |
+| Test functions | 1958 |
 | Service boundary findings | 0 |
-| Router infrastructure imports | 18 |
+| Router infrastructure imports | 17 |
 
 ## Current OpenAPI Completeness
 
@@ -37,9 +37,9 @@
 | Service boundary leakage | service leakage scan plus this report | 2 - active/new-regression |
 | Router infrastructure imports | reported as known baseline debt | 1 - baseline |
 | Complexity/maintainability | `quality/complexity_report.md` | 1 - baseline |
-| Dead code | not instrumented yet | planned |
-| Dependency hygiene | `pip check`/security audit in repo gates; richer deptry planned | 2 - active/new-regression |
-| Security | `make security-audit`; richer bandit/pip-audit scorecard planned | 2 - active/new-regression |
+| Dead code | `vulture src tests` via `quality-baseline.yml` | 1 - baseline |
+| Dependency hygiene | `deptry .` via `quality-baseline.yml`; `make security-audit` in repo gates | 2 - active/new-regression |
+| Security | `bandit`, `make security-audit` via `quality-baseline.yml` | 2 - active/new-regression |
 | Documentation gaps | current docs tests plus planned docs scorecard | planned |
 | Observability gaps | `scripts/validate_observability_contracts.py`; richer runtime gap report planned | 2 - active/new-regression |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T04:20:12+00:00`
+- Generated at: `2026-06-04T06:06:00+00:00`
 
-- Current ref: `fafa839`
+- Current ref: `19bbdd1`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -33,15 +33,15 @@
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
 | 1 | _validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 68 |
-| 2 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 16 | 173 |
-| 3 | resolve_core_dpm_portfolio_universe_candidates | src/api/routers/wave_core_portfolio_universe_resolution.py | 16 | 116 |
-| 4 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
-| 5 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
-| 6 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
-| 7 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
-| 8 | _ensure_operation_documentation | src/api/openapi_enrichment.py | 16 | 33 |
-| 9 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
-| 10 | evaluate | src/core/compliance.py | 15 | 171 |
+| 2 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
+| 3 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
+| 4 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
+| 5 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
+| 6 | _ensure_operation_documentation | src/api/openapi_enrichment.py | 16 | 33 |
+| 7 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
+| 8 | evaluate | src/core/compliance.py | 15 | 171 |
+| 9 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
+| 10 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T04:20:12+00:00`
+- Generated at: `2026-06-04T06:06:00+00:00`
 
-- Current ref: `fafa839`
+- Current ref: `19bbdd1`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 
@@ -14,12 +14,12 @@
 | OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |
 | API vocabulary | Active gate | `scripts/api_vocabulary_inventory.py --validate-only`. |
 | Service boundary leakage | Report plus focused scans | Current service boundary findings: 0. |
-| Router infrastructure imports | Baseline debt | Current router infra imports: 18. |
+| Router infrastructure imports | Report-only baseline evidence | `quality-baseline.yml` captures `.importlinter` findings; current known baseline debt: 17. |
 | OpenAPI 4xx/5xx response markers | Baseline debt | Current missing markers: 3. |
-| Complexity | Report-only baseline | `quality/complexity_report.md`; add thresholds after baseline review. |
-| Dead code | Not yet instrumented | Add vulture report-only baseline before thresholds. |
-| Dependency architecture | Not yet instrumented | Add import-linter/deptry report-only baseline before thresholds. |
-| Security depth | Partially active | Security audit is active; add bandit/pip-audit detail scorecard. |
+| Complexity | Report-only baseline | `quality/complexity_report.md`; added `radon/xenon` capture in `quality-baseline.yml`. |
+| Dead code | Report-only baseline | `vulture` capture added in `quality-baseline.yml`. |
+| Dependency architecture | Report-only baseline | `deptry` and `import-linter` capture added in `quality-baseline.yml`. |
+| Security depth | Report-only + active | `bandit` and `pip-audit` are now captured in `quality-baseline.yml`; `make security-audit` remains active. |
 | Documentation coverage | Partially active | Docs current-state tests exist; add docs-gap scoring later. |
 | Observability | Partially active | Observability contract validator exists; add runtime posture scoring later. |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T04:20:12+00:00`
+- Generated at: `2026-06-04T06:06:00+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `fafa839`
+- Current ref: `19bbdd1`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,11 +12,11 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 768 | 770 | +2 |
-| Total Python LOC | 145874 | 149079 | +3205 |
-| Test functions | 1855 | 1950 | +95 |
+| Python files | 772 | 772 | +0 |
+| Total Python LOC | 149604 | 149604 | +0 |
+| Test functions | 1958 | 1958 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
-| Router infrastructure imports | 18 | 18 | +0 |
+| Router infrastructure imports | 17 | 17 | +0 |
 
 ## Current OpenAPI Completeness
 
@@ -40,11 +40,11 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2099 |
+| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2140 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
 | 8 | src/core/dpm_source_context.py | 1878 |
-| 9 | tests/unit/dpm/api/test_construction_api.py | 1667 |
-| 10 | src/infrastructure/core_sourcing/client.py | 1639 |
+| 9 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 1727 |
+| 10 | tests/unit/dpm/api/test_construction_api.py | 1667 |
 
 ### current branch
 
@@ -69,14 +69,14 @@
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1546 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 754 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 465 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
-| 5 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
-| 6 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
-| 7 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
-| 8 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
-| 9 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
-| 10 | generate_intents | src/core/rebalance/intents.py | 236 |
+| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 382 |
+| 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
+| 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
+| 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
+| 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
+| 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
+| 9 | test_source_context_lifts_external_hedge_readiness_as_fail_closed_currency_context | tests/unit/dpm/construction/test_enrichment.py | 235 |
+| 10 | test_dpm_supportability_and_async_schemas_have_descriptions_and_examples | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 234 |
 
 ### current branch
 
@@ -105,10 +105,10 @@
 | 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 100 | 221 |
 | 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 95 | 382 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
-| 7 | _section_payload | src/core/proof_packs/builder.py | 85 | 465 |
-| 8 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
-| 9 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
-| 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+| 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
+| 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 72 | 133 |
+| 9 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
+| 10 | test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_posture | tests/unit/dpm/api/test_waves_api.py | 66 | 220 |
 
 ### current branch
 
@@ -147,7 +147,6 @@ No findings.
 - `src/api/routers/monitoring_run_once_routes.py:25: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
 - `src/api/routers/pm_operating_quality_book_scope_builder.py:24: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
 - `src/api/routers/pm_operating_quality_http.py:13: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
-- `src/api/routers/wave_core_portfolio_universe_resolution.py:19: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
 - `src/api/routers/wave_core_source_resolution.py:22: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
 - `src/api/routers/wave_create_preview_http.py:12: from src.infrastructure.advise_authority import LotusAdviseAuthorityClient`
 - `src/api/routers/wave_create_preview_http.py:13: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`
@@ -169,7 +168,6 @@ No findings.
 - `src/api/routers/monitoring_run_once_routes.py:25: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
 - `src/api/routers/pm_operating_quality_book_scope_builder.py:24: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
 - `src/api/routers/pm_operating_quality_http.py:13: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
-- `src/api/routers/wave_core_portfolio_universe_resolution.py:19: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
 - `src/api/routers/wave_core_source_resolution.py:22: from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError`
 - `src/api/routers/wave_create_preview_http.py:12: from src.infrastructure.advise_authority import LotusAdviseAuthorityClient`
 - `src/api/routers/wave_create_preview_http.py:13: from src.infrastructure.risk_authority import LotusRiskAuthorityClient`


### PR DESCRIPTION
## Summary
- Add repository baseline quality infrastructure for enterprise-readiness hardening (no functional behavior change).
- Add `.github/workflows/quality-baseline.yml`, `.spectral.yaml`, `.importlinter`.
- Add quality dependency group and bandit/deptry/interrogate/radon/vulture/import-linter/pip-audit config to `pyproject.toml`.
- Add quality/report docs (`quality/*.md`) and governance docs (`docs/architecture.md`, `docs/api-governance.md`, `docs/observability.md`, `docs/security.md`, `docs/operations-runbook.md`, `docs/supported-features.md`).
- Update CODEBASE review ledger and scorecard entries with this slice.

## Evidence
- python -m ruff check src/api/services/construction_source_product_context.py src/api/services/construction_service.py
- python -m mypy --config-file mypy.ini src/api/services src/core src/infrastructure
- python -m pytest tests/unit/dpm/construction/test_source_product_context.py tests/unit/test_engineering_health_report.py
- python -m pytest tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- python -m pytest -q tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py
- make check

## Boundary check
- rg scan for forbidden service-layer imports (src/api/services): no findings.

## Scope
Phase 1/report-only baseline only; no behavior changes.