### PR TITLE
refactor(routing): route construction service risk client through alias

### DIFF
--- a/src/api/services/construction_service.py
+++ b/src/api/services/construction_service.py
@@ -17,6 +17,7 @@ from src.api.services.construction_selection import build_construction_selection
 from src.api.services.construction_source_product_context import (
     authority_context_with_source_products,
 )
+from src.api.services.authority_client_service import RiskAuthorityClient
 from src.core.common.capabilities import has_solver_dependencies as has_solver_dependencies
 from src.core.construction.models import (
     ConstructionAlternativeSelection,
@@ -36,9 +37,13 @@ from src.core.dpm_source_context import (
 )
 from src.core.rebalance_runs.service import DpmRunSupportService
 from src.api.request_models import RebalanceRequest
-from src.infrastructure.risk_authority import (
-    LotusRiskAuthorityClient,
-)
+
+__all__ = [
+    "generate_construction_alternative_set",
+    "get_construction_alternative_set",
+    "select_construction_alternative",
+    "RiskAuthorityClient",
+]
 
 
 def generate_construction_alternative_set(
@@ -50,7 +55,7 @@ def generate_construction_alternative_set(
     methods: list[ConstructionMethod] | None = None,
     source_context: Optional[DpmResolvedSourceContext] = None,
     authority_context: ConstructionAuthorityContext | None = None,
-    risk_authority_client: LotusRiskAuthorityClient | None = None,
+    risk_authority_client: RiskAuthorityClient | None = None,
     run_service: DpmRunSupportService | None = None,
 ) -> ConstructionAlternativeSet:
     method_set = list(methods or FIRST_WAVE_CONSTRUCTION_METHODS)

--- a/tests/unit/api/test_construction_service_boundary.py
+++ b/tests/unit/api/test_construction_service_boundary.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import get_type_hints
+
+from src.api.services import authority_client_service, construction_service
+
+
+def test_construction_service_exposes_authority_client_aliases() -> None:
+    assert construction_service.RiskAuthorityClient is authority_client_service.RiskAuthorityClient
+    assert "RiskAuthorityClient" in construction_service.__all__
+
+
+def test_construction_service_generate_alt_set_signature_uses_alias() -> None:
+    annotations = get_type_hints(construction_service.generate_construction_alternative_set)
+    risk_client_annotation = annotations["risk_authority_client"]
+    assert risk_client_annotation == (construction_service.RiskAuthorityClient | None)


### PR DESCRIPTION
## Summary
- Move `construction_service` from directly typing against `src.infrastructure.risk_authority.LotusRiskAuthorityClient` to the boundary alias exported by `src.api.services.authority_client_service`.
- Add `__all__` export for `RiskAuthorityClient` in `construction_service` for direct alias surface proof.
- Add regression tests in `tests/unit/api/test_construction_service_boundary.py` validating alias identity and signature typing through the service boundary.

## Validation
- `python -m ruff check src/api/services/construction_service.py tests/unit/api/test_construction_service_boundary.py`
- `python -m ruff format --check` on touched files
- `python -m mypy --config-file mypy.ini src/api/services/construction_service.py`
- `python -m pytest tests/unit/api/test_construction_service_boundary.py tests/unit/api/test_authority_client_service.py tests/unit/api/test_wave_source_dependency_http.py tests/unit/api/test_wave_http_errors.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan for router/API-layer imports in services