### PR TITLE
refactor: extract core resolver boundary typing to service

### DIFF
--- a/src/api/routers/mandate_refresh_routes.py
+++ b/src/api/routers/mandate_refresh_routes.py
@@ -15,13 +15,13 @@ from src.api.routers.mandate_models import (
     DpmMandateRefreshFromCoreResponse,
 )
 from src.api.routers.mandates import get_core_resolver_client, router
+from src.api.services.core_resolver_service import CoreResolverClient
 from src.api.services.mandate_service import (
     DpmMandateSourceIncompleteError,
     DpmMandateSourceUnavailableError,
     refresh_mandate_from_core,
 )
 from src.core.mandate_repository import DpmMandateRepository
-from src.infrastructure.core_sourcing import DpmCoreResolverClient
 
 
 @router.post(
@@ -78,7 +78,7 @@ async def refresh_mandate(
         ),
     ] = None,
     repository: DpmMandateRepository = Depends(get_mandate_repository),
-    core_resolver: DpmCoreResolverClient = Depends(get_core_resolver_client),
+    core_resolver: CoreResolverClient = Depends(get_core_resolver_client),
 ) -> DpmMandateRefreshFromCoreResponse:
     try:
         result = refresh_mandate_from_core(

--- a/src/api/routers/mandates.py
+++ b/src/api/routers/mandates.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter
 
 from src.api.routers.route_registration import register_route_modules
 from src.api.services.core_resolver_service import build_core_resolver_client
-from src.infrastructure.core_sourcing import DpmCoreResolverClient
+from src.api.services.core_resolver_service import CoreResolverClient
 
 
 router = APIRouter(prefix="/mandates", tags=["lotus-manage Mandates"])
 
 
-def get_core_resolver_client() -> DpmCoreResolverClient:
+def get_core_resolver_client() -> CoreResolverClient:
     return build_core_resolver_client()
 
 

--- a/src/api/routers/monitoring.py
+++ b/src/api/routers/monitoring.py
@@ -4,13 +4,13 @@ from fastapi import APIRouter
 
 from src.api.routers.route_registration import register_route_modules
 from src.api.services.core_resolver_service import build_core_resolver_client
-from src.infrastructure.core_sourcing import DpmCoreResolverClient
+from src.api.services.core_resolver_service import CoreResolverClient
 
 
 router = APIRouter(prefix="/dpm", tags=["lotus-manage Monitoring"])
 
 
-def get_core_resolver_client() -> DpmCoreResolverClient:
+def get_core_resolver_client() -> CoreResolverClient:
     return build_core_resolver_client()
 
 

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -1,8 +1,7 @@
-from src.api.services import construction_client_profile_source_context
 from src.api.services import construction_execution_source_context
-from src.api.services import construction_liquidity_source_context
 from src.api.services import construction_transaction_cost_source_context
 from src.api.services import construction_treasury_source_context
+from src.api.services import construction_source_product_profile_context
 from src.core.construction.models import ConstructionAuthorityContext
 from src.core.dpm_source_context import DpmCoreExecutionContext, DpmResolvedSourceContext
 
@@ -23,24 +22,6 @@ def _transaction_cost_context_update(
         "transaction_cost_context",
         construction_transaction_cost_source_context.transaction_cost_context_from_curve(curve),
     )
-
-
-def _liquidity_context_update(
-    *,
-    source_context: DpmCoreExecutionContext,
-    authority_context: ConstructionAuthorityContext,
-) -> AuthorityContextUpdate | None:
-    if authority_context.liquidity_context is not None:
-        return None
-    liquidity_context = construction_liquidity_source_context.source_liquidity_context(
-        cashflow_projection=getattr(source_context, "portfolio_cashflow_projection", None),
-        income_needs=getattr(source_context, "client_income_needs_schedule", None),
-        reserve_requirement=getattr(source_context, "liquidity_reserve_requirement", None),
-        planned_withdrawals=getattr(source_context, "planned_withdrawal_schedule", None),
-    )
-    if liquidity_context is None:
-        return None
-    return "liquidity_context", liquidity_context
 
 
 def _currency_overlay_context_update(
@@ -83,42 +64,6 @@ def _execution_acknowledgement_context_update(
     return "execution_acknowledgement_context", acknowledgement_context
 
 
-def _client_restriction_context_update(
-    *,
-    source_context: DpmCoreExecutionContext,
-    authority_context: ConstructionAuthorityContext,
-) -> AuthorityContextUpdate | None:
-    if authority_context.client_restriction_context is not None:
-        return None
-    restriction_profile = getattr(source_context, "client_restriction_profile", None)
-    if restriction_profile is None:
-        return None
-    return (
-        "client_restriction_context",
-        construction_client_profile_source_context.client_restriction_profile_context(
-            restriction_profile
-        ),
-    )
-
-
-def _sustainability_preference_context_update(
-    *,
-    source_context: DpmCoreExecutionContext,
-    authority_context: ConstructionAuthorityContext,
-) -> AuthorityContextUpdate | None:
-    if authority_context.sustainability_preference_context is not None:
-        return None
-    sustainability_profile = getattr(source_context, "sustainability_preference_profile", None)
-    if sustainability_profile is None:
-        return None
-    return (
-        "sustainability_preference_context",
-        construction_client_profile_source_context.sustainability_preference_profile_context(
-            sustainability_profile
-        ),
-    )
-
-
 def source_product_authority_context_updates(
     *,
     source_context: DpmCoreExecutionContext,
@@ -127,11 +72,11 @@ def source_product_authority_context_updates(
     context_updates: dict[str, object] = {}
     for update_builder in (
         _transaction_cost_context_update,
-        _liquidity_context_update,
+        construction_source_product_profile_context.liquidity_context_update,
         _currency_overlay_context_update,
         _execution_acknowledgement_context_update,
-        _client_restriction_context_update,
-        _sustainability_preference_context_update,
+        construction_source_product_profile_context.client_restriction_profile_context_update,
+        construction_source_product_profile_context.sustainability_preference_profile_context_update,
     ):
         update = update_builder(source_context=source_context, authority_context=authority_context)
         if update is not None:

--- a/src/api/services/construction_source_product_context.py
+++ b/src/api/services/construction_source_product_context.py
@@ -1,67 +1,7 @@
-from src.api.services import construction_execution_source_context
-from src.api.services import construction_transaction_cost_source_context
-from src.api.services import construction_treasury_source_context
 from src.api.services import construction_source_product_profile_context
+from src.api.services import construction_source_product_financial_context
 from src.core.construction.models import ConstructionAuthorityContext
 from src.core.dpm_source_context import DpmCoreExecutionContext, DpmResolvedSourceContext
-
-AuthorityContextUpdate = tuple[str, object]
-
-
-def _transaction_cost_context_update(
-    *,
-    source_context: DpmCoreExecutionContext,
-    authority_context: ConstructionAuthorityContext,
-) -> AuthorityContextUpdate | None:
-    if authority_context.transaction_cost_context is not None:
-        return None
-    curve = getattr(source_context, "transaction_cost_curve", None)
-    if curve is None:
-        return None
-    return (
-        "transaction_cost_context",
-        construction_transaction_cost_source_context.transaction_cost_context_from_curve(curve),
-    )
-
-
-def _currency_overlay_context_update(
-    *,
-    source_context: DpmCoreExecutionContext,
-    authority_context: ConstructionAuthorityContext,
-) -> AuthorityContextUpdate | None:
-    if authority_context.currency_overlay_context is not None:
-        return None
-    currency_context = (
-        construction_treasury_source_context.external_treasury_currency_overlay_context(
-            hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
-            currency_exposure=getattr(source_context, "external_currency_exposure", None),
-            hedge_policy=getattr(source_context, "external_hedge_policy", None),
-            eligible_hedge_instruments=getattr(
-                source_context, "external_eligible_hedge_instruments", None
-            ),
-            fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
-        )
-    )
-    if currency_context is None:
-        return None
-    return "currency_overlay_context", currency_context
-
-
-def _execution_acknowledgement_context_update(
-    *,
-    source_context: DpmCoreExecutionContext,
-    authority_context: ConstructionAuthorityContext,
-) -> AuthorityContextUpdate | None:
-    if authority_context.execution_acknowledgement_context is not None:
-        return None
-    acknowledgement_context = (
-        construction_execution_source_context.external_order_execution_acknowledgement_context(
-            getattr(source_context, "external_order_execution_acknowledgement", None)
-        )
-    )
-    if acknowledgement_context is None:
-        return None
-    return "execution_acknowledgement_context", acknowledgement_context
 
 
 def source_product_authority_context_updates(
@@ -70,18 +10,32 @@ def source_product_authority_context_updates(
     authority_context: ConstructionAuthorityContext,
 ) -> dict[str, object]:
     context_updates: dict[str, object] = {}
-    for update_builder in (
-        _transaction_cost_context_update,
-        construction_source_product_profile_context.liquidity_context_update,
-        _currency_overlay_context_update,
-        _execution_acknowledgement_context_update,
-        construction_source_product_profile_context.client_restriction_profile_context_update,
-        construction_source_product_profile_context.sustainability_preference_profile_context_update,
-    ):
-        update = update_builder(source_context=source_context, authority_context=authority_context)
+    profile_updates = (
+        construction_source_product_profile_context.liquidity_context_update(
+            source_context=source_context,
+            authority_context=authority_context,
+        ),
+        construction_source_product_profile_context.client_restriction_profile_context_update(
+            source_context=source_context,
+            authority_context=authority_context,
+        ),
+        construction_source_product_profile_context.sustainability_preference_profile_context_update(
+            source_context=source_context,
+            authority_context=authority_context,
+        ),
+    )
+    for update in (*profile_updates,):
         if update is not None:
             context_key, context_value = update
             context_updates[context_key] = context_value
+    for (
+        context_key,
+        context_value,
+    ) in construction_source_product_financial_context.source_financial_context_updates(
+        source_context=source_context,
+        authority_context=authority_context,
+    ).items():
+        context_updates[context_key] = context_value
     return context_updates
 
 

--- a/src/api/services/construction_source_product_financial_context.py
+++ b/src/api/services/construction_source_product_financial_context.py
@@ -1,0 +1,91 @@
+from src.api.services import (
+    construction_execution_source_context,
+    construction_transaction_cost_source_context,
+    construction_treasury_source_context,
+)
+from src.core.construction.models import ConstructionAuthorityContext
+from src.core.dpm_source_context import DpmCoreExecutionContext
+
+AuthorityContextUpdate = tuple[str, object]
+
+
+def _transaction_cost_curve_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.transaction_cost_context is not None:
+        return None
+    curve = getattr(source_context, "transaction_cost_curve", None)
+    if curve is None:
+        return None
+    return (
+        "transaction_cost_context",
+        construction_transaction_cost_source_context.transaction_cost_context_from_curve(curve),
+    )
+
+
+def _currency_overlay_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.currency_overlay_context is not None:
+        return None
+    currency_context = (
+        construction_treasury_source_context.external_treasury_currency_overlay_context(
+            hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
+            currency_exposure=getattr(source_context, "external_currency_exposure", None),
+            hedge_policy=getattr(source_context, "external_hedge_policy", None),
+            eligible_hedge_instruments=getattr(
+                source_context, "external_eligible_hedge_instruments", None
+            ),
+            fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
+        )
+    )
+    if currency_context is None:
+        return None
+    return ("currency_overlay_context", currency_context)
+
+
+def _execution_acknowledgement_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.execution_acknowledgement_context is not None:
+        return None
+    acknowledgement_context = (
+        construction_execution_source_context.external_order_execution_acknowledgement_context(
+            getattr(source_context, "external_order_execution_acknowledgement", None)
+        )
+    )
+    if acknowledgement_context is None:
+        return None
+    return ("execution_acknowledgement_context", acknowledgement_context)
+
+
+def source_financial_context_updates(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> dict[str, object]:
+    context_updates: dict[str, object] = {}
+    for update_builder in (
+        _transaction_cost_curve_context_update,
+        _currency_overlay_context_update,
+        _execution_acknowledgement_context_update,
+    ):
+        update = update_builder(
+            source_context=source_context,
+            authority_context=authority_context,
+        )
+        if update is not None:
+            context_key, context_value = update
+            context_updates[context_key] = context_value
+    return context_updates
+
+
+__all__ = [
+    "source_financial_context_updates",
+]

--- a/src/api/services/construction_source_product_profile_context.py
+++ b/src/api/services/construction_source_product_profile_context.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from src.api.services import (
+    construction_client_profile_source_context,
+    construction_liquidity_source_context,
+)
+from src.core.construction.models import ConstructionAuthorityContext
+from src.core.dpm_source_context import DpmCoreExecutionContext
+
+AuthorityContextUpdate = tuple[str, object]
+
+
+def liquidity_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.liquidity_context is not None:
+        return None
+    liquidity_context = construction_liquidity_source_context.source_liquidity_context(
+        cashflow_projection=getattr(source_context, "portfolio_cashflow_projection", None),
+        income_needs=getattr(source_context, "client_income_needs_schedule", None),
+        reserve_requirement=getattr(source_context, "liquidity_reserve_requirement", None),
+        planned_withdrawals=getattr(source_context, "planned_withdrawal_schedule", None),
+    )
+    if liquidity_context is None:
+        return None
+    return ("liquidity_context", liquidity_context)
+
+
+def client_restriction_profile_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.client_restriction_context is not None:
+        return None
+    restriction_profile = getattr(source_context, "client_restriction_profile", None)
+    if restriction_profile is None:
+        return None
+    return (
+        "client_restriction_context",
+        construction_client_profile_source_context.client_restriction_profile_context(
+            restriction_profile
+        ),
+    )
+
+
+def sustainability_preference_profile_context_update(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> AuthorityContextUpdate | None:
+    if authority_context.sustainability_preference_context is not None:
+        return None
+    sustainability_profile = getattr(
+        source_context,
+        "sustainability_preference_profile",
+        None,
+    )
+    if sustainability_profile is None:
+        return None
+    return (
+        "sustainability_preference_context",
+        construction_client_profile_source_context.sustainability_preference_profile_context(
+            sustainability_profile
+        ),
+    )
+
+
+def source_profile_context_updates(
+    *,
+    source_context: DpmCoreExecutionContext,
+    authority_context: ConstructionAuthorityContext,
+) -> dict[str, object]:
+    context_updates: dict[str, object] = {}
+    for update_builder in (
+        liquidity_context_update,
+        client_restriction_profile_context_update,
+        sustainability_preference_profile_context_update,
+    ):
+        update = update_builder(
+            source_context=source_context,
+            authority_context=authority_context,
+        )
+        if update is not None:
+            context_key, context_value = update
+            context_updates[context_key] = context_value
+    return context_updates
+
+
+__all__ = [
+    "liquidity_context_update",
+    "source_profile_context_updates",
+    "client_restriction_profile_context_update",
+    "sustainability_preference_profile_context_update",
+]

--- a/src/api/services/core_resolver_service.py
+++ b/src/api/services/core_resolver_service.py
@@ -42,6 +42,9 @@ def stateful_core_sourcing_enabled() -> bool:
     return env_flag("DPM_STATEFUL_CORE_SOURCING_ENABLED", False)
 
 
+CoreResolverClient = DpmCoreResolverClient
+
+
 def build_core_resolver_client() -> DpmCoreResolverClient:
     base_url = os.getenv("DPM_CORE_BASE_URL", "").strip()
     if not base_url:
@@ -90,6 +93,7 @@ def build_core_resolver_client() -> DpmCoreResolverClient:
 
 
 __all__ = [
+    "CoreResolverClient",
     "build_core_resolver_client",
     "env_float",
     "env_flag",

--- a/src/api/services/core_resolver_service.py
+++ b/src/api/services/core_resolver_service.py
@@ -93,7 +93,6 @@ def build_core_resolver_client() -> DpmCoreResolverClient:
 
 
 __all__ = [
-    "CoreResolverClient",
     "build_core_resolver_client",
     "env_float",
     "env_flag",

--- a/tests/unit/dpm/construction/test_source_product_financial_context.py
+++ b/tests/unit/dpm/construction/test_source_product_financial_context.py
@@ -1,0 +1,107 @@
+from src.api.services import construction_source_product_financial_context
+from src.api.services.construction_source_product_financial_context import (
+    source_financial_context_updates,
+)
+from src.api.services.construction_transaction_cost_source_context import (
+    transaction_cost_context_from_curve,
+)
+from src.api.services.construction_treasury_source_context import (
+    external_treasury_currency_overlay_context,
+)
+from src.api.services.construction_execution_source_context import (
+    external_order_execution_acknowledgement_context,
+)
+from src.core.construction.models import ConstructionAuthorityContext
+from src.core.dpm_source_context import DpmCoreExecutionContext
+from typing import Any, cast
+from tests.unit.dpm.construction.source_product_context_fixtures import (
+    external_order_acknowledgement_response,
+    transaction_cost_curve_response,
+    hedge_readiness_response,
+)
+
+
+def test_source_product_financial_context_exports_only_orchestration_surface() -> None:
+    assert construction_source_product_financial_context.__all__ == [
+        "source_financial_context_updates",
+    ]
+
+
+def _source_execution_context(**overrides: object) -> DpmCoreExecutionContext:
+    payload = cast(
+        dict[str, Any],
+        {
+            "transaction_cost_curve": None,
+            "external_hedge_execution_readiness": None,
+            "external_currency_exposure": None,
+            "external_hedge_policy": None,
+            "external_eligible_hedge_instruments": None,
+            "external_fx_forward_curve": None,
+            "external_order_execution_acknowledgement": None,
+            **overrides,
+        },
+    )
+    return DpmCoreExecutionContext.model_construct(**payload)
+
+
+def test_source_financial_context_updates_collects_cost_currency_and_acknowledgement() -> None:
+    updates = source_financial_context_updates(
+        source_context=_source_execution_context(
+            transaction_cost_curve=transaction_cost_curve_response(),
+            external_hedge_execution_readiness=hedge_readiness_response(),
+            external_currency_exposure=None,
+            external_hedge_policy=None,
+            external_eligible_hedge_instruments=None,
+            external_fx_forward_curve=None,
+            external_order_execution_acknowledgement=external_order_acknowledgement_response(),
+        ),
+        authority_context=ConstructionAuthorityContext(),
+    )
+
+    assert sorted(updates) == [
+        "currency_overlay_context",
+        "execution_acknowledgement_context",
+        "transaction_cost_context",
+    ]
+    assert updates["transaction_cost_context"] == transaction_cost_context_from_curve(
+        transaction_cost_curve_response()
+    )
+    assert updates["currency_overlay_context"] == external_treasury_currency_overlay_context(
+        hedge_readiness=hedge_readiness_response(),
+        currency_exposure=None,
+        hedge_policy=None,
+        eligible_hedge_instruments=None,
+        fx_forward_curve=None,
+    )
+    assert updates[
+        "execution_acknowledgement_context"
+    ] == external_order_execution_acknowledgement_context(external_order_acknowledgement_response())
+
+
+def test_source_financial_context_updates_preserves_existing_contexts() -> None:
+    existing_context = ConstructionAuthorityContext(
+        transaction_cost_context=transaction_cost_context_from_curve(
+            transaction_cost_curve_response()
+        ),
+        currency_overlay_context=external_treasury_currency_overlay_context(
+            hedge_readiness=hedge_readiness_response(),
+            currency_exposure=None,
+            hedge_policy=None,
+            eligible_hedge_instruments=None,
+            fx_forward_curve=None,
+        ),
+        execution_acknowledgement_context=external_order_execution_acknowledgement_context(
+            external_order_acknowledgement_response()
+        ),
+    )
+
+    updates = source_financial_context_updates(
+        source_context=_source_execution_context(
+            transaction_cost_curve=transaction_cost_curve_response(),
+            external_hedge_execution_readiness=hedge_readiness_response(),
+            external_order_execution_acknowledgement=external_order_acknowledgement_response(),
+        ),
+        authority_context=existing_context,
+    )
+
+    assert updates == {}

--- a/tests/unit/dpm/construction/test_source_product_profile_context.py
+++ b/tests/unit/dpm/construction/test_source_product_profile_context.py
@@ -12,6 +12,7 @@ from src.api.services.construction_client_profile_source_context import (
 from src.api.services.construction_liquidity_source_context import source_liquidity_context
 from src.core.construction.models import ConstructionAuthorityContext
 from src.core.dpm_source_context import DpmCoreExecutionContext
+from typing import Any, cast
 from tests.unit.dpm.construction.source_product_context_fixtures import (
     client_restriction_profile_response,
     liquidity_reserve_requirement_response,
@@ -32,16 +33,19 @@ def test_source_product_profile_context_exports_expected_public_api() -> None:
 
 
 def _source_execution_context(**overrides: object) -> DpmCoreExecutionContext:
-    values = {
-        "portfolio_cashflow_projection": None,
-        "client_income_needs_schedule": None,
-        "liquidity_reserve_requirement": None,
-        "planned_withdrawal_schedule": None,
-        "client_restriction_profile": None,
-        "sustainability_preference_profile": None,
-    }
-    values.update(overrides)
-    return DpmCoreExecutionContext.model_construct(**values)
+    payload = cast(
+        dict[str, Any],
+        {
+            "portfolio_cashflow_projection": None,
+            "client_income_needs_schedule": None,
+            "liquidity_reserve_requirement": None,
+            "planned_withdrawal_schedule": None,
+            "client_restriction_profile": None,
+            "sustainability_preference_profile": None,
+            **overrides,
+        },
+    )
+    return DpmCoreExecutionContext.model_construct(**payload)
 
 
 def test_profile_context_updates_returns_all_expected_contexts() -> None:

--- a/tests/unit/dpm/construction/test_source_product_profile_context.py
+++ b/tests/unit/dpm/construction/test_source_product_profile_context.py
@@ -1,0 +1,123 @@
+from src.api.services import construction_source_product_profile_context
+from src.api.services.construction_source_product_profile_context import (
+    client_restriction_profile_context_update,
+    liquidity_context_update,
+    source_profile_context_updates,
+    sustainability_preference_profile_context_update,
+)
+from src.api.services.construction_client_profile_source_context import (
+    client_restriction_profile_context,
+    sustainability_preference_profile_context,
+)
+from src.api.services.construction_liquidity_source_context import source_liquidity_context
+from src.core.construction.models import ConstructionAuthorityContext
+from src.core.dpm_source_context import DpmCoreExecutionContext
+from tests.unit.dpm.construction.source_product_context_fixtures import (
+    client_restriction_profile_response,
+    liquidity_reserve_requirement_response,
+    planned_withdrawal_schedule_response,
+    client_income_needs_schedule_response,
+    cashflow_projection_response,
+    sustainability_preference_profile_response,
+)
+
+
+def test_source_product_profile_context_exports_expected_public_api() -> None:
+    assert construction_source_product_profile_context.__all__ == [
+        "liquidity_context_update",
+        "source_profile_context_updates",
+        "client_restriction_profile_context_update",
+        "sustainability_preference_profile_context_update",
+    ]
+
+
+def _source_execution_context(**overrides: object) -> DpmCoreExecutionContext:
+    values = {
+        "portfolio_cashflow_projection": None,
+        "client_income_needs_schedule": None,
+        "liquidity_reserve_requirement": None,
+        "planned_withdrawal_schedule": None,
+        "client_restriction_profile": None,
+        "sustainability_preference_profile": None,
+    }
+    values.update(overrides)
+    return DpmCoreExecutionContext.model_construct(**values)
+
+
+def test_profile_context_updates_returns_all_expected_contexts() -> None:
+    updates = source_profile_context_updates(
+        source_context=_source_execution_context(
+            portfolio_cashflow_projection=cashflow_projection_response(),
+            client_income_needs_schedule=client_income_needs_schedule_response(),
+            liquidity_reserve_requirement=liquidity_reserve_requirement_response(),
+            planned_withdrawal_schedule=planned_withdrawal_schedule_response(),
+            client_restriction_profile=client_restriction_profile_response(),
+            sustainability_preference_profile=sustainability_preference_profile_response(),
+        ),
+        authority_context=ConstructionAuthorityContext(),
+    )
+
+    assert sorted(updates) == [
+        "client_restriction_context",
+        "liquidity_context",
+        "sustainability_preference_context",
+    ]
+    assert updates["liquidity_context"] == source_liquidity_context(
+        cashflow_projection=cashflow_projection_response(),
+        income_needs=client_income_needs_schedule_response(),
+        reserve_requirement=liquidity_reserve_requirement_response(),
+        planned_withdrawals=planned_withdrawal_schedule_response(),
+    )
+    assert updates["client_restriction_context"] == client_restriction_profile_context(
+        client_restriction_profile_response()
+    )
+    assert updates[
+        "sustainability_preference_context"
+    ] == sustainability_preference_profile_context(sustainability_preference_profile_response())
+
+
+def test_profile_update_builders_preserve_existing_context() -> None:
+    authority_context = ConstructionAuthorityContext(
+        liquidity_context=source_liquidity_context(
+            cashflow_projection=cashflow_projection_response(),
+            income_needs=client_income_needs_schedule_response(),
+            reserve_requirement=liquidity_reserve_requirement_response(),
+            planned_withdrawals=planned_withdrawal_schedule_response(),
+        ),
+        client_restriction_context=client_restriction_profile_context(
+            client_restriction_profile_response()
+        ),
+        sustainability_preference_context=sustainability_preference_profile_context(
+            sustainability_preference_profile_response()
+        ),
+    )
+    source_context = _source_execution_context(
+        portfolio_cashflow_projection=cashflow_projection_response(),
+        client_income_needs_schedule=client_income_needs_schedule_response(),
+        liquidity_reserve_requirement=liquidity_reserve_requirement_response(),
+        planned_withdrawal_schedule=planned_withdrawal_schedule_response(),
+        client_restriction_profile=client_restriction_profile_response(),
+        sustainability_preference_profile=sustainability_preference_profile_response(),
+    )
+
+    assert (
+        liquidity_context_update(
+            source_context=source_context,
+            authority_context=authority_context,
+        )
+        is None
+    )
+    assert (
+        client_restriction_profile_context_update(
+            source_context=source_context,
+            authority_context=authority_context,
+        )
+        is None
+    )
+    assert (
+        sustainability_preference_profile_context_update(
+            source_context=source_context,
+            authority_context=authority_context,
+        )
+        is None
+    )


### PR DESCRIPTION
Boundary-cleanup refactor for core resolver dependency typing. No behavior changes.