### PR TITLE
refactor: route core resolver errors through service boundary

### DIFF
--- a/src/api/routers/monitoring_http.py
+++ b/src/api/routers/monitoring_http.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from fastapi import HTTPException, status
 
 from src.api.services.mandate_service import DpmMandateSourceIncompleteError
+from src.api.services.core_resolver_service import (
+    CoreResolverError,
+    CoreResolverUnavailableError,
+)
 from src.core.dpm_source_context import DpmCorePortfolioManagerBookMembershipResponse
-from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
 
 
 def monitoring_selector_required_http_exception() -> HTTPException:
@@ -28,7 +31,7 @@ def monitoring_pm_book_portfolio_types_required_http_exception() -> HTTPExceptio
 
 
 def monitoring_core_resolver_unavailable_http_exception(
-    exc: DpmCoreResolverUnavailableError,
+    exc: CoreResolverUnavailableError,
 ) -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -36,7 +39,7 @@ def monitoring_core_resolver_unavailable_http_exception(
     )
 
 
-def monitoring_core_resolver_incomplete_http_exception(exc: DpmCoreResolverError) -> HTTPException:
+def monitoring_core_resolver_incomplete_http_exception(exc: CoreResolverError) -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_424_FAILED_DEPENDENCY,
         detail={"code": str(exc) or "DPM_CORE_PM_BOOK_MEMBERSHIP_INCOMPLETE"},

--- a/src/api/routers/monitoring_run_once_routes.py
+++ b/src/api/routers/monitoring_run_once_routes.py
@@ -20,9 +20,12 @@ from src.api.services.mandate_service import (
     mandate_ids_from_pm_book_membership,
     run_mandate_monitoring_once,
 )
+from src.api.services.core_resolver_service import (
+    CoreResolverError,
+    CoreResolverUnavailableError,
+)
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import DpmMonitoringRun
-from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
 
 
 @monitoring_router.router.post(
@@ -66,9 +69,9 @@ async def run_once(
                 include_inactive=False,
                 correlation_id=None,
             )
-        except DpmCoreResolverUnavailableError as exc:
+        except CoreResolverUnavailableError as exc:
             raise monitoring_core_resolver_unavailable_http_exception(exc) from exc
-        except DpmCoreResolverError as exc:
+        except CoreResolverError as exc:
             raise monitoring_core_resolver_incomplete_http_exception(exc) from exc
         if membership.supportability.state != "READY":
             raise monitoring_pm_book_membership_not_ready_http_exception(membership)

--- a/src/api/routers/pm_operating_quality_book_scope_builder.py
+++ b/src/api/routers/pm_operating_quality_book_scope_builder.py
@@ -21,7 +21,10 @@ from src.core.pm_quality import (
     DpmPmQualityBookScopeEvidence,
     DpmPmQualityEvidenceItem,
 )
-from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
+from src.api.services.core_resolver_service import (
+    CoreResolverError,
+    CoreResolverUnavailableError,
+)
 
 
 def resolve_pm_book_scope_evidence(
@@ -48,9 +51,9 @@ def resolve_pm_book_scope_evidence(
             include_inactive=scope.include_inactive,
             correlation_id=correlation_id,
         )
-    except DpmCoreResolverUnavailableError as exc:
+    except CoreResolverUnavailableError as exc:
         raise pm_quality_core_resolver_unavailable_http_exception(exc) from exc
-    except DpmCoreResolverError as exc:
+    except CoreResolverError as exc:
         raise pm_quality_core_resolver_incomplete_http_exception(exc) from exc
 
     if membership.supportability.state != "READY":

--- a/src/api/routers/pm_operating_quality_http.py
+++ b/src/api/routers/pm_operating_quality_http.py
@@ -10,7 +10,10 @@ from src.core.pm_quality import (
     DpmPmQualitySummaryInvocationConflictError,
 )
 from src.core.dpm_source_context import DpmCorePortfolioManagerBookMembershipResponse
-from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
+from src.api.services.core_resolver_service import (
+    CoreResolverError,
+    CoreResolverUnavailableError,
+)
 
 PmQualityConflictError = (
     DpmPmQualityScoreRunConflictError
@@ -42,7 +45,7 @@ def pm_quality_validation_http_exception(detail: str | Exception) -> HTTPExcepti
 
 
 def pm_quality_core_resolver_unavailable_http_exception(
-    exc: DpmCoreResolverUnavailableError,
+    exc: CoreResolverUnavailableError,
 ) -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -50,7 +53,7 @@ def pm_quality_core_resolver_unavailable_http_exception(
     )
 
 
-def pm_quality_core_resolver_incomplete_http_exception(exc: DpmCoreResolverError) -> HTTPException:
+def pm_quality_core_resolver_incomplete_http_exception(exc: CoreResolverError) -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_424_FAILED_DEPENDENCY,
         detail={"code": str(exc) or "DPM_CORE_PM_BOOK_MEMBERSHIP_INCOMPLETE"},

--- a/src/api/routers/wave_core_source_resolution.py
+++ b/src/api/routers/wave_core_source_resolution.py
@@ -19,7 +19,10 @@ from src.api.routers.wave_source_dependency_http import (
     upstream_unavailable_http_exception,
 )
 from src.api.services import wave_service
-from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
+from src.api.services.core_resolver_service import (
+    CoreResolverError,
+    CoreResolverUnavailableError,
+)
 
 
 CoreResolverFactory = Callable[[], Any]
@@ -57,12 +60,12 @@ def resolve_pm_book_portfolios(
             include_inactive=False,
             correlation_id=correlation_id,
         )
-    except DpmCoreResolverUnavailableError as exc:
+    except CoreResolverUnavailableError as exc:
         raise upstream_unavailable_http_exception(
             exc,
             default_code="DPM_CORE_PM_BOOK_MEMBERSHIP_UNAVAILABLE",
         ) from exc
-    except DpmCoreResolverError as exc:
+    except CoreResolverError as exc:
         raise upstream_dependency_failed_http_exception(
             exc,
             default_code="DPM_CORE_PM_BOOK_MEMBERSHIP_INCOMPLETE",
@@ -106,12 +109,12 @@ def resolve_cio_model_change_portfolios(
             include_inactive_mandates=False,
             correlation_id=correlation_id,
         )
-    except DpmCoreResolverUnavailableError as exc:
+    except CoreResolverUnavailableError as exc:
         raise upstream_unavailable_http_exception(
             exc,
             default_code="DPM_CORE_CIO_MODEL_CHANGE_COHORT_UNAVAILABLE",
         ) from exc
-    except DpmCoreResolverError as exc:
+    except CoreResolverError as exc:
         raise upstream_dependency_failed_http_exception(
             exc,
             default_code="DPM_CORE_CIO_MODEL_CHANGE_COHORT_INCOMPLETE",

--- a/src/api/services/core_resolver_service.py
+++ b/src/api/services/core_resolver_service.py
@@ -6,6 +6,7 @@ from src.infrastructure.core_sourcing import (
     DpmCoreResolverClient,
     DpmCoreResolverConfig,
     DpmCoreResolverUnavailableError,
+    DpmCoreResolverError,
 )
 
 
@@ -43,6 +44,8 @@ def stateful_core_sourcing_enabled() -> bool:
 
 
 CoreResolverClient = DpmCoreResolverClient
+CoreResolverError = DpmCoreResolverError
+CoreResolverUnavailableError = DpmCoreResolverUnavailableError
 
 
 def build_core_resolver_client() -> DpmCoreResolverClient:


### PR DESCRIPTION
Boundary cleanup commit. Keep behavior unchanged; move core-sourcing error typing behind core_resolver_service and remove infra error imports from selected routers.