### PR TITLE
refactor(routing): route wave authority types behind services

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -12726,3 +12726,24 @@ and improves internal transaction-cost source posture maintainability only.
   `rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP" src/api/services -g "*.py"`,
   `git diff --check`.
 - Wiki decision: no wiki source change required; slice is repository-local quality governance scaffolding.
+
+## BACKEND-REVIEW-20260604-517: Wave authority client boundary aliases routed through services
+
+- Date: 2026-06-04
+- Scope: `src/api/services/authority_client_service.py`, `src/api/routers/construction_generate_routes.py`,
+  `src/api/routers/wave_simulation_routes.py`, `src/api/routers/wave_simulation_http.py`,
+  `src/api/routers/wave_create_preview_routes.py`, `src/api/routers/wave_create_preview_http.py`,
+  `src/api/routers/wave_portfolio_resolution.py`.
+- Finding: wave construction/simulation and portfolio-resolution routers imported concrete authority client and
+  unavailable-error types directly from infrastructure modules, creating brittle route-level coupling.
+- Action: introduced a dedicated authority-client service alias module and migrated wave router signatures and
+  exception catch points to these service aliases, preserving behavior while reducing infrastructure coupling at
+  router boundaries.
+- Status: hardened
+- Evidence: `python -m ruff check` on touched files, `python -m ruff format --check` on touched files,
+  `python -m mypy --config-file mypy.ini` on touched files, `python -m pytest tests/unit/api/test_wave_source_dependency_http.py
+  tests/unit/api/test_wave_http_errors.py tests/unit/dpm/api/test_waves_api.py`, `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`, `python -m ruff format` touched files, `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP"`
+  `src/api/services -g "*.py"`).
+- Wiki decision: no wiki source change required; this is an internal service-boundary refactor.

--- a/src/api/routers/construction_generate_routes.py
+++ b/src/api/routers/construction_generate_routes.py
@@ -19,10 +19,10 @@ from src.api.routers.rebalance_simulation_http import rebalance_envelope_http_ex
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services import construction_service
 from src.api.services import rebalance_simulation_service
+from src.api.services.authority_client_service import RiskAuthorityClient
 from src.core.construction.models import ConstructionAlternativeSet
 from src.core.construction.repository import ConstructionRepository
 from src.core.rebalance_runs.service import DpmRunSupportService
-from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 
 @router.post(
@@ -63,7 +63,7 @@ def generate_alternative_set(
         ),
     ] = None,
     repository: ConstructionRepository = Depends(get_construction_repository),
-    risk_authority_client: LotusRiskAuthorityClient | None = Depends(get_risk_authority_client),
+    risk_authority_client: RiskAuthorityClient | None = Depends(get_risk_authority_client),
     run_service: DpmRunSupportService = Depends(get_dpm_run_support_service),
     db: Annotated[None, Depends(get_db_session)] = None,
 ) -> ConstructionAlternativeSet:

--- a/src/api/routers/wave_create_preview_http.py
+++ b/src/api/routers/wave_create_preview_http.py
@@ -9,8 +9,10 @@ from src.api.routers.wave_response_contracts import DpmWaveResponse, wave_respon
 from src.api.services import wave_service
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.waves import DpmBulkReviewCampaignDefinitionRepository, DpmWaveRepository
-from src.infrastructure.advise_authority import LotusAdviseAuthorityClient
-from src.infrastructure.risk_authority import LotusRiskAuthorityClient
+from src.api.services.authority_client_service import (
+    AdviseAuthorityClient,
+    RiskAuthorityClient,
+)
 
 
 def preview_wave_response(
@@ -18,8 +20,8 @@ def preview_wave_response(
     request: DpmWavePreviewRequest,
     correlation_id: str,
     mandate_repository: DpmMandateRepository,
-    advise_authority_client: LotusAdviseAuthorityClient | None,
-    risk_authority_client: LotusRiskAuthorityClient | None,
+    advise_authority_client: AdviseAuthorityClient | None,
+    risk_authority_client: RiskAuthorityClient | None,
     campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository,
     core_resolver_factory: Callable[[], object],
 ) -> DpmWaveResponse:
@@ -54,8 +56,8 @@ def create_wave_response(
     correlation_id: str,
     mandate_repository: DpmMandateRepository,
     wave_repository: DpmWaveRepository,
-    advise_authority_client: LotusAdviseAuthorityClient | None,
-    risk_authority_client: LotusRiskAuthorityClient | None,
+    advise_authority_client: AdviseAuthorityClient | None,
+    risk_authority_client: RiskAuthorityClient | None,
     campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository,
     core_resolver_factory: Callable[[], object],
 ) -> DpmWaveResponse:

--- a/src/api/routers/wave_create_preview_routes.py
+++ b/src/api/routers/wave_create_preview_routes.py
@@ -20,13 +20,15 @@ from src.api.routers.wave_route_parameters import (
     WaveCreateIdempotencyKeyHeader,
 )
 from src.api.services.core_resolver_service import build_core_resolver_client
+from src.api.services.authority_client_service import (
+    AdviseAuthorityClient,
+    RiskAuthorityClient,
+)
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.waves import (
     DpmBulkReviewCampaignDefinitionRepository,
     DpmWaveRepository,
 )
-from src.infrastructure.advise_authority import LotusAdviseAuthorityClient
-from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 
 def register_wave_create_preview_routes(
@@ -86,10 +88,10 @@ def register_wave_create_preview_routes(
         request: DpmWavePreviewRequest,
         x_correlation_id: WaveCorrelationIdHeader = None,
         mandate_repository: DpmMandateRepository = Depends(get_mandate_repository),
-        advise_authority_client: LotusAdviseAuthorityClient | None = Depends(
+        advise_authority_client: AdviseAuthorityClient | None = Depends(
             get_advise_authority_client
         ),
-        risk_authority_client: LotusRiskAuthorityClient | None = Depends(get_risk_authority_client),
+        risk_authority_client: RiskAuthorityClient | None = Depends(get_risk_authority_client),
         campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository = Depends(
             get_campaign_definition_repository
         ),
@@ -167,10 +169,10 @@ def register_wave_create_preview_routes(
         x_correlation_id: WaveCorrelationIdHeader = None,
         mandate_repository: DpmMandateRepository = Depends(get_mandate_repository),
         wave_repository: DpmWaveRepository = Depends(get_wave_repository),
-        advise_authority_client: LotusAdviseAuthorityClient | None = Depends(
+        advise_authority_client: AdviseAuthorityClient | None = Depends(
             get_advise_authority_client
         ),
-        risk_authority_client: LotusRiskAuthorityClient | None = Depends(get_risk_authority_client),
+        risk_authority_client: RiskAuthorityClient | None = Depends(get_risk_authority_client),
         campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository = Depends(
             get_campaign_definition_repository
         ),

--- a/src/api/routers/wave_portfolio_resolution.py
+++ b/src/api/routers/wave_portfolio_resolution.py
@@ -35,13 +35,11 @@ from src.api.routers.wave_tactical_candidate_selection import (
 )
 from src.api.services import wave_service
 from src.core.waves import DpmBulkReviewCampaignDefinitionRepository
-from src.infrastructure.advise_authority import (
-    LotusAdviseAuthorityClient,
-    LotusAdviseAuthorityUnavailableError,
-)
-from src.infrastructure.risk_authority import (
-    LotusRiskAuthorityClient,
-    LotusRiskAuthorityUnavailableError,
+from src.api.services.authority_client_service import (
+    AdviseAuthorityClient,
+    AdviseAuthorityUnavailableError,
+    RiskAuthorityClient,
+    RiskAuthorityUnavailableError,
 )
 
 
@@ -49,8 +47,8 @@ def resolve_portfolio_inputs_for_request(
     *,
     request: DpmWavePreviewRequest,
     correlation_id: str,
-    advise_authority_client: LotusAdviseAuthorityClient | None,
-    risk_authority_client: LotusRiskAuthorityClient | None,
+    advise_authority_client: AdviseAuthorityClient | None,
+    risk_authority_client: RiskAuthorityClient | None,
     campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository,
     core_resolver_factory: Callable[[], object],
 ) -> list[dict[str, object]]:
@@ -97,7 +95,7 @@ def _resolve_tactical_house_view_portfolios(
     *,
     request: DpmWavePreviewRequest,
     correlation_id: str,
-    advise_authority_client: LotusAdviseAuthorityClient | None,
+    advise_authority_client: AdviseAuthorityClient | None,
 ) -> list[dict[str, object]]:
     tactical_view = request.tactical_house_view
     if tactical_view is None:
@@ -150,7 +148,7 @@ def _resolve_tactical_house_view_portfolios(
             ),
             correlation_id=correlation_id,
         )
-    except LotusAdviseAuthorityUnavailableError as exc:
+    except AdviseAuthorityUnavailableError as exc:
         raise source_authority_unavailable_http_exception(
             exc,
             default_code="DPM_TACTICAL_HOUSE_VIEW_COHORT_UNAVAILABLE",
@@ -178,7 +176,7 @@ def _resolve_risk_event_portfolios(
     *,
     request: DpmWavePreviewRequest,
     correlation_id: str,
-    risk_authority_client: LotusRiskAuthorityClient | None,
+    risk_authority_client: RiskAuthorityClient | None,
 ) -> list[dict[str, object]]:
     risk_event_id = normalize_required_text(
         request.risk_event_id,
@@ -207,7 +205,7 @@ def _resolve_risk_event_portfolios(
             minimum_impact_score=Decimal(str(request.minimum_impact_score)),
             correlation_id=correlation_id,
         )
-    except LotusRiskAuthorityUnavailableError as exc:
+    except RiskAuthorityUnavailableError as exc:
         raise source_authority_unavailable_http_exception(
             exc,
             default_code="DPM_RISK_EVENT_COHORT_UNAVAILABLE",

--- a/src/api/routers/wave_simulation_http.py
+++ b/src/api/routers/wave_simulation_http.py
@@ -8,10 +8,10 @@ from src.api.routers.wave_http_errors import (
 from src.api.routers.wave_request_models import DpmWaveSimulationRequest
 from src.api.routers.wave_response_contracts import DpmWaveResponse, wave_response
 from src.api.services import wave_service
+from src.api.services.authority_client_service import RiskAuthorityClient
 from src.core.construction.repository import ConstructionRepository
 from src.core.rebalance_runs.service import DpmRunSupportService
 from src.core.waves import DpmWaveRepository
-from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 
 def build_wave_simulation_item_inputs(
@@ -38,7 +38,7 @@ def simulate_wave_response(
     construction_repository: ConstructionRepository,
     run_service: DpmRunSupportService,
     wave_repository: DpmWaveRepository,
-    risk_authority_client: LotusRiskAuthorityClient | None,
+    risk_authority_client: RiskAuthorityClient | None,
 ) -> DpmWaveResponse:
     try:
         wave, replayed = wave_service.simulate_wave(

--- a/src/api/routers/wave_simulation_routes.py
+++ b/src/api/routers/wave_simulation_routes.py
@@ -12,10 +12,10 @@ from src.api.routers.wave_request_models import DpmWaveSimulationRequest
 from src.api.routers.wave_response_contracts import DpmWaveResponse
 from src.api.routers.wave_route_parameters import WaveCorrelationIdHeader, WaveIdPath
 from src.api.routers.wave_simulation_http import simulate_wave_response
+from src.api.services.authority_client_service import RiskAuthorityClient
 from src.core.construction.repository import ConstructionRepository
 from src.core.rebalance_runs.service import DpmRunSupportService
 from src.core.waves import DpmWaveRepository
-from src.infrastructure.risk_authority import LotusRiskAuthorityClient
 
 
 router = APIRouter()
@@ -45,7 +45,7 @@ def simulate_wave(
     request: DpmWaveSimulationRequest,
     x_correlation_id: WaveCorrelationIdHeader = None,
     construction_repository: ConstructionRepository = Depends(get_construction_repository),
-    risk_authority_client: LotusRiskAuthorityClient | None = Depends(get_risk_authority_client),
+    risk_authority_client: RiskAuthorityClient | None = Depends(get_risk_authority_client),
     run_service: DpmRunSupportService = Depends(get_dpm_run_support_service),
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:

--- a/src/api/services/authority_client_service.py
+++ b/src/api/services/authority_client_service.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from src.infrastructure.advise_authority import (
+    LotusAdviseAuthorityClient,
+    LotusAdviseAuthorityUnavailableError,
+)
+from src.infrastructure.risk_authority import (
+    LotusRiskAuthorityClient,
+    LotusRiskAuthorityUnavailableError,
+)
+
+AdviseAuthorityClient = LotusAdviseAuthorityClient
+AdviseAuthorityUnavailableError = LotusAdviseAuthorityUnavailableError
+RiskAuthorityClient = LotusRiskAuthorityClient
+RiskAuthorityUnavailableError = LotusRiskAuthorityUnavailableError
+
+__all__ = [
+    "AdviseAuthorityClient",
+    "AdviseAuthorityUnavailableError",
+    "RiskAuthorityClient",
+    "RiskAuthorityUnavailableError",
+]

--- a/tests/unit/api/test_authority_client_service.py
+++ b/tests/unit/api/test_authority_client_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from src.api.services import authority_client_service
+from src.api.services.authority_client_service import (
+    AdviseAuthorityClient,
+    AdviseAuthorityUnavailableError,
+    RiskAuthorityClient,
+    RiskAuthorityUnavailableError,
+)
+from src.infrastructure.advise_authority import (
+    LotusAdviseAuthorityClient,
+    LotusAdviseAuthorityUnavailableError,
+)
+from src.infrastructure.risk_authority import (
+    LotusRiskAuthorityClient,
+    LotusRiskAuthorityUnavailableError,
+)
+
+
+def test_authority_client_service_exports_aliases() -> None:
+    assert AdviseAuthorityClient is LotusAdviseAuthorityClient
+    assert AdviseAuthorityUnavailableError is LotusAdviseAuthorityUnavailableError
+    assert RiskAuthorityClient is LotusRiskAuthorityClient
+    assert RiskAuthorityUnavailableError is LotusRiskAuthorityUnavailableError
+    assert authority_client_service.__all__ == [
+        "AdviseAuthorityClient",
+        "AdviseAuthorityUnavailableError",
+        "RiskAuthorityClient",
+        "RiskAuthorityUnavailableError",
+    ]


### PR DESCRIPTION
## Summary
- Move wave authority client and unavailable-error types behind a dedicated `src.api.services.authority_client_service` alias module.
- Update wave-related routers to consume service aliases (`RiskAuthorityClient`, `AdviseAuthorityClient`, `RiskAuthorityUnavailableError`, `AdviseAuthorityUnavailableError`).
- Add direct `tests/unit/api/test_authority_client_service.py` proving alias surface and __all__.
- Add CODEBASE review ledger entry `BACKEND-REVIEW-20260604-517`.

## Validation
- `python -m ruff check` on touched files
- `python -m ruff format --check` on touched files
- `python -m mypy --config-file mypy.ini` on touched src files
- `python -m pytest tests/unit/api/test_authority_client_service.py tests/unit/api/test_wave_source_dependency_http.py tests/unit/api/test_wave_http_errors.py tests/unit/dpm/api/test_waves_api.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan for router/API-layer imports in services