### PR TITLE
Enterprise backend refactor quality checkpoint

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14490,3 +14490,25 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal proof-pack router
   error-translation hardening.
+
+## BACKEND-REVIEW-20260604-595: Campaign repository protocol bodies clarified
+
+- Date: 2026-06-04
+- Scope: `src/core/waves/campaign_repository.py`.
+- Finding: the bulk-review campaign definition repository is a `Protocol`, but its method bodies
+  raised `NotImplementedError`, creating stale scan noise and diverging from the repository
+  contract style used by other Lotus Manage protocols.
+- Action: replaced protocol method raises with concise contract docstrings, preserving the same
+  structural typing surface while eliminating abstract-runtime placeholders from the core scan.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_repository.py`,
+  `python -m ruff format --check src/core/waves/campaign_repository.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_repository.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_definition_repository.py tests/unit/dpm/portfolio_memory/test_campaign_collection.py tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal repository protocol
+  contract cleanup.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14463,3 +14463,30 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal construction router
   error-translation hardening.
+
+## BACKEND-REVIEW-20260604-594: Proof-pack router error translation narrowed
+
+- Date: 2026-06-04
+- Scope: `src/api/routers/proof_pack_http.py`,
+  `src/api/routers/proof_pack_generate_routes.py`,
+  `src/api/routers/proof_pack_read_routes.py`,
+  `src/api/routers/proof_pack_handoff_routes.py`, and
+  `tests/unit/dpm/api/test_proof_pack_api.py`.
+- Finding: proof-pack router endpoints caught every service exception and mapped unexpected
+  runtime failures into generic proof-pack HTTP responses, obscuring defects that should surface
+  during tests and CI.
+- Action: introduced a shared `PROOF_PACK_ROUTE_ERRORS` tuple for mapped proof-pack domain errors,
+  narrowed generate/read/handoff route catches to that tuple, removed duplicate HTTPException
+  reconstruction, and updated API coverage to prove unexpected service failures are not hidden.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/proof_pack_http.py src/api/routers/proof_pack_generate_routes.py src/api/routers/proof_pack_read_routes.py src/api/routers/proof_pack_handoff_routes.py tests/unit/dpm/api/test_proof_pack_api.py`,
+  `python -m ruff format --check src/api/routers/proof_pack_http.py src/api/routers/proof_pack_generate_routes.py src/api/routers/proof_pack_read_routes.py src/api/routers/proof_pack_handoff_routes.py tests/unit/dpm/api/test_proof_pack_api.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/proof_pack_http.py src/api/routers/proof_pack_generate_routes.py src/api/routers/proof_pack_read_routes.py src/api/routers/proof_pack_handoff_routes.py`,
+  `python -m pytest tests/unit/dpm/api/test_proof_pack_api.py::test_generate_proof_pack_preserves_governed_http_exceptions tests/unit/dpm/api/test_proof_pack_api.py::test_generate_proof_pack_does_not_hide_unexpected_service_exceptions tests/unit/dpm/api/test_proof_pack_api.py::test_proof_pack_read_routes_return_404_for_missing_pack -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal proof-pack router
+  error-translation hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15075,3 +15075,30 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-620: Valuation simulated-state helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/valuation.py` and
+  `tests/unit/dpm/engine/test_engine_valuation_service.py`.
+- Finding: `build_simulated_state` still mixed option defaulting, position valuation, price/FX
+  data-quality logging, cash conversion, safe-total handling, asset-class aggregation, attribute
+  aggregation, and response model assembly in one function.
+- Action: extracted `_valuation_options`, `_valued_position_summaries`,
+  `_record_position_fx_gap`, `_total_cash_value`, `_safe_total_value`, `_allocation_metric`,
+  `_position_allocation_maps`, `_add_attribute_allocations`, `_allocation_metrics`, and
+  `_allocation_by_attribute_metrics`. Kept `build_simulated_state` as the orchestration point and
+  added direct helper tests for price/FX data-quality capture plus shelf-backed allocation
+  aggregation.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/valuation.py tests/unit/dpm/engine/test_engine_valuation_service.py`,
+  `python -m ruff format --check src/core/valuation.py tests/unit/dpm/engine/test_engine_valuation_service.py`,
+  `python -m mypy --config-file mypy.ini src/core/valuation.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_valuation_service.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal valuation maintainability
+  refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14683,3 +14683,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal construction client-profile
   source-product mapping maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-603: Financial source currency-overlay inputs extracted
+
+- Date: 2026-06-04
+- Scope: `src/api/services/construction_source_product_financial_context.py` and
+  `tests/unit/dpm/construction/test_source_product_financial_context.py`.
+- Finding: `currency_overlay_context_update` pulled five external treasury source-product fields
+  from `DpmCoreExecutionContext` inline before calling the treasury mapper, making the
+  source-field boundary implicit.
+- Action: introduced `CurrencyOverlaySourceInputs` and `currency_overlay_source_inputs`, kept
+  `currency_overlay_context_update` as the authority-context update coordinator, and added a
+  direct test for source-input capture and absent-source preservation.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_source_product_financial_context.py tests/unit/dpm/construction/test_source_product_financial_context.py`,
+  `python -m ruff format --check src/api/services/construction_source_product_financial_context.py tests/unit/dpm/construction/test_source_product_financial_context.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_source_product_financial_context.py`,
+  `python -m pytest tests/unit/dpm/construction/test_source_product_financial_context.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal construction financial
+  source-product mapping maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14893,3 +14893,29 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-612: Portfolio-memory search item metadata validators extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/portfolio_memory/models.py` and
+  `tests/unit/dpm/portfolio_memory/test_search_page.py`.
+- Finding: `_validate_search_item_metadata` still combined count reconciliation, aggregate
+  ordering, empty/non-empty latest-event posture, and latest matching-event posture in one
+  high-complexity validator, making search-result metadata invariants harder to inspect and test
+  independently.
+- Action: extracted `_validate_search_item_counts`,
+  `_validate_search_item_sorted_aggregates`, `_validate_search_item_latest_event_metadata`, and
+  `_validate_search_item_latest_matching_event_metadata`. Added direct tests for each helper edge
+  while preserving the existing Pydantic search-item validation behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/portfolio_memory/models.py tests/unit/dpm/portfolio_memory/test_search_page.py`,
+  `python -m ruff format --check src/core/portfolio_memory/models.py tests/unit/dpm/portfolio_memory/test_search_page.py`,
+  `python -m mypy --config-file mypy.ini src/core/portfolio_memory/models.py`,
+  `python -m pytest tests/unit/dpm/portfolio_memory/test_search_page.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal portfolio-memory metadata
+  validation maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14939,3 +14939,27 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-614: Compliance rule result helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/compliance.py` and `tests/unit/core/test_common_edge_coverage.py`.
+- Finding: `RuleEngine.evaluate` still assembled single-position, data-quality, minimum-trade-size,
+  no-shorting, and insufficient-cash rule results inline, making individual post-trade compliance
+  rules harder to inspect and test independently.
+- Action: extracted `_single_position_max_rule_results`, `_data_quality_rule_result`,
+  `_min_trade_size_rule_result`, `_no_shorting_rule_result`, and
+  `_insufficient_cash_rule_result`. Kept `RuleEngine.evaluate` as the orchestration point and added
+  direct tests for each helper edge.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/compliance.py tests/unit/core/test_common_edge_coverage.py`,
+  `python -m ruff format --check src/core/compliance.py tests/unit/core/test_common_edge_coverage.py`,
+  `python -m mypy --config-file mypy.ini src/core/compliance.py`,
+  `python -m pytest tests/unit/core/test_common_edge_coverage.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal post-trade compliance
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14586,3 +14586,28 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal policy-pack domain helper
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-599: Intent dependency helpers extracted
+
+- Date: 2026-06-04
+- Scope: `src/core/common/intent_dependencies.py` and
+  `tests/unit/core/test_intent_dependencies.py`.
+- Finding: `link_buy_intent_dependencies` mixed sell-intent currency indexing, duplicate-safe
+  dependency append behavior, and BUY intent orchestration in one function, leaving execution-order
+  edge rules covered only through broader common edge tests.
+- Action: extracted `sell_intent_id_by_currency` and `append_intent_dependency_once`, kept
+  `link_buy_intent_dependencies` as the in-place orchestration entrypoint, and added direct helper
+  tests for latest sell selection, duplicate-safe append ordering, and FX-before-sell dependency
+  ordering.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/common/intent_dependencies.py tests/unit/core/test_intent_dependencies.py`,
+  `python -m ruff format --check src/core/common/intent_dependencies.py tests/unit/core/test_intent_dependencies.py`,
+  `python -m mypy --config-file mypy.ini src/core/common/intent_dependencies.py`,
+  `python -m pytest tests/unit/core/test_intent_dependencies.py tests/unit/core/test_common_edge_coverage.py::test_intent_dependency_linking_and_simulated_state_edges -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal rebalance intent dependency
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15221,3 +15221,28 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-626: Tax-budget lot allowance helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/rebalance/intents.py` and
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`.
+- Finding: `_tax_budget_limited_sell_quantity` still mixed HIFO lot traversal, realized-gain
+  calculation, remaining tax-budget headroom math, allowed lot quantity selection, gain/loss
+  accumulator mutation, and partial-lot stopping behavior in one loop.
+- Action: introduced `_TaxBudgetLotAllowance`, `_tax_budget_allowed_lot_quantity`,
+  `_tax_budget_lot_allowance`, and `_apply_tax_budget_lot_allowance`. Kept
+  `_tax_budget_limited_sell_quantity` as the orchestration boundary and added direct helper tests
+  for exhausted gain-budget handling and realized-loss accumulator behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m ruff format --check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal tax-budget intent-generation
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14707,3 +14707,29 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal construction financial
   source-product mapping maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-604: Treasury source identities extracted
+
+- Date: 2026-06-04
+- Scope: `src/api/services/construction_treasury_source_context.py` and
+  `tests/unit/dpm/construction/test_treasury_source_context.py`.
+- Finding: `external_treasury_currency_overlay_context` resolved readiness, exposure,
+  hedge-policy, eligible-instrument, and FX-forward source identities inline before constructing
+  the currency-overlay context, making source identity fallback behavior harder to verify as one
+  unit.
+- Action: introduced `TreasurySourceIdentities` and `treasury_source_identities`, kept
+  `external_treasury_currency_overlay_context` as the family-level context assembler, and added a
+  direct test for readiness aggregate-hash fallback plus optional source-family identity
+  preservation.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_treasury_source_context.py tests/unit/dpm/construction/test_treasury_source_context.py`,
+  `python -m ruff format --check src/api/services/construction_treasury_source_context.py tests/unit/dpm/construction/test_treasury_source_context.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_treasury_source_context.py`,
+  `python -m pytest tests/unit/dpm/construction/test_treasury_source_context.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal construction treasury
+  source-product identity maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14422,7 +14422,9 @@ and improves internal transaction-cost source posture maintainability only.
   conflicts, and value-level construction/input failures, and added tests proving expected
   construction conflicts block the item while unexpected runtime failures propagate. Updated the
   wave selection API degradation test to use the proof-pack validation error now required by the
-  narrowed proof-pack degradation contract.
+  narrowed proof-pack degradation contract, aligned the wave simulation API degradation test to
+  construction idempotency conflict, and model-validated direct service simulation inputs that were
+  previously relying on broad exception masking.
 - Status: hardened.
 - Evidence:
   `python -m ruff check src/api/services/wave_simulation_item.py tests/unit/dpm/waves/test_wave_simulation_item.py`,
@@ -14434,4 +14436,30 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal wave simulation
+  error-translation hardening.
+
+## BACKEND-REVIEW-20260604-593: Construction router error translation narrowed
+
+- Date: 2026-06-04
+- Scope: `src/api/routers/construction_generate_routes.py`,
+  `src/api/routers/construction_read_routes.py`,
+  `src/api/routers/construction_selection_routes.py`, and
+  `tests/unit/dpm/api/test_construction_api.py`.
+- Finding: construction router endpoints caught every service exception and passed it through the
+  construction HTTP mapper, which could hide unexpected runtime defects behind generic typed
+  construction responses.
+- Action: narrowed route translation to construction idempotency and not-found domain exceptions,
+  removed an extra HTTPException reconstruction in selection routing, and added API coverage
+  proving unexpected generation failures are not hidden by the router mapper.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/construction_generate_routes.py src/api/routers/construction_read_routes.py src/api/routers/construction_selection_routes.py tests/unit/dpm/api/test_construction_api.py`,
+  `python -m ruff format --check src/api/routers/construction_generate_routes.py src/api/routers/construction_read_routes.py src/api/routers/construction_selection_routes.py tests/unit/dpm/api/test_construction_api.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/construction_generate_routes.py src/api/routers/construction_read_routes.py src/api/routers/construction_selection_routes.py`,
+  `python -m pytest tests/unit/dpm/api/test_construction_api.py::test_generate_construction_alternative_set_idempotency_conflict tests/unit/dpm/api/test_construction_api.py::test_read_and_select_construction_alternative_set tests/unit/dpm/api/test_construction_api.py::test_generate_construction_route_does_not_hide_unexpected_failures -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal construction router
   error-translation hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14983,3 +14983,27 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-616: Intent trade delta and tax-impact helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/rebalance/intents.py` and
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`.
+- Finding: `generate_intents` still calculated trade side/raw quantity and tax-impact budget
+  projection inline while also orchestrating market lookup, sell clamping, tax-budget limiting,
+  dust suppression, and intent construction.
+- Action: introduced `_TargetTradeDelta`, `_target_trade_delta`, and `_tax_impact_from_budget`.
+  Kept `generate_intents` as the orchestration point and added direct tests for buy/sell quantity
+  flooring and tax-budget-used normalization at the tolerance boundary.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m ruff format --check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal rebalance intent-generation
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15102,3 +15102,25 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal valuation maintainability
   refactoring.
+
+## BACKEND-REVIEW-20260605-621: Valuation refactor quality reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `299a455a`, before the valuation helper
+  extraction, so the latest source-complexity improvement was not represented in the branch
+  scorecard.
+- Action: regenerated current-state refactor reports after the valuation helper extraction.
+  Preserved `quality/baseline_report.md` so the original baseline remains stable. The refreshed
+  complexity report shows `build_simulated_state` dropped out of the top current source-complexity
+  list, with `resolve_core_dpm_portfolio_universe_candidates` now the top source hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14733,3 +14733,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal construction treasury
   source-product identity maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-605: Treasury source hash helper extracted
+
+- Date: 2026-06-04
+- Scope: `src/api/services/construction_treasury_source_context.py` and
+  `tests/unit/dpm/construction/test_treasury_source_context.py`.
+- Finding: `external_treasury_currency_overlay_context` still computed the aggregate treasury
+  source hash inline from source payloads, while payload collection was already isolated and
+  directly tested.
+- Action: extracted `treasury_source_hash`, kept the currency-overlay assembler focused on context
+  construction, and added a direct test proving the hash is derived from the aggregate treasury
+  source payload bundle.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_treasury_source_context.py tests/unit/dpm/construction/test_treasury_source_context.py`,
+  `python -m ruff format --check src/api/services/construction_treasury_source_context.py tests/unit/dpm/construction/test_treasury_source_context.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_treasury_source_context.py`,
+  `python -m pytest tests/unit/dpm/construction/test_treasury_source_context.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal construction treasury
+  source-product hash maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14659,3 +14659,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal construction source-product
   mapping maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-602: Client profile source child mappers extracted
+
+- Date: 2026-06-04
+- Scope: `src/api/services/construction_client_profile_source_context.py` and
+  `tests/unit/dpm/construction/test_client_profile_source_context.py`.
+- Finding: client restriction and sustainability source-profile context builders still performed
+  child-list conversion inline, so source rule/preference projection was only indirectly tested
+  through the parent context builders.
+- Action: extracted `client_restriction_rules` and `sustainability_preferences`, kept parent
+  profile context builders as source-profile coordinators, and added direct tests for restriction
+  rule and sustainability preference projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_client_profile_source_context.py tests/unit/dpm/construction/test_client_profile_source_context.py`,
+  `python -m ruff format --check src/api/services/construction_client_profile_source_context.py tests/unit/dpm/construction/test_client_profile_source_context.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_client_profile_source_context.py`,
+  `python -m pytest tests/unit/dpm/construction/test_client_profile_source_context.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal construction client-profile
+  source-product mapping maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15268,3 +15268,29 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-628: Target heuristic policy helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/rebalance/targets.py` and
+  `tests/unit/dpm/engine/coverage/test_engine_target_generation.py`.
+- Finding: `generate_targets_heuristic` still mixed orchestration with single-position maximum
+  redistribution and minimum-cash-buffer scaling policy math, making target-generation behavior
+  harder to verify directly.
+- Action: extracted `_apply_single_position_max_weight` and `_apply_min_cash_buffer`, leaving
+  `generate_targets_heuristic` to sequence sell-only redistribution, group constraints,
+  tradeability caps, position caps, cash-buffer policy, and trace building. Added direct helper
+  tests for successful cap redistribution, remaining-excess pending review, and locked-weight
+  cash-buffer scaling.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/targets.py tests/unit/dpm/engine/coverage/test_engine_target_generation.py`,
+  `python -m ruff format --check src/core/rebalance/targets.py tests/unit/dpm/engine/coverage/test_engine_target_generation.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/targets.py`,
+  `python -m pytest tests/unit/dpm/engine/coverage/test_engine_target_generation.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal target-generation
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15007,3 +15007,23 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal rebalance intent-generation
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-617: Intent refactor quality reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `b444ee84`, before the intent trade-delta
+  helper extraction, so the latest source-complexity improvement was not represented in the branch
+  scorecard.
+- Action: regenerated current-state refactor reports after the intent helper extraction. Preserved
+  `quality/baseline_report.md` so the original baseline remains stable.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15173,3 +15173,29 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-624: Settlement-ladder helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/rebalance/execution.py` and
+  `tests/unit/dpm/engine/test_engine_settlement_awareness.py`.
+- Finding: `build_settlement_ladder` still mixed settlement-day lookup, horizon calculation,
+  cash-flow initialization, security-trade and FX flow projection, projected-balance ladder
+  assembly, breach detection, and overdraft-warning emission in one function.
+- Action: extracted `_settlement_days_by_instrument`, `_settlement_horizon_days`,
+  `_settlement_cash_flows`, `_ensure_settlement_currency`, `_apply_intent_settlement_flows`,
+  `_append_settlement_ladder_points`, and `_append_cash_ladder_point`. Kept
+  `build_settlement_ladder` as the orchestration boundary and added direct helper tests for
+  security/FX settlement flow projection plus breach and overdraft-warning generation.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/execution.py tests/unit/dpm/engine/test_engine_settlement_awareness.py`,
+  `python -m ruff format --check src/core/rebalance/execution.py tests/unit/dpm/engine/test_engine_settlement_awareness.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/execution.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_settlement_awareness.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal settlement-ladder
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15438,3 +15438,26 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal construction treasury
   source-context maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-635: Treasury source-context reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `d2f3c827`, before the treasury
+  currency-overlay field helper extraction, so the latest source-complexity improvement was not
+  represented in the branch scorecard.
+- Action: regenerated current-state refactor reports after the treasury source-context helper
+  extraction. Preserved `quality/baseline_report.md` so the original baseline remains stable. The
+  refreshed complexity report shows `external_treasury_currency_overlay_context` dropped out of
+  the top current source-complexity list, with `generate_fx_and_simulate` now the top source
+  hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14757,3 +14757,24 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal construction treasury
   source-product hash maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-606: Refactor quality reports refreshed
+
+- Date: 2026-06-04
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: the refactor scorecard still pointed at the early branch ref after multiple focused
+  hardening commits, so the current-state quality evidence no longer reflected the latest measured
+  branch posture.
+- Action: refreshed the report-only current-state quality artifacts with
+  `scripts/engineering_health_report.py`, preserving the original baseline report values while
+  updating current ref, current test count, current size deltas, and complexity rankings that show
+  recently extracted helpers leaving the top source-complexity list.
+- Status: evidence refreshed.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15246,3 +15246,25 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal tax-budget intent-generation
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-627: Tax-budget refactor reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `141099d4`, before the tax-budget lot
+  helper extraction, so the latest source-complexity improvement was not represented in the branch
+  scorecard.
+- Action: regenerated current-state refactor reports after the tax-budget helper extraction.
+  Preserved `quality/baseline_report.md` so the original baseline remains stable. The refreshed
+  complexity report shows `_tax_budget_limited_sell_quantity` dropped out of the top current
+  source-complexity list, with `generate_targets_heuristic` now the top source hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14635,3 +14635,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal API governance helper
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-601: Liquidity source child contexts extracted
+
+- Date: 2026-06-04
+- Scope: `src/api/services/construction_liquidity_source_context.py` and
+  `tests/unit/dpm/construction/test_liquidity_source_context.py`.
+- Finding: `source_liquidity_context` still assembled cashflow, income-needs, liquidity-reserve,
+  and planned-withdrawal child contexts inline before constructing the source-owned liquidity
+  authority context, making source-family projection harder to verify independently.
+- Action: introduced `LiquiditySourceChildContexts` and `liquidity_source_child_contexts`, kept
+  `source_liquidity_context` as the family-level coordinator, and added direct tests for fully
+  populated and partially absent source-product child context bundles.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_liquidity_source_context.py tests/unit/dpm/construction/test_liquidity_source_context.py`,
+  `python -m ruff format --check src/api/services/construction_liquidity_source_context.py tests/unit/dpm/construction/test_liquidity_source_context.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_liquidity_source_context.py`,
+  `python -m pytest tests/unit/dpm/construction/test_liquidity_source_context.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal construction source-product
+  mapping maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15364,3 +15364,28 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-632: Campaign lifecycle validation helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/waves/campaign_definitions.py` and
+  `tests/unit/dpm/waves/test_campaign_definition_repository.py`.
+- Finding: the campaign definition lifecycle validators repeated required-field and
+  forbidden-field checks across active, retired, and superseded states, with the superseded path
+  carrying the highest current source complexity.
+- Action: introduced `_validate_lifecycle_fields_absent` and
+  `_validate_required_lifecycle_value`, then reused them across active, retired, and superseded
+  lifecycle validation. Added direct helper tests for missing/blank required values and forbidden
+  lifecycle fields while preserving existing lifecycle reason-code tests.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_definitions.py tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `python -m ruff format --check src/core/waves/campaign_definitions.py tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_definitions.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_definition_repository.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal campaign-definition
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14611,3 +14611,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal rebalance intent dependency
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-600: OpenAPI operation documentation helpers extracted
+
+- Date: 2026-06-04
+- Scope: `src/api/openapi_enrichment.py` and
+  `tests/unit/api/test_openapi_enrichment_helpers.py`.
+- Finding: `_ensure_operation_documentation` mixed operation traversal, summary/description
+  defaults, path-to-tag classification, and error-response detection, leaving two API-governance
+  decisions testable only through the broader enrichment path.
+- Action: extracted `_operation_tag_for_path` and `_operation_has_error_response`, kept
+  `_ensure_operation_documentation` as the schema traversal coordinator, and added direct tests for
+  health/metrics/default tag classification plus default/4xx/5xx error response detection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`,
+  `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal API governance helper
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14849,3 +14849,27 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260604-610: Maker-checker control validation dispatch extracted
+
+- Date: 2026-06-04
+- Scope: `src/core/waves/campaign_maker_checker_controls.py` and
+  `tests/unit/dpm/waves/test_campaign_maker_checker_control_helpers.py`.
+- Finding: maker-checker control action validation was concentrated in one nested conditional
+  chain, keeping submission, reviewer-assignment, review-completion, exception-raised, and
+  exception-resolved rules harder to inspect and test independently.
+- Action: introduced `CampaignControlValidationContext`, named rule validators, and a dispatch
+  table for control-action validation. Added direct helper tests covering all valid action/outcome
+  pairs plus representative invalid rule failures.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_maker_checker_controls.py tests/unit/dpm/waves/test_campaign_maker_checker_control_helpers.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_maker_checker_controls.py tests/unit/dpm/waves/test_campaign_maker_checker_control_helpers.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_maker_checker_controls.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_maker_checker_control_helpers.py tests/unit/dpm/waves/test_campaign_discovery.py::test_campaign_maker_checker_controls_record_actor_separation tests/unit/dpm/waves/test_campaign_discovery.py::test_campaign_maker_checker_controls_record_reviewer_assignment_and_exceptions tests/unit/dpm/waves/test_campaign_discovery.py::test_campaign_maker_checker_controls_validate_required_fields -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal maker-checker validation
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14273,3 +14273,26 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal client-restriction
   supportability helper refactoring with direct tests.
+
+## BACKEND-REVIEW-20260604-586: Solver optional-import failure handling narrowed
+
+- Date: 2026-06-04
+- Scope: `src/core/target_generation.py` and
+  `tests/unit/core/test_target_generation_solver_fallbacks.py`.
+- Finding: optional solver-module loading caught all exceptions, which could hide genuine runtime
+  defects behind the bounded `SOLVER_ERROR` optional-dependency posture.
+- Action: narrowed solver module loading to handle only import failures, extracted
+  `_import_solver_modules`, and added a regression test proving non-import failures propagate
+  without mutating solver diagnostics.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m mypy --config-file mypy.ini src/core/target_generation.py`,
+  `python -m pytest tests/unit/core/test_target_generation_solver_fallbacks.py tests/unit/core/test_target_generation_helpers.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal solver optional-dependency
+  hardening with direct regression coverage.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14963,3 +14963,23 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal post-trade compliance
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-615: Compliance refactor quality reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `e31faaea`, before the compliance rule
+  helper extraction, so the latest source-complexity improvement was not represented in the branch
+  scorecard.
+- Action: regenerated current-state refactor reports after the compliance helper extraction.
+  Preserved `quality/baseline_report.md` so the original baseline remains stable.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14804,3 +14804,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal solver target-generation
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-608: Solver group-member projection helper extracted
+
+- Date: 2026-06-04
+- Scope: `src/core/target_generation.py` and
+  `tests/unit/core/test_target_generation_helpers.py`.
+- Finding: `generate_targets_solver` still assembled group-constraint tradeable members and locked
+  member weight inline while also building CVXPY expressions, which made pure membership semantics
+  harder to test independently from solver orchestration.
+- Action: introduced `SolverGroupMembers` and `_solver_group_members`, then routed solver
+  group-constraint construction through that helper. Added direct coverage for mixed tradeable,
+  locked, non-matching, and missing-attribute group members.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m mypy --config-file mypy.ini src/core/target_generation.py`,
+  `python -m pytest tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal solver target-generation
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15199,3 +15199,25 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal settlement-ladder
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-625: Settlement-ladder reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `a44976a9`, before the settlement-ladder
+  helper extraction, so the latest source-complexity improvement was not represented in the branch
+  scorecard.
+- Action: regenerated current-state refactor reports after the settlement-ladder helper
+  extraction. Preserved `quality/baseline_report.md` so the original baseline remains stable. The
+  refreshed complexity report shows `build_settlement_ladder` dropped out of the top current
+  source-complexity list, with `_tax_budget_limited_sell_quantity` now the top source hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15027,3 +15027,29 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-618: Proof-pack build context extracted
+
+- Date: 2026-06-05
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Finding: `_build_proof_pack` still resolved run artifacts, source hashes, source analytics,
+  source refs, proof-pack identity, portfolio identity, and correlation-id precedence inline while
+  also assembling sections, supportability, summary, timeline, and the final immutable content hash.
+- Action: introduced `_ProofPackBuildContext`, `_proof_pack_build_context`,
+  `_resolve_proof_pack_correlation_id`, `_proof_pack_sections`, and
+  `_finalize_proof_pack_content_hash`. Kept the public proof-pack builders as orchestration entry
+  points and added direct helper tests for correlation-id precedence and direct source-owned
+  regime-scenario evidence hashes/refs.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal proof-pack builder
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14336,3 +14336,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal optional dependency
   capability-detection hardening.
+
+## BACKEND-REVIEW-20260604-589: Outcome proof-pack state mapping made explicit
+
+- Date: 2026-06-04
+- Scope: `src/core/outcomes/snapshots.py` and
+  `tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`.
+- Finding: expected outcome snapshot assembly used a local `type: ignore[return-value]` to return
+  proof-pack status strings as bounded outcome dimension states, obscuring the defensive fallback
+  for unknown status values.
+- Action: replaced the ignore with an explicit proof-pack-status-to-outcome-state mapping and
+  added direct coverage proving supported statuses are preserved while unknown values fail closed
+  to `BLOCKED`.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m ruff format --check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/snapshots.py`,
+  `python -m pytest tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal expected-outcome snapshot
+  maintainability hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15053,3 +15053,25 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal proof-pack builder
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-619: Proof-pack refactor quality reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `8b772a14`, before the proof-pack build
+  context extraction, so the latest source-complexity improvement was not represented in the
+  branch scorecard.
+- Action: regenerated current-state refactor reports after the proof-pack helper extraction.
+  Preserved `quality/baseline_report.md` so the original baseline remains stable. The refreshed
+  complexity report shows `_build_proof_pack` dropped out of the top current source-complexity
+  list, with `build_simulated_state` now the top source hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14296,3 +14296,21 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal solver optional-dependency
   hardening with direct regression coverage.
+
+## BACKEND-REVIEW-20260604-587: Solver import helper preserves fallback contract
+
+- Date: 2026-06-04
+- Scope: `src/core/target_generation.py`,
+  `tests/unit/dpm/engine/test_engine_solver_behavior.py`, and
+  `tests/unit/core/test_target_generation_solver_fallbacks.py`.
+- Finding: the extracted solver import helper used `importlib.import_module`, which could return
+  cached solver modules and bypass the existing import-hook simulation used to prove missing
+  optional solver dependencies fail closed.
+- Action: switched the helper to ordinary in-function imports, retaining the narrowed
+  `ImportError` handling while preserving the established missing-`cvxpy` fallback contract.
+- Status: hardened.
+- Evidence:
+  `python -m pytest tests/unit/dpm/engine/test_engine_solver_behavior.py::test_solver_returns_blocked_when_solver_dependencies_unavailable tests/unit/core/test_target_generation_solver_fallbacks.py -q`,
+  plus the slice gates recorded for this commit.
+- Wiki decision: no wiki source change required; this is internal solver optional-dependency
+  contract hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15342,3 +15342,25 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal core-sourcing adapter
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-631: Core snapshot refactor reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `5dc6fccb`, before the core snapshot row
+  mapper extraction, so the latest source-complexity improvement was not represented in the branch
+  scorecard.
+- Action: regenerated current-state refactor reports after the core snapshot mapper extraction.
+  Preserved `quality/baseline_report.md` so the original baseline remains stable. The refreshed
+  complexity report shows `_portfolio_snapshot_from_core_snapshot` dropped out of the top current
+  source-complexity list, with `_validate_superseded_lifecycle` now the top source hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14562,3 +14562,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal policy-pack parser
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-598: Policy-pack engine option updates extracted
+
+- Date: 2026-06-04
+- Scope: `src/core/rebalance/policy_packs.py` and
+  `tests/unit/dpm/engine/test_policy_pack_resolution.py`.
+- Finding: `apply_policy_pack_to_engine_options` mixed domain override selection with the
+  `EngineOptions` model-copy operation, making the policy-pack mutation surface harder to verify
+  directly.
+- Action: extracted `policy_pack_engine_option_updates` as a pure helper that returns only the
+  configured policy-pack engine-option overrides, and added direct tests for populated and empty
+  override maps while preserving the existing `EngineOptions` application behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/policy_packs.py tests/unit/dpm/engine/test_policy_pack_resolution.py`,
+  `python -m ruff format --check src/core/rebalance/policy_packs.py tests/unit/dpm/engine/test_policy_pack_resolution.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/policy_packs.py`,
+  `python -m pytest tests/unit/dpm/engine/test_policy_pack_resolution.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal policy-pack domain helper
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14314,3 +14314,25 @@ and improves internal transaction-cost source posture maintainability only.
   plus the slice gates recorded for this commit.
 - Wiki decision: no wiki source change required; this is internal solver optional-dependency
   contract hardening.
+
+## BACKEND-REVIEW-20260604-588: Psycopg optional-import failure handling narrowed
+
+- Date: 2026-06-04
+- Scope: `src/core/common/capabilities.py` and `tests/unit/core/test_capabilities.py`.
+- Finding: `psycopg_error_type` caught every exception during optional driver import, which could
+  hide genuine driver import side effects or packaging defects behind the same posture as a
+  missing optional dependency.
+- Action: extracted `_import_psycopg`, narrowed the tolerated failure to `ImportError`, and added
+  direct tests for missing-driver fallback and non-import failure propagation.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/common/capabilities.py tests/unit/core/test_capabilities.py`,
+  `python -m ruff format --check src/core/common/capabilities.py tests/unit/core/test_capabilities.py`,
+  `python -m mypy --config-file mypy.ini src/core/common/capabilities.py`,
+  `python -m pytest tests/unit/core/test_capabilities.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal optional dependency
+  capability-detection hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15151,3 +15151,25 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal wave Core portfolio-universe
   resolver maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-623: Core portfolio-universe resolver reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `816cb1a0`, before the Core
+  portfolio-universe resolver helper extraction, so the latest source-complexity improvement was
+  not represented in the branch scorecard.
+- Action: regenerated current-state refactor reports after the resolver helper extraction.
+  Preserved `quality/baseline_report.md` so the original baseline remains stable. The refreshed
+  complexity report shows `resolve_core_dpm_portfolio_universe_candidates` dropped out of the top
+  current source-complexity list, with `build_settlement_ladder` now the top source hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15316,3 +15316,29 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-630: Core snapshot row mapper helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/infrastructure/core_sourcing/client.py` and
+  `tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`.
+- Finding: `_portfolio_snapshot_from_core_snapshot` still combined base-currency resolution,
+  source-row identifier cleanup, blank-row filtering, cash aggregation, and position market-value
+  construction in one adapter mapper.
+- Action: introduced `_CoreSnapshotMappedRow`, `_core_snapshot_base_currency`,
+  `_core_snapshot_row_instrument_id`, `_map_core_snapshot_row`, and
+  `_portfolio_positions_and_cash_from_core_rows`. Kept `_portfolio_snapshot_from_core_snapshot`
+  as the payload-level orchestration boundary and added direct helper tests for blank identifiers,
+  position market-value currency preservation, and cash aggregation by currency.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `python -m ruff format --check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/core_sourcing/client.py`,
+  `python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal core-sourcing adapter
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14512,3 +14512,28 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal repository protocol
   contract cleanup.
+
+## BACKEND-REVIEW-20260604-596: Command-center summary projection helpers extracted
+
+- Date: 2026-06-04
+- Scope: `src/api/services/mandate_command_center.py` and
+  `tests/unit/dpm/mandates/test_mandate_command_center.py`.
+- Finding: `build_command_center_summary` mixed health-distribution projection, partial-readiness
+  reason assembly, completeness classification, and response construction in one moderately
+  complex service function.
+- Action: extracted `command_center_health_distribution`, `command_center_partial_reasons`, and
+  `command_center_completeness`, kept summary orchestration in `build_command_center_summary`,
+  and added direct helper tests for selected-state filtering, missing-run/limit reasons, and
+  completeness classification.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python -m ruff format --check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/mandate_command_center.py`,
+  `python -m pytest tests/unit/dpm/mandates/test_mandate_command_center.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal command-center service
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14919,3 +14919,23 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal portfolio-memory metadata
   validation maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-613: Portfolio-memory refactor quality reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `f2aab1b9`, before the portfolio-memory
+  search metadata validator extraction, so the latest source-complexity improvement was not
+  represented in the branch scorecard.
+- Action: regenerated current-state refactor reports after the portfolio-memory validator helper
+  extraction. Preserved `quality/baseline_report.md` so the original baseline remains stable.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15412,3 +15412,29 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-634: Treasury currency-overlay field helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/api/services/construction_treasury_source_context.py` and
+  `tests/unit/dpm/construction/test_treasury_source_context.py`.
+- Finding: `external_treasury_currency_overlay_context` still assembled readiness,
+  currency-exposure, hedge-policy, eligible-instrument, and FX-forward-curve fields inline, making
+  source-family supportability projection harder to review and test directly.
+- Action: extracted focused treasury context field builders for readiness, currency exposure,
+  hedge policy, eligible hedge instruments, FX forward curve, and aggregate source-family fields.
+  Kept the public mapper as orchestration over primary supportability, aggregate source hash,
+  source identities, diagnostics, reason codes, and final context construction. Added direct helper
+  tests for readiness fallback source ids and optional source-family field projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_treasury_source_context.py tests/unit/dpm/construction/test_treasury_source_context.py`,
+  `python -m ruff format --check src/api/services/construction_treasury_source_context.py tests/unit/dpm/construction/test_treasury_source_context.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_treasury_source_context.py`,
+  `python -m pytest tests/unit/dpm/construction/test_treasury_source_context.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal construction treasury
+  source-context maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15294,3 +15294,25 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal target-generation
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-629: Target heuristic refactor reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `70c61b70`, before the target heuristic
+  policy helper extraction, so the latest source-complexity improvement was not represented in the
+  branch scorecard.
+- Action: regenerated current-state refactor reports after the target heuristic helper extraction.
+  Preserved `quality/baseline_report.md` so the original baseline remains stable. The refreshed
+  complexity report shows `generate_targets_heuristic` dropped out of the top current
+  source-complexity list, with `_portfolio_snapshot_from_core_snapshot` now the top source hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14360,3 +14360,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal expected-outcome snapshot
   maintainability hardening.
+
+## BACKEND-REVIEW-20260604-590: Wave construction selection error translation narrowed
+
+- Date: 2026-06-04
+- Scope: `src/api/services/wave_construction_selection.py` and
+  `tests/unit/dpm/waves/test_wave_construction_selection.py`.
+- Finding: the wave construction-selection adapter converted every service exception into
+  `DpmWaveLookupError`, which could hide repository write or unexpected runtime defects behind an
+  alternative-not-found posture.
+- Action: narrowed translation to construction set/alternative not-found domain exceptions and
+  added tests proving domain lookup failures still map to bounded wave lookup errors while
+  unexpected runtime failures propagate.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/wave_construction_selection.py tests/unit/dpm/waves/test_wave_construction_selection.py`,
+  `python -m ruff format --check src/api/services/wave_construction_selection.py tests/unit/dpm/waves/test_wave_construction_selection.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/wave_construction_selection.py`,
+  `python -m pytest tests/unit/dpm/waves/test_wave_construction_selection.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal wave service error-translation
+  hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15389,3 +15389,26 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal campaign-definition
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260605-633: Campaign lifecycle refactor reports refreshed
+
+- Date: 2026-06-05
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `028746a3`, before the campaign
+  lifecycle validation helper extraction, so the latest source-complexity improvement was not
+  represented in the branch scorecard.
+- Action: regenerated current-state refactor reports after the lifecycle helper extraction.
+  Preserved `quality/baseline_report.md` so the original baseline remains stable. The refreshed
+  complexity report shows `_validate_superseded_lifecycle` dropped out of the top current
+  source-complexity list, with `external_treasury_currency_overlay_context` now the top source
+  hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14828,3 +14828,24 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal solver target-generation
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-609: Solver refactor quality reports refreshed
+
+- Date: 2026-06-04
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: the quality reports still pointed at `226d8694`, before the two solver target-generation
+  helper extractions, so the before/after scorecard did not show the latest maintainability
+  improvement.
+- Action: regenerated current-state refactor reports after the solver target-universe and
+  group-member helper extractions. Preserved `quality/baseline_report.md` so the original baseline
+  remains stable.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14537,3 +14537,28 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal command-center service
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-597: Policy-pack catalog parser helpers extracted
+
+- Date: 2026-06-04
+- Scope: `src/core/rebalance/policy_packs.py` and
+  `tests/unit/dpm/engine/test_policy_pack_resolution.py`.
+- Finding: `parse_policy_pack_catalog` combined environment JSON normalization, raw catalog shape
+  checks, row normalization, Pydantic validation, and invalid-row skipping in a single function,
+  making malformed catalog behavior harder to inspect directly.
+- Action: extracted `_load_policy_pack_catalog_payload`,
+  `_policy_pack_definition_payload`, and `_parse_policy_pack_definition`, kept
+  `parse_policy_pack_catalog` as the catalog coordinator, and added direct helper tests for
+  default payload normalization plus invalid row rejection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/policy_packs.py tests/unit/dpm/engine/test_policy_pack_resolution.py`,
+  `python -m ruff format --check src/core/rebalance/policy_packs.py tests/unit/dpm/engine/test_policy_pack_resolution.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/policy_packs.py`,
+  `python -m pytest tests/unit/dpm/engine/test_policy_pack_resolution.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal policy-pack parser
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14408,3 +14408,30 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal wave proof-pack error-translation
   hardening.
+
+## BACKEND-REVIEW-20260604-592: Wave simulation construction errors narrowed
+
+- Date: 2026-06-04
+- Scope: `src/api/services/wave_simulation_item.py`,
+  `tests/unit/dpm/waves/test_wave_simulation_item.py`, and
+  `tests/unit/dpm/api/test_waves_api.py`.
+- Finding: wave simulation converted every construction-generation exception into a blocked wave
+  item, which could hide unexpected repository or runtime side effects behind a normal
+  construction-input review posture.
+- Action: narrowed blocked simulation handling to construction idempotency conflicts, async run
+  conflicts, and value-level construction/input failures, and added tests proving expected
+  construction conflicts block the item while unexpected runtime failures propagate. Updated the
+  wave selection API degradation test to use the proof-pack validation error now required by the
+  narrowed proof-pack degradation contract.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/wave_simulation_item.py tests/unit/dpm/waves/test_wave_simulation_item.py`,
+  `python -m ruff format --check src/api/services/wave_simulation_item.py tests/unit/dpm/waves/test_wave_simulation_item.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/wave_simulation_item.py`,
+  `python -m pytest tests/unit/dpm/api/test_waves_api.py::test_wave_selection_degrades_when_proof_pack_generation_fails tests/unit/dpm/waves/test_wave_selection_item.py tests/unit/dpm/waves/test_wave_simulation_item.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal wave simulation
+  error-translation hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -15124,3 +15124,30 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260605-622: Core portfolio-universe resolver helpers extracted
+
+- Date: 2026-06-05
+- Scope: `src/api/services/wave_core_portfolio_universe_resolution.py` and
+  `tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`.
+- Finding: `resolve_core_dpm_portfolio_universe_candidates` still mixed Core resolver request
+  assembly, bounded pagination, dependency-error translation, readiness/partial-page checks,
+  candidate flattening, duplicate detection, source-ref construction, and portfolio payload
+  projection in one function.
+- Action: introduced `_PortfolioUniverseResolutionRequest`, `_resolve_candidate_pages`,
+  `_portfolio_payloads_from_candidate_pages`, `_candidate_rows`, `_candidate_key`, and
+  `_candidate_portfolio_payloads`. Kept the public resolver as the orchestration boundary and
+  added direct helper tests for bounded page-token propagation and source-ref preserving payload
+  assembly.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/wave_core_portfolio_universe_resolution.py tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`,
+  `python -m ruff format --check src/api/services/wave_core_portfolio_universe_resolution.py tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/wave_core_portfolio_universe_resolution.py`,
+  `python -m pytest tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal wave Core portfolio-universe
+  resolver maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14778,3 +14778,29 @@ and improves internal transaction-cost source posture maintainability only.
   `python scripts/api_vocabulary_inventory.py --validate-only`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260604-607: Solver target universe helpers extracted
+
+- Date: 2026-06-04
+- Scope: `src/core/target_generation.py` and
+  `tests/unit/core/test_target_generation_helpers.py`.
+- Finding: `generate_targets_solver` still mixed solver dependency loading, sell-only
+  redistribution, tradeable/locked target universe assembly, cash-band invested-bound
+  calculation, constraint construction, solving, and result projection in one high-complexity
+  source function.
+- Action: introduced `SolverTargetUniverse`, `SolverInvestedBounds`,
+  `_solver_target_universe`, and `_solver_invested_bounds`, keeping solver orchestration behavior
+  unchanged while making the tradeable/locked split and invested-bound calculation directly
+  testable.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m mypy --config-file mypy.ini src/core/target_generation.py`,
+  `python -m pytest tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal solver target-generation
+  maintainability refactoring.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14384,3 +14384,27 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal wave service error-translation
   hardening.
+
+## BACKEND-REVIEW-20260604-591: Wave proof-pack degradation errors narrowed
+
+- Date: 2026-06-04
+- Scope: `src/api/services/wave_selection_item.py` and
+  `tests/unit/dpm/waves/test_wave_selection_item.py`.
+- Finding: wave item selection degraded proof-pack state for every proof-pack generation
+  exception, which could hide unexpected repository or runtime side effects behind a normal
+  source-validation failure posture.
+- Action: narrowed degradation handling to proof-pack source validation, proof-pack conflict, and
+  run-not-found domain errors, and added tests proving expected validation failures degrade the
+  wave item while unexpected runtime failures propagate.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/wave_selection_item.py tests/unit/dpm/waves/test_wave_selection_item.py`,
+  `python -m ruff format --check src/api/services/wave_selection_item.py tests/unit/dpm/waves/test_wave_selection_item.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/wave_selection_item.py`,
+  `python -m pytest tests/unit/dpm/waves/test_wave_selection_item.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal wave proof-pack error-translation
+  hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -14873,3 +14873,23 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal maker-checker validation
   maintainability refactoring.
+
+## BACKEND-REVIEW-20260604-611: Maker-checker refactor quality reports refreshed
+
+- Date: 2026-06-04
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at `64620b5d`, before the maker-checker
+  validation dispatch extraction, so the latest source-complexity improvement was not visible in
+  the branch scorecard.
+- Action: regenerated current-state refactor reports after the maker-checker validation helper
+  extraction. Preserved `quality/baseline_report.md` so the original baseline remains stable.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T16:41:40+00:00`
+- Generated at: `2026-06-04T16:49:19+00:00`
 
-- Current ref: `816cb1a0`
+- Current ref: `a44976a9`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
-| 2 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 3 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 5 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 6 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 7 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 8 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
-| 9 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
-| 10 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
+| 1 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 2 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 3 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 4 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 5 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 6 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 7 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 8 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 9 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
+| 10 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T16:36:10+00:00`
+- Generated at: `2026-06-04T16:41:40+00:00`
 
-- Current ref: `299a455a`
+- Current ref: `816cb1a0`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_simulated_state | src/core/valuation.py | 15 | 118 |
-| 2 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
-| 3 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 4 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 5 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 6 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 7 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 8 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 9 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
-| 10 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 1 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
+| 2 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 3 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 5 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 6 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 7 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 8 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 9 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 10 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T17:14:00+00:00`
+- Generated at: `2026-06-04T17:18:27+00:00`
 
-- Current ref: `95394f19`
+- Current ref: `095f7319`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 2 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 3 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
-| 4 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
-| 5 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
-| 6 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
-| 7 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
-| 8 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
-| 9 | record_bulk_review_campaign_definition_assignment_action | src/core/waves/campaign_assignment_actions.py | 13 | 55 |
-| 10 | purge_expired_runs | src/infrastructure/rebalance_runs/in_memory.py | 13 | 50 |
+| 1 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 3 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 4 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
+| 5 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
+| 6 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
+| 7 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
+| 8 | record_bulk_review_campaign_definition_assignment_action | src/core/waves/campaign_assignment_actions.py | 13 | 55 |
+| 9 | purge_expired_runs | src/infrastructure/rebalance_runs/in_memory.py | 13 | 50 |
+| 10 | _example_from_schema | src/api/openapi_enrichment.py | 13 | 46 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T17:18:27+00:00`
+- Generated at: `2026-06-04T23:03:04+00:00`
 
-- Current ref: `095f7319`
+- Current ref: `5561b776`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 2 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
-| 3 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
-| 4 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
-| 5 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
-| 6 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
-| 7 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
-| 8 | record_bulk_review_campaign_definition_assignment_action | src/core/waves/campaign_assignment_actions.py | 13 | 55 |
-| 9 | purge_expired_runs | src/infrastructure/rebalance_runs/in_memory.py | 13 | 50 |
-| 10 | _example_from_schema | src/api/openapi_enrichment.py | 13 | 46 |
+| 1 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 2 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 3 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
+| 4 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
+| 5 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
+| 6 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
+| 7 | record_bulk_review_campaign_definition_assignment_action | src/core/waves/campaign_assignment_actions.py | 13 | 55 |
+| 8 | purge_expired_runs | src/infrastructure/rebalance_runs/in_memory.py | 13 | 50 |
+| 9 | _example_from_schema | src/api/openapi_enrichment.py | 13 | 46 |
+| 10 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 13 | 44 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T16:11:58+00:00`
+- Generated at: `2026-06-04T16:18:13+00:00`
 
-- Current ref: `e31faaea`
+- Current ref: `b444ee84`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | evaluate | src/core/compliance.py | 15 | 171 |
-| 2 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
-| 3 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
-| 4 | build_simulated_state | src/core/valuation.py | 15 | 118 |
-| 5 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
-| 6 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 7 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 9 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 10 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
+| 2 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
+| 3 | build_simulated_state | src/core/valuation.py | 15 | 118 |
+| 4 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
+| 5 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 6 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 7 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 8 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 9 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 10 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T16:05:06+00:00`
+- Generated at: `2026-06-04T16:11:58+00:00`
 
-- Current ref: `f2aab1b9`
+- Current ref: `e31faaea`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 68 |
-| 2 | evaluate | src/core/compliance.py | 15 | 171 |
-| 3 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
-| 4 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
-| 5 | build_simulated_state | src/core/valuation.py | 15 | 118 |
-| 6 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
-| 7 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 8 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 9 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 10 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 1 | evaluate | src/core/compliance.py | 15 | 171 |
+| 2 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
+| 3 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
+| 4 | build_simulated_state | src/core/valuation.py | 15 | 118 |
+| 5 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
+| 6 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 7 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 9 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 10 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T15:57:06+00:00`
+- Generated at: `2026-06-04T16:05:06+00:00`
 
-- Current ref: `64620b5d`
+- Current ref: `f2aab1b9`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -33,15 +33,15 @@
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
 | 1 | _validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 68 |
-| 2 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
-| 3 | evaluate | src/core/compliance.py | 15 | 171 |
-| 4 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
-| 5 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
-| 6 | build_simulated_state | src/core/valuation.py | 15 | 118 |
-| 7 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
-| 8 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 9 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 10 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 2 | evaluate | src/core/compliance.py | 15 | 171 |
+| 3 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
+| 4 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
+| 5 | build_simulated_state | src/core/valuation.py | 15 | 118 |
+| 6 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
+| 7 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 8 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 9 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 10 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T15:47:26+00:00`
+- Generated at: `2026-06-04T15:57:06+00:00`
 
-- Current ref: `226d8694`
+- Current ref: `64620b5d`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -33,15 +33,15 @@
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
 | 1 | _validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 68 |
-| 2 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
-| 3 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
-| 4 | evaluate | src/core/compliance.py | 15 | 171 |
-| 5 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
-| 6 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
-| 7 | build_simulated_state | src/core/valuation.py | 15 | 118 |
-| 8 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
-| 9 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 10 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 2 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
+| 3 | evaluate | src/core/compliance.py | 15 | 171 |
+| 4 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
+| 5 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
+| 6 | build_simulated_state | src/core/valuation.py | 15 | 118 |
+| 7 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
+| 8 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 9 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 10 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T16:25:32+00:00`
+- Generated at: `2026-06-04T16:36:10+00:00`
 
-- Current ref: `8b772a14`
+- Current ref: `299a455a`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
-| 2 | build_simulated_state | src/core/valuation.py | 15 | 118 |
-| 3 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
-| 4 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 5 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 6 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 7 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 8 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 9 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 10 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 1 | build_simulated_state | src/core/valuation.py | 15 | 118 |
+| 2 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
+| 3 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 4 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 5 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 6 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 7 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 8 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 9 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 10 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T16:56:10+00:00`
+- Generated at: `2026-06-04T17:01:59+00:00`
 
-- Current ref: `141099d4`
+- Current ref: `b09057f2`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 2 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 3 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 4 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 5 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 6 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
-| 7 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
-| 8 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
-| 9 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
-| 10 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
+| 1 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 2 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 3 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 4 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 5 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 6 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 7 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
+| 8 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
+| 9 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
+| 10 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T17:01:59+00:00`
+- Generated at: `2026-06-04T17:09:13+00:00`
 
-- Current ref: `b09057f2`
+- Current ref: `09590feb`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 2 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 3 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 4 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 5 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
-| 6 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
-| 7 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
-| 8 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
-| 9 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
-| 10 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
+| 1 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 2 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 3 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 4 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 5 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 6 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
+| 7 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
+| 8 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
+| 9 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
+| 10 | record_bulk_review_campaign_definition_assignment_action | src/core/waves/campaign_assignment_actions.py | 13 | 55 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T16:49:19+00:00`
+- Generated at: `2026-06-04T16:56:10+00:00`
 
-- Current ref: `a44976a9`
+- Current ref: `141099d4`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 2 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 3 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 4 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 5 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 6 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 7 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
-| 8 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
-| 9 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
-| 10 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
+| 1 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 2 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 3 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 4 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 5 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 6 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 7 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 8 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
+| 9 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
+| 10 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T13:53:42+00:00`
+- Generated at: `2026-06-04T15:47:26+00:00`
 
-- Current ref: `e197d2cc`
+- Current ref: `226d8694`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -34,14 +34,14 @@
 | --- | --- | --- | --- | --- |
 | 1 | _validate_search_item_metadata | src/core/portfolio_memory/models.py | 17 | 68 |
 | 2 | generate_targets_solver | src/core/target_generation.py | 16 | 102 |
-| 3 | build_command_center_summary | src/api/services/mandate_command_center.py | 16 | 60 |
-| 4 | parse_policy_pack_catalog | src/core/rebalance/policy_packs.py | 16 | 36 |
-| 5 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 16 | 34 |
-| 6 | _ensure_operation_documentation | src/api/openapi_enrichment.py | 16 | 33 |
-| 7 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
-| 8 | evaluate | src/core/compliance.py | 15 | 171 |
-| 9 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
-| 10 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
+| 3 | _validate_control_action | src/core/waves/campaign_maker_checker_controls.py | 16 | 30 |
+| 4 | evaluate | src/core/compliance.py | 15 | 171 |
+| 5 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
+| 6 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
+| 7 | build_simulated_state | src/core/valuation.py | 15 | 118 |
+| 8 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
+| 9 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 10 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T16:18:13+00:00`
+- Generated at: `2026-06-04T16:25:32+00:00`
 
-- Current ref: `b444ee84`
+- Current ref: `8b772a14`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 15 | 144 |
-| 2 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
-| 3 | build_simulated_state | src/core/valuation.py | 15 | 118 |
-| 4 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
-| 5 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
-| 6 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
-| 7 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
-| 8 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 9 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 10 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 1 | _build_proof_pack | src/core/proof_packs/builder.py | 15 | 136 |
+| 2 | build_simulated_state | src/core/valuation.py | 15 | 118 |
+| 3 | resolve_core_dpm_portfolio_universe_candidates | src/api/services/wave_core_portfolio_universe_resolution.py | 15 | 101 |
+| 4 | build_settlement_ladder | src/core/rebalance/execution.py | 15 | 80 |
+| 5 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 15 | 68 |
+| 6 | generate_targets_heuristic | src/core/rebalance/targets.py | 15 | 63 |
+| 7 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
+| 8 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 9 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 10 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-04T17:09:13+00:00`
+- Generated at: `2026-06-04T17:14:00+00:00`
 
-- Current ref: `09590feb`
+- Current ref: `95394f19`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _portfolio_snapshot_from_core_snapshot | src/infrastructure/core_sourcing/client.py | 15 | 46 |
-| 2 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
-| 3 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
-| 4 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
-| 5 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
-| 6 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
-| 7 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
-| 8 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
-| 9 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
-| 10 | record_bulk_review_campaign_definition_assignment_action | src/core/waves/campaign_assignment_actions.py | 13 | 55 |
+| 1 | _validate_superseded_lifecycle | src/core/waves/campaign_definitions.py | 15 | 23 |
+| 2 | external_treasury_currency_overlay_context | src/api/services/construction_treasury_source_context.py | 14 | 121 |
+| 3 | generate_fx_and_simulate | src/core/rebalance/execution.py | 14 | 120 |
+| 4 | apply_group_constraints | src/core/rebalance/targets.py | 14 | 87 |
+| 5 | _pre_run_section_payload | src/core/proof_packs/builder.py | 14 | 80 |
+| 6 | build_universe | src/core/rebalance/universe.py | 14 | 78 |
+| 7 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 14 | 50 |
+| 8 | _transitioned_task | src/core/waves/campaign_assignment_tasks.py | 13 | 61 |
+| 9 | record_bulk_review_campaign_definition_assignment_action | src/core/waves/campaign_assignment_actions.py | 13 | 55 |
+| 10 | purge_expired_runs | src/infrastructure/rebalance_runs/in_memory.py | 13 | 50 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T16:25:32+00:00`
+- Generated at: `2026-06-04T16:36:10+00:00`
 
-- Current ref: `8b772a14`
+- Current ref: `299a455a`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T17:14:00+00:00`
+- Generated at: `2026-06-04T17:18:27+00:00`
 
-- Current ref: `95394f19`
+- Current ref: `095f7319`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T15:47:26+00:00`
+- Generated at: `2026-06-04T15:57:06+00:00`
 
-- Current ref: `226d8694`
+- Current ref: `64620b5d`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T17:01:59+00:00`
+- Generated at: `2026-06-04T17:09:13+00:00`
 
-- Current ref: `b09057f2`
+- Current ref: `09590feb`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T16:05:06+00:00`
+- Generated at: `2026-06-04T16:11:58+00:00`
 
-- Current ref: `f2aab1b9`
+- Current ref: `e31faaea`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T16:49:19+00:00`
+- Generated at: `2026-06-04T16:56:10+00:00`
 
-- Current ref: `a44976a9`
+- Current ref: `141099d4`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T16:11:58+00:00`
+- Generated at: `2026-06-04T16:18:13+00:00`
 
-- Current ref: `e31faaea`
+- Current ref: `b444ee84`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T16:36:10+00:00`
+- Generated at: `2026-06-04T16:41:40+00:00`
 
-- Current ref: `299a455a`
+- Current ref: `816cb1a0`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T17:18:27+00:00`
+- Generated at: `2026-06-04T23:03:04+00:00`
 
-- Current ref: `095f7319`
+- Current ref: `5561b776`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T15:57:06+00:00`
+- Generated at: `2026-06-04T16:05:06+00:00`
 
-- Current ref: `64620b5d`
+- Current ref: `f2aab1b9`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T16:56:10+00:00`
+- Generated at: `2026-06-04T17:01:59+00:00`
 
-- Current ref: `141099d4`
+- Current ref: `b09057f2`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T16:41:40+00:00`
+- Generated at: `2026-06-04T16:49:19+00:00`
 
-- Current ref: `816cb1a0`
+- Current ref: `a44976a9`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T13:53:42+00:00`
+- Generated at: `2026-06-04T15:47:26+00:00`
 
-- Current ref: `e197d2cc`
+- Current ref: `226d8694`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T16:18:13+00:00`
+- Generated at: `2026-06-04T16:25:32+00:00`
 
-- Current ref: `b444ee84`
+- Current ref: `8b772a14`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-04T17:09:13+00:00`
+- Generated at: `2026-06-04T17:14:00+00:00`
 
-- Current ref: `09590feb`
+- Current ref: `95394f19`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T17:14:00+00:00`
+- Generated at: `2026-06-04T17:18:27+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `95394f19`
+- Current ref: `095f7319`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 155738 | +2346 |
-| Test functions | 2078 | 2137 | +59 |
+| Total Python LOC | 153392 | 155793 | +2401 |
+| Test functions | 2078 | 2139 | +61 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -55,7 +55,7 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2140 |
+| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2156 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
 | 8 | src/core/dpm_source_context.py | 1878 |
 | 9 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 1830 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T15:57:06+00:00`
+- Generated at: `2026-06-04T16:05:06+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `64620b5d`
+- Current ref: `f2aab1b9`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 796 | 797 | +1 |
-| Total Python LOC | 153392 | 154261 | +869 |
-| Test functions | 2078 | 2108 | +30 |
+| Python files | 796 | 798 | +2 |
+| Total Python LOC | 153392 | 154405 | +1013 |
+| Test functions | 2078 | 2110 | +32 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T16:49:19+00:00`
+- Generated at: `2026-06-04T16:56:10+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `a44976a9`
+- Current ref: `141099d4`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 155255 | +1863 |
-| Test functions | 2078 | 2127 | +49 |
+| Total Python LOC | 153392 | 155449 | +2057 |
+| Test functions | 2078 | 2129 | +51 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T16:56:10+00:00`
+- Generated at: `2026-06-04T17:01:59+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `141099d4`
+- Current ref: `b09057f2`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 155449 | +2057 |
-| Test functions | 2078 | 2129 | +51 |
+| Total Python LOC | 153392 | 155538 | +2146 |
+| Test functions | 2078 | 2131 | +53 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T16:11:58+00:00`
+- Generated at: `2026-06-04T16:18:13+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `e31faaea`
+- Current ref: `b444ee84`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 154521 | +1129 |
-| Test functions | 2078 | 2114 | +36 |
+| Total Python LOC | 153392 | 154656 | +1264 |
+| Test functions | 2078 | 2119 | +41 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T15:47:26+00:00`
+- Generated at: `2026-06-04T15:57:06+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `226d8694`
+- Current ref: `64620b5d`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 797 | +1 |
-| Total Python LOC | 153392 | 154136 | +744 |
-| Test functions | 2078 | 2105 | +27 |
+| Total Python LOC | 153392 | 154261 | +869 |
+| Test functions | 2078 | 2108 | +30 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T16:18:13+00:00`
+- Generated at: `2026-06-04T16:25:32+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `b444ee84`
+- Current ref: `8b772a14`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 154656 | +1264 |
-| Test functions | 2078 | 2119 | +41 |
+| Total Python LOC | 153392 | 154725 | +1333 |
+| Test functions | 2078 | 2121 | +43 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T16:36:10+00:00`
+- Generated at: `2026-06-04T16:41:40+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `299a455a`
+- Current ref: `816cb1a0`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 154927 | +1535 |
-| Test functions | 2078 | 2123 | +45 |
+| Total Python LOC | 153392 | 155118 | +1726 |
+| Test functions | 2078 | 2125 | +47 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T16:05:06+00:00`
+- Generated at: `2026-06-04T16:11:58+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f2aab1b9`
+- Current ref: `e31faaea`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 154405 | +1013 |
-| Test functions | 2078 | 2110 | +32 |
+| Total Python LOC | 153392 | 154521 | +1129 |
+| Test functions | 2078 | 2114 | +36 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T13:53:42+00:00`
+- Generated at: `2026-06-04T15:47:26+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `e197d2cc`
+- Current ref: `226d8694`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 793 | 796 | +3 |
-| Total Python LOC | 151662 | 153392 | +1730 |
-| Test functions | 2009 | 2078 | +69 |
+| Python files | 796 | 797 | +1 |
+| Total Python LOC | 153392 | 154136 | +744 |
+| Test functions | 2078 | 2105 | +27 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -50,7 +50,7 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 6402 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
@@ -59,7 +59,7 @@
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
 | 8 | src/core/dpm_source_context.py | 1878 |
 | 9 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 1727 |
-| 10 | tests/unit/dpm/api/test_construction_api.py | 1667 |
+| 10 | tests/unit/dpm/api/test_construction_api.py | 1691 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T17:01:59+00:00`
+- Generated at: `2026-06-04T17:09:13+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `b09057f2`
+- Current ref: `09590feb`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 155538 | +2146 |
-| Test functions | 2078 | 2131 | +53 |
+| Total Python LOC | 153392 | 155652 | +2260 |
+| Test functions | 2078 | 2134 | +56 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T16:25:32+00:00`
+- Generated at: `2026-06-04T16:36:10+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `8b772a14`
+- Current ref: `299a455a`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 154725 | +1333 |
-| Test functions | 2078 | 2121 | +43 |
+| Total Python LOC | 153392 | 154927 | +1535 |
+| Test functions | 2078 | 2123 | +45 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -58,7 +58,7 @@
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2140 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 1887 |
 | 8 | src/core/dpm_source_context.py | 1878 |
-| 9 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 1727 |
+| 9 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 1830 |
 | 10 | tests/unit/dpm/api/test_construction_api.py | 1691 |
 
 ## Largest Functions

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T17:09:13+00:00`
+- Generated at: `2026-06-04T17:14:00+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `09590feb`
+- Current ref: `95394f19`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 155652 | +2260 |
-| Test functions | 2078 | 2134 | +56 |
+| Total Python LOC | 153392 | 155738 | +2346 |
+| Test functions | 2078 | 2137 | +59 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T17:18:27+00:00`
+- Generated at: `2026-06-04T23:03:04+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `095f7319`
+- Current ref: `5561b776`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 155793 | +2401 |
-| Test functions | 2078 | 2139 | +61 |
+| Total Python LOC | 153392 | 155953 | +2561 |
+| Test functions | 2078 | 2141 | +63 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-04T16:41:40+00:00`
+- Generated at: `2026-06-04T16:49:19+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `816cb1a0`
+- Current ref: `a44976a9`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 796 | 798 | +2 |
-| Total Python LOC | 153392 | 155118 | +1726 |
-| Test functions | 2078 | 2125 | +47 |
+| Total Python LOC | 153392 | 155255 | +1863 |
+| Test functions | 2078 | 2127 | +49 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -403,22 +403,26 @@ def _ensure_operation_documentation(schema: dict[str, Any], service_name: str) -
                     f"{method.upper()} operation for {path} in {service_name}."
                 )
             if not operation.get("tags"):
-                if path.startswith("/health"):
-                    operation["tags"] = ["Health"]
-                elif path == "/metrics":
-                    operation["tags"] = ["Monitoring"]
-                else:
-                    segment = path.strip("/").split("/", 1)[0] or "default"
-                    operation["tags"] = [segment.replace("-", " ").title()]
+                operation["tags"] = [_operation_tag_for_path(path)]
 
             responses = operation.get("responses")
-            if isinstance(responses, dict):
-                has_error = any(
-                    code.startswith("4") or code.startswith("5") or code == "default"
-                    for code in responses
-                )
-                if not has_error:
-                    responses["default"] = {"description": "Unexpected error response."}
+            if isinstance(responses, dict) and not _operation_has_error_response(responses):
+                responses["default"] = {"description": "Unexpected error response."}
+
+
+def _operation_tag_for_path(path: str) -> str:
+    if path.startswith("/health"):
+        return "Health"
+    if path == "/metrics":
+        return "Monitoring"
+    segment = path.strip("/").split("/", 1)[0] or "default"
+    return segment.replace("-", " ").title()
+
+
+def _operation_has_error_response(responses: dict[str, Any]) -> bool:
+    return any(
+        code.startswith("4") or code.startswith("5") or code == "default" for code in responses
+    )
 
 
 def _ensure_schema_documentation(schema: dict[str, Any]) -> None:

--- a/src/api/routers/construction_generate_routes.py
+++ b/src/api/routers/construction_generate_routes.py
@@ -21,7 +21,10 @@ from src.api.services import construction_service
 from src.api.services import rebalance_simulation_service
 from src.api.services.authority_client_service import RiskAuthorityClient
 from src.core.construction.models import ConstructionAlternativeSet
-from src.core.construction.repository import ConstructionRepository
+from src.core.construction.repository import (
+    ConstructionIdempotencyConflictError,
+    ConstructionRepository,
+)
 from src.core.rebalance_runs.service import DpmRunSupportService
 
 
@@ -89,5 +92,5 @@ def generate_alternative_set(
             risk_authority_client=risk_authority_client,
             run_service=run_service,
         )
-    except Exception as exc:
+    except ConstructionIdempotencyConflictError as exc:
         raise construction_http_exception(exc) from exc

--- a/src/api/routers/construction_read_routes.py
+++ b/src/api/routers/construction_read_routes.py
@@ -10,7 +10,10 @@ from src.api.routers.construction_http import construction_http_exception
 from src.api.routers.construction_models import CONSTRUCTION_ALTERNATIVE_SET_EXAMPLE
 from src.api.services import construction_service
 from src.core.construction.models import ConstructionAlternativeSet
-from src.core.construction.repository import ConstructionRepository
+from src.core.construction.repository import (
+    ConstructionAlternativeSetNotFoundError,
+    ConstructionRepository,
+)
 
 
 @router.get(
@@ -42,5 +45,5 @@ def read_alternative_set(
             repository=repository,
             alternative_set_id=alternative_set_id,
         )
-    except Exception as exc:
+    except ConstructionAlternativeSetNotFoundError as exc:
         raise construction_http_exception(exc) from exc

--- a/src/api/routers/construction_selection_routes.py
+++ b/src/api/routers/construction_selection_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Annotated, Optional
 
-from fastapi import Depends, Header, HTTPException, Path, status
+from fastapi import Depends, Header, Path, status
 
 from src.api.dependencies import get_construction_repository
 from src.api.routers.construction import router
@@ -10,7 +10,16 @@ from src.api.routers.construction_http import construction_http_exception
 from src.api.routers.construction_models import ConstructionAlternativeSelectionRequest
 from src.api.services import construction_service
 from src.core.construction.models import ConstructionAlternativeSelection
-from src.core.construction.repository import ConstructionRepository
+from src.core.construction.repository import (
+    ConstructionAlternativeNotFoundError,
+    ConstructionAlternativeSetNotFoundError,
+    ConstructionRepository,
+)
+
+_CONSTRUCTION_SELECTION_ROUTE_ERRORS = (
+    ConstructionAlternativeNotFoundError,
+    ConstructionAlternativeSetNotFoundError,
+)
 
 
 @router.post(
@@ -53,6 +62,5 @@ def select_alternative(
             comment=request.comment,
             correlation_id=x_correlation_id,
         )
-    except Exception as exc:
-        http_exc = construction_http_exception(exc)
-        raise HTTPException(status_code=http_exc.status_code, detail=http_exc.detail) from exc
+    except _CONSTRUCTION_SELECTION_ROUTE_ERRORS as exc:
+        raise construction_http_exception(exc) from exc

--- a/src/api/routers/proof_pack_generate_routes.py
+++ b/src/api/routers/proof_pack_generate_routes.py
@@ -14,7 +14,7 @@ from src.api.routers.proof_pack_models import (
     DpmProofPackGenerateRequest,
     DpmProofPackGenerateResponse,
 )
-from src.api.routers.proof_pack_http import proof_pack_http_exception
+from src.api.routers.proof_pack_http import PROOF_PACK_ROUTE_ERRORS, proof_pack_http_exception
 from src.api.routers.proof_packs import router
 from src.api.routers.rebalance_runs import get_dpm_run_support_service
 from src.api.services import proof_pack_service
@@ -122,9 +122,8 @@ def generate_proof_pack(
         )
     except HTTPException:
         raise
-    except Exception as exc:
-        http_exc = proof_pack_http_exception(exc)
-        raise HTTPException(status_code=http_exc.status_code, detail=http_exc.detail) from exc
+    except PROOF_PACK_ROUTE_ERRORS as exc:
+        raise proof_pack_http_exception(exc) from exc
 
 
 def _to_generate_response(

--- a/src/api/routers/proof_pack_handoff_routes.py
+++ b/src/api/routers/proof_pack_handoff_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, Path, status
+from fastapi import Depends, Path, status
 
 from src.api.dependencies import (
     get_mandate_repository,
@@ -10,7 +10,7 @@ from src.api.dependencies import (
     get_proof_pack_repository,
     get_wave_repository,
 )
-from src.api.routers.proof_pack_http import proof_pack_http_exception
+from src.api.routers.proof_pack_http import PROOF_PACK_ROUTE_ERRORS, proof_pack_http_exception
 from src.api.routers.proof_packs import router
 from src.api.services import proof_pack_service
 from src.core.mandate_repository import DpmMandateRepository
@@ -49,9 +49,8 @@ def get_proof_pack_report_input(
             outcome_review_repository=outcome_review_repository,
             mandate_repository=mandate_repository,
         )
-    except Exception as exc:
-        http_exc = proof_pack_http_exception(exc)
-        raise HTTPException(status_code=http_exc.status_code, detail=http_exc.detail) from exc
+    except PROOF_PACK_ROUTE_ERRORS as exc:
+        raise proof_pack_http_exception(exc) from exc
 
 
 @router.get(
@@ -83,6 +82,5 @@ def get_proof_pack_ai_evidence_input(
             outcome_review_repository=outcome_review_repository,
             mandate_repository=mandate_repository,
         )
-    except Exception as exc:
-        http_exc = proof_pack_http_exception(exc)
-        raise HTTPException(status_code=http_exc.status_code, detail=http_exc.detail) from exc
+    except PROOF_PACK_ROUTE_ERRORS as exc:
+        raise proof_pack_http_exception(exc) from exc

--- a/src/api/routers/proof_pack_http.py
+++ b/src/api/routers/proof_pack_http.py
@@ -10,6 +10,14 @@ from src.core.proof_packs import ProofPackSourceValidationError
 from src.core.proof_packs.repository import DpmProofPackConflictError
 from src.core.rebalance_runs.service import DpmRunNotFoundError
 
+PROOF_PACK_ROUTE_ERRORS = (
+    DpmProofPackConflictError,
+    DpmRunNotFoundError,
+    ProofPackSourceValidationError,
+    DpmProofPackReportInputNotGeneratedError,
+    DpmProofPackAiEvidenceInputNotGeneratedError,
+)
+
 
 def proof_pack_http_exception(exc: Exception) -> HTTPException:
     if isinstance(exc, DpmProofPackConflictError):

--- a/src/api/routers/proof_pack_read_routes.py
+++ b/src/api/routers/proof_pack_read_routes.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, Path, status
+from fastapi import Depends, Path, status
 from fastapi.responses import PlainTextResponse
 
 from src.api.dependencies import get_proof_pack_repository
-from src.api.routers.proof_pack_http import proof_pack_http_exception
+from src.api.routers.proof_pack_http import PROOF_PACK_ROUTE_ERRORS, proof_pack_http_exception
 from src.api.routers.proof_pack_models import DpmProofPackLookupResponse
 from src.api.routers.proof_packs import router
 from src.api.services import proof_pack_service
@@ -39,9 +39,8 @@ def get_proof_pack(
                 proof_pack_repository=proof_pack_repository,
             )
         )
-    except Exception as exc:
-        http_exc = proof_pack_http_exception(exc)
-        raise HTTPException(status_code=http_exc.status_code, detail=http_exc.detail) from exc
+    except PROOF_PACK_ROUTE_ERRORS as exc:
+        raise proof_pack_http_exception(exc) from exc
 
 
 @router.get(
@@ -68,6 +67,5 @@ def get_proof_pack_markdown(
             proof_pack_repository=proof_pack_repository,
         )
         return render_proof_pack_markdown(proof_pack)
-    except Exception as exc:
-        http_exc = proof_pack_http_exception(exc)
-        raise HTTPException(status_code=http_exc.status_code, detail=http_exc.detail) from exc
+    except PROOF_PACK_ROUTE_ERRORS as exc:
+        raise proof_pack_http_exception(exc) from exc

--- a/src/api/services/construction_client_profile_source_context.py
+++ b/src/api/services/construction_client_profile_source_context.py
@@ -42,13 +42,19 @@ def client_restriction_profile_context(
             **client_profile_source_fields(restriction_profile),
             "restriction_count": restriction_profile.supportability.restriction_count,
             "missing_data_families": restriction_profile.supportability.missing_data_families,
-            "restrictions": [
-                AuthoritativeClientRestrictionRule.model_validate(rule.model_dump(mode="python"))
-                for rule in restriction_profile.restrictions
-            ],
+            "restrictions": client_restriction_rules(restriction_profile),
             "reason_codes": [restriction_profile.supportability.reason],
         }
     )
+
+
+def client_restriction_rules(
+    restriction_profile: DpmCoreClientRestrictionProfileResponse,
+) -> list[AuthoritativeClientRestrictionRule]:
+    return [
+        AuthoritativeClientRestrictionRule.model_validate(rule.model_dump(mode="python"))
+        for rule in restriction_profile.restrictions
+    ]
 
 
 def sustainability_preference_profile_context(
@@ -59,20 +65,26 @@ def sustainability_preference_profile_context(
             **client_profile_source_fields(sustainability_profile),
             "preference_count": sustainability_profile.supportability.preference_count,
             "missing_data_families": sustainability_profile.supportability.missing_data_families,
-            "preferences": [
-                AuthoritativeSustainabilityPreference.model_validate(
-                    preference.model_dump(mode="python")
-                )
-                for preference in sustainability_profile.preferences
-            ],
+            "preferences": sustainability_preferences(sustainability_profile),
             "reason_codes": [sustainability_profile.supportability.reason],
         }
     )
 
 
+def sustainability_preferences(
+    sustainability_profile: DpmCoreSustainabilityPreferenceProfileResponse,
+) -> list[AuthoritativeSustainabilityPreference]:
+    return [
+        AuthoritativeSustainabilityPreference.model_validate(preference.model_dump(mode="python"))
+        for preference in sustainability_profile.preferences
+    ]
+
+
 __all__ = [
     "ClientProfileSourceResponse",
+    "client_restriction_rules",
     "client_profile_source_fields",
     "client_restriction_profile_context",
     "sustainability_preference_profile_context",
+    "sustainability_preferences",
 ]

--- a/src/api/services/construction_liquidity_source_context.py
+++ b/src/api/services/construction_liquidity_source_context.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import TypeAlias
 
@@ -36,6 +37,14 @@ _MANAGE_MINIMUM_CASH_WEIGHT = Decimal("0.02")
 _MANAGE_ALLOWED_LIQUIDITY_TIERS = ["L1", "L2", "L3"]
 _MANAGE_LIQUIDITY_POLICY_REASON = "LIQUIDITY_POLICY_DERIVED_FROM_MANAGE_SETTLEMENT_RULES"
 _CORE_LIQUIDITY_SOURCE_REASON = "CORE_LIQUIDITY_SOURCE_CONTEXT_PRESENT"
+
+
+@dataclass(frozen=True)
+class LiquiditySourceChildContexts:
+    cashflow_projection: AuthoritativeLiquidityCashflowProjection | None
+    client_income_needs_schedule: AuthoritativeClientIncomeNeedsSchedule | None
+    liquidity_reserve_requirement: AuthoritativeLiquidityReserveRequirement | None
+    planned_withdrawal_schedule: AuthoritativePlannedWithdrawalSchedule | None
 
 
 def source_liquidity_reason_codes(
@@ -153,6 +162,35 @@ def planned_withdrawal_schedule_context(
     )
 
 
+def liquidity_source_child_contexts(
+    *,
+    cashflow_projection: DpmCorePortfolioCashflowProjectionResponse | None,
+    income_needs: DpmCoreClientIncomeNeedsScheduleResponse | None,
+    reserve_requirement: DpmCoreLiquidityReserveRequirementResponse | None,
+    planned_withdrawals: DpmCorePlannedWithdrawalScheduleResponse | None,
+) -> LiquiditySourceChildContexts:
+    return LiquiditySourceChildContexts(
+        cashflow_projection=(
+            liquidity_cashflow_projection_context(cashflow_projection)
+            if cashflow_projection is not None
+            else None
+        ),
+        client_income_needs_schedule=(
+            client_income_needs_schedule_context(income_needs) if income_needs is not None else None
+        ),
+        liquidity_reserve_requirement=(
+            liquidity_reserve_requirement_context(reserve_requirement)
+            if reserve_requirement is not None
+            else None
+        ),
+        planned_withdrawal_schedule=(
+            planned_withdrawal_schedule_context(planned_withdrawals)
+            if planned_withdrawals is not None
+            else None
+        ),
+    )
+
+
 def source_liquidity_context(
     *,
     cashflow_projection: DpmCorePortfolioCashflowProjectionResponse | None,
@@ -168,23 +206,11 @@ def source_liquidity_context(
     ):
         return None
 
-    cashflow_context = (
-        liquidity_cashflow_projection_context(cashflow_projection)
-        if cashflow_projection is not None
-        else None
-    )
-    income_context = (
-        client_income_needs_schedule_context(income_needs) if income_needs is not None else None
-    )
-    reserve_context = (
-        liquidity_reserve_requirement_context(reserve_requirement)
-        if reserve_requirement is not None
-        else None
-    )
-    withdrawal_context = (
-        planned_withdrawal_schedule_context(planned_withdrawals)
-        if planned_withdrawals is not None
-        else None
+    child_contexts = liquidity_source_child_contexts(
+        cashflow_projection=cashflow_projection,
+        income_needs=income_needs,
+        reserve_requirement=reserve_requirement,
+        planned_withdrawals=planned_withdrawals,
     )
 
     return AuthoritativeLiquidityContext(
@@ -193,22 +219,24 @@ def source_liquidity_context(
         policy_id=_MANAGE_LIQUIDITY_POLICY_ID,
         minimum_cash_weight=_MANAGE_MINIMUM_CASH_WEIGHT,
         allowed_liquidity_tiers=_MANAGE_ALLOWED_LIQUIDITY_TIERS,
-        cashflow_projection=cashflow_context,
-        client_income_needs_schedule=income_context,
-        liquidity_reserve_requirement=reserve_context,
-        planned_withdrawal_schedule=withdrawal_context,
+        cashflow_projection=child_contexts.cashflow_projection,
+        client_income_needs_schedule=child_contexts.client_income_needs_schedule,
+        liquidity_reserve_requirement=child_contexts.liquidity_reserve_requirement,
+        planned_withdrawal_schedule=child_contexts.planned_withdrawal_schedule,
         reason_codes=source_liquidity_reason_codes(
-            has_income_needs=income_context is not None,
-            has_reserve_requirement=reserve_context is not None,
-            has_planned_withdrawals=withdrawal_context is not None,
+            has_income_needs=child_contexts.client_income_needs_schedule is not None,
+            has_reserve_requirement=child_contexts.liquidity_reserve_requirement is not None,
+            has_planned_withdrawals=child_contexts.planned_withdrawal_schedule is not None,
         ),
     )
 
 
 __all__ = [
+    "LiquiditySourceChildContexts",
     "LiquiditySourceResponse",
     "client_income_needs_schedule_context",
     "liquidity_cashflow_projection_context",
+    "liquidity_source_child_contexts",
     "liquidity_source_identity_fields",
     "liquidity_reserve_requirement_context",
     "planned_withdrawal_schedule_context",

--- a/src/api/services/construction_source_product_financial_context.py
+++ b/src/api/services/construction_source_product_financial_context.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from src.api.services import (
     construction_execution_source_context,
     construction_transaction_cost_source_context,
@@ -8,7 +10,23 @@ from src.api.services.construction_authority_context_updates import (
     collect_authority_context_updates,
 )
 from src.core.construction.models import ConstructionAuthorityContext
-from src.core.dpm_source_context import DpmCoreExecutionContext
+from src.core.dpm_source_context import (
+    DpmCoreExecutionContext,
+    DpmCoreExternalCurrencyExposureResponse,
+    DpmCoreExternalEligibleHedgeInstrumentResponse,
+    DpmCoreExternalFXForwardCurveResponse,
+    DpmCoreExternalHedgeExecutionReadinessResponse,
+    DpmCoreExternalHedgePolicyResponse,
+)
+
+
+@dataclass(frozen=True)
+class CurrencyOverlaySourceInputs:
+    hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None
+    currency_exposure: DpmCoreExternalCurrencyExposureResponse | None
+    hedge_policy: DpmCoreExternalHedgePolicyResponse | None
+    eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None
+    fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None
 
 
 def transaction_cost_curve_context_update(
@@ -34,20 +52,33 @@ def currency_overlay_context_update(
 ) -> AuthorityContextUpdate | None:
     if authority_context.currency_overlay_context is not None:
         return None
+    source_inputs = currency_overlay_source_inputs(source_context)
     currency_context = (
         construction_treasury_source_context.external_treasury_currency_overlay_context(
-            hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
-            currency_exposure=getattr(source_context, "external_currency_exposure", None),
-            hedge_policy=getattr(source_context, "external_hedge_policy", None),
-            eligible_hedge_instruments=getattr(
-                source_context, "external_eligible_hedge_instruments", None
-            ),
-            fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
+            hedge_readiness=source_inputs.hedge_readiness,
+            currency_exposure=source_inputs.currency_exposure,
+            hedge_policy=source_inputs.hedge_policy,
+            eligible_hedge_instruments=source_inputs.eligible_hedge_instruments,
+            fx_forward_curve=source_inputs.fx_forward_curve,
         )
     )
     if currency_context is None:
         return None
     return ("currency_overlay_context", currency_context)
+
+
+def currency_overlay_source_inputs(
+    source_context: DpmCoreExecutionContext,
+) -> CurrencyOverlaySourceInputs:
+    return CurrencyOverlaySourceInputs(
+        hedge_readiness=getattr(source_context, "external_hedge_execution_readiness", None),
+        currency_exposure=getattr(source_context, "external_currency_exposure", None),
+        hedge_policy=getattr(source_context, "external_hedge_policy", None),
+        eligible_hedge_instruments=getattr(
+            source_context, "external_eligible_hedge_instruments", None
+        ),
+        fx_forward_curve=getattr(source_context, "external_fx_forward_curve", None),
+    )
 
 
 def execution_acknowledgement_context_update(
@@ -84,7 +115,9 @@ def source_financial_context_updates(
 
 
 __all__ = [
+    "CurrencyOverlaySourceInputs",
     "currency_overlay_context_update",
+    "currency_overlay_source_inputs",
     "execution_acknowledgement_context_update",
     "source_financial_context_updates",
     "transaction_cost_curve_context_update",

--- a/src/api/services/construction_treasury_source_context.py
+++ b/src/api/services/construction_treasury_source_context.py
@@ -191,6 +191,25 @@ def treasury_source_identities(
     )
 
 
+def treasury_source_hash(
+    *,
+    hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
+    currency_exposure: DpmCoreExternalCurrencyExposureResponse | None,
+    hedge_policy: DpmCoreExternalHedgePolicyResponse | None,
+    eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None,
+    fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None,
+) -> str:
+    return hash_canonical_payload(
+        treasury_source_payloads(
+            hedge_readiness=hedge_readiness,
+            currency_exposure=currency_exposure,
+            hedge_policy=hedge_policy,
+            eligible_hedge_instruments=eligible_hedge_instruments,
+            fx_forward_curve=fx_forward_curve,
+        )
+    )
+
+
 def external_treasury_currency_overlay_context(
     *,
     hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
@@ -209,14 +228,12 @@ def external_treasury_currency_overlay_context(
     if primary_supportability is None:
         return None
 
-    source_hash = hash_canonical_payload(
-        treasury_source_payloads(
-            hedge_readiness=hedge_readiness,
-            currency_exposure=currency_exposure,
-            hedge_policy=hedge_policy,
-            eligible_hedge_instruments=eligible_hedge_instruments,
-            fx_forward_curve=fx_forward_curve,
-        )
+    source_hash = treasury_source_hash(
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=hedge_policy,
+        eligible_hedge_instruments=eligible_hedge_instruments,
+        fx_forward_curve=fx_forward_curve,
     )
 
     identities = treasury_source_identities(
@@ -328,6 +345,7 @@ __all__ = [
     "treasury_response_blocked_capabilities",
     "treasury_response_missing_data_families",
     "treasury_source_identities",
+    "treasury_source_hash",
     "treasury_source_identity_fields",
     "treasury_source_payload",
     "treasury_source_payloads",

--- a/src/api/services/construction_treasury_source_context.py
+++ b/src/api/services/construction_treasury_source_context.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import NamedTuple, TypeAlias
+from typing import Any, NamedTuple, TypeAlias
 
 from src.api.services.construction_source_product_status import source_status_to_method_status
 from src.api.services.construction_source_identity import (
@@ -210,6 +210,144 @@ def treasury_source_hash(
     )
 
 
+def _treasury_readiness_context_fields(
+    *,
+    identities: TreasurySourceIdentities,
+    source_hash: str,
+    hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
+) -> dict[str, Any]:
+    return {
+        "source_product_name": (
+            identities.readiness.source_product_name if identities.readiness is not None else None
+        ),
+        "source_product_version": (
+            identities.readiness.source_product_version
+            if identities.readiness is not None
+            else None
+        ),
+        "source_id": identities.readiness.source_id
+        if identities.readiness is not None
+        else source_hash,
+        "content_hash": source_hash,
+        "readiness_checks": hedge_readiness.readiness_checks if hedge_readiness is not None else [],
+    }
+
+
+def _treasury_currency_exposure_context_fields(
+    *,
+    identities: TreasurySourceIdentities,
+    currency_exposure: DpmCoreExternalCurrencyExposureResponse | None,
+) -> dict[str, Any]:
+    return {
+        **treasury_source_identity_fields(
+            prefix="external_currency_exposure",
+            identity=identities.exposure,
+        ),
+        "external_currency_exposure_count": (
+            currency_exposure.supportability.exposure_count if currency_exposure is not None else 0
+        ),
+        "external_currency_exposure_rows": (
+            currency_exposure.exposures if currency_exposure is not None else []
+        ),
+    }
+
+
+def _treasury_hedge_policy_context_fields(
+    *,
+    identities: TreasurySourceIdentities,
+    hedge_policy: DpmCoreExternalHedgePolicyResponse | None,
+) -> dict[str, Any]:
+    return {
+        **treasury_source_identity_fields(
+            prefix="external_hedge_policy",
+            identity=identities.hedge_policy,
+        ),
+        "external_hedge_policy_rule_count": (
+            hedge_policy.supportability.policy_rule_count if hedge_policy is not None else 0
+        ),
+        "external_hedge_policy_rules": (
+            hedge_policy.policy_rules if hedge_policy is not None else []
+        ),
+    }
+
+
+def _treasury_eligible_hedge_instrument_context_fields(
+    *,
+    identities: TreasurySourceIdentities,
+    eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None,
+) -> dict[str, Any]:
+    return {
+        **treasury_source_identity_fields(
+            prefix="external_eligible_hedge_instrument",
+            identity=identities.eligible_hedge_instruments,
+        ),
+        "external_eligible_hedge_instrument_count": (
+            eligible_hedge_instruments.supportability.instrument_count
+            if eligible_hedge_instruments is not None
+            else 0
+        ),
+        "external_eligible_hedge_instruments": (
+            eligible_hedge_instruments.eligible_instruments
+            if eligible_hedge_instruments is not None
+            else []
+        ),
+    }
+
+
+def _treasury_fx_forward_curve_context_fields(
+    *,
+    identities: TreasurySourceIdentities,
+    fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None,
+) -> dict[str, Any]:
+    return {
+        **treasury_source_identity_fields(
+            prefix="external_fx_forward_curve",
+            identity=identities.fx_forward_curve,
+        ),
+        "external_fx_forward_curve_point_count": (
+            fx_forward_curve.supportability.curve_point_count if fx_forward_curve is not None else 0
+        ),
+        "external_fx_forward_curve_points": (
+            fx_forward_curve.curve_points if fx_forward_curve is not None else []
+        ),
+    }
+
+
+def _treasury_source_family_context_fields(
+    *,
+    identities: TreasurySourceIdentities,
+    source_hash: str,
+    hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
+    currency_exposure: DpmCoreExternalCurrencyExposureResponse | None,
+    hedge_policy: DpmCoreExternalHedgePolicyResponse | None,
+    eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None,
+    fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None,
+) -> dict[str, Any]:
+    return {
+        **_treasury_readiness_context_fields(
+            identities=identities,
+            source_hash=source_hash,
+            hedge_readiness=hedge_readiness,
+        ),
+        **_treasury_currency_exposure_context_fields(
+            identities=identities,
+            currency_exposure=currency_exposure,
+        ),
+        **_treasury_hedge_policy_context_fields(
+            identities=identities,
+            hedge_policy=hedge_policy,
+        ),
+        **_treasury_eligible_hedge_instrument_context_fields(
+            identities=identities,
+            eligible_hedge_instruments=eligible_hedge_instruments,
+        ),
+        **_treasury_fx_forward_curve_context_fields(
+            identities=identities,
+            fx_forward_curve=fx_forward_curve,
+        ),
+    }
+
+
 def external_treasury_currency_overlay_context(
     *,
     hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
@@ -260,18 +398,6 @@ def external_treasury_currency_overlay_context(
         hedge_ratio_min=Decimal("0.00"),
         hedge_ratio_max=Decimal("0.00"),
         eligible_currencies=primary_supportability.exposure_currencies,
-        source_product_name=(
-            identities.readiness.source_product_name if identities.readiness is not None else None
-        ),
-        source_product_version=(
-            identities.readiness.source_product_version
-            if identities.readiness is not None
-            else None
-        ),
-        source_id=identities.readiness.source_id
-        if identities.readiness is not None
-        else source_hash,
-        content_hash=source_hash,
         missing_data_families=treasury_missing_data_families(
             hedge_readiness,
             currency_exposure,
@@ -286,48 +412,14 @@ def external_treasury_currency_overlay_context(
             eligible_hedge_instruments,
             fx_forward_curve,
         ),
-        readiness_checks=hedge_readiness.readiness_checks if hedge_readiness is not None else [],
-        **treasury_source_identity_fields(
-            prefix="external_currency_exposure",
-            identity=identities.exposure,
-        ),
-        external_currency_exposure_count=(
-            currency_exposure.supportability.exposure_count if currency_exposure is not None else 0
-        ),
-        external_currency_exposure_rows=(
-            currency_exposure.exposures if currency_exposure is not None else []
-        ),
-        **treasury_source_identity_fields(
-            prefix="external_hedge_policy",
-            identity=identities.hedge_policy,
-        ),
-        external_hedge_policy_rule_count=(
-            hedge_policy.supportability.policy_rule_count if hedge_policy is not None else 0
-        ),
-        external_hedge_policy_rules=(hedge_policy.policy_rules if hedge_policy is not None else []),
-        **treasury_source_identity_fields(
-            prefix="external_eligible_hedge_instrument",
-            identity=identities.eligible_hedge_instruments,
-        ),
-        external_eligible_hedge_instrument_count=(
-            eligible_hedge_instruments.supportability.instrument_count
-            if eligible_hedge_instruments is not None
-            else 0
-        ),
-        external_eligible_hedge_instruments=(
-            eligible_hedge_instruments.eligible_instruments
-            if eligible_hedge_instruments is not None
-            else []
-        ),
-        **treasury_source_identity_fields(
-            prefix="external_fx_forward_curve",
-            identity=identities.fx_forward_curve,
-        ),
-        external_fx_forward_curve_point_count=(
-            fx_forward_curve.supportability.curve_point_count if fx_forward_curve is not None else 0
-        ),
-        external_fx_forward_curve_points=(
-            fx_forward_curve.curve_points if fx_forward_curve is not None else []
+        **_treasury_source_family_context_fields(
+            identities=identities,
+            source_hash=source_hash,
+            hedge_readiness=hedge_readiness,
+            currency_exposure=currency_exposure,
+            hedge_policy=hedge_policy,
+            eligible_hedge_instruments=eligible_hedge_instruments,
+            fx_forward_curve=fx_forward_curve,
         ),
         reason_codes=reason_codes,
     )

--- a/src/api/services/construction_treasury_source_context.py
+++ b/src/api/services/construction_treasury_source_context.py
@@ -141,6 +141,14 @@ class TreasuryPrimarySupportability(NamedTuple):
     exposure_currencies: list[str]
 
 
+class TreasurySourceIdentities(NamedTuple):
+    readiness: SourceProductIdentity | None
+    exposure: SourceProductIdentity | None
+    hedge_policy: SourceProductIdentity | None
+    eligible_hedge_instruments: SourceProductIdentity | None
+    fx_forward_curve: SourceProductIdentity | None
+
+
 def treasury_primary_supportability(
     *,
     hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
@@ -163,6 +171,24 @@ def treasury_primary_supportability(
                 exposure_currencies=response.exposure_currencies,
             )
     return None
+
+
+def treasury_source_identities(
+    *,
+    source_hash: str,
+    hedge_readiness: DpmCoreExternalHedgeExecutionReadinessResponse | None,
+    currency_exposure: DpmCoreExternalCurrencyExposureResponse | None,
+    hedge_policy: DpmCoreExternalHedgePolicyResponse | None,
+    eligible_hedge_instruments: DpmCoreExternalEligibleHedgeInstrumentResponse | None,
+    fx_forward_curve: DpmCoreExternalFXForwardCurveResponse | None,
+) -> TreasurySourceIdentities:
+    return TreasurySourceIdentities(
+        readiness=treasury_optional_source_identity(hedge_readiness, source_hash),
+        exposure=treasury_optional_source_identity(currency_exposure),
+        hedge_policy=treasury_optional_source_identity(hedge_policy),
+        eligible_hedge_instruments=treasury_optional_source_identity(eligible_hedge_instruments),
+        fx_forward_curve=treasury_optional_source_identity(fx_forward_curve),
+    )
 
 
 def external_treasury_currency_overlay_context(
@@ -193,13 +219,14 @@ def external_treasury_currency_overlay_context(
         )
     )
 
-    readiness_identity = treasury_optional_source_identity(hedge_readiness, source_hash)
-    exposure_identity = treasury_optional_source_identity(currency_exposure)
-    hedge_policy_identity = treasury_optional_source_identity(hedge_policy)
-    eligible_hedge_instruments_identity = treasury_optional_source_identity(
-        eligible_hedge_instruments
+    identities = treasury_source_identities(
+        source_hash=source_hash,
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=hedge_policy,
+        eligible_hedge_instruments=eligible_hedge_instruments,
+        fx_forward_curve=fx_forward_curve,
     )
-    fx_forward_curve_identity = treasury_optional_source_identity(fx_forward_curve)
     reason_codes = treasury_fail_closed_reason_codes(
         primary_reason=primary_supportability.reason,
         hedge_readiness=hedge_readiness,
@@ -217,12 +244,16 @@ def external_treasury_currency_overlay_context(
         hedge_ratio_max=Decimal("0.00"),
         eligible_currencies=primary_supportability.exposure_currencies,
         source_product_name=(
-            readiness_identity.source_product_name if readiness_identity is not None else None
+            identities.readiness.source_product_name if identities.readiness is not None else None
         ),
         source_product_version=(
-            readiness_identity.source_product_version if readiness_identity is not None else None
+            identities.readiness.source_product_version
+            if identities.readiness is not None
+            else None
         ),
-        source_id=readiness_identity.source_id if readiness_identity is not None else source_hash,
+        source_id=identities.readiness.source_id
+        if identities.readiness is not None
+        else source_hash,
         content_hash=source_hash,
         missing_data_families=treasury_missing_data_families(
             hedge_readiness,
@@ -241,7 +272,7 @@ def external_treasury_currency_overlay_context(
         readiness_checks=hedge_readiness.readiness_checks if hedge_readiness is not None else [],
         **treasury_source_identity_fields(
             prefix="external_currency_exposure",
-            identity=exposure_identity,
+            identity=identities.exposure,
         ),
         external_currency_exposure_count=(
             currency_exposure.supportability.exposure_count if currency_exposure is not None else 0
@@ -251,7 +282,7 @@ def external_treasury_currency_overlay_context(
         ),
         **treasury_source_identity_fields(
             prefix="external_hedge_policy",
-            identity=hedge_policy_identity,
+            identity=identities.hedge_policy,
         ),
         external_hedge_policy_rule_count=(
             hedge_policy.supportability.policy_rule_count if hedge_policy is not None else 0
@@ -259,7 +290,7 @@ def external_treasury_currency_overlay_context(
         external_hedge_policy_rules=(hedge_policy.policy_rules if hedge_policy is not None else []),
         **treasury_source_identity_fields(
             prefix="external_eligible_hedge_instrument",
-            identity=eligible_hedge_instruments_identity,
+            identity=identities.eligible_hedge_instruments,
         ),
         external_eligible_hedge_instrument_count=(
             eligible_hedge_instruments.supportability.instrument_count
@@ -273,7 +304,7 @@ def external_treasury_currency_overlay_context(
         ),
         **treasury_source_identity_fields(
             prefix="external_fx_forward_curve",
-            identity=fx_forward_curve_identity,
+            identity=identities.fx_forward_curve,
         ),
         external_fx_forward_curve_point_count=(
             fx_forward_curve.supportability.curve_point_count if fx_forward_curve is not None else 0
@@ -287,6 +318,7 @@ def external_treasury_currency_overlay_context(
 
 __all__ = [
     "TreasuryPrimarySupportability",
+    "TreasurySourceIdentities",
     "external_treasury_currency_overlay_context",
     "treasury_blocked_capabilities",
     "treasury_fail_closed_reason_codes",
@@ -295,6 +327,7 @@ __all__ = [
     "treasury_primary_supportability",
     "treasury_response_blocked_capabilities",
     "treasury_response_missing_data_families",
+    "treasury_source_identities",
     "treasury_source_identity_fields",
     "treasury_source_payload",
     "treasury_source_payloads",

--- a/src/api/services/mandate_command_center.py
+++ b/src/api/services/mandate_command_center.py
@@ -78,6 +78,47 @@ def latest_command_center_run(
     )
 
 
+def command_center_health_distribution(
+    *,
+    latest_run: DpmMonitoringRun | None,
+    health_state: str | None,
+) -> dict[str, int]:
+    health_distribution = dict(latest_run.health_distribution) if latest_run else {}
+    if health_state is None:
+        return health_distribution
+    return {health_state: health_distribution.get(health_state, 0)}
+
+
+def command_center_partial_reasons(
+    *,
+    latest_run: DpmMonitoringRun | None,
+    portfolio_manager_id: str | None,
+    book_id: str | None,
+    active_exception_count: int,
+    limit: int,
+) -> list[str]:
+    partial_reasons: list[str] = []
+    if latest_run is None:
+        partial_reasons.append("NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS")
+    if portfolio_manager_id is None and book_id is None:
+        partial_reasons.append("PM_BOOK_DISCOVERY_NOT_YET_SOURCED")
+    if active_exception_count >= limit:
+        partial_reasons.append("ATTENTION_QUEUE_LIMIT_REACHED")
+    return partial_reasons
+
+
+def command_center_completeness(
+    *,
+    latest_run: DpmMonitoringRun | None,
+    partial_reasons: list[str],
+) -> Literal["COMPLETE", "PARTIAL", "EMPTY"]:
+    if latest_run is None:
+        return "EMPTY"
+    if partial_reasons:
+        return "PARTIAL"
+    return "COMPLETE"
+
+
 def build_command_center_summary(
     *,
     tenant_id: str | None,
@@ -90,23 +131,21 @@ def build_command_center_summary(
     limit: int,
     generated_at: datetime,
 ) -> DpmCommandCenterSummary:
-    health_distribution = dict(latest_run.health_distribution) if latest_run else {}
-    if health_state is not None:
-        health_distribution = {health_state: health_distribution.get(health_state, 0)}
-
-    partial_reasons: list[str] = []
-    if latest_run is None:
-        partial_reasons.append("NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS")
-    if portfolio_manager_id is None and book_id is None:
-        partial_reasons.append("PM_BOOK_DISCOVERY_NOT_YET_SOURCED")
-    if len(active_exceptions) >= limit:
-        partial_reasons.append("ATTENTION_QUEUE_LIMIT_REACHED")
-
-    completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"] = "COMPLETE"
-    if latest_run is None:
-        completeness = "EMPTY"
-    elif partial_reasons:
-        completeness = "PARTIAL"
+    health_distribution = command_center_health_distribution(
+        latest_run=latest_run,
+        health_state=health_state,
+    )
+    partial_reasons = command_center_partial_reasons(
+        latest_run=latest_run,
+        portfolio_manager_id=portfolio_manager_id,
+        book_id=book_id,
+        active_exception_count=len(active_exceptions),
+        limit=limit,
+    )
+    completeness = command_center_completeness(
+        latest_run=latest_run,
+        partial_reasons=partial_reasons,
+    )
     supportability_state, supportability_reason = command_center_supportability_state(
         latest_run=latest_run,
         completeness=completeness,
@@ -216,6 +255,9 @@ def severity_rank(severity: str) -> int:
 __all__ = [
     "attention_buckets",
     "build_command_center_summary",
+    "command_center_completeness",
+    "command_center_health_distribution",
+    "command_center_partial_reasons",
     "command_center_supportability_state",
     "latest_command_center_run",
     "recommended_actions",

--- a/src/api/services/wave_construction_selection.py
+++ b/src/api/services/wave_construction_selection.py
@@ -2,7 +2,16 @@ from __future__ import annotations
 
 from src.api.services import construction_service
 from src.api.services.wave_errors import DpmWaveLookupError
-from src.core.construction.repository import ConstructionRepository
+from src.core.construction.repository import (
+    ConstructionAlternativeNotFoundError,
+    ConstructionAlternativeSetNotFoundError,
+    ConstructionRepository,
+)
+
+_CONSTRUCTION_SELECTION_LOOKUP_ERRORS = (
+    ConstructionAlternativeNotFoundError,
+    ConstructionAlternativeSetNotFoundError,
+)
 
 
 def select_construction_alternative_for_wave(
@@ -25,7 +34,7 @@ def select_construction_alternative_for_wave(
             comment=comment,
             correlation_id=correlation_id,
         )
-    except Exception as exc:
+    except _CONSTRUCTION_SELECTION_LOOKUP_ERRORS as exc:
         raise DpmWaveLookupError("DPM_CONSTRUCTION_ALTERNATIVE_NOT_FOUND", str(exc)) from exc
 
 

--- a/src/api/services/wave_core_portfolio_universe_resolution.py
+++ b/src/api/services/wave_core_portfolio_universe_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import date
 from typing import Any
 
@@ -21,6 +22,17 @@ from src.core.waves import DpmWaveSourceRef
 CoreResolverFactory = Callable[[], Any]
 
 MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES = 10
+
+
+@dataclass(frozen=True)
+class _PortfolioUniverseResolutionRequest:
+    as_of_date: date
+    tenant_id: str | None
+    booking_center_code: str | None
+    model_portfolio_ids: list[str]
+    include_inactive_mandates: bool
+    campaign_candidate_page_size: int
+    correlation_id: str
 
 
 def _selection_basis_payload(
@@ -70,34 +82,18 @@ def resolve_core_dpm_portfolio_universe_candidates(
     correlation_id: str,
     core_resolver_factory: CoreResolverFactory,
 ) -> list[dict[str, object]]:
+    request = _PortfolioUniverseResolutionRequest(
+        as_of_date=as_of_date,
+        tenant_id=tenant_id,
+        booking_center_code=booking_center_code,
+        model_portfolio_ids=model_portfolio_ids,
+        include_inactive_mandates=include_inactive_mandates,
+        campaign_candidate_page_size=campaign_candidate_page_size,
+        correlation_id=correlation_id,
+    )
     resolver = core_resolver_factory()
-    candidate_pages: list[DpmCorePortfolioUniverseCandidateResponse] = []
-    next_page_token: str | None = None
-    seen_page_tokens: set[str] = set()
-
     try:
-        for _ in range(MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES):
-            candidate_page = resolver.resolve_dpm_portfolio_universe_candidates(
-                as_of_date=as_of_date,
-                tenant_id=tenant_id,
-                booking_center_code=booking_center_code,
-                model_portfolio_ids=model_portfolio_ids,
-                include_inactive_mandates=include_inactive_mandates,
-                page_size=campaign_candidate_page_size,
-                page_token=next_page_token,
-                correlation_id=correlation_id,
-            )
-            candidate_pages.append(candidate_page)
-            if candidate_page.supportability.state != "READY":
-                break
-            next_page_token = candidate_page.page.next_page_token
-            if not next_page_token:
-                break
-            if next_page_token in seen_page_tokens:
-                raise CoreResolverError("DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING")
-            seen_page_tokens.add(next_page_token)
-        else:
-            raise CoreResolverError("DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING")
+        candidate_pages = _resolve_candidate_pages(resolver=resolver, request=request)
     except CoreResolverUnavailableError as exc:
         raise DpmWaveDependencyUnavailableError(
             code=str(exc) or "DPM_CORE_PORTFOLIO_UNIVERSE_UNAVAILABLE"
@@ -107,13 +103,54 @@ def resolve_core_dpm_portfolio_universe_candidates(
             code=str(exc) or "DPM_CORE_PORTFOLIO_UNIVERSE_INCOMPLETE"
         ) from exc
 
+    return _portfolio_payloads_from_candidate_pages(candidate_pages)
+
+
+def _resolve_candidate_pages(
+    *,
+    resolver: Any,
+    request: _PortfolioUniverseResolutionRequest,
+) -> list[DpmCorePortfolioUniverseCandidateResponse]:
+    candidate_pages: list[DpmCorePortfolioUniverseCandidateResponse] = []
+    next_page_token: str | None = None
+    seen_page_tokens: set[str] = set()
+
+    for _ in range(MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES):
+        candidate_page = resolver.resolve_dpm_portfolio_universe_candidates(
+            as_of_date=request.as_of_date,
+            tenant_id=request.tenant_id,
+            booking_center_code=request.booking_center_code,
+            model_portfolio_ids=request.model_portfolio_ids,
+            include_inactive_mandates=request.include_inactive_mandates,
+            page_size=request.campaign_candidate_page_size,
+            page_token=next_page_token,
+            correlation_id=request.correlation_id,
+        )
+        candidate_pages.append(candidate_page)
+        if candidate_page.supportability.state != "READY":
+            break
+        next_page_token = candidate_page.page.next_page_token
+        if not next_page_token:
+            break
+        if next_page_token in seen_page_tokens:
+            raise CoreResolverError("DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING")
+        seen_page_tokens.add(next_page_token)
+    else:
+        raise CoreResolverError("DPM_CORE_PORTFOLIO_UNIVERSE_NON_TERMINATING")
+
+    return candidate_pages
+
+
+def _portfolio_payloads_from_candidate_pages(
+    candidate_pages: list[DpmCorePortfolioUniverseCandidateResponse],
+) -> list[dict[str, object]]:
     candidate_page = candidate_pages[-1]
     if candidate_page.supportability.state != "READY":
         raise DpmWaveDependencyFailedError(
             code=candidate_page.supportability.reason,
             message="Core DPM portfolio-universe candidates are not source-ready.",
         )
-    if next_page_token or candidate_page.supportability.page_truncated:
+    if candidate_page.page.next_page_token or candidate_page.supportability.page_truncated:
         raise DpmWaveDependencyFailedError(
             code="DPM_CORE_PORTFOLIO_UNIVERSE_PAGE_PARTIAL",
             message=(
@@ -122,24 +159,49 @@ def resolve_core_dpm_portfolio_universe_candidates(
             ),
         )
 
-    candidates = [candidate for page in candidate_pages for candidate in page.candidates]
+    candidates = _candidate_rows(candidate_pages)
     if not candidates:
         raise DpmWaveDependencyFailedError(
             code="DPM_CORE_PORTFOLIO_UNIVERSE_EMPTY",
             message="Core DPM portfolio-universe discovery returned no candidate portfolios.",
         )
-    candidate_keys: set[tuple[str, str | None, str | None]] = set()
     first_page = candidate_pages[0]
     selection_basis = _selection_basis_payload(first_page)
     universe_ref = _portfolio_universe_candidate_page_ref(page=first_page)
+    return _candidate_portfolio_payloads(
+        candidates=candidates,
+        universe_ref=universe_ref,
+        selection_basis=selection_basis,
+    )
+
+
+def _candidate_rows(
+    candidate_pages: list[DpmCorePortfolioUniverseCandidateResponse],
+) -> list[DpmCorePortfolioUniverseCandidate]:
+    return [candidate for page in candidate_pages for candidate in page.candidates]
+
+
+def _candidate_key(
+    candidate: DpmCorePortfolioUniverseCandidate,
+) -> tuple[str, str | None, str | None]:
+    return (
+        candidate.portfolio_id,
+        candidate.mandate_id,
+        candidate.source_record_id,
+    )
+
+
+def _candidate_portfolio_payloads(
+    *,
+    candidates: list[DpmCorePortfolioUniverseCandidate],
+    universe_ref: dict[str, object],
+    selection_basis: dict[str, object] | None,
+) -> list[dict[str, object]]:
+    candidate_keys: set[tuple[str, str | None, str | None]] = set()
     portfolios: list[dict[str, object]] = []
 
     for candidate in candidates:
-        candidate_key = (
-            candidate.portfolio_id,
-            candidate.mandate_id,
-            candidate.source_record_id,
-        )
+        candidate_key = _candidate_key(candidate)
         if candidate_key in candidate_keys:
             raise DpmWaveDependencyFailedError(
                 code="DPM_CORE_PORTFOLIO_UNIVERSE_DUPLICATE_CANDIDATE",

--- a/src/api/services/wave_selection_item.py
+++ b/src/api/services/wave_selection_item.py
@@ -1,9 +1,16 @@
 from src.api.services import proof_pack_service
 from src.core.construction.repository import ConstructionRepository
 from src.core.mandate_repository import DpmMandateRepository
-from src.core.proof_packs.repository import DpmProofPackRepository
-from src.core.rebalance_runs.service import DpmRunSupportService
+from src.core.proof_packs import ProofPackSourceValidationError
+from src.core.proof_packs.repository import DpmProofPackConflictError, DpmProofPackRepository
+from src.core.rebalance_runs.service import DpmRunNotFoundError, DpmRunSupportService
 from src.core.waves import DpmRebalanceWaveItem
+
+_PROOF_PACK_GENERATION_DEGRADATION_ERRORS = (
+    DpmProofPackConflictError,
+    DpmRunNotFoundError,
+    ProofPackSourceValidationError,
+)
 
 
 def with_selection_and_proof_pack(
@@ -55,7 +62,7 @@ def with_selection_and_proof_pack(
             mandate_repository=mandate_repository,
             proof_pack_repository=proof_pack_repository,
         )
-    except Exception as exc:
+    except _PROOF_PACK_GENERATION_DEGRADATION_ERRORS as exc:
         return item.model_copy(
             update={
                 "state": "SELECTED",

--- a/src/api/services/wave_simulation_item.py
+++ b/src/api/services/wave_simulation_item.py
@@ -4,12 +4,21 @@ from src.api.request_models import RebalanceRequest
 from src.api.services import construction_service
 from src.api.services.wave_construction_diagnostics import proposed_changes_from_alternative_set
 from src.api.services.authority_client_service import RiskAuthorityClient
-from src.core.construction.repository import ConstructionRepository
+from src.core.construction.repository import (
+    ConstructionIdempotencyConflictError,
+    ConstructionRepository,
+)
 from src.core.construction.vocabulary import ConstructionMethod
-from src.core.rebalance_runs.service import DpmRunSupportService
+from src.core.rebalance_runs.service import DpmAsyncOperationConflictError, DpmRunSupportService
 from src.core.waves import DpmRebalanceWaveItem
 from src.core.waves.source_analytics import build_source_analytics_from_alternative_set
 from src.core.construction.models import ConstructionAuthorityContext
+
+_CONSTRUCTION_SIMULATION_BLOCKING_ERRORS = (
+    ConstructionIdempotencyConflictError,
+    DpmAsyncOperationConflictError,
+    ValueError,
+)
 
 
 @dataclass(frozen=True)
@@ -61,7 +70,7 @@ def simulate_item(
             risk_authority_client=risk_authority_client,
             run_service=run_service,
         )
-    except Exception as exc:
+    except _CONSTRUCTION_SIMULATION_BLOCKING_ERRORS as exc:
         return item.model_copy(
             update={
                 "state": "SIMULATION_BLOCKED",

--- a/src/core/common/capabilities.py
+++ b/src/core/common/capabilities.py
@@ -1,4 +1,5 @@
 from importlib.util import find_spec
+from types import ModuleType
 
 
 def has_optional_dependency(module_name: str) -> bool:
@@ -17,10 +18,16 @@ def psycopg_error_type() -> type[BaseException] | None:
     if not has_psycopg():
         return None
     try:
-        import psycopg
-    except Exception:
+        psycopg = _import_psycopg()
+    except ImportError:
         return None
     return getattr(psycopg, "Error", None)
+
+
+def _import_psycopg() -> ModuleType:
+    import psycopg
+
+    return psycopg
 
 
 __all__ = [

--- a/src/core/common/intent_dependencies.py
+++ b/src/core/common/intent_dependencies.py
@@ -14,14 +14,9 @@ def link_buy_intent_dependencies(
 ) -> None:
     """Attach deterministic dependencies to BUY security intents in-place."""
     fx_dependencies = dict(fx_intent_id_by_currency or {})
-
-    sell_intent_id_by_currency: dict[str, str] = {}
-    if include_same_currency_sell_dependency:
-        for intent in intents:
-            if intent.intent_type == "SECURITY_TRADE" and intent.side == "SELL":
-                if intent.notional is None:
-                    continue
-                sell_intent_id_by_currency[intent.notional.currency] = intent.intent_id
+    sell_dependencies = (
+        sell_intent_id_by_currency(intents) if include_same_currency_sell_dependency else {}
+    )
 
     for intent in intents:
         if intent.intent_type != "SECURITY_TRADE" or intent.side != "BUY":
@@ -31,12 +26,32 @@ def link_buy_intent_dependencies(
             continue
         currency = intent.notional.currency
         fx_dependency = fx_dependencies.get(currency)
-        if fx_dependency is not None and fx_dependency not in intent.dependencies:
-            intent.dependencies.append(fx_dependency)
+        append_intent_dependency_once(intent, fx_dependency)
 
         if not include_same_currency_sell_dependency:
             continue
 
-        sell_dependency = sell_intent_id_by_currency.get(currency)
-        if sell_dependency is not None and sell_dependency not in intent.dependencies:
-            intent.dependencies.append(sell_dependency)
+        append_intent_dependency_once(intent, sell_dependencies.get(currency))
+
+
+def sell_intent_id_by_currency(intents: Sequence[RebalanceIntent]) -> dict[str, str]:
+    """Return the latest sell intent id by notional currency."""
+    dependencies: dict[str, str] = {}
+    for intent in intents:
+        if intent.intent_type != "SECURITY_TRADE" or intent.side != "SELL":
+            continue
+        if intent.notional is None:
+            continue
+        dependencies[intent.notional.currency] = intent.intent_id
+    return dependencies
+
+
+def append_intent_dependency_once(
+    intent: SecurityTradeIntent | FxSpotIntent,
+    dependency_id: str | None,
+) -> None:
+    if dependency_id is None:
+        return
+    if dependency_id in intent.dependencies:
+        return
+    intent.dependencies.append(dependency_id)

--- a/src/core/compliance.py
+++ b/src/core/compliance.py
@@ -4,7 +4,6 @@ Post-trade Rule Engine implementation (RFC-0005/RFC-0006B).
 """
 
 from decimal import Decimal
-from typing import List
 
 from src.core.models import DiagnosticsData, EngineOptions, RuleResult, SimulatedState
 
@@ -41,6 +40,168 @@ def _cash_band_rule_result(
     )
 
 
+def _single_position_max_rule_results(
+    *,
+    state: SimulatedState,
+    options: EngineOptions,
+) -> list[RuleResult]:
+    limit_w = options.single_position_max_weight
+    if limit_w is None:
+        return [
+            RuleResult(
+                rule_id="SINGLE_POSITION_MAX",
+                severity="HARD",
+                status="PASS",
+                measured=Decimal("0"),
+                threshold={"max": Decimal("-1")},
+                reason_code="NO_LIMIT_SET",
+            )
+        ]
+
+    breach_results: list[RuleResult] = []
+    max_measured = Decimal("0")
+    for pos in state.allocation_by_instrument:
+        max_measured = max(max_measured, pos.weight)
+        if pos.weight > limit_w + Decimal("0.001"):
+            breach_results.append(
+                RuleResult(
+                    rule_id="SINGLE_POSITION_MAX",
+                    severity="HARD",
+                    status="FAIL",
+                    measured=pos.weight,
+                    threshold={"max": limit_w},
+                    reason_code="LIMIT_BREACH",
+                    remediation_hint=f"Instrument {pos.key} exceeds max weight.",
+                )
+            )
+
+    if breach_results:
+        return breach_results
+
+    return [
+        RuleResult(
+            rule_id="SINGLE_POSITION_MAX",
+            severity="HARD",
+            status="PASS",
+            measured=max_measured,
+            threshold={"max": limit_w},
+            reason_code="OK",
+        )
+    ]
+
+
+def _data_quality_rule_result(
+    *,
+    diagnostics: DiagnosticsData,
+    options: EngineOptions,
+) -> RuleResult:
+    dq_count = 0
+
+    if options.block_on_missing_prices:
+        dq_count += len(diagnostics.data_quality.get("price_missing", []))
+
+    if options.block_on_missing_fx:
+        dq_count += len(diagnostics.data_quality.get("fx_missing", []))
+
+    dq_count += len(diagnostics.data_quality.get("shelf_missing", []))
+
+    if dq_count > 0:
+        return RuleResult(
+            rule_id="DATA_QUALITY",
+            severity="HARD",
+            status="FAIL",
+            measured=Decimal(dq_count),
+            threshold={"max": Decimal("0")},
+            reason_code="MISSING_DATA",
+            remediation_hint="Check diagnostics for missing prices/FX.",
+        )
+
+    return RuleResult(
+        rule_id="DATA_QUALITY",
+        severity="HARD",
+        status="PASS",
+        measured=Decimal(dq_count),
+        threshold={"max": Decimal("0")},
+        reason_code="OK",
+    )
+
+
+def _min_trade_size_rule_result(*, diagnostics: DiagnosticsData) -> RuleResult:
+    suppressed_count = len(diagnostics.suppressed_intents)
+    if suppressed_count > 0:
+        return RuleResult(
+            rule_id="MIN_TRADE_SIZE",
+            severity="SOFT",
+            status="PASS",
+            measured=Decimal(suppressed_count),
+            threshold={"min": Decimal("0")},
+            reason_code="INTENTS_SUPPRESSED",
+        )
+
+    return RuleResult(
+        rule_id="MIN_TRADE_SIZE",
+        severity="SOFT",
+        status="PASS",
+        measured=Decimal("0"),
+        threshold={"min": Decimal("0")},
+        reason_code="OK",
+    )
+
+
+def _no_shorting_rule_result(*, state: SimulatedState) -> RuleResult:
+    min_qty = Decimal("0")
+    for position in state.positions:
+        if position.quantity < Decimal("0"):
+            min_qty = min(min_qty, position.quantity)
+
+    if min_qty < Decimal("0"):
+        return RuleResult(
+            rule_id="NO_SHORTING",
+            severity="HARD",
+            status="FAIL",
+            measured=min_qty,
+            threshold={"min": Decimal("0")},
+            reason_code="SELL_EXCEEDS_HOLDINGS",
+            remediation_hint="Reduce sell quantity.",
+        )
+
+    return RuleResult(
+        rule_id="NO_SHORTING",
+        severity="HARD",
+        status="PASS",
+        measured=Decimal("0"),
+        threshold={"min": Decimal("0")},
+        reason_code="OK",
+    )
+
+
+def _insufficient_cash_rule_result(*, state: SimulatedState) -> RuleResult:
+    min_cash = Decimal("0")
+    for cash_balance in state.cash_balances:
+        if cash_balance.amount < Decimal("0"):
+            min_cash = min(min_cash, cash_balance.amount)
+
+    if min_cash < Decimal("0"):
+        return RuleResult(
+            rule_id="INSUFFICIENT_CASH",
+            severity="HARD",
+            status="FAIL",
+            measured=min_cash,
+            threshold={"min": Decimal("0")},
+            reason_code="CASH_BALANCE_NEGATIVE",
+            remediation_hint="Ensure sufficient funding.",
+        )
+
+    return RuleResult(
+        rule_id="INSUFFICIENT_CASH",
+        severity="HARD",
+        status="PASS",
+        measured=Decimal("0"),
+        threshold={"min": Decimal("0")},
+        reason_code="OK",
+    )
+
+
 class RuleEngine:
     """
     Evaluates business rules against the simulated after-state.
@@ -51,172 +212,15 @@ class RuleEngine:
     @staticmethod
     def evaluate(
         state: SimulatedState, options: EngineOptions, diagnostics: DiagnosticsData
-    ) -> List[RuleResult]:
+    ) -> list[RuleResult]:
         results = []
 
         results.append(_cash_band_rule_result(state=state, options=options))
 
-        limit_w = options.single_position_max_weight
-        if limit_w is not None:
-            breach = False
-            max_measured = Decimal("0")
-            for pos in state.allocation_by_instrument:
-                max_measured = max(max_measured, pos.weight)
-                if pos.weight > limit_w + Decimal("0.001"):
-                    breach = True
-                    results.append(
-                        RuleResult(
-                            rule_id="SINGLE_POSITION_MAX",
-                            severity="HARD",
-                            status="FAIL",
-                            measured=pos.weight,
-                            threshold={"max": limit_w},
-                            reason_code="LIMIT_BREACH",
-                            remediation_hint=f"Instrument {pos.key} exceeds max weight.",
-                        )
-                    )
-
-            if not breach:
-                results.append(
-                    RuleResult(
-                        rule_id="SINGLE_POSITION_MAX",
-                        severity="HARD",
-                        status="PASS",
-                        measured=max_measured,
-                        threshold={"max": limit_w},
-                        reason_code="OK",
-                    )
-                )
-        else:
-            results.append(
-                RuleResult(
-                    rule_id="SINGLE_POSITION_MAX",
-                    severity="HARD",
-                    status="PASS",
-                    measured=Decimal("0"),
-                    threshold={"max": Decimal("-1")},
-                    reason_code="NO_LIMIT_SET",
-                )
-            )
-
-        dq_count = 0
-
-        if options.block_on_missing_prices:
-            dq_count += len(diagnostics.data_quality.get("price_missing", []))
-
-        if options.block_on_missing_fx:
-            dq_count += len(diagnostics.data_quality.get("fx_missing", []))
-
-        dq_count += len(diagnostics.data_quality.get("shelf_missing", []))
-
-        if dq_count > 0:
-            results.append(
-                RuleResult(
-                    rule_id="DATA_QUALITY",
-                    severity="HARD",
-                    status="FAIL",
-                    measured=Decimal(dq_count),
-                    threshold={"max": Decimal("0")},
-                    reason_code="MISSING_DATA",
-                    remediation_hint="Check diagnostics for missing prices/FX.",
-                )
-            )
-        else:
-            results.append(
-                RuleResult(
-                    rule_id="DATA_QUALITY",
-                    severity="HARD",
-                    status="PASS",
-                    measured=Decimal(dq_count),
-                    threshold={"max": Decimal("0")},
-                    reason_code="OK",
-                )
-            )
-
-        suppressed_count = len(diagnostics.suppressed_intents)
-        if suppressed_count > 0:
-            results.append(
-                RuleResult(
-                    rule_id="MIN_TRADE_SIZE",
-                    severity="SOFT",
-                    status="PASS",
-                    measured=Decimal(suppressed_count),
-                    threshold={"min": Decimal("0")},
-                    reason_code="INTENTS_SUPPRESSED",
-                )
-            )
-        else:
-            results.append(
-                RuleResult(
-                    rule_id="MIN_TRADE_SIZE",
-                    severity="SOFT",
-                    status="PASS",
-                    measured=Decimal("0"),
-                    threshold={"min": Decimal("0")},
-                    reason_code="OK",
-                )
-            )
-
-        shorting_breach = False
-        min_qty = Decimal("0")
-        for p in state.positions:
-            if p.quantity < Decimal("0"):
-                shorting_breach = True
-                min_qty = min(min_qty, p.quantity)
-
-        if shorting_breach:
-            results.append(
-                RuleResult(
-                    rule_id="NO_SHORTING",
-                    severity="HARD",
-                    status="FAIL",
-                    measured=min_qty,
-                    threshold={"min": Decimal("0")},
-                    reason_code="SELL_EXCEEDS_HOLDINGS",
-                    remediation_hint="Reduce sell quantity.",
-                )
-            )
-        else:
-            results.append(
-                RuleResult(
-                    rule_id="NO_SHORTING",
-                    severity="HARD",
-                    status="PASS",
-                    measured=Decimal("0"),
-                    threshold={"min": Decimal("0")},
-                    reason_code="OK",
-                )
-            )
-
-        cash_breach = False
-        min_cash = Decimal("0")
-        for c in state.cash_balances:
-            if c.amount < Decimal("0"):
-                cash_breach = True
-                min_cash = min(min_cash, c.amount)
-
-        if cash_breach:
-            results.append(
-                RuleResult(
-                    rule_id="INSUFFICIENT_CASH",
-                    severity="HARD",
-                    status="FAIL",
-                    measured=min_cash,
-                    threshold={"min": Decimal("0")},
-                    reason_code="CASH_BALANCE_NEGATIVE",
-                    remediation_hint="Ensure sufficient funding.",
-                )
-            )
-        else:
-            results.append(
-                RuleResult(
-                    rule_id="INSUFFICIENT_CASH",
-                    severity="HARD",
-                    status="PASS",
-                    measured=Decimal("0"),
-                    threshold={"min": Decimal("0")},
-                    reason_code="OK",
-                )
-            )
+        results.extend(_single_position_max_rule_results(state=state, options=options))
+        results.append(_data_quality_rule_result(diagnostics=diagnostics, options=options))
+        results.append(_min_trade_size_rule_result(diagnostics=diagnostics))
+        results.append(_no_shorting_rule_result(state=state))
+        results.append(_insufficient_cash_rule_result(state=state))
 
         return results

--- a/src/core/outcomes/snapshots.py
+++ b/src/core/outcomes/snapshots.py
@@ -22,6 +22,14 @@ class DpmExpectedSnapshotAssemblyError(ValueError):
     """Raised when expected outcome evidence is missing or inconsistent."""
 
 
+_PROOF_PACK_OUTCOME_STATES: dict[str, OutcomeDimensionState] = {
+    "READY": "READY",
+    "PENDING_REVIEW": "PENDING_REVIEW",
+    "DEGRADED": "DEGRADED",
+    "BLOCKED": "BLOCKED",
+}
+
+
 def assemble_expected_outcome_snapshot(
     *,
     alternative_set: ConstructionAlternativeSet,
@@ -453,9 +461,7 @@ def _construction_state(
 
 
 def _proof_pack_state(status: str) -> OutcomeDimensionState:
-    if status in {"READY", "PENDING_REVIEW", "DEGRADED", "BLOCKED"}:
-        return status  # type: ignore[return-value]
-    return "BLOCKED"
+    return _PROOF_PACK_OUTCOME_STATES.get(status, "BLOCKED")
 
 
 def _wave_item_state(wave_item: DpmRebalanceWaveItem) -> OutcomeDimensionState:

--- a/src/core/portfolio_memory/models.py
+++ b/src/core/portfolio_memory/models.py
@@ -572,6 +572,43 @@ def _validate_search_item_metadata(
     latest_matching_event_source_id: str | None,
     latest_matching_event_content_hash: str | None,
 ) -> None:
+    _validate_search_item_counts(
+        event_count=event_count,
+        event_type_counts=event_type_counts,
+        matching_event_count=matching_event_count,
+    )
+    _validate_search_item_sorted_aggregates(
+        source_systems=source_systems,
+        reason_codes=reason_codes,
+    )
+    _validate_search_item_latest_event_metadata(
+        event_count=event_count,
+        supportability_state=supportability_state,
+        event_type_counts=event_type_counts,
+        source_systems=source_systems,
+        reason_codes=reason_codes,
+        latest_event_time=latest_event_time,
+        latest_event_type=latest_event_type,
+    )
+    _validate_search_item_latest_matching_event_metadata(
+        matching_event_count=matching_event_count,
+        latest_matching_event_time=latest_matching_event_time,
+        latest_matching_event_type=latest_matching_event_type,
+        latest_matching_event_id=latest_matching_event_id,
+        latest_matching_event_identity=latest_matching_event_identity,
+        latest_matching_event_source_system=latest_matching_event_source_system,
+        latest_matching_event_source_type=latest_matching_event_source_type,
+        latest_matching_event_source_id=latest_matching_event_source_id,
+        latest_matching_event_content_hash=latest_matching_event_content_hash,
+    )
+
+
+def _validate_search_item_counts(
+    *,
+    event_count: int,
+    event_type_counts: dict[str, int],
+    matching_event_count: int,
+) -> None:
     expected_event_count = sum(event_type_counts.values())
     if event_count != expected_event_count:
         raise ValueError("event_count must equal the sum of event_type_counts.")
@@ -579,12 +616,29 @@ def _validate_search_item_metadata(
     if matching_event_count > event_count:
         raise ValueError("matching_event_count must not exceed event_count.")
 
+
+def _validate_search_item_sorted_aggregates(
+    *,
+    source_systems: list[str],
+    reason_codes: list[str],
+) -> None:
     if source_systems != sorted(set(source_systems)):
         raise ValueError("source_systems must be sorted and unique.")
 
     if reason_codes != sorted(set(reason_codes)):
         raise ValueError("reason_codes must be sorted and unique.")
 
+
+def _validate_search_item_latest_event_metadata(
+    *,
+    event_count: int,
+    supportability_state: PortfolioMemorySupportabilityState,
+    event_type_counts: dict[str, int],
+    source_systems: list[str],
+    reason_codes: list[str],
+    latest_event_time: str | None,
+    latest_event_type: PortfolioMemoryEventType | None,
+) -> None:
     latest_event_fields = [latest_event_time, latest_event_type]
     if event_count == 0:
         if supportability_state != "EMPTY":
@@ -599,6 +653,19 @@ def _validate_search_item_metadata(
         if any(value is None for value in latest_event_fields):
             raise ValueError("non-empty search items must carry latest event metadata.")
 
+
+def _validate_search_item_latest_matching_event_metadata(
+    *,
+    matching_event_count: int,
+    latest_matching_event_time: str | None,
+    latest_matching_event_type: PortfolioMemoryEventType | None,
+    latest_matching_event_id: str | None,
+    latest_matching_event_identity: str | None,
+    latest_matching_event_source_system: str | None,
+    latest_matching_event_source_type: str | None,
+    latest_matching_event_source_id: str | None,
+    latest_matching_event_content_hash: str | None,
+) -> None:
     latest_matching_fields = [
         latest_matching_event_time,
         latest_matching_event_type,

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -1,5 +1,6 @@
 """Pure RFC-0040 proof-pack builders."""
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, cast
 
@@ -86,6 +87,20 @@ class ProofPackSourceValidationError(ValueError):
 
 
 _SectionPayload = tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]
+
+
+@dataclass(frozen=True)
+class _ProofPackBuildContext:
+    created_at: datetime
+    generated_at: str
+    result: RebalanceResult | None
+    run_artifact_hash: str | None
+    source_hashes: dict[str, str]
+    source_analytics: dict[str, ProofPackSourceAnalytics]
+    source_refs: list[DpmProofPackSourceRef]
+    proof_pack_id: str
+    portfolio_id: str
+    correlation_id: str
 
 
 def build_proof_pack_from_run(
@@ -190,84 +205,44 @@ def _build_proof_pack(
     workflow_decisions: list[DpmRunWorkflowDecisionRecord],
     direct_regime_stress_context: AuthoritativeRegimeStressContext | None,
 ) -> DpmPreTradeProofPack:
-    resolved_created_at = created_at or datetime.now(timezone.utc)
-    result = RebalanceResult.model_validate(run.result_json) if run is not None else None
-    run_artifact = build_dpm_run_artifact(run=run) if run is not None else None
-    source_hashes = _source_hashes(
-        run=run,
-        alternative_set=alternative_set,
-        selected_alternative=selected_alternative,
-        mandate_twin=mandate_twin,
-        mandate_health=mandate_health,
-    )
-    source_analytics = _source_analytics(
-        selected_alternative=selected_alternative,
-        direct_regime_stress_context=direct_regime_stress_context,
-    )
-    for analytics in source_analytics.values():
-        source_hashes[analytics.source_hash_key] = analytics.content_hash
-    portfolio_id = _resolve_portfolio_id(run=run, alternative_set=alternative_set)
-    resolved_correlation_id = (
-        correlation_id
-        or (
-            selection.correlation_id if selection is not None and selection.correlation_id else None
-        )
-        or (run.correlation_id if run is not None else None)
-        or f"proof-pack-{resolved_created_at.strftime('%Y%m%d%H%M%S')}"
-    )
-    proof_pack_id = _proof_pack_id(
+    context = _proof_pack_build_context(
         source_type=source_type,
         run=run,
         alternative_set=alternative_set,
         selected_alternative=selected_alternative,
+        selection=selection,
+        correlation_id=correlation_id,
+        created_at=created_at,
+        mandate_twin=mandate_twin,
+        mandate_health=mandate_health,
+        direct_regime_stress_context=direct_regime_stress_context,
     )
-    generated_at = resolved_created_at.isoformat()
-    source_refs = _source_refs(
+
+    sections = _proof_pack_sections(
+        context=context,
         run=run,
         alternative_set=alternative_set,
         selected_alternative=selected_alternative,
-        source_hashes=source_hashes,
+        selection=selection,
+        reason=reason,
+        mandate_id=mandate_id,
         mandate_twin=mandate_twin,
         mandate_health=mandate_health,
+        mandate_evidence_gap_codes=mandate_evidence_gap_codes,
+        created_by=created_by,
+        workflow_decisions=workflow_decisions,
     )
-    source_refs.extend(analytics.source_ref for analytics in source_analytics.values())
-
-    sections = [
-        _build_section(
-            section_type=section_type,
-            generated_at=generated_at,
-            result=result,
-            run=run,
-            run_artifact_hash=(
-                run_artifact.evidence.hashes.artifact_hash if run_artifact is not None else None
-            ),
-            alternative_set=alternative_set,
-            selected_alternative=selected_alternative,
-            selection=selection,
-            source_refs=source_refs,
-            source_ref_count=len(source_refs),
-            source_analytics=source_analytics,
-            reason=reason,
-            mandate_id=mandate_id,
-            mandate_twin=mandate_twin,
-            mandate_health=mandate_health,
-            mandate_evidence_gap_codes=mandate_evidence_gap_codes,
-            created_by=created_by,
-            workflow_decisions=workflow_decisions,
-        )
-        for section_type in _SECTION_ORDER
-    ]
     supportability = _supportability(sections)
     decision_summary = _decision_summary(
         source_type=source_type,
-        result=result,
+        result=context.result,
         selected_alternative=selected_alternative,
         reason=reason,
         supportability=supportability,
     )
     timeline = _decision_timeline(
-        proof_pack_id=proof_pack_id,
-        generated_at=generated_at,
+        proof_pack_id=context.proof_pack_id,
+        generated_at=context.generated_at,
         source_type=source_type,
         run=run,
         alternative_set=alternative_set,
@@ -278,9 +253,9 @@ def _build_proof_pack(
     )
     section_by_type = {section.section_type: section for section in sections}
     pack = DpmPreTradeProofPack(
-        proof_pack_id=proof_pack_id,
+        proof_pack_id=context.proof_pack_id,
         proof_pack_version=PROOF_PACK_VERSION,
-        portfolio_id=portfolio_id,
+        portfolio_id=context.portfolio_id,
         mandate_id=mandate_id,
         source_type=source_type,
         rebalance_run_id=run.rebalance_run_id if run is not None else None,
@@ -300,11 +275,135 @@ def _build_proof_pack(
         lineage=section_by_type["lineage"],
         supportability=supportability,
         content_hash="",
-        source_hashes=source_hashes,
-        created_at=resolved_created_at,
+        source_hashes=context.source_hashes,
+        created_at=context.created_at,
         created_by=created_by,
-        correlation_id=resolved_correlation_id,
+        correlation_id=context.correlation_id,
     )
+    return _finalize_proof_pack_content_hash(pack)
+
+
+def _proof_pack_build_context(
+    *,
+    source_type: ProofPackSourceType,
+    run: DpmRunRecord | None,
+    alternative_set: ConstructionAlternativeSet | None,
+    selected_alternative: ConstructionAlternative | None,
+    selection: ConstructionAlternativeSelection | None,
+    correlation_id: str | None,
+    created_at: datetime | None,
+    mandate_twin: DpmMandateDigitalTwin | None,
+    mandate_health: DpmMandateHealthSnapshot | None,
+    direct_regime_stress_context: AuthoritativeRegimeStressContext | None,
+) -> _ProofPackBuildContext:
+    resolved_created_at = created_at or datetime.now(timezone.utc)
+    source_hashes = _source_hashes(
+        run=run,
+        alternative_set=alternative_set,
+        selected_alternative=selected_alternative,
+        mandate_twin=mandate_twin,
+        mandate_health=mandate_health,
+    )
+    source_analytics = _source_analytics(
+        selected_alternative=selected_alternative,
+        direct_regime_stress_context=direct_regime_stress_context,
+    )
+    for analytics in source_analytics.values():
+        source_hashes[analytics.source_hash_key] = analytics.content_hash
+    source_refs = _source_refs(
+        run=run,
+        alternative_set=alternative_set,
+        selected_alternative=selected_alternative,
+        source_hashes=source_hashes,
+        mandate_twin=mandate_twin,
+        mandate_health=mandate_health,
+    )
+    source_refs.extend(analytics.source_ref for analytics in source_analytics.values())
+    run_artifact = build_dpm_run_artifact(run=run) if run is not None else None
+    return _ProofPackBuildContext(
+        created_at=resolved_created_at,
+        generated_at=resolved_created_at.isoformat(),
+        result=RebalanceResult.model_validate(run.result_json) if run is not None else None,
+        run_artifact_hash=(
+            run_artifact.evidence.hashes.artifact_hash if run_artifact is not None else None
+        ),
+        source_hashes=source_hashes,
+        source_analytics=source_analytics,
+        source_refs=source_refs,
+        proof_pack_id=_proof_pack_id(
+            source_type=source_type,
+            run=run,
+            alternative_set=alternative_set,
+            selected_alternative=selected_alternative,
+        ),
+        portfolio_id=_resolve_portfolio_id(run=run, alternative_set=alternative_set),
+        correlation_id=_resolve_proof_pack_correlation_id(
+            correlation_id=correlation_id,
+            selection=selection,
+            run=run,
+            created_at=resolved_created_at,
+        ),
+    )
+
+
+def _resolve_proof_pack_correlation_id(
+    *,
+    correlation_id: str | None,
+    selection: ConstructionAlternativeSelection | None,
+    run: DpmRunRecord | None,
+    created_at: datetime,
+) -> str:
+    return (
+        correlation_id
+        or (
+            selection.correlation_id if selection is not None and selection.correlation_id else None
+        )
+        or (run.correlation_id if run is not None else None)
+        or f"proof-pack-{created_at.strftime('%Y%m%d%H%M%S')}"
+    )
+
+
+def _proof_pack_sections(
+    *,
+    context: _ProofPackBuildContext,
+    run: DpmRunRecord | None,
+    alternative_set: ConstructionAlternativeSet | None,
+    selected_alternative: ConstructionAlternative | None,
+    selection: ConstructionAlternativeSelection | None,
+    reason: str | None,
+    mandate_id: str | None,
+    mandate_twin: DpmMandateDigitalTwin | None,
+    mandate_health: DpmMandateHealthSnapshot | None,
+    mandate_evidence_gap_codes: list[str],
+    created_by: str,
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
+) -> list[DpmProofPackSection]:
+    return [
+        _build_section(
+            section_type=section_type,
+            generated_at=context.generated_at,
+            result=context.result,
+            run=run,
+            run_artifact_hash=context.run_artifact_hash,
+            alternative_set=alternative_set,
+            selected_alternative=selected_alternative,
+            selection=selection,
+            source_refs=context.source_refs,
+            source_ref_count=len(context.source_refs),
+            source_analytics=context.source_analytics,
+            reason=reason,
+            mandate_id=mandate_id,
+            mandate_twin=mandate_twin,
+            mandate_health=mandate_health,
+            mandate_evidence_gap_codes=mandate_evidence_gap_codes,
+            created_by=created_by,
+            workflow_decisions=workflow_decisions,
+        )
+        for section_type in _SECTION_ORDER
+    ]
+
+
+def _finalize_proof_pack_content_hash(pack: DpmPreTradeProofPack) -> DpmPreTradeProofPack:
     payload = pack.model_dump(mode="json")
     payload["content_hash"] = hash_canonical_payload(strip_keys(payload, exclude={"content_hash"}))
     return DpmPreTradeProofPack.model_validate(payload)

--- a/src/core/rebalance/execution.py
+++ b/src/core/rebalance/execution.py
@@ -38,7 +38,37 @@ def build_settlement_ladder(
     options: EngineOptions,
     diagnostics: DiagnosticsData,
 ) -> None:
-    settlement_days_by_instrument = {entry.instrument_id: entry.settlement_days for entry in shelf}
+    settlement_days_by_instrument = _settlement_days_by_instrument(shelf)
+    horizon_days = _settlement_horizon_days(
+        settlement_days_by_instrument=settlement_days_by_instrument,
+        intents=intents,
+        options=options,
+    )
+    flows = _settlement_cash_flows(
+        portfolio=portfolio,
+        intents=intents,
+        settlement_days_by_instrument=settlement_days_by_instrument,
+        horizon_days=horizon_days,
+        options=options,
+    )
+    _append_settlement_ladder_points(
+        flows=flows,
+        horizon_days=horizon_days,
+        options=options,
+        diagnostics=diagnostics,
+    )
+
+
+def _settlement_days_by_instrument(shelf: list[ShelfEntry]) -> dict[str, int]:
+    return {entry.instrument_id: entry.settlement_days for entry in shelf}
+
+
+def _settlement_horizon_days(
+    *,
+    settlement_days_by_instrument: dict[str, int],
+    intents: list[OrderIntent],
+    options: EngineOptions,
+) -> int:
     max_security_day = max(
         (
             settlement_days_by_instrument.get(intent.instrument_id, 2)
@@ -47,26 +77,61 @@ def build_settlement_ladder(
         ),
         default=0,
     )
-    horizon_days = max(
-        options.settlement_horizon_days, options.fx_settlement_days, max_security_day
-    )
+    return max(options.settlement_horizon_days, options.fx_settlement_days, max_security_day)
 
+
+def _settlement_cash_flows(
+    *,
+    portfolio: PortfolioSnapshot,
+    intents: list[OrderIntent],
+    settlement_days_by_instrument: dict[str, int],
+    horizon_days: int,
+    options: EngineOptions,
+) -> dict[str, list[Decimal]]:
     flows: dict[str, list[Decimal]] = {}
 
-    def ensure_currency(currency: str) -> None:
-        if currency not in flows:
-            flows[currency] = [Decimal("0")] * (horizon_days + 1)
-
     for cash in portfolio.cash_balances:
-        ensure_currency(cash.currency)
+        _ensure_settlement_currency(flows=flows, currency=cash.currency, horizon_days=horizon_days)
         flows[cash.currency][0] += cash.settled if cash.settled is not None else cash.amount
 
+    _apply_intent_settlement_flows(
+        flows=flows,
+        intents=intents,
+        settlement_days_by_instrument=settlement_days_by_instrument,
+        horizon_days=horizon_days,
+        options=options,
+    )
+    return flows
+
+
+def _ensure_settlement_currency(
+    *,
+    flows: dict[str, list[Decimal]],
+    currency: str,
+    horizon_days: int,
+) -> None:
+    if currency not in flows:
+        flows[currency] = [Decimal("0")] * (horizon_days + 1)
+
+
+def _apply_intent_settlement_flows(
+    *,
+    flows: dict[str, list[Decimal]],
+    intents: list[OrderIntent],
+    settlement_days_by_instrument: dict[str, int],
+    horizon_days: int,
+    options: EngineOptions,
+) -> None:
     for intent in sorted(intents, key=lambda item: item.intent_id):
         if intent.intent_type == "SECURITY_TRADE":
             if intent.notional is None:
                 continue
             settlement_day = settlement_days_by_instrument.get(intent.instrument_id, 2)
-            ensure_currency(intent.notional.currency)
+            _ensure_settlement_currency(
+                flows=flows,
+                currency=intent.notional.currency,
+                horizon_days=horizon_days,
+            )
             signed_flow = (
                 intent.notional.amount if intent.side == "SELL" else -intent.notional.amount
             )
@@ -76,23 +141,38 @@ def build_settlement_ladder(
         if intent.intent_type != "FX_SPOT":
             continue
 
-        ensure_currency(intent.sell_currency)
-        ensure_currency(intent.buy_currency)
+        _ensure_settlement_currency(
+            flows=flows,
+            currency=intent.sell_currency,
+            horizon_days=horizon_days,
+        )
+        _ensure_settlement_currency(
+            flows=flows,
+            currency=intent.buy_currency,
+            horizon_days=horizon_days,
+        )
         flows[intent.sell_currency][options.fx_settlement_days] -= intent.sell_amount_estimated
         flows[intent.buy_currency][options.fx_settlement_days] += intent.buy_amount
 
+
+def _append_settlement_ladder_points(
+    *,
+    flows: dict[str, list[Decimal]],
+    horizon_days: int,
+    options: EngineOptions,
+    diagnostics: DiagnosticsData,
+) -> None:
     overdraft_utilized = False
     for currency in sorted(flows.keys()):
         projected_balance = Decimal("0")
         allowed_floor = -options.max_overdraft_by_ccy.get(currency, Decimal("0"))
         for day in range(horizon_days + 1):
             projected_balance += flows[currency][day]
-            diagnostics.cash_ladder.append(
-                CashLadderPoint(
-                    date_offset=day,
-                    currency=currency,
-                    projected_balance=projected_balance,
-                )
+            _append_cash_ladder_point(
+                diagnostics=diagnostics,
+                day=day,
+                currency=currency,
+                projected_balance=projected_balance,
             )
             if projected_balance < Decimal("0") and options.max_overdraft_by_ccy.get(
                 currency, Decimal("0")
@@ -111,6 +191,22 @@ def build_settlement_ladder(
 
     if overdraft_utilized:
         diagnostics.warnings.append("SETTLEMENT_OVERDRAFT_UTILIZED")
+
+
+def _append_cash_ladder_point(
+    *,
+    diagnostics: DiagnosticsData,
+    day: int,
+    currency: str,
+    projected_balance: Decimal,
+) -> None:
+    diagnostics.cash_ladder.append(
+        CashLadderPoint(
+            date_offset=day,
+            currency=currency,
+            projected_balance=projected_balance,
+        )
+    )
 
 
 def _project_cash_after_security_trades(

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -161,6 +161,24 @@ class _TaxBudgetAccumulator:
     tax_budget_limit_base: Decimal | None
 
 
+@dataclass(frozen=True)
+class _TargetTradeDelta:
+    side: Literal["BUY", "SELL"]
+    raw_quantity: Decimal
+
+
+def _target_trade_delta(
+    *,
+    target_instrument_value: Decimal,
+    current_instrument_value: Decimal,
+    unit_value: Decimal,
+) -> _TargetTradeDelta:
+    delta = target_instrument_value - current_instrument_value
+    side: Literal["BUY", "SELL"] = "BUY" if delta > 0 else "SELL"
+    raw_quantity = Decimal(int(abs(delta) // unit_value))
+    return _TargetTradeDelta(side=side, raw_quantity=raw_quantity)
+
+
 def _tax_budget_limited_sell_quantity(
     *,
     options: EngineOptions,
@@ -271,6 +289,44 @@ def _current_instrument_value_and_unit_value(
     return current_value, price.price
 
 
+def _tax_impact_from_budget(
+    *,
+    tax_budget: _TaxBudgetAccumulator,
+    base_currency: str,
+) -> TaxImpact:
+    normalized_budget_used = tax_budget.tax_budget_used_base
+    if tax_budget.tax_budget_limit_base is not None:
+        if abs(tax_budget.tax_budget_limit_base - normalized_budget_used) <= Decimal(
+            "0.0000000001"
+        ):
+            normalized_budget_used = tax_budget.tax_budget_limit_base
+    budget_limit = (
+        Money(amount=tax_budget.tax_budget_limit_base, currency=base_currency)
+        if tax_budget.tax_budget_limit_base is not None
+        else None
+    )
+    budget_used = (
+        Money(
+            amount=min(normalized_budget_used, tax_budget.tax_budget_limit_base),
+            currency=base_currency,
+        )
+        if tax_budget.tax_budget_limit_base is not None
+        else None
+    )
+    return TaxImpact(
+        total_realized_gain=Money(
+            amount=tax_budget.total_realized_gain_base,
+            currency=base_currency,
+        ),
+        total_realized_loss=Money(
+            amount=tax_budget.total_realized_loss_base,
+            currency=base_currency,
+        ),
+        budget_limit=budget_limit,
+        budget_used=budget_used,
+    )
+
+
 def generate_intents(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -309,16 +365,19 @@ def generate_intents(
 
         target_instr_val = (total_val * target_w) / rate
 
-        delta = target_instr_val - curr_instr_val
-        side: Literal["BUY", "SELL"] = "BUY" if delta > 0 else "SELL"
-        qty = int(abs(delta) // unit_value)
-        quantity = Decimal(qty)
+        trade_delta = _target_trade_delta(
+            target_instrument_value=target_instr_val,
+            current_instrument_value=curr_instr_val,
+            unit_value=unit_value,
+        )
+        side = trade_delta.side
+        requested_quantity = trade_delta.raw_quantity
+        quantity = requested_quantity
 
         sell_quantity_before_tax: Decimal | None = None
-        if side == "SELL" and qty > 0:
-            requested_qty = Decimal(qty)
+        if side == "SELL" and requested_quantity > 0:
             quantity = _clamped_sell_quantity(
-                requested_qty=requested_qty,
+                requested_qty=requested_quantity,
                 position=curr,
                 diagnostics=diagnostics,
             )
@@ -363,7 +422,7 @@ def generate_intents(
                 threshold=threshold,
                 side=side,
                 quantity=quantity,
-                requested_quantity=Decimal(qty),
+                requested_quantity=requested_quantity,
                 sell_quantity_before_tax=sell_quantity_before_tax,
                 tax_awareness_enabled=options.enable_tax_awareness,
             )
@@ -382,36 +441,9 @@ def generate_intents(
 
     tax_impact = None
     if options.enable_tax_awareness:
-        normalized_budget_used = tax_budget.tax_budget_used_base
-        if tax_budget.tax_budget_limit_base is not None:
-            if abs(tax_budget.tax_budget_limit_base - normalized_budget_used) <= Decimal(
-                "0.0000000001"
-            ):
-                normalized_budget_used = tax_budget.tax_budget_limit_base
-        budget_limit = (
-            Money(amount=tax_budget.tax_budget_limit_base, currency=portfolio.base_currency)
-            if tax_budget.tax_budget_limit_base is not None
-            else None
-        )
-        budget_used = (
-            Money(
-                amount=min(normalized_budget_used, tax_budget.tax_budget_limit_base),
-                currency=portfolio.base_currency,
-            )
-            if tax_budget.tax_budget_limit_base is not None
-            else None
-        )
-        tax_impact = TaxImpact(
-            total_realized_gain=Money(
-                amount=tax_budget.total_realized_gain_base,
-                currency=portfolio.base_currency,
-            ),
-            total_realized_loss=Money(
-                amount=tax_budget.total_realized_loss_base,
-                currency=portfolio.base_currency,
-            ),
-            budget_limit=budget_limit,
-            budget_used=budget_used,
+        tax_impact = _tax_impact_from_budget(
+            tax_budget=tax_budget,
+            base_currency=portfolio.base_currency,
         )
 
     return intents, tax_impact

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -167,6 +167,13 @@ class _TargetTradeDelta:
     raw_quantity: Decimal
 
 
+@dataclass(frozen=True)
+class _TaxBudgetLotAllowance:
+    requested_quantity: Decimal
+    allowed_quantity: Decimal
+    realized_base: Decimal
+
+
 def _target_trade_delta(
     *,
     target_instrument_value: Decimal,
@@ -177,6 +184,57 @@ def _target_trade_delta(
     side: Literal["BUY", "SELL"] = "BUY" if delta > 0 else "SELL"
     raw_quantity = Decimal(int(abs(delta) // unit_value))
     return _TargetTradeDelta(side=side, raw_quantity=raw_quantity)
+
+
+def _tax_budget_allowed_lot_quantity(
+    *,
+    lot_sell_qty: Decimal,
+    per_unit_gain_base: Decimal,
+    tax_budget: _TaxBudgetAccumulator,
+) -> Decimal:
+    if tax_budget.tax_budget_limit_base is None or per_unit_gain_base <= Decimal("0"):
+        return lot_sell_qty
+    if tax_budget.tax_budget_used_base >= tax_budget.tax_budget_limit_base:
+        return Decimal("0")
+
+    remaining_headroom = tax_budget.tax_budget_limit_base - tax_budget.tax_budget_used_base
+    max_qty_headroom = remaining_headroom / per_unit_gain_base
+    return min(lot_sell_qty, max_qty_headroom)
+
+
+def _tax_budget_lot_allowance(
+    *,
+    remaining_quantity: Decimal,
+    lot_quantity: Decimal,
+    lot_unit_cost: Decimal,
+    sell_price: Decimal,
+    base_rate: Decimal,
+    tax_budget: _TaxBudgetAccumulator,
+) -> _TaxBudgetLotAllowance:
+    lot_sell_qty = min(remaining_quantity, lot_quantity)
+    per_unit_gain_base = (sell_price - lot_unit_cost) * base_rate
+    allowed_quantity = _tax_budget_allowed_lot_quantity(
+        lot_sell_qty=lot_sell_qty,
+        per_unit_gain_base=per_unit_gain_base,
+        tax_budget=tax_budget,
+    )
+    return _TaxBudgetLotAllowance(
+        requested_quantity=lot_sell_qty,
+        allowed_quantity=allowed_quantity,
+        realized_base=per_unit_gain_base * allowed_quantity,
+    )
+
+
+def _apply_tax_budget_lot_allowance(
+    *,
+    allowance: _TaxBudgetLotAllowance,
+    tax_budget: _TaxBudgetAccumulator,
+) -> None:
+    if allowance.realized_base >= Decimal("0"):
+        tax_budget.total_realized_gain_base += allowance.realized_base
+        tax_budget.tax_budget_used_base += allowance.realized_base
+    else:
+        tax_budget.total_realized_loss_base += abs(allowance.realized_base)
 
 
 def _tax_budget_limited_sell_quantity(
@@ -211,39 +269,23 @@ def _tax_budget_limited_sell_quantity(
         if lot.quantity <= Decimal("0"):
             continue
 
-        lot_sell_qty = min(remaining, lot.quantity)
-        per_unit_gain_base = (sell_price - lot_unit_cost) * base_rate
-        allowed_from_lot = lot_sell_qty
-
-        if (
-            tax_budget.tax_budget_limit_base is not None
-            and per_unit_gain_base > Decimal("0")
-            and tax_budget.tax_budget_used_base < tax_budget.tax_budget_limit_base
-        ):
-            remaining_headroom = tax_budget.tax_budget_limit_base - tax_budget.tax_budget_used_base
-            max_qty_headroom = remaining_headroom / per_unit_gain_base
-            allowed_from_lot = min(lot_sell_qty, max_qty_headroom)
-        elif (
-            tax_budget.tax_budget_limit_base is not None
-            and per_unit_gain_base > Decimal("0")
-            and tax_budget.tax_budget_used_base >= tax_budget.tax_budget_limit_base
-        ):
-            allowed_from_lot = Decimal("0")
-
-        if allowed_from_lot <= Decimal("0"):
+        allowance = _tax_budget_lot_allowance(
+            remaining_quantity=remaining,
+            lot_quantity=lot.quantity,
+            lot_unit_cost=lot_unit_cost,
+            sell_price=sell_price,
+            base_rate=base_rate,
+            tax_budget=tax_budget,
+        )
+        if allowance.allowed_quantity <= Decimal("0"):
             break
 
-        lot_realized_base = per_unit_gain_base * allowed_from_lot
-        if lot_realized_base >= Decimal("0"):
-            tax_budget.total_realized_gain_base += lot_realized_base
-            tax_budget.tax_budget_used_base += lot_realized_base
-        else:
-            tax_budget.total_realized_loss_base += abs(lot_realized_base)
+        _apply_tax_budget_lot_allowance(allowance=allowance, tax_budget=tax_budget)
 
-        allowed_qty += allowed_from_lot
-        remaining -= allowed_from_lot
+        allowed_qty += allowance.allowed_quantity
+        remaining -= allowance.allowed_quantity
 
-        if allowed_from_lot < lot_sell_qty:
+        if allowance.allowed_quantity < allowance.requested_quantity:
             break
 
     return allowed_qty

--- a/src/core/rebalance/policy_packs.py
+++ b/src/core/rebalance/policy_packs.py
@@ -1,6 +1,6 @@
 import json
 from decimal import Decimal
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, Field, ValidationError
 
@@ -272,6 +272,22 @@ def _normalize_policy_pack_id(value: Optional[str]) -> Optional[str]:
 
 
 def parse_policy_pack_catalog(catalog_json: Optional[str]) -> dict[str, DpmPolicyPackDefinition]:
+    raw = _load_policy_pack_catalog_payload(catalog_json)
+
+    catalog: dict[str, DpmPolicyPackDefinition] = {}
+    for policy_pack_id, definition in raw.items():
+        parsed = _parse_policy_pack_definition(
+            policy_pack_id=policy_pack_id,
+            definition=definition,
+        )
+        if parsed is None:
+            continue
+        normalized_id, policy_pack = parsed
+        catalog[normalized_id] = policy_pack
+    return catalog
+
+
+def _load_policy_pack_catalog_payload(catalog_json: Optional[str]) -> dict[Any, Any]:
     normalized_json = (catalog_json or "").strip()
     if not normalized_json:
         return {}
@@ -281,17 +297,24 @@ def parse_policy_pack_catalog(catalog_json: Optional[str]) -> dict[str, DpmPolic
         return {}
     if not isinstance(raw, dict):
         return {}
+    return raw
 
-    catalog: dict[str, DpmPolicyPackDefinition] = {}
-    for policy_pack_id, definition in raw.items():
-        if not isinstance(policy_pack_id, str):
-            continue
-        if not isinstance(definition, dict):
-            continue
-        normalized_id = policy_pack_id.strip()
-        if not normalized_id:
-            continue
-        payload = {
+
+def _policy_pack_definition_payload(
+    *,
+    policy_pack_id: Any,
+    definition: Any,
+) -> tuple[str, dict[str, object]] | None:
+    if not isinstance(policy_pack_id, str):
+        return None
+    if not isinstance(definition, dict):
+        return None
+    normalized_id = policy_pack_id.strip()
+    if not normalized_id:
+        return None
+    return (
+        normalized_id,
+        {
             "policy_pack_id": normalized_id,
             "version": str(definition.get("version", "1")),
             "turnover_policy": definition.get("turnover_policy") or {},
@@ -300,13 +323,26 @@ def parse_policy_pack_catalog(catalog_json: Optional[str]) -> dict[str, DpmPolic
             "constraint_policy": definition.get("constraint_policy") or {},
             "workflow_policy": definition.get("workflow_policy") or {},
             "idempotency_policy": definition.get("idempotency_policy") or {},
-        }
-        try:
-            parsed = DpmPolicyPackDefinition.model_validate(payload)
-        except ValidationError:
-            continue
-        catalog[normalized_id] = parsed
-    return catalog
+        },
+    )
+
+
+def _parse_policy_pack_definition(
+    *,
+    policy_pack_id: Any,
+    definition: Any,
+) -> tuple[str, DpmPolicyPackDefinition] | None:
+    payload = _policy_pack_definition_payload(
+        policy_pack_id=policy_pack_id,
+        definition=definition,
+    )
+    if payload is None:
+        return None
+    normalized_id, model_payload = payload
+    try:
+        return normalized_id, DpmPolicyPackDefinition.model_validate(model_payload)
+    except ValidationError:
+        return None
 
 
 def resolve_policy_pack_definition(

--- a/src/core/rebalance/policy_packs.py
+++ b/src/core/rebalance/policy_packs.py
@@ -362,6 +362,16 @@ def apply_policy_pack_to_engine_options(
 ) -> EngineOptions:
     if policy_pack is None:
         return options
+    updates = policy_pack_engine_option_updates(policy_pack=policy_pack)
+    if not updates:
+        return options
+    return options.model_copy(update=updates)
+
+
+def policy_pack_engine_option_updates(
+    *,
+    policy_pack: DpmPolicyPackDefinition,
+) -> dict[str, object]:
     updates: dict[str, object] = {}
     if policy_pack.turnover_policy.max_turnover_pct is not None:
         updates["max_turnover_pct"] = policy_pack.turnover_policy.max_turnover_pct
@@ -391,9 +401,7 @@ def apply_policy_pack_to_engine_options(
         updates["mandate_approval_already_obtained"] = (
             policy_pack.workflow_policy.mandate_approval_already_obtained
         )
-    if not updates:
-        return options
-    return options.model_copy(update=updates)
+    return updates
 
 
 def resolve_policy_pack_replay_enabled(

--- a/src/core/rebalance/targets.py
+++ b/src/core/rebalance/targets.py
@@ -242,6 +242,70 @@ def _cap_tradeable_targets_to_available_weight(
     return "PENDING_REVIEW"
 
 
+def _apply_single_position_max_weight(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+    max_weight: Decimal,
+) -> Literal["READY", "PENDING_REVIEW"]:
+    excess = sum(max(Decimal("0.0"), weight - max_weight) for weight in eligible_targets.values())
+    for instrument_id in eligible_targets:
+        eligible_targets[instrument_id] = min(eligible_targets[instrument_id], max_weight)
+
+    if excess <= Decimal("0.0"):
+        return "READY"
+
+    candidates = {
+        instrument_id: weight
+        for instrument_id, weight in eligible_targets.items()
+        if instrument_id in buy_set and weight < max_weight
+    }
+    total_candidate_weight = sum(candidates.values())
+    if total_candidate_weight <= Decimal("0.0"):
+        return "PENDING_REVIEW"
+
+    remainder = excess
+    for instrument_id, weight in candidates.items():
+        share = min(remainder * (weight / total_candidate_weight), max_weight - weight)
+        eligible_targets[instrument_id] += share
+        remainder -= share
+
+    if remainder > Decimal("0.001"):
+        return "PENDING_REVIEW"
+    return "READY"
+
+
+def _apply_min_cash_buffer(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+    min_cash_buffer_pct: Decimal,
+) -> Literal["READY", "PENDING_REVIEW"]:
+    if min_cash_buffer_pct <= Decimal("0.0"):
+        return "READY"
+
+    tradeable_weight = sum(
+        weight for instrument_id, weight in eligible_targets.items() if instrument_id in buy_set
+    )
+    locked_weight = sum(
+        weight for instrument_id, weight in eligible_targets.items() if instrument_id not in buy_set
+    )
+    allowed_tradeable_weight = max(
+        Decimal("0.0"),
+        Decimal("1.0") - min_cash_buffer_pct - locked_weight,
+    )
+    if tradeable_weight <= allowed_tradeable_weight:
+        return "READY"
+
+    if tradeable_weight > Decimal("0.0"):
+        scale = allowed_tradeable_weight / tradeable_weight
+        for instrument_id in eligible_targets:
+            if instrument_id in buy_set:
+                eligible_targets[instrument_id] *= scale
+
+    return "PENDING_REVIEW"
+
+
 def generate_targets_heuristic(
     model: ModelPortfolio,
     eligible_targets: dict[str, Decimal],
@@ -274,34 +338,20 @@ def generate_targets_heuristic(
         status = "PENDING_REVIEW"
 
     if options.single_position_max_weight is not None:
-        max_w = options.single_position_max_weight
-        excess = sum(max(Decimal("0.0"), w - max_w) for w in eligible_targets.values())
-        for i_id in eligible_targets:
-            eligible_targets[i_id] = min(eligible_targets[i_id], max_w)
-        if excess > Decimal("0.0"):
-            cands = {k: v for k, v in eligible_targets.items() if k in buy_set and v < max_w}
-            total_cand = sum(cands.values())
-            if total_cand > Decimal("0.0"):
-                rem = excess
-                for i_id, w in cands.items():
-                    share = min(rem * (w / total_cand), max_w - w)
-                    eligible_targets[i_id] += share
-                    rem -= share
-                if rem > Decimal("0.001"):
-                    status = "PENDING_REVIEW"
-            else:
-                status = "PENDING_REVIEW"
-
-    if options.min_cash_buffer_pct > Decimal("0.0"):
-        tw = sum(v for k, v in eligible_targets.items() if k in buy_set)
-        lw = sum(v for k, v in eligible_targets.items() if k not in buy_set)
-        allowed = max(Decimal("0.0"), Decimal("1.0") - options.min_cash_buffer_pct - lw)
-        if tw > allowed:
-            if tw > Decimal("0.0"):
-                scale = allowed / tw
-                for k in eligible_targets:
-                    if k in buy_set:
-                        eligible_targets[k] *= scale
+        single_position_status = _apply_single_position_max_weight(
+            eligible_targets=eligible_targets,
+            buy_set=buy_set,
+            max_weight=options.single_position_max_weight,
+        )
+        if single_position_status == "PENDING_REVIEW":
             status = "PENDING_REVIEW"
+
+    cash_buffer_status = _apply_min_cash_buffer(
+        eligible_targets=eligible_targets,
+        buy_set=buy_set,
+        min_cash_buffer_pct=options.min_cash_buffer_pct,
+    )
+    if cash_buffer_status == "PENDING_REVIEW":
+        status = "PENDING_REVIEW"
 
     return build_target_trace(model, eligible_targets, buy_list, total_val, base_ccy), status

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -21,6 +21,11 @@ class SolverInvestedBounds(NamedTuple):
     maximum: Decimal
 
 
+class SolverGroupMembers(NamedTuple):
+    tradeable_ids: list[str]
+    locked_weight: Decimal
+
+
 def _build_solver_attempts(cp: Any) -> tuple[tuple[Any, tuple[dict[str, Any], ...]], ...]:
     """
     Ordered solver attempts with bounded runtime and compatibility fallbacks.
@@ -165,6 +170,30 @@ def _solver_invested_bounds(
     )
 
 
+def _solver_group_members(
+    *,
+    attr_key: str,
+    attr_val: str,
+    eligible_targets: dict[str, Decimal],
+    shelf_attrs_by_id: dict[str, dict[str, str]],
+    indexed_tradeable: dict[str, int],
+) -> SolverGroupMembers:
+    tradeable_ids: list[str] = []
+    locked_weight = Decimal("0")
+    for i_id in eligible_targets:
+        attrs = shelf_attrs_by_id.get(i_id)
+        if attrs is None or attrs.get(attr_key) != attr_val:
+            continue
+        if i_id in indexed_tradeable:
+            tradeable_ids.append(i_id)
+        else:
+            locked_weight += eligible_targets[i_id]
+    return SolverGroupMembers(
+        tradeable_ids=tradeable_ids,
+        locked_weight=locked_weight,
+    )
+
+
 def _load_solver_modules(diagnostics: DiagnosticsData) -> tuple[Any, Any] | None:
     if not has_solver_dependencies():
         diagnostics.warnings.append("SOLVER_ERROR")
@@ -289,23 +318,20 @@ def generate_targets_solver(
             diagnostics.warnings.append(f"UNKNOWN_CONSTRAINT_ATTRIBUTE_{attr_key}")
             continue
 
-        group_tradeable = []
-        group_locked_weight = Decimal("0")
-        for i_id in eligible_targets:
-            attrs = shelf_attrs_by_id.get(i_id)
-            if attrs is None or attrs.get(attr_key) != attr_val:
-                continue
-            if i_id in indexed_tradeable:
-                group_tradeable.append(i_id)
-            else:
-                group_locked_weight += eligible_targets[i_id]
+        group_members = _solver_group_members(
+            attr_key=attr_key,
+            attr_val=attr_val,
+            eligible_targets=eligible_targets,
+            shelf_attrs_by_id=shelf_attrs_by_id,
+            indexed_tradeable=indexed_tradeable,
+        )
 
-        if not group_tradeable and group_locked_weight == Decimal("0"):
+        if not group_members.tradeable_ids and group_members.locked_weight == Decimal("0"):
             continue
 
-        group_expr = cp.sum([w[indexed_tradeable[i_id]] for i_id in group_tradeable]) + float(
-            group_locked_weight
-        )
+        group_expr = cp.sum(
+            [w[indexed_tradeable[i_id]] for i_id in group_members.tradeable_ids]
+        ) + float(group_members.locked_weight)
         constraints.append(group_expr <= float(constraint.max_weight))
 
     prob = cp.Problem(objective, constraints)

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from importlib import import_module
 from typing import Any
 
 from src.core.common.capabilities import has_solver_dependencies
@@ -132,12 +133,15 @@ def _load_solver_modules(diagnostics: DiagnosticsData) -> tuple[Any, Any] | None
         diagnostics.warnings.append("SOLVER_ERROR")
         return None
     try:
-        import cvxpy as cp
-        import numpy as np
-    except Exception:
+        cp, np = _import_solver_modules()
+    except ImportError:
         diagnostics.warnings.append("SOLVER_ERROR")
         return None
     return cp, np
+
+
+def _import_solver_modules() -> tuple[Any, Any]:
+    return import_module("cvxpy"), import_module("numpy")
 
 
 def build_target_trace(

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Any
+from typing import Any, NamedTuple
 
 from src.core.common.capabilities import has_solver_dependencies
 from src.core.common.target_redistribution import redistribute_sell_only_excess
@@ -8,6 +8,17 @@ from src.core.models import DiagnosticsData, EngineOptions, Money, ShelfEntry, T
 _SOLVER_STATUS_OPTIMAL = {"optimal", "optimal_inaccurate"}
 _SOLVER_STATUS_INFEASIBLE = {"infeasible", "infeasible_inaccurate"}
 _SOLVER_STATUS_UNBOUNDED = {"unbounded", "unbounded_inaccurate"}
+
+
+class SolverTargetUniverse(NamedTuple):
+    tradeable_ids: list[str]
+    locked_ids: list[str]
+    locked_weight: Decimal
+
+
+class SolverInvestedBounds(NamedTuple):
+    minimum: Decimal
+    maximum: Decimal
 
 
 def _build_solver_attempts(cp: Any) -> tuple[tuple[Any, tuple[dict[str, Any], ...]], ...]:
@@ -127,6 +138,33 @@ def _collect_infeasibility_hints(
     return hints
 
 
+def _solver_target_universe(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_list: list[str],
+) -> SolverTargetUniverse:
+    buy_set = set(buy_list)
+    tradeable_ids = [i_id for i_id in eligible_targets if i_id in buy_set]
+    locked_ids = [i_id for i_id in eligible_targets if i_id not in buy_set]
+    locked_weight = sum((eligible_targets[i_id] for i_id in locked_ids), Decimal("0"))
+    return SolverTargetUniverse(
+        tradeable_ids=tradeable_ids,
+        locked_ids=locked_ids,
+        locked_weight=locked_weight,
+    )
+
+
+def _solver_invested_bounds(
+    *,
+    locked_weight: Decimal,
+    options: EngineOptions,
+) -> SolverInvestedBounds:
+    return SolverInvestedBounds(
+        minimum=Decimal("1.0") - options.cash_band_max_weight - locked_weight,
+        maximum=Decimal("1.0") - options.cash_band_min_weight - locked_weight,
+    )
+
+
 def _load_solver_modules(diagnostics: DiagnosticsData) -> tuple[Any, Any] | None:
     if not has_solver_dependencies():
         diagnostics.warnings.append("SOLVER_ERROR")
@@ -212,9 +250,12 @@ def generate_targets_solver(
         sell_only_excess=sell_only_excess,
     )
 
-    tradeable_ids = [i_id for i_id in eligible_targets if i_id in buy_list]
-    locked_ids = [i_id for i_id in eligible_targets if i_id not in buy_list]
-    locked_weight = sum((eligible_targets[i_id] for i_id in locked_ids), Decimal("0"))
+    universe = _solver_target_universe(
+        eligible_targets=eligible_targets,
+        buy_list=buy_list,
+    )
+    tradeable_ids = universe.tradeable_ids
+    locked_weight = universe.locked_weight
     shelf_attrs_by_id = {s.instrument_id: s.attributes for s in shelf}
     known_attr_keys = {k for attrs in shelf_attrs_by_id.values() for k in attrs}
 
@@ -228,10 +269,12 @@ def generate_targets_solver(
     objective = cp.Minimize(cp.sum_squares(w - w_model))
     constraints = [w >= 0]
 
-    invested_min = Decimal("1.0") - options.cash_band_max_weight - locked_weight
-    invested_max = Decimal("1.0") - options.cash_band_min_weight - locked_weight
-    constraints.append(cp.sum(w) >= float(invested_min))
-    constraints.append(cp.sum(w) <= float(invested_max))
+    invested_bounds = _solver_invested_bounds(
+        locked_weight=locked_weight,
+        options=options,
+    )
+    constraints.append(cp.sum(w) >= float(invested_bounds.minimum))
+    constraints.append(cp.sum(w) <= float(invested_bounds.maximum))
 
     if options.single_position_max_weight is not None:
         constraints.append(w <= float(options.single_position_max_weight))

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from importlib import import_module
 from typing import Any
 
 from src.core.common.capabilities import has_solver_dependencies
@@ -141,7 +140,10 @@ def _load_solver_modules(diagnostics: DiagnosticsData) -> tuple[Any, Any] | None
 
 
 def _import_solver_modules() -> tuple[Any, Any]:
-    return import_module("cvxpy"), import_module("numpy")
+    import cvxpy
+    import numpy
+
+    return cvxpy, numpy
 
 
 def build_target_trace(

--- a/src/core/valuation.py
+++ b/src/core/valuation.py
@@ -114,6 +114,156 @@ def _cash_value_in_base(
     return Decimal("0")
 
 
+def _valuation_options(options: Optional[EngineOptions]) -> EngineOptions:
+    return options or EngineOptions()
+
+
+def _valued_position_summaries(
+    *,
+    portfolio: PortfolioSnapshot,
+    market_data: MarketDataSnapshot,
+    options: EngineOptions,
+    dq_log: Dict[str, List[str]],
+) -> tuple[list[PositionSummary], Decimal]:
+    price_instruments = {price.instrument_id for price in market_data.prices}
+    summaries: list[PositionSummary] = []
+    total_value = Decimal("0")
+
+    for position in portfolio.positions:
+        if position.instrument_id not in price_instruments:
+            dq_log.setdefault("price_missing", []).append(position.instrument_id)
+
+        summary = ValuationService.value_position(
+            position,
+            market_data,
+            portfolio.base_currency,
+            options,
+            dq_log,
+        )
+        _record_position_fx_gap(
+            summary=summary,
+            base_ccy=portfolio.base_currency,
+            market_data=market_data,
+            dq_log=dq_log,
+        )
+        summaries.append(summary)
+        total_value += summary.value_in_base_ccy.amount
+
+    return summaries, total_value
+
+
+def _record_position_fx_gap(
+    *,
+    summary: PositionSummary,
+    base_ccy: str,
+    market_data: MarketDataSnapshot,
+    dq_log: Dict[str, List[str]],
+) -> None:
+    if summary.instrument_currency == base_ccy:
+        return
+    if get_fx_rate(market_data, summary.instrument_currency, base_ccy) is None:
+        dq_log.setdefault("fx_missing", []).append(f"{summary.instrument_currency}/{base_ccy}")
+
+
+def _total_cash_value(
+    *,
+    cash_balances: list[CashBalance],
+    market_data: MarketDataSnapshot,
+    base_ccy: str,
+    dq_log: Dict[str, List[str]] | None = None,
+) -> Decimal:
+    total = Decimal("0")
+    for cash in cash_balances:
+        total += _cash_value_in_base(
+            cash=cash,
+            market_data=market_data,
+            base_ccy=base_ccy,
+            dq_log=dq_log,
+        )
+    return total
+
+
+def _safe_total_value(total_value: Decimal) -> Decimal:
+    if total_value == 0:
+        return Decimal("1")
+    return total_value
+
+
+def _allocation_metric(
+    *, key: str, value: Decimal, total_value: Decimal, base_ccy: str
+) -> AllocationMetric:
+    return AllocationMetric(
+        key=key,
+        weight=value / total_value,
+        value=Money(amount=value, currency=base_ccy),
+    )
+
+
+def _position_allocation_maps(
+    *,
+    position_summaries: list[PositionSummary],
+    shelf: list[ShelfEntry],
+) -> tuple[dict[str, Decimal], dict[str, dict[str, Decimal]]]:
+    shelf_by_instrument = {entry.instrument_id: entry for entry in shelf}
+    allocation_by_asset_class: dict[str, Decimal] = {}
+    allocation_by_attribute: dict[str, dict[str, Decimal]] = {}
+
+    for position in position_summaries:
+        value = position.value_in_base_ccy.amount
+        shelf_entry = shelf_by_instrument.get(position.instrument_id)
+        if shelf_entry is not None:
+            position.asset_class = shelf_entry.asset_class
+            _add_attribute_allocations(
+                allocation_by_attribute=allocation_by_attribute,
+                shelf_entry=shelf_entry,
+                value=value,
+            )
+        allocation_by_asset_class[position.asset_class] = (
+            allocation_by_asset_class.get(position.asset_class, Decimal("0")) + value
+        )
+
+    return allocation_by_asset_class, allocation_by_attribute
+
+
+def _add_attribute_allocations(
+    *,
+    allocation_by_attribute: dict[str, dict[str, Decimal]],
+    shelf_entry: ShelfEntry,
+    value: Decimal,
+) -> None:
+    for attr_key, attr_val in shelf_entry.attributes.items():
+        value_map = allocation_by_attribute.setdefault(attr_key, {})
+        value_map[attr_val] = value_map.get(attr_val, Decimal("0")) + value
+
+
+def _allocation_metrics(
+    *,
+    values_by_key: dict[str, Decimal],
+    total_value: Decimal,
+    base_ccy: str,
+) -> list[AllocationMetric]:
+    return [
+        _allocation_metric(key=key, value=value, total_value=total_value, base_ccy=base_ccy)
+        for key, value in values_by_key.items()
+    ]
+
+
+def _allocation_by_attribute_metrics(
+    *,
+    allocation_by_attribute: dict[str, dict[str, Decimal]],
+    total_value: Decimal,
+    base_ccy: str,
+) -> dict[str, list[AllocationMetric]]:
+    return {
+        attr_key: _allocation_metrics(
+            values_by_key=value_map,
+            total_value=total_value,
+            base_ccy=base_ccy,
+        )
+        for attr_key, value_map in allocation_by_attribute.items()
+    }
+
+
 def build_simulated_state(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -125,110 +275,56 @@ def build_simulated_state(
     """
     Constructs a full valuation of the portfolio.
     """
-    if options is None:
-        options = EngineOptions()
-
+    options = _valuation_options(options)
     base_ccy = portfolio.base_currency
-    pos_summaries = []
-    total_val = Decimal("0")
+    pos_summaries, position_value = _valued_position_summaries(
+        portfolio=portfolio,
+        market_data=market_data,
+        options=options,
+        dq_log=dq_log,
+    )
+    cash_value = _total_cash_value(
+        cash_balances=portfolio.cash_balances,
+        market_data=market_data,
+        base_ccy=base_ccy,
+        dq_log=dq_log,
+    )
+    total_val = position_value + cash_value
+    total_val_safe = _safe_total_value(total_val)
 
-    for pos in portfolio.positions:
-        has_price = any(p.instrument_id == pos.instrument_id for p in market_data.prices)
-        if not has_price:
-            dq_log.setdefault("price_missing", []).append(pos.instrument_id)
+    for position in pos_summaries:
+        position.weight = position.value_in_base_ccy.amount / total_val_safe
 
-        summary = ValuationService.value_position(pos, market_data, base_ccy, options, dq_log)
-
-        if summary.instrument_currency != base_ccy:
-            rate = get_fx_rate(market_data, summary.instrument_currency, base_ccy)
-            if rate is None:
-                dq_log.setdefault("fx_missing", []).append(
-                    f"{summary.instrument_currency}/{base_ccy}"
-                )
-
-        pos_summaries.append(summary)
-        total_val += summary.value_in_base_ccy.amount
-
-    for cash in portfolio.cash_balances:
-        total_val += _cash_value_in_base(
-            cash=cash,
-            market_data=market_data,
-            base_ccy=base_ccy,
-            dq_log=dq_log,
-        )
-
-    if total_val == 0:
-        total_val_safe = Decimal("1")
-    else:
-        total_val_safe = total_val
-
-    # Aggregation containers
-    alloc_class_map: Dict[str, Decimal] = {}
-    alloc_attr_map: Dict[str, Dict[str, Decimal]] = {}
-
-    for p in pos_summaries:
-        p.weight = p.value_in_base_ccy.amount / total_val_safe
-        shelf_entry = next((s for s in shelf if s.instrument_id == p.instrument_id), None)
-
-        # Asset Class Aggregation
-        if shelf_entry:
-            p.asset_class = shelf_entry.asset_class
-            # Attribute Aggregation
-            for attr_key, attr_val in shelf_entry.attributes.items():
-                if attr_key not in alloc_attr_map:
-                    alloc_attr_map[attr_key] = {}
-                alloc_attr_map[attr_key][attr_val] = (
-                    alloc_attr_map[attr_key].get(attr_val, Decimal("0"))
-                    + p.value_in_base_ccy.amount
-                )
-
-        ac = p.asset_class
-        alloc_class_map[ac] = alloc_class_map.get(ac, Decimal("0")) + p.value_in_base_ccy.amount
-
+    alloc_class_map, alloc_attr_map = _position_allocation_maps(
+        position_summaries=pos_summaries,
+        shelf=shelf,
+    )
     alloc_instr = [
-        AllocationMetric(key=p.instrument_id, weight=p.weight, value=p.value_in_base_ccy)
-        for p in pos_summaries
-    ]
-
-    total_cash_val = Decimal("0")
-    for cash in portfolio.cash_balances:
-        total_cash_val += _cash_value_in_base(
-            cash=cash,
-            market_data=market_data,
-            base_ccy=base_ccy,
-        )
-
-    alloc_class_map["CASH"] = alloc_class_map.get("CASH", Decimal("0")) + total_cash_val
-
-    alloc_asset_class = [
         AllocationMetric(
-            key=k,
-            weight=v / total_val_safe,
-            value=Money(amount=v, currency=base_ccy),
+            key=position.instrument_id, weight=position.weight, value=position.value_in_base_ccy
         )
-        for k, v in alloc_class_map.items()
+        for position in pos_summaries
     ]
-
-    # Convert attribute map to model output
-    alloc_by_attr = {}
-    for attr_key, val_map in alloc_attr_map.items():
-        metrics = []
-        for val_key, val_amount in val_map.items():
-            metrics.append(
-                AllocationMetric(
-                    key=val_key,
-                    weight=val_amount / total_val_safe,
-                    value=Money(amount=val_amount, currency=base_ccy),
-                )
-            )
-        alloc_by_attr[attr_key] = metrics
+    alloc_class_map["CASH"] = alloc_class_map.get("CASH", Decimal("0")) + _total_cash_value(
+        cash_balances=portfolio.cash_balances,
+        market_data=market_data,
+        base_ccy=base_ccy,
+    )
 
     return SimulatedState(
         total_value=Money(amount=total_val, currency=base_ccy),
         cash_balances=portfolio.cash_balances,
         positions=pos_summaries,
-        allocation_by_asset_class=alloc_asset_class,
+        allocation_by_asset_class=_allocation_metrics(
+            values_by_key=alloc_class_map,
+            total_value=total_val_safe,
+            base_ccy=base_ccy,
+        ),
         allocation_by_instrument=alloc_instr,
         allocation=alloc_instr,
-        allocation_by_attribute=alloc_by_attr,
+        allocation_by_attribute=_allocation_by_attribute_metrics(
+            allocation_by_attribute=alloc_attr_map,
+            total_value=total_val_safe,
+            base_ccy=base_ccy,
+        ),
     )

--- a/src/core/waves/campaign_definitions.py
+++ b/src/core/waves/campaign_definitions.py
@@ -381,6 +381,26 @@ class DpmBulkReviewCampaignDefinitionMakerCheckerControl(BaseModel):
     content_hash: str = Field(description="Deterministic hash of the maker-checker record.")
 
 
+def _validate_lifecycle_fields_absent(
+    lifecycle_fields: list[object | None],
+    *,
+    reason_code: str,
+) -> None:
+    if any(value is not None for value in lifecycle_fields):
+        raise ValueError(reason_code)
+
+
+def _validate_required_lifecycle_value(
+    value: object | None,
+    *,
+    reason_code: str,
+) -> None:
+    if value is None:
+        raise ValueError(reason_code)
+    if isinstance(value, str) and not value.strip():
+        raise ValueError(reason_code)
+
+
 class DpmBulkReviewCampaignDefinition(BaseModel):
     """Manage-owned bulk-review campaign definition over source-backed candidates."""
 
@@ -481,66 +501,85 @@ class DpmBulkReviewCampaignDefinition(BaseModel):
     content_hash: str = Field(default="")
 
     def _validate_active_lifecycle(self) -> None:
-        lifecycle_fields = [
-            self.retired_at,
-            self.retired_by,
-            self.retirement_reason,
-            self.retirement_correlation_id,
-            self.superseded_at,
-            self.superseded_by,
-            self.supersession_reason,
-            self.supersession_correlation_id,
-            self.superseded_by_campaign_id,
-            self.superseded_by_campaign_version,
-            self.superseded_by_content_hash,
-        ]
-        if any(value is not None for value in lifecycle_fields):
-            raise ValueError("BULK_REVIEW_CAMPAIGN_ACTIVE_LIFECYCLE_FIELDS_FORBIDDEN")
+        _validate_lifecycle_fields_absent(
+            [
+                self.retired_at,
+                self.retired_by,
+                self.retirement_reason,
+                self.retirement_correlation_id,
+                self.superseded_at,
+                self.superseded_by,
+                self.supersession_reason,
+                self.supersession_correlation_id,
+                self.superseded_by_campaign_id,
+                self.superseded_by_campaign_version,
+                self.superseded_by_content_hash,
+            ],
+            reason_code="BULK_REVIEW_CAMPAIGN_ACTIVE_LIFECYCLE_FIELDS_FORBIDDEN",
+        )
 
     def _validate_retired_lifecycle(self) -> None:
-        if self.retired_at is None:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_TIMESTAMP_REQUIRED")
-        if not (self.retired_by or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_ACTOR_REQUIRED")
-        if not (self.retirement_reason or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_REASON_REQUIRED")
-        if not (self.retirement_correlation_id or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIREMENT_CORRELATION_REQUIRED")
-        supersession_fields = [
-            self.superseded_at,
-            self.superseded_by,
-            self.supersession_reason,
-            self.supersession_correlation_id,
-            self.superseded_by_campaign_id,
-            self.superseded_by_campaign_version,
-            self.superseded_by_content_hash,
-        ]
-        if any(value is not None for value in supersession_fields):
-            raise ValueError("BULK_REVIEW_CAMPAIGN_RETIRED_SUPERSESSION_FIELDS_FORBIDDEN")
+        _validate_required_lifecycle_value(
+            self.retired_at,
+            reason_code="BULK_REVIEW_CAMPAIGN_RETIREMENT_TIMESTAMP_REQUIRED",
+        )
+        _validate_required_lifecycle_value(
+            self.retired_by,
+            reason_code="BULK_REVIEW_CAMPAIGN_RETIREMENT_ACTOR_REQUIRED",
+        )
+        _validate_required_lifecycle_value(
+            self.retirement_reason,
+            reason_code="BULK_REVIEW_CAMPAIGN_RETIREMENT_REASON_REQUIRED",
+        )
+        _validate_required_lifecycle_value(
+            self.retirement_correlation_id,
+            reason_code="BULK_REVIEW_CAMPAIGN_RETIREMENT_CORRELATION_REQUIRED",
+        )
+        _validate_lifecycle_fields_absent(
+            [
+                self.superseded_at,
+                self.superseded_by,
+                self.supersession_reason,
+                self.supersession_correlation_id,
+                self.superseded_by_campaign_id,
+                self.superseded_by_campaign_version,
+                self.superseded_by_content_hash,
+            ],
+            reason_code="BULK_REVIEW_CAMPAIGN_RETIRED_SUPERSESSION_FIELDS_FORBIDDEN",
+        )
 
     def _validate_superseded_lifecycle(self) -> None:
-        if self.superseded_at is None:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_TIMESTAMP_REQUIRED")
-        if not (self.superseded_by or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_ACTOR_REQUIRED")
-        if not (self.supersession_reason or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_REASON_REQUIRED")
-        if not (self.supersession_correlation_id or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CORRELATION_REQUIRED")
-        if not (self.superseded_by_campaign_id or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CAMPAIGN_ID_REQUIRED")
-        if not (self.superseded_by_campaign_version or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CAMPAIGN_VERSION_REQUIRED")
-        if not (self.superseded_by_content_hash or "").strip():
-            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSESSION_CONTENT_HASH_REQUIRED")
-        retirement_fields = [
-            self.retired_at,
-            self.retired_by,
-            self.retirement_reason,
-            self.retirement_correlation_id,
-        ]
-        if any(value is not None for value in retirement_fields):
-            raise ValueError("BULK_REVIEW_CAMPAIGN_SUPERSEDED_RETIREMENT_FIELDS_FORBIDDEN")
+        for value, reason_code in [
+            (self.superseded_at, "BULK_REVIEW_CAMPAIGN_SUPERSESSION_TIMESTAMP_REQUIRED"),
+            (self.superseded_by, "BULK_REVIEW_CAMPAIGN_SUPERSESSION_ACTOR_REQUIRED"),
+            (self.supersession_reason, "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REASON_REQUIRED"),
+            (
+                self.supersession_correlation_id,
+                "BULK_REVIEW_CAMPAIGN_SUPERSESSION_CORRELATION_REQUIRED",
+            ),
+            (
+                self.superseded_by_campaign_id,
+                "BULK_REVIEW_CAMPAIGN_SUPERSESSION_CAMPAIGN_ID_REQUIRED",
+            ),
+            (
+                self.superseded_by_campaign_version,
+                "BULK_REVIEW_CAMPAIGN_SUPERSESSION_CAMPAIGN_VERSION_REQUIRED",
+            ),
+            (
+                self.superseded_by_content_hash,
+                "BULK_REVIEW_CAMPAIGN_SUPERSESSION_CONTENT_HASH_REQUIRED",
+            ),
+        ]:
+            _validate_required_lifecycle_value(value, reason_code=reason_code)
+        _validate_lifecycle_fields_absent(
+            [
+                self.retired_at,
+                self.retired_by,
+                self.retirement_reason,
+                self.retirement_correlation_id,
+            ],
+            reason_code="BULK_REVIEW_CAMPAIGN_SUPERSEDED_RETIREMENT_FIELDS_FORBIDDEN",
+        )
 
     @model_validator(mode="after")
     def validate_definition(self) -> "DpmBulkReviewCampaignDefinition":

--- a/src/core/waves/campaign_maker_checker_controls.py
+++ b/src/core/waves/campaign_maker_checker_controls.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Callable, Literal, NamedTuple
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -28,6 +28,13 @@ CampaignMakerCheckerControlOutcome = Literal[
     "EXCEPTION_OPEN",
     "EXCEPTION_RESOLVED",
 ]
+
+
+class CampaignControlValidationContext(NamedTuple):
+    control_outcome: CampaignMakerCheckerControlOutcome
+    submitter_actor_id: str | None
+    reviewer_actor_id: str | None
+    required_reviewer_role: str | None
 
 
 class DpmBulkReviewCampaignDefinitionMakerCheckerControlPage(BaseModel):
@@ -164,28 +171,59 @@ def _validate_control_action(
     reviewer_actor_id: str | None,
     required_reviewer_role: str | None,
 ) -> None:
-    if control_action == "SUBMITTED_FOR_REVIEW":
-        if not submitter_actor_id:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_SUBMITTER_REQUIRED")
-        if control_outcome != "PENDING":
-            raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_SUBMISSION_OUTCOME_INVALID")
-    elif control_action == "REVIEWER_ASSIGNED":
-        if not reviewer_actor_id or not required_reviewer_role:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_REVIEWER_REQUIRED")
-        if control_outcome != "PENDING":
-            raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_ASSIGNMENT_OUTCOME_INVALID")
-    elif control_action == "REVIEW_COMPLETED":
-        if not submitter_actor_id or not reviewer_actor_id:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_ACTORS_REQUIRED")
-        if submitter_actor_id == reviewer_actor_id:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_ACTOR_SEPARATION_REQUIRED")
-        if control_outcome not in {"PASSED", "FAILED"}:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_REVIEW_OUTCOME_INVALID")
-    elif control_action == "CONTROL_EXCEPTION_RAISED":
-        if control_outcome != "EXCEPTION_OPEN":
-            raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_EXCEPTION_OUTCOME_INVALID")
-    elif control_outcome != "EXCEPTION_RESOLVED":
+    context = CampaignControlValidationContext(
+        control_outcome=control_outcome,
+        submitter_actor_id=submitter_actor_id,
+        reviewer_actor_id=reviewer_actor_id,
+        required_reviewer_role=required_reviewer_role,
+    )
+    validator = _CONTROL_ACTION_VALIDATORS.get(control_action, _validate_exception_resolved_control)
+    validator(context)
+
+
+def _validate_submission_control(context: CampaignControlValidationContext) -> None:
+    if not context.submitter_actor_id:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_SUBMITTER_REQUIRED")
+    if context.control_outcome != "PENDING":
+        raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_SUBMISSION_OUTCOME_INVALID")
+
+
+def _validate_reviewer_assignment_control(context: CampaignControlValidationContext) -> None:
+    if not context.reviewer_actor_id or not context.required_reviewer_role:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_REVIEWER_REQUIRED")
+    if context.control_outcome != "PENDING":
+        raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_ASSIGNMENT_OUTCOME_INVALID")
+
+
+def _validate_review_completed_control(context: CampaignControlValidationContext) -> None:
+    if not context.submitter_actor_id or not context.reviewer_actor_id:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_ACTORS_REQUIRED")
+    if context.submitter_actor_id == context.reviewer_actor_id:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_ACTOR_SEPARATION_REQUIRED")
+    if context.control_outcome not in {"PASSED", "FAILED"}:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_REVIEW_OUTCOME_INVALID")
+
+
+def _validate_exception_raised_control(context: CampaignControlValidationContext) -> None:
+    if context.control_outcome != "EXCEPTION_OPEN":
+        raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_EXCEPTION_OUTCOME_INVALID")
+
+
+def _validate_exception_resolved_control(context: CampaignControlValidationContext) -> None:
+    if context.control_outcome != "EXCEPTION_RESOLVED":
         raise ValueError("BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_EXCEPTION_RESOLUTION_INVALID")
+
+
+_CONTROL_ACTION_VALIDATORS: dict[
+    CampaignMakerCheckerControlAction,
+    Callable[[CampaignControlValidationContext], None],
+] = {
+    "SUBMITTED_FOR_REVIEW": _validate_submission_control,
+    "REVIEWER_ASSIGNED": _validate_reviewer_assignment_control,
+    "REVIEW_COMPLETED": _validate_review_completed_control,
+    "CONTROL_EXCEPTION_RAISED": _validate_exception_raised_control,
+    "CONTROL_EXCEPTION_RESOLVED": _validate_exception_resolved_control,
+}
 
 
 def _build_control(

--- a/src/core/waves/campaign_repository.py
+++ b/src/core/waves/campaign_repository.py
@@ -11,7 +11,7 @@ class DpmBulkReviewCampaignDefinitionConflictError(ValueError):
 
 class DpmBulkReviewCampaignDefinitionRepository(Protocol):
     def save_definition(self, *, definition: DpmBulkReviewCampaignDefinition) -> None:
-        raise NotImplementedError
+        """Persist a campaign definition."""
 
     def get_definition(
         self,
@@ -19,7 +19,7 @@ class DpmBulkReviewCampaignDefinitionRepository(Protocol):
         campaign_id: str,
         campaign_version: str,
     ) -> DpmBulkReviewCampaignDefinition | None:
-        raise NotImplementedError
+        """Return a campaign definition by identifier and version."""
 
     def list_definitions(
         self,
@@ -30,53 +30,53 @@ class DpmBulkReviewCampaignDefinitionRepository(Protocol):
         limit: int = 50,
         offset: int = 0,
     ) -> list[DpmBulkReviewCampaignDefinition]:
-        raise NotImplementedError
+        """Return a bounded page of campaign definitions."""
 
     def retire_definition(
         self,
         *,
         definition: DpmBulkReviewCampaignDefinition,
     ) -> DpmBulkReviewCampaignDefinition | None:
-        raise NotImplementedError
+        """Persist a retired campaign definition version."""
 
     def supersede_definition(
         self,
         *,
         definition: DpmBulkReviewCampaignDefinition,
     ) -> DpmBulkReviewCampaignDefinition | None:
-        raise NotImplementedError
+        """Persist a superseded campaign definition version."""
 
     def record_definition_launch(
         self,
         *,
         definition: DpmBulkReviewCampaignDefinition,
     ) -> DpmBulkReviewCampaignDefinition | None:
-        raise NotImplementedError
+        """Persist launch evidence for a campaign definition."""
 
     def record_definition_approval_decision(
         self,
         *,
         definition: DpmBulkReviewCampaignDefinition,
     ) -> DpmBulkReviewCampaignDefinition | None:
-        raise NotImplementedError
+        """Persist approval-decision evidence for a campaign definition."""
 
     def record_definition_assignment_action(
         self,
         *,
         definition: DpmBulkReviewCampaignDefinition,
     ) -> DpmBulkReviewCampaignDefinition | None:
-        raise NotImplementedError
+        """Persist assignment-action evidence for a campaign definition."""
 
     def record_definition_assignment_task(
         self,
         *,
         definition: DpmBulkReviewCampaignDefinition,
     ) -> DpmBulkReviewCampaignDefinition | None:
-        raise NotImplementedError
+        """Persist assignment-task evidence for a campaign definition."""
 
     def record_definition_maker_checker_control(
         self,
         *,
         definition: DpmBulkReviewCampaignDefinition,
     ) -> DpmBulkReviewCampaignDefinition | None:
-        raise NotImplementedError
+        """Persist maker-checker control evidence for a campaign definition."""

--- a/src/infrastructure/core_sourcing/client.py
+++ b/src/infrastructure/core_sourcing/client.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 import httpx
 
@@ -51,6 +51,13 @@ class DpmCoreResolverUnavailableError(DpmCoreResolverError):
 
 
 LEGACY_DPM_EXECUTION_CONTEXT_PATH = "/integration/portfolios/{portfolio_id}/dpm-execution-context"
+
+
+@dataclass(frozen=True)
+class _CoreSnapshotMappedRow:
+    position: Position | None = None
+    cash_currency: str | None = None
+    cash_amount: Decimal | None = None
 
 
 @dataclass(frozen=True)
@@ -1576,40 +1583,77 @@ class DpmCoreResolverClient:
             return None
 
 
-def _portfolio_snapshot_from_core_snapshot(payload: dict[str, Any]) -> PortfolioSnapshot:
-    sections = payload.get("sections") or {}
-    rows = sections.get("positions_baseline") or []
+def _core_snapshot_base_currency(payload: Mapping[str, Any]) -> str:
     valuation_context = payload.get("valuation_context") or {}
-    base_currency = str(
+    return str(
         valuation_context.get("portfolio_currency")
         or valuation_context.get("reporting_currency")
         or "USD"
     )
 
+
+def _core_snapshot_row_instrument_id(row: Mapping[str, Any]) -> str:
+    return str(row.get("security_id") or row.get("instrument_id") or "").strip()
+
+
+def _map_core_snapshot_row(
+    row: Mapping[str, Any],
+    *,
+    base_currency: str,
+) -> _CoreSnapshotMappedRow | None:
+    instrument_id = _core_snapshot_row_instrument_id(row)
+    if not instrument_id:
+        return None
+
+    quantity = Decimal(str(row.get("quantity") or "0"))
+    currency = str(row.get("currency") or base_currency).upper()
+    if instrument_id.startswith("CASH_"):
+        return _CoreSnapshotMappedRow(cash_currency=currency, cash_amount=quantity)
+
+    market_value = row.get("market_value_local")
+    return _CoreSnapshotMappedRow(
+        position=Position(
+            instrument_id=instrument_id,
+            quantity=quantity,
+            market_value=(
+                Money(amount=Decimal(str(market_value)), currency=currency)
+                if market_value is not None
+                else None
+            ),
+        )
+    )
+
+
+def _portfolio_positions_and_cash_from_core_rows(
+    rows: list[Mapping[str, Any]],
+    *,
+    base_currency: str,
+) -> tuple[list[Position], dict[str, Decimal]]:
     positions: list[Position] = []
     cash_by_currency: dict[str, Decimal] = {}
     for row in rows:
-        instrument_id = str(row.get("security_id") or row.get("instrument_id") or "").strip()
-        if not instrument_id:
+        mapped_row = _map_core_snapshot_row(row, base_currency=base_currency)
+        if mapped_row is None:
             continue
-        quantity = Decimal(str(row.get("quantity") or "0"))
-        currency = str(row.get("currency") or base_currency).upper()
-        if instrument_id.startswith("CASH_"):
-            cash_by_currency[currency] = cash_by_currency.get(currency, Decimal("0")) + quantity
-            continue
-
-        market_value = row.get("market_value_local")
-        positions.append(
-            Position(
-                instrument_id=instrument_id,
-                quantity=quantity,
-                market_value=(
-                    Money(amount=Decimal(str(market_value)), currency=currency)
-                    if market_value is not None
-                    else None
-                ),
+        if mapped_row.position is not None:
+            positions.append(mapped_row.position)
+        elif mapped_row.cash_currency is not None and mapped_row.cash_amount is not None:
+            cash_by_currency[mapped_row.cash_currency] = (
+                cash_by_currency.get(mapped_row.cash_currency, Decimal("0"))
+                + mapped_row.cash_amount
             )
-        )
+
+    return positions, cash_by_currency
+
+
+def _portfolio_snapshot_from_core_snapshot(payload: dict[str, Any]) -> PortfolioSnapshot:
+    sections = payload.get("sections") or {}
+    rows = sections.get("positions_baseline") or []
+    base_currency = _core_snapshot_base_currency(payload)
+    positions, cash_by_currency = _portfolio_positions_and_cash_from_core_rows(
+        rows,
+        base_currency=base_currency,
+    )
 
     return PortfolioSnapshot(
         snapshot_id=payload.get("snapshot_id")

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -5,6 +5,8 @@ from src.api.openapi_enrichment import (
     _infer_example,
     _number_example_for_key,
     _collection_example_from_schema,
+    _operation_has_error_response,
+    _operation_tag_for_path,
     _schema_declared_example,
     _semantic_string_example_for_key,
     enrich_openapi_schema,
@@ -210,6 +212,19 @@ def test_openapi_enrichment_adds_operation_level_examples_and_errors() -> None:
         ]["status"]
         == 409
     )
+
+
+def test_openapi_enrichment_operation_tag_for_path_uses_governed_fallbacks() -> None:
+    assert _operation_tag_for_path("/health/live") == "Health"
+    assert _operation_tag_for_path("/metrics") == "Monitoring"
+    assert _operation_tag_for_path("/api/v1/rebalance") == "Api"
+    assert _operation_tag_for_path("/") == "Default"
+
+
+def test_openapi_enrichment_operation_error_response_detection() -> None:
+    assert _operation_has_error_response({"200": {}, "409": {}}) is True
+    assert _operation_has_error_response({"200": {}, "default": {}}) is True
+    assert _operation_has_error_response({"200": {}, "302": {}}) is False
 
 
 def test_openapi_enrichment_adds_operation_docs_errors_and_prometheus_examples() -> None:

--- a/tests/unit/core/test_capabilities.py
+++ b/tests/unit/core/test_capabilities.py
@@ -1,6 +1,7 @@
 import sys
 from types import ModuleType
 
+import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
 from src.core.common import capabilities
@@ -16,6 +17,29 @@ def test_solver_dependency_flag_matches_component_flags() -> None:
 def test_psycopg_error_type_none_when_driver_missing(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(capabilities, "has_psycopg", lambda: False)
     assert capabilities.psycopg_error_type() is None
+
+
+def test_psycopg_error_type_none_when_driver_import_fails(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(capabilities, "has_psycopg", lambda: True)
+
+    def missing_driver() -> ModuleType:
+        raise ImportError("psycopg unavailable")
+
+    monkeypatch.setattr(capabilities, "_import_psycopg", missing_driver)
+
+    assert capabilities.psycopg_error_type() is None
+
+
+def test_psycopg_error_type_does_not_hide_non_import_failures(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(capabilities, "has_psycopg", lambda: True)
+
+    def broken_driver() -> ModuleType:
+        raise RuntimeError("psycopg import side effect failed")
+
+    monkeypatch.setattr(capabilities, "_import_psycopg", broken_driver)
+
+    with pytest.raises(RuntimeError, match="psycopg import side effect failed"):
+        capabilities.psycopg_error_type()
 
 
 def test_psycopg_error_type_from_driver_module(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/core/test_common_edge_coverage.py
+++ b/tests/unit/core/test_common_edge_coverage.py
@@ -14,10 +14,19 @@ from src.core.common.simulation_shared import (
     sort_execution_intents,
 )
 from src.core.common.workflow_gates import evaluate_gate_decision
-from src.core.compliance import RuleEngine, _cash_band_rule_result
+from src.core.compliance import (
+    RuleEngine,
+    _cash_band_rule_result,
+    _data_quality_rule_result,
+    _insufficient_cash_rule_result,
+    _min_trade_size_rule_result,
+    _no_shorting_rule_result,
+    _single_position_max_rule_results,
+)
 from src.core.models import (
     AllocationMetric,
     BatchRebalanceRequest,
+    CashBalance,
     DiagnosticsData,
     EngineOptions,
     FxSpotIntent,
@@ -31,6 +40,7 @@ from src.core.models import (
     SuitabilityEvidenceSnapshotIds,
     SecurityTradeIntent,
     SimulatedState,
+    SuppressedIntent,
     SuitabilityIssue,
     SuitabilityResult,
     SuitabilitySummary,
@@ -366,6 +376,127 @@ def test_rule_engine_flags_single_position_limit_breaches() -> None:
         and result.reason_code == "LIMIT_BREACH"
         for result in results
     )
+
+
+def test_single_position_rule_results_pass_when_limit_is_not_set() -> None:
+    state = SimulatedState(
+        total_value=Money(amount=Decimal("100"), currency="USD"),
+        positions=[],
+        cash_balances=[],
+        allocation_by_asset_class=[],
+        allocation_by_instrument=[],
+    )
+
+    results = _single_position_max_rule_results(state=state, options=EngineOptions())
+
+    assert len(results) == 1
+    assert results[0].rule_id == "SINGLE_POSITION_MAX"
+    assert results[0].status == "PASS"
+    assert results[0].reason_code == "NO_LIMIT_SET"
+
+
+def test_data_quality_rule_result_respects_blocking_options() -> None:
+    diagnostics = DiagnosticsData(
+        data_quality={
+            "price_missing": ["EQ_1"],
+            "fx_missing": ["EURUSD"],
+            "shelf_missing": ["EQ_2"],
+        },
+        suppressed_intents=[],
+        warnings=[],
+    )
+
+    result = _data_quality_rule_result(
+        diagnostics=diagnostics,
+        options=EngineOptions(block_on_missing_prices=True, block_on_missing_fx=False),
+    )
+
+    assert result.rule_id == "DATA_QUALITY"
+    assert result.status == "FAIL"
+    assert result.measured == Decimal("2")
+    assert result.reason_code == "MISSING_DATA"
+
+
+def test_min_trade_size_rule_result_reports_suppressed_intent_count() -> None:
+    diagnostics = DiagnosticsData(
+        data_quality={},
+        suppressed_intents=[
+            SuppressedIntent(
+                instrument_id="EQ_1",
+                reason="MIN_NOTIONAL",
+                intended_notional=Money(amount=Decimal("75"), currency="USD"),
+                threshold=Money(amount=Decimal("100"), currency="USD"),
+            ),
+            SuppressedIntent(
+                instrument_id="EQ_2",
+                reason="MIN_NOTIONAL",
+                intended_notional=Money(amount=Decimal("80"), currency="USD"),
+                threshold=Money(amount=Decimal("100"), currency="USD"),
+            ),
+        ],
+        warnings=[],
+    )
+
+    result = _min_trade_size_rule_result(diagnostics=diagnostics)
+
+    assert result.rule_id == "MIN_TRADE_SIZE"
+    assert result.status == "PASS"
+    assert result.measured == Decimal("2")
+    assert result.reason_code == "INTENTS_SUPPRESSED"
+
+
+def test_no_shorting_rule_result_reports_most_negative_position_quantity() -> None:
+    state = SimulatedState(
+        total_value=Money(amount=Decimal("100"), currency="USD"),
+        positions=[
+            PositionSummary(
+                instrument_id="EQ_1",
+                quantity=Decimal("-1"),
+                instrument_currency="USD",
+                value_in_instrument_ccy=Money(amount=Decimal("-10"), currency="USD"),
+                value_in_base_ccy=Money(amount=Decimal("-10"), currency="USD"),
+                weight=Decimal("-0.1"),
+            ),
+            PositionSummary(
+                instrument_id="EQ_2",
+                quantity=Decimal("-3"),
+                instrument_currency="USD",
+                value_in_instrument_ccy=Money(amount=Decimal("-30"), currency="USD"),
+                value_in_base_ccy=Money(amount=Decimal("-30"), currency="USD"),
+                weight=Decimal("-0.3"),
+            ),
+        ],
+        cash_balances=[],
+        allocation_by_asset_class=[],
+        allocation_by_instrument=[],
+    )
+
+    result = _no_shorting_rule_result(state=state)
+
+    assert result.rule_id == "NO_SHORTING"
+    assert result.status == "FAIL"
+    assert result.measured == Decimal("-3")
+    assert result.reason_code == "SELL_EXCEEDS_HOLDINGS"
+
+
+def test_insufficient_cash_rule_result_reports_most_negative_cash_balance() -> None:
+    state = SimulatedState(
+        total_value=Money(amount=Decimal("100"), currency="USD"),
+        positions=[],
+        cash_balances=[
+            CashBalance(currency="USD", amount=Decimal("-5")),
+            CashBalance(currency="EUR", amount=Decimal("-8")),
+        ],
+        allocation_by_asset_class=[],
+        allocation_by_instrument=[],
+    )
+
+    result = _insufficient_cash_rule_result(state=state)
+
+    assert result.rule_id == "INSUFFICIENT_CASH"
+    assert result.status == "FAIL"
+    assert result.measured == Decimal("-8")
+    assert result.reason_code == "CASH_BALANCE_NEGATIVE"
 
 
 def test_cash_band_rule_result_passes_when_cash_is_inside_policy_band() -> None:

--- a/tests/unit/core/test_intent_dependencies.py
+++ b/tests/unit/core/test_intent_dependencies.py
@@ -1,0 +1,62 @@
+from decimal import Decimal
+
+from src.core.common.intent_dependencies import (
+    append_intent_dependency_once,
+    link_buy_intent_dependencies,
+    sell_intent_id_by_currency,
+)
+from src.core.models import Money, SecurityTradeIntent
+
+
+def _security_intent(
+    *,
+    intent_id: str,
+    side: str,
+    currency: str | None = "USD",
+) -> SecurityTradeIntent:
+    return SecurityTradeIntent(
+        intent_id=intent_id,
+        instrument_id=f"EQ_{intent_id}",
+        side=side,
+        quantity=Decimal("1"),
+        notional=(Money(amount=Decimal("10"), currency=currency) if currency is not None else None),
+    )
+
+
+def test_sell_intent_id_by_currency_indexes_latest_sell_with_notional() -> None:
+    assert sell_intent_id_by_currency(
+        [
+            _security_intent(intent_id="sell_usd_1", side="SELL", currency="USD"),
+            _security_intent(intent_id="buy_usd", side="BUY", currency="USD"),
+            _security_intent(intent_id="sell_missing_notional", side="SELL", currency=None),
+            _security_intent(intent_id="sell_usd_2", side="SELL", currency="USD"),
+            _security_intent(intent_id="sell_sgd", side="SELL", currency="SGD"),
+        ]
+    ) == {
+        "USD": "sell_usd_2",
+        "SGD": "sell_sgd",
+    }
+
+
+def test_append_intent_dependency_once_preserves_existing_order() -> None:
+    intent = _security_intent(intent_id="buy_usd", side="BUY")
+    intent.dependencies.append("existing")
+
+    append_intent_dependency_once(intent, "fx_usd")
+    append_intent_dependency_once(intent, "fx_usd")
+    append_intent_dependency_once(intent, None)
+
+    assert intent.dependencies == ["existing", "fx_usd"]
+
+
+def test_link_buy_intent_dependencies_uses_fx_then_sell_dependencies() -> None:
+    sell = _security_intent(intent_id="sell_usd", side="SELL", currency="USD")
+    buy = _security_intent(intent_id="buy_usd", side="BUY", currency="USD")
+
+    link_buy_intent_dependencies(
+        [sell, buy],
+        fx_intent_id_by_currency={"USD": "fx_usd"},
+        include_same_currency_sell_dependency=True,
+    )
+
+    assert buy.dependencies == ["fx_usd", "sell_usd"]

--- a/tests/unit/core/test_target_generation_helpers.py
+++ b/tests/unit/core/test_target_generation_helpers.py
@@ -4,7 +4,9 @@ from src.core.models import EngineOptions, GroupConstraint, ShelfEntry
 from src.core.target_generation import (
     _build_solver_attempts,
     _collect_infeasibility_hints,
+    _solver_invested_bounds,
     _solver_failure_reason,
+    _solver_target_universe,
 )
 
 
@@ -25,6 +27,35 @@ def test_solver_failure_reason_classification() -> None:
     assert _solver_failure_reason("infeasible") == "INFEASIBLE_INFEASIBLE"
     assert _solver_failure_reason("unbounded_inaccurate") == "UNBOUNDED_UNBOUNDED_INACCURATE"
     assert _solver_failure_reason("optimal") == "SOLVER_NON_OPTIMAL_OPTIMAL"
+
+
+def test_solver_target_universe_splits_tradeable_and_locked_weights() -> None:
+    universe = _solver_target_universe(
+        eligible_targets={
+            "BUY_1": Decimal("0.25"),
+            "LOCKED_1": Decimal("0.35"),
+            "BUY_2": Decimal("0.15"),
+            "LOCKED_2": Decimal("0.05"),
+        },
+        buy_list=["BUY_1", "BUY_2"],
+    )
+
+    assert universe.tradeable_ids == ["BUY_1", "BUY_2"]
+    assert universe.locked_ids == ["LOCKED_1", "LOCKED_2"]
+    assert universe.locked_weight == Decimal("0.40")
+
+
+def test_solver_invested_bounds_subtract_locked_weight_from_cash_band() -> None:
+    bounds = _solver_invested_bounds(
+        locked_weight=Decimal("0.35"),
+        options=EngineOptions(
+            cash_band_min_weight=Decimal("0.05"),
+            cash_band_max_weight=Decimal("0.15"),
+        ),
+    )
+
+    assert bounds.minimum == Decimal("0.50")
+    assert bounds.maximum == Decimal("0.60")
 
 
 def test_collect_infeasibility_hints_reports_capacity_and_group_lock() -> None:

--- a/tests/unit/core/test_target_generation_helpers.py
+++ b/tests/unit/core/test_target_generation_helpers.py
@@ -4,6 +4,7 @@ from src.core.models import EngineOptions, GroupConstraint, ShelfEntry
 from src.core.target_generation import (
     _build_solver_attempts,
     _collect_infeasibility_hints,
+    _solver_group_members,
     _solver_invested_bounds,
     _solver_failure_reason,
     _solver_target_universe,
@@ -56,6 +57,30 @@ def test_solver_invested_bounds_subtract_locked_weight_from_cash_band() -> None:
 
     assert bounds.minimum == Decimal("0.50")
     assert bounds.maximum == Decimal("0.60")
+
+
+def test_solver_group_members_splits_tradeable_members_from_locked_weight() -> None:
+    members = _solver_group_members(
+        attr_key="sector",
+        attr_val="TECH",
+        eligible_targets={
+            "TRADEABLE_1": Decimal("0.25"),
+            "LOCKED_1": Decimal("0.35"),
+            "TRADEABLE_2": Decimal("0.15"),
+            "NON_MATCH": Decimal("0.05"),
+            "MISSING_ATTRS": Decimal("0.20"),
+        },
+        shelf_attrs_by_id={
+            "TRADEABLE_1": {"sector": "TECH"},
+            "LOCKED_1": {"sector": "TECH"},
+            "TRADEABLE_2": {"sector": "TECH"},
+            "NON_MATCH": {"sector": "HEALTH"},
+        },
+        indexed_tradeable={"TRADEABLE_1": 0, "TRADEABLE_2": 1},
+    )
+
+    assert members.tradeable_ids == ["TRADEABLE_1", "TRADEABLE_2"]
+    assert members.locked_weight == Decimal("0.35")
 
 
 def test_collect_infeasibility_hints_reports_capacity_and_group_lock() -> None:

--- a/tests/unit/core/test_target_generation_solver_fallbacks.py
+++ b/tests/unit/core/test_target_generation_solver_fallbacks.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 import sys
 
+import pytest
+
 from src.core.models import DiagnosticsData, EngineOptions, ModelPortfolio, ModelTarget, ShelfEntry
 from src.core.target_generation import (
     _load_solver_modules,
@@ -181,6 +183,20 @@ def test_load_solver_modules_records_error_when_import_fails(monkeypatch) -> Non
 
     assert _load_solver_modules(diagnostics) is None
     assert diagnostics.warnings == ["SOLVER_ERROR"]
+
+
+def test_load_solver_modules_does_not_hide_non_import_failures(monkeypatch) -> None:
+    monkeypatch.setattr("src.core.target_generation.has_solver_dependencies", lambda: True)
+
+    def broken_import() -> tuple[object, object]:
+        raise RuntimeError("solver import side effect failed")
+
+    monkeypatch.setattr("src.core.target_generation._import_solver_modules", broken_import)
+    diagnostics = DiagnosticsData(data_quality={}, suppressed_intents=[], warnings=[])
+
+    with pytest.raises(RuntimeError, match="solver import side effect failed"):
+        _load_solver_modules(diagnostics)
+    assert diagnostics.warnings == []
 
 
 def test_generate_targets_solver_reports_pending_review_when_sell_excess_has_no_recipient(

--- a/tests/unit/dpm/api/test_construction_api.py
+++ b/tests/unit/dpm/api/test_construction_api.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api.dependencies import (
@@ -1624,6 +1625,29 @@ def test_construction_http_exception_mapping() -> None:
 
         assert http_exc.status_code == status_code
         assert http_exc.detail == detail
+
+
+def test_generate_construction_route_does_not_hide_unexpected_failures(monkeypatch) -> None:
+    repository = InMemoryConstructionRepository()
+
+    def fail_generation(**_kwargs):
+        raise RuntimeError("construction repository side effect failed")
+
+    monkeypatch.setattr(
+        construction_service,
+        "generate_construction_alternative_set",
+        fail_generation,
+    )
+
+    with _client(repository) as client:
+        with pytest.raises(RuntimeError, match="construction repository side effect failed"):
+            client.post(
+                "/api/v1/construction/alternative-sets/generate",
+                json=_payload(),
+                headers={"Idempotency-Key": "idem-construction-runtime-failure"},
+            )
+
+    app.dependency_overrides = {}
 
 
 def test_read_and_select_construction_alternative_set() -> None:

--- a/tests/unit/dpm/api/test_proof_pack_api.py
+++ b/tests/unit/dpm/api/test_proof_pack_api.py
@@ -434,7 +434,7 @@ def test_generate_proof_pack_preserves_governed_http_exceptions(
     assert response.json()["detail"] == "DPM_TEST_HTTP_EXCEPTION"
 
 
-def test_generate_proof_pack_maps_unexpected_service_exceptions(
+def test_generate_proof_pack_does_not_hide_unexpected_service_exceptions(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -449,19 +449,17 @@ def test_generate_proof_pack_maps_unexpected_service_exceptions(
         raise_unexpected_exception,
     )
 
-    response = client.post(
-        "/api/v1/rebalance/proof-packs",
-        json={
-            "source_type": "REBALANCE_RUN",
-            "rebalance_run_id": run_id,
-            "actor_id": "pm_api",
-            "mandate_id": "mandate_api_001",
-        },
-        headers={"Idempotency-Key": "proof-pack-api-unexpected-exception"},
-    )
-
-    assert response.status_code == 500
-    assert response.json()["detail"] == "RuntimeError"
+    with pytest.raises(RuntimeError, match="boom"):
+        client.post(
+            "/api/v1/rebalance/proof-packs",
+            json={
+                "source_type": "REBALANCE_RUN",
+                "rebalance_run_id": run_id,
+                "actor_id": "pm_api",
+                "mandate_id": "mandate_api_001",
+            },
+            headers={"Idempotency-Key": "proof-pack-api-unexpected-exception"},
+        )
 
 
 def test_proof_pack_read_routes_return_404_for_missing_pack(client: TestClient) -> None:

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -26,6 +26,7 @@ from src.api.services import construction_service, proof_pack_service, wave_serv
 from src.api.services.wave_aggregate_metrics import simulation_result_state
 from src.api.services.wave_event_append import append_same_state_event
 from src.api.services.wave_event_evidence import build_wave_event
+from src.core.construction.repository import ConstructionIdempotencyConflictError
 from src.core.mandates import (
     DpmMandateConstraintSet,
     DpmMandateDigitalTwin,
@@ -4595,7 +4596,7 @@ def test_wave_simulation_degrades_generation_failure(monkeypatch: pytest.MonkeyP
     wave_repository = InMemoryDpmWaveRepository()
 
     def fail_generation(**_: object) -> None:
-        raise RuntimeError("construction unavailable")
+        raise ConstructionIdempotencyConflictError("CONSTRUCTION_IDEMPOTENCY_KEY_CONFLICT")
 
     monkeypatch.setattr(
         construction_service,
@@ -4639,7 +4640,7 @@ def test_wave_simulation_degrades_generation_failure(monkeypatch: pytest.MonkeyP
     assert simulated.json()["wave"]["state"] == "SIMULATION_FAILED"
     assert item["state"] == "SIMULATION_BLOCKED"
     assert item["reason_codes"] == ["CONSTRUCTION_ALTERNATIVE_GENERATION_FAILED"]
-    assert item["diagnostics"]["construction_error"] == "RuntimeError"
+    assert item["diagnostics"]["construction_error"] == "ConstructionIdempotencyConflictError"
 
 
 def test_wave_selection_degrades_when_proof_pack_generation_is_not_requested() -> None:
@@ -5302,7 +5303,11 @@ def test_wave_services_translate_durable_write_conflicts_to_governed_errors() ->
             wave_id=simulate_wave.wave_id,
             actor_id="pm_001",
             correlation_id="corr-conflict-simulate",
-            item_inputs={simulate_wave.items[0].wave_item_id: _rebalance_request(PORTFOLIO_ID)},
+            item_inputs={
+                simulate_wave.items[0].wave_item_id: RebalanceRequest.model_validate(
+                    _rebalance_request(PORTFOLIO_ID)
+                )
+            },
             methods=None,
             construction_repository=InMemoryConstructionRepository(),
             run_service=_run_service(),

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -40,6 +40,7 @@ from src.core.dpm_source_context import (
     DpmCorePortfolioManagerBookMembershipResponse,
 )
 from src.core.rebalance_runs.service import DpmRunSupportService
+from src.core.proof_packs import ProofPackSourceValidationError
 from src.infrastructure.mandates import InMemoryDpmMandateRepository
 from src.infrastructure.construction import InMemoryConstructionRepository
 from src.infrastructure.outcomes import InMemoryDpmOutcomeReviewRepository
@@ -4844,7 +4845,7 @@ def test_wave_selection_degrades_when_proof_pack_generation_fails(
     wave_repository = InMemoryDpmWaveRepository()
 
     def fail_proof_pack(**_: object) -> None:
-        raise RuntimeError("proof pack unavailable")
+        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_NOT_FOUND")
 
     monkeypatch.setattr(
         proof_pack_service,
@@ -4897,7 +4898,7 @@ def test_wave_selection_degrades_when_proof_pack_generation_fails(
     assert item["proof_pack_id"] is None
     assert item["diagnostics"]["proof_pack_state"] == "DEGRADED"
     assert item["diagnostics"]["proof_pack_reason_code"] == "PROOF_PACK_GENERATION_FAILED"
-    assert item["diagnostics"]["proof_pack_error"] == "RuntimeError"
+    assert item["diagnostics"]["proof_pack_error"] == "ProofPackSourceValidationError"
 
 
 def test_wave_approval_staging_and_handoff_are_durable_and_idempotent() -> None:

--- a/tests/unit/dpm/construction/test_client_profile_source_context.py
+++ b/tests/unit/dpm/construction/test_client_profile_source_context.py
@@ -2,9 +2,11 @@ from decimal import Decimal
 
 from src.api.services import construction_client_profile_source_context
 from src.api.services.construction_client_profile_source_context import (
+    client_restriction_rules,
     client_profile_source_fields,
     client_restriction_profile_context,
     sustainability_preference_profile_context,
+    sustainability_preferences,
 )
 from src.core.common.canonical import hash_canonical_payload
 from src.core.construction.vocabulary import ConstructionMethodStatus
@@ -17,9 +19,11 @@ from tests.unit.dpm.construction.source_product_context_fixtures import (
 def test_client_profile_source_context_exports_only_client_profile_mappers() -> None:
     assert construction_client_profile_source_context.__all__ == [
         "ClientProfileSourceResponse",
+        "client_restriction_rules",
         "client_profile_source_fields",
         "client_restriction_profile_context",
         "sustainability_preference_profile_context",
+        "sustainability_preferences",
     ]
 
 
@@ -73,6 +77,15 @@ def test_client_restriction_profile_context_preserves_rules_and_lineage() -> Non
     assert context.restrictions[0].source_record_id == "restriction-record-1"
 
 
+def test_client_restriction_rules_project_source_rules() -> None:
+    rules = client_restriction_rules(client_restriction_profile_response())
+
+    assert len(rules) == 1
+    assert rules[0].restriction_code == "NO_SINGLE_STOCK_A"
+    assert rules[0].instrument_ids == ["EQ_A"]
+    assert rules[0].source_record_id == "restriction-record-1"
+
+
 def test_client_restriction_profile_context_falls_back_to_content_hash_source_id() -> None:
     response = client_restriction_profile_response().model_copy(
         update={
@@ -103,6 +116,15 @@ def test_sustainability_preference_context_preserves_preferences_and_status() ->
     assert context.preferences[0].preference_code == "MIN_ARTICLE_8"
     assert context.preferences[0].minimum_allocation == Decimal("0.40")
     assert context.preferences[0].positive_tilt_codes == ["LOW_CARBON"]
+
+
+def test_sustainability_preferences_project_source_preferences() -> None:
+    preferences = sustainability_preferences(sustainability_preference_profile_response())
+
+    assert len(preferences) == 1
+    assert preferences[0].preference_code == "MIN_ARTICLE_8"
+    assert preferences[0].minimum_allocation == Decimal("0.40")
+    assert preferences[0].positive_tilt_codes == ["LOW_CARBON"]
 
 
 def test_sustainability_preference_context_falls_back_to_content_hash_source_id() -> None:

--- a/tests/unit/dpm/construction/test_liquidity_source_context.py
+++ b/tests/unit/dpm/construction/test_liquidity_source_context.py
@@ -4,6 +4,7 @@ from src.api.services import construction_liquidity_source_context
 from src.api.services.construction_liquidity_source_context import (
     client_income_needs_schedule_context,
     liquidity_cashflow_projection_context,
+    liquidity_source_child_contexts,
     liquidity_source_identity_fields,
     liquidity_reserve_requirement_context,
     planned_withdrawal_schedule_context,
@@ -22,9 +23,11 @@ from tests.unit.dpm.construction.source_product_context_fixtures import (
 
 def test_liquidity_source_context_exports_only_liquidity_mappers() -> None:
     assert construction_liquidity_source_context.__all__ == [
+        "LiquiditySourceChildContexts",
         "LiquiditySourceResponse",
         "client_income_needs_schedule_context",
         "liquidity_cashflow_projection_context",
+        "liquidity_source_child_contexts",
         "liquidity_source_identity_fields",
         "liquidity_reserve_requirement_context",
         "planned_withdrawal_schedule_context",
@@ -199,6 +202,38 @@ def test_liquidity_cashflow_context_falls_back_to_content_hash_source_id() -> No
     context = liquidity_cashflow_projection_context(response)
 
     assert context.source_batch_fingerprint == expected_hash
+
+
+def test_liquidity_source_child_contexts_lifts_all_present_children() -> None:
+    child_contexts = liquidity_source_child_contexts(
+        cashflow_projection=cashflow_projection_response(),
+        income_needs=client_income_needs_schedule_response(),
+        reserve_requirement=liquidity_reserve_requirement_response(),
+        planned_withdrawals=planned_withdrawal_schedule_response(),
+    )
+
+    assert child_contexts.cashflow_projection is not None
+    assert child_contexts.cashflow_projection.source_batch_fingerprint == "cashflow-lineage"
+    assert child_contexts.client_income_needs_schedule is not None
+    assert child_contexts.client_income_needs_schedule.source_id == "income-lineage"
+    assert child_contexts.liquidity_reserve_requirement is not None
+    assert child_contexts.liquidity_reserve_requirement.source_id == "reserve-lineage"
+    assert child_contexts.planned_withdrawal_schedule is not None
+    assert child_contexts.planned_withdrawal_schedule.source_id == "withdrawal-lineage"
+
+
+def test_liquidity_source_child_contexts_keeps_absent_children_none() -> None:
+    child_contexts = liquidity_source_child_contexts(
+        cashflow_projection=None,
+        income_needs=client_income_needs_schedule_response(),
+        reserve_requirement=None,
+        planned_withdrawals=None,
+    )
+
+    assert child_contexts.cashflow_projection is None
+    assert child_contexts.client_income_needs_schedule is not None
+    assert child_contexts.liquidity_reserve_requirement is None
+    assert child_contexts.planned_withdrawal_schedule is None
 
 
 def test_source_liquidity_context_preserves_source_family_policy_and_children() -> None:

--- a/tests/unit/dpm/construction/test_source_product_financial_context.py
+++ b/tests/unit/dpm/construction/test_source_product_financial_context.py
@@ -1,6 +1,7 @@
 from src.api.services import construction_source_product_financial_context
 from src.api.services.construction_source_product_financial_context import (
     currency_overlay_context_update,
+    currency_overlay_source_inputs,
     execution_acknowledgement_context_update,
     source_financial_context_updates,
     transaction_cost_curve_context_update,
@@ -26,7 +27,9 @@ from tests.unit.dpm.construction.source_product_context_fixtures import (
 
 def test_source_product_financial_context_exports_only_orchestration_surface() -> None:
     assert construction_source_product_financial_context.__all__ == [
+        "CurrencyOverlaySourceInputs",
         "currency_overlay_context_update",
+        "currency_overlay_source_inputs",
         "execution_acknowledgement_context_update",
         "source_financial_context_updates",
         "transaction_cost_curve_context_update",
@@ -78,6 +81,20 @@ def test_currency_overlay_context_update_builds_missing_currency_context() -> No
             fx_forward_curve=None,
         ),
     )
+
+
+def test_currency_overlay_source_inputs_capture_treasury_sources() -> None:
+    source_inputs = currency_overlay_source_inputs(
+        _source_execution_context(
+            external_hedge_execution_readiness=hedge_readiness_response(),
+        )
+    )
+
+    assert source_inputs.hedge_readiness == hedge_readiness_response()
+    assert source_inputs.currency_exposure is None
+    assert source_inputs.hedge_policy is None
+    assert source_inputs.eligible_hedge_instruments is None
+    assert source_inputs.fx_forward_curve is None
 
 
 def test_execution_acknowledgement_context_update_builds_missing_acknowledgement_context() -> None:

--- a/tests/unit/dpm/construction/test_treasury_source_context.py
+++ b/tests/unit/dpm/construction/test_treasury_source_context.py
@@ -4,6 +4,8 @@ from src.api.services import construction_treasury_source_context
 from src.api.services.construction_treasury_source_context import (
     TreasuryPrimarySupportability,
     TreasurySourceIdentities,
+    _treasury_readiness_context_fields,
+    _treasury_source_family_context_fields,
     external_treasury_currency_overlay_context,
     treasury_blocked_capabilities,
     treasury_fail_closed_reason_codes,
@@ -174,6 +176,72 @@ def test_treasury_source_identities_resolve_source_families_and_readiness_fallba
     assert identities.eligible_hedge_instruments is not None
     assert identities.eligible_hedge_instruments.source_id == "core-eligible-hedges"
     assert identities.fx_forward_curve is None
+
+
+def test_treasury_readiness_context_fields_use_readiness_identity_or_source_hash() -> None:
+    source_hash = "aggregate-hash"
+    readiness = _without_source_lineage(hedge_readiness_response())
+    identities = treasury_source_identities(
+        source_hash=source_hash,
+        hedge_readiness=readiness,
+        currency_exposure=None,
+        hedge_policy=None,
+        eligible_hedge_instruments=None,
+        fx_forward_curve=None,
+    )
+
+    assert _treasury_readiness_context_fields(
+        identities=identities,
+        source_hash=source_hash,
+        hedge_readiness=readiness,
+    ) == {
+        "source_product_name": "ExternalHedgeExecutionReadiness",
+        "source_product_version": "v1",
+        "source_id": source_hash,
+        "content_hash": source_hash,
+        "readiness_checks": [{"check": "source_ingestion", "status": "missing"}],
+    }
+
+
+def test_treasury_source_family_context_fields_project_optional_source_families() -> None:
+    hedge_readiness = hedge_readiness_response()
+    currency_exposure = currency_exposure_response()
+    eligible_hedge_instruments = eligible_hedge_instruments_response()
+    source_hash = treasury_source_hash(
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=None,
+        eligible_hedge_instruments=eligible_hedge_instruments,
+        fx_forward_curve=None,
+    )
+    identities = treasury_source_identities(
+        source_hash=source_hash,
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=None,
+        eligible_hedge_instruments=eligible_hedge_instruments,
+        fx_forward_curve=None,
+    )
+
+    fields = _treasury_source_family_context_fields(
+        identities=identities,
+        source_hash=source_hash,
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=None,
+        eligible_hedge_instruments=eligible_hedge_instruments,
+        fx_forward_curve=None,
+    )
+
+    assert fields["source_id"] == "core-hedge-readiness"
+    assert fields["external_currency_exposure_source_id"] == "core-currency-exposure"
+    assert fields["external_currency_exposure_count"] == 1
+    assert fields["external_hedge_policy_source_id"] is None
+    assert fields["external_hedge_policy_rule_count"] == 0
+    assert fields["external_eligible_hedge_instrument_source_id"] == "core-eligible-hedges"
+    assert fields["external_eligible_hedge_instrument_count"] == 1
+    assert fields["external_fx_forward_curve_source_id"] is None
+    assert fields["external_fx_forward_curve_point_count"] == 0
 
 
 def test_treasury_fail_closed_reason_codes_include_present_source_families() -> None:

--- a/tests/unit/dpm/construction/test_treasury_source_context.py
+++ b/tests/unit/dpm/construction/test_treasury_source_context.py
@@ -3,6 +3,7 @@ from typing import Any
 from src.api.services import construction_treasury_source_context
 from src.api.services.construction_treasury_source_context import (
     TreasuryPrimarySupportability,
+    TreasurySourceIdentities,
     external_treasury_currency_overlay_context,
     treasury_blocked_capabilities,
     treasury_fail_closed_reason_codes,
@@ -11,6 +12,7 @@ from src.api.services.construction_treasury_source_context import (
     treasury_primary_supportability,
     treasury_response_blocked_capabilities,
     treasury_response_missing_data_families,
+    treasury_source_identities,
     treasury_source_identity_fields,
     treasury_source_payload,
     treasury_source_payloads,
@@ -29,6 +31,7 @@ from tests.unit.dpm.construction.source_product_context_fixtures import (
 def test_treasury_source_context_exports_only_currency_overlay_mapper() -> None:
     assert construction_treasury_source_context.__all__ == [
         "TreasuryPrimarySupportability",
+        "TreasurySourceIdentities",
         "external_treasury_currency_overlay_context",
         "treasury_blocked_capabilities",
         "treasury_fail_closed_reason_codes",
@@ -37,6 +40,7 @@ def test_treasury_source_context_exports_only_currency_overlay_mapper() -> None:
         "treasury_primary_supportability",
         "treasury_response_blocked_capabilities",
         "treasury_response_missing_data_families",
+        "treasury_source_identities",
         "treasury_source_identity_fields",
         "treasury_source_payload",
         "treasury_source_payloads",
@@ -127,6 +131,27 @@ def test_source_identity_fields_project_absent_identity_as_nulls() -> None:
         "external_currency_exposure_source_id": None,
         "external_currency_exposure_content_hash": None,
     }
+
+
+def test_treasury_source_identities_resolve_source_families_and_readiness_fallback() -> None:
+    identities = treasury_source_identities(
+        source_hash="aggregate-hash",
+        hedge_readiness=_without_source_lineage(hedge_readiness_response()),
+        currency_exposure=currency_exposure_response(),
+        hedge_policy=None,
+        eligible_hedge_instruments=eligible_hedge_instruments_response(),
+        fx_forward_curve=None,
+    )
+
+    assert isinstance(identities, TreasurySourceIdentities)
+    assert identities.readiness is not None
+    assert identities.readiness.source_id == "aggregate-hash"
+    assert identities.exposure is not None
+    assert identities.exposure.source_id == "core-currency-exposure"
+    assert identities.hedge_policy is None
+    assert identities.eligible_hedge_instruments is not None
+    assert identities.eligible_hedge_instruments.source_id == "core-eligible-hedges"
+    assert identities.fx_forward_curve is None
 
 
 def test_treasury_fail_closed_reason_codes_include_present_source_families() -> None:

--- a/tests/unit/dpm/construction/test_treasury_source_context.py
+++ b/tests/unit/dpm/construction/test_treasury_source_context.py
@@ -13,6 +13,7 @@ from src.api.services.construction_treasury_source_context import (
     treasury_response_blocked_capabilities,
     treasury_response_missing_data_families,
     treasury_source_identities,
+    treasury_source_hash,
     treasury_source_identity_fields,
     treasury_source_payload,
     treasury_source_payloads,
@@ -41,6 +42,7 @@ def test_treasury_source_context_exports_only_currency_overlay_mapper() -> None:
         "treasury_response_blocked_capabilities",
         "treasury_response_missing_data_families",
         "treasury_source_identities",
+        "treasury_source_hash",
         "treasury_source_identity_fields",
         "treasury_source_payload",
         "treasury_source_payloads",
@@ -88,6 +90,26 @@ def test_treasury_source_payloads_preserve_aggregate_hash_inputs() -> None:
     )
     assert payloads["external_hedge_policy"] is None
     assert hash_canonical_payload(payloads)
+
+
+def test_treasury_source_hash_uses_aggregate_source_payloads() -> None:
+    hedge_readiness = hedge_readiness_response()
+    currency_exposure = currency_exposure_response()
+    payloads = treasury_source_payloads(
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=None,
+        eligible_hedge_instruments=None,
+        fx_forward_curve=None,
+    )
+
+    assert treasury_source_hash(
+        hedge_readiness=hedge_readiness,
+        currency_exposure=currency_exposure,
+        hedge_policy=None,
+        eligible_hedge_instruments=None,
+        fx_forward_curve=None,
+    ) == hash_canonical_payload(payloads)
 
 
 def test_primary_treasury_supportability_uses_first_available_source_family() -> None:

--- a/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
@@ -4,7 +4,11 @@ import pytest
 from pydantic import ValidationError
 
 from src.core.common.target_redistribution import redistribute_sell_only_excess
-from src.core.rebalance.targets import _cap_tradeable_targets_to_available_weight
+from src.core.rebalance.targets import (
+    _apply_min_cash_buffer,
+    _apply_single_position_max_weight,
+    _cap_tradeable_targets_to_available_weight,
+)
 from src.core.rebalance.engine import _apply_group_constraints, _generate_targets, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, GroupConstraint, ShelfEntry
 from tests.shared.assertions import assert_status
@@ -96,6 +100,66 @@ class TestTargetGeneration:
 
         assert status == "PENDING_REVIEW"
         assert eligible_targets == {"BUY_A": Decimal("0.00"), "LOCKED": Decimal("1.10")}
+
+    def test_apply_single_position_max_weight_caps_and_redistributes_excess(self):
+        eligible_targets = {
+            "BUY_A": Decimal("0.80"),
+            "BUY_B": Decimal("0.20"),
+            "LOCKED": Decimal("0.10"),
+        }
+
+        status = _apply_single_position_max_weight(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A", "BUY_B"},
+            max_weight=Decimal("0.50"),
+        )
+
+        assert status == "READY"
+        assert eligible_targets == {
+            "BUY_A": Decimal("0.50"),
+            "BUY_B": Decimal("0.50"),
+            "LOCKED": Decimal("0.10"),
+        }
+
+    def test_apply_single_position_max_weight_marks_pending_when_excess_remains(self):
+        eligible_targets = {
+            "BUY_A": Decimal("0.90"),
+            "BUY_B": Decimal("0.10"),
+            "LOCKED": Decimal("0.80"),
+        }
+
+        status = _apply_single_position_max_weight(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A", "BUY_B"},
+            max_weight=Decimal("0.50"),
+        )
+
+        assert status == "PENDING_REVIEW"
+        assert eligible_targets == {
+            "BUY_A": Decimal("0.50"),
+            "BUY_B": Decimal("0.50"),
+            "LOCKED": Decimal("0.50"),
+        }
+
+    def test_apply_min_cash_buffer_scales_tradeable_weight_after_locked_weight(self):
+        eligible_targets = {
+            "BUY_A": Decimal("0.50"),
+            "BUY_B": Decimal("0.30"),
+            "LOCKED": Decimal("0.10"),
+        }
+
+        status = _apply_min_cash_buffer(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A", "BUY_B"},
+            min_cash_buffer_pct=Decimal("0.20"),
+        )
+
+        assert status == "PENDING_REVIEW"
+        assert eligible_targets == {
+            "BUY_A": Decimal("0.43750"),
+            "BUY_B": Decimal("0.26250"),
+            "LOCKED": Decimal("0.10"),
+        }
 
     def test_target_locked_over_100(self, base_inputs):
         pf, mkt, model, shelf = base_inputs

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 from src.core.rebalance.engine import _generate_fx_and_simulate, run_simulation
 from src.core.rebalance.intents import (
     _TaxBudgetAccumulator,
+    _TaxBudgetLotAllowance,
+    _apply_tax_budget_lot_allowance,
     _clamped_sell_quantity,
     _current_instrument_value_and_unit_value,
     _hifo_sorted_lots,
@@ -12,6 +14,7 @@ from src.core.rebalance.intents import (
     _suppress_dust_trade,
     _target_trade_delta,
     _tax_impact_from_budget,
+    _tax_budget_lot_allowance,
     _tax_budget_limited_sell_quantity,
     _trade_notional_threshold,
     generate_intents,
@@ -352,6 +355,50 @@ def test_tax_budget_limited_sell_quantity_caps_realized_gain_to_budget() -> None
     assert tax_budget.total_realized_gain_base == Decimal("50")
     assert tax_budget.total_realized_loss_base == Decimal("0")
     assert tax_budget.tax_budget_used_base == Decimal("50")
+
+
+def test_tax_budget_lot_allowance_returns_zero_when_gain_budget_exhausted() -> None:
+    allowance = _tax_budget_lot_allowance(
+        remaining_quantity=Decimal("10"),
+        lot_quantity=Decimal("10"),
+        lot_unit_cost=Decimal("90"),
+        sell_price=Decimal("100"),
+        base_rate=Decimal("1"),
+        tax_budget=_TaxBudgetAccumulator(
+            total_realized_gain_base=Decimal("50"),
+            total_realized_loss_base=Decimal("0"),
+            tax_budget_used_base=Decimal("50"),
+            tax_budget_limit_base=Decimal("50"),
+        ),
+    )
+
+    assert allowance == _TaxBudgetLotAllowance(
+        requested_quantity=Decimal("10"),
+        allowed_quantity=Decimal("0"),
+        realized_base=Decimal("0"),
+    )
+
+
+def test_apply_tax_budget_lot_allowance_records_realized_losses_without_using_budget() -> None:
+    tax_budget = _TaxBudgetAccumulator(
+        total_realized_gain_base=Decimal("0"),
+        total_realized_loss_base=Decimal("0"),
+        tax_budget_used_base=Decimal("0"),
+        tax_budget_limit_base=Decimal("25"),
+    )
+
+    _apply_tax_budget_lot_allowance(
+        allowance=_TaxBudgetLotAllowance(
+            requested_quantity=Decimal("4"),
+            allowed_quantity=Decimal("4"),
+            realized_base=Decimal("-12"),
+        ),
+        tax_budget=tax_budget,
+    )
+
+    assert tax_budget.total_realized_gain_base == Decimal("0")
+    assert tax_budget.total_realized_loss_base == Decimal("12")
+    assert tax_budget.tax_budget_used_base == Decimal("0")
 
 
 def test_tax_budget_limited_sell_quantity_bypasses_when_tax_awareness_disabled() -> None:

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -10,6 +10,8 @@ from src.core.rebalance.intents import (
     _record_tax_budget_limit_reached,
     _security_intent_constraints,
     _suppress_dust_trade,
+    _target_trade_delta,
+    _tax_impact_from_budget,
     _tax_budget_limited_sell_quantity,
     _trade_notional_threshold,
     generate_intents,
@@ -277,6 +279,41 @@ def test_suppress_dust_trade_keeps_supported_notional_unsuppressed() -> None:
 
     assert suppressed_trade is False
     assert suppressed == []
+
+
+def test_target_trade_delta_classifies_side_and_floor_quantity() -> None:
+    buy_delta = _target_trade_delta(
+        target_instrument_value=Decimal("127"),
+        current_instrument_value=Decimal("100"),
+        unit_value=Decimal("10"),
+    )
+    sell_delta = _target_trade_delta(
+        target_instrument_value=Decimal("70"),
+        current_instrument_value=Decimal("100"),
+        unit_value=Decimal("12"),
+    )
+
+    assert buy_delta.side == "BUY"
+    assert buy_delta.raw_quantity == Decimal("2")
+    assert sell_delta.side == "SELL"
+    assert sell_delta.raw_quantity == Decimal("2")
+
+
+def test_tax_impact_from_budget_normalizes_budget_used_at_tolerance_boundary() -> None:
+    tax_impact = _tax_impact_from_budget(
+        tax_budget=_TaxBudgetAccumulator(
+            total_realized_gain_base=Decimal("100.00000000001"),
+            total_realized_loss_base=Decimal("25"),
+            tax_budget_used_base=Decimal("99.99999999999"),
+            tax_budget_limit_base=Decimal("100"),
+        ),
+        base_currency="SGD",
+    )
+
+    assert tax_impact.total_realized_gain.amount == Decimal("100.00000000001")
+    assert tax_impact.total_realized_loss.amount == Decimal("25")
+    assert tax_impact.budget_limit == Money(amount=Decimal("100"), currency="SGD")
+    assert tax_impact.budget_used == Money(amount=Decimal("100"), currency="SGD")
 
 
 def test_tax_budget_limited_sell_quantity_caps_realized_gain_to_budget() -> None:

--- a/tests/unit/dpm/engine/test_engine_settlement_awareness.py
+++ b/tests/unit/dpm/engine/test_engine_settlement_awareness.py
@@ -1,6 +1,15 @@
+from decimal import Decimal
+
 from src.core.rebalance.engine import run_simulation
-from src.core.models import EngineOptions
+from src.core.rebalance.execution import (
+    _append_settlement_ladder_points,
+    _settlement_cash_flows,
+    _settlement_days_by_instrument,
+    _settlement_horizon_days,
+)
+from src.core.models import EngineOptions, FxSpotIntent, IntentRationale, Money, SecurityTradeIntent
 from tests.shared.assertions import assert_status
+from tests.unit.dpm.engine.coverage.helpers import empty_diagnostics
 from tests.shared.factories import (
     cash,
     market_data_snapshot,
@@ -94,3 +103,92 @@ def test_settlement_awareness_allows_configured_overdraft():
     assert result.diagnostics.cash_ladder
     assert result.diagnostics.cash_ladder_breaches == []
     assert "SETTLEMENT_OVERDRAFT_UTILIZED" in result.diagnostics.warnings
+
+
+def test_settlement_cash_flows_apply_security_and_fx_settlement_days() -> None:
+    portfolio = portfolio_snapshot(
+        portfolio_id="pf_settlement_helpers",
+        base_currency="USD",
+        cash_balances=[cash("USD", "100"), cash("EUR", "0")],
+    )
+    shelf = [
+        shelf_entry("SLOW_FUND", status="APPROVED", settlement_days=3),
+        shelf_entry("FAST_STOCK", status="APPROVED", settlement_days=1),
+    ]
+    intents = [
+        SecurityTradeIntent(
+            intent_id="oi_buy_fast",
+            instrument_id="FAST_STOCK",
+            side="BUY",
+            quantity=Decimal("2"),
+            notional=Money(amount=Decimal("80"), currency="USD"),
+            notional_base=Money(amount=Decimal("80"), currency="USD"),
+        ),
+        SecurityTradeIntent(
+            intent_id="oi_sell_slow",
+            instrument_id="SLOW_FUND",
+            side="SELL",
+            quantity=Decimal("1"),
+            notional=Money(amount=Decimal("30"), currency="USD"),
+            notional_base=Money(amount=Decimal("30"), currency="USD"),
+        ),
+        FxSpotIntent(
+            intent_id="oi_fx_eur",
+            pair="EUR/USD",
+            buy_currency="EUR",
+            buy_amount=Decimal("50"),
+            sell_currency="USD",
+            sell_amount_estimated=Decimal("55"),
+            rationale=IntentRationale(code="FUNDING", message="Fund EUR purchase."),
+        ),
+    ]
+    settlement_days = _settlement_days_by_instrument(shelf)
+    options = EngineOptions(fx_settlement_days=2, settlement_horizon_days=1)
+
+    horizon = _settlement_horizon_days(
+        settlement_days_by_instrument=settlement_days,
+        intents=intents,
+        options=options,
+    )
+    flows = _settlement_cash_flows(
+        portfolio=portfolio,
+        intents=intents,
+        settlement_days_by_instrument=settlement_days,
+        horizon_days=horizon,
+        options=options,
+    )
+
+    assert horizon == 3
+    assert flows["USD"] == [
+        Decimal("100"),
+        Decimal("-80"),
+        Decimal("-55"),
+        Decimal("30"),
+    ]
+    assert flows["EUR"] == [
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("50"),
+        Decimal("0"),
+    ]
+
+
+def test_append_settlement_ladder_points_records_breach_and_overdraft_warning() -> None:
+    diagnostics = empty_diagnostics()
+
+    _append_settlement_ladder_points(
+        flows={"USD": [Decimal("50"), Decimal("-90"), Decimal("10")]},
+        horizon_days=2,
+        options=EngineOptions(max_overdraft_by_ccy={"USD": Decimal("25")}),
+        diagnostics=diagnostics,
+    )
+
+    assert [point.projected_balance for point in diagnostics.cash_ladder] == [
+        Decimal("50"),
+        Decimal("-40"),
+        Decimal("-30"),
+    ]
+    assert diagnostics.cash_ladder_breaches[0].date_offset == 1
+    assert diagnostics.cash_ladder_breaches[0].allowed_floor == Decimal("-25")
+    assert diagnostics.cash_ladder_breaches[0].reason_code == "OVERDRAFT_ON_T_PLUS_1"
+    assert "SETTLEMENT_OVERDRAFT_UTILIZED" in diagnostics.warnings

--- a/tests/unit/dpm/engine/test_engine_valuation_service.py
+++ b/tests/unit/dpm/engine/test_engine_valuation_service.py
@@ -8,12 +8,21 @@ from src.core.models import (
     CashBalance,
     EngineOptions,
     MarketDataSnapshot,
+    Money,
     PortfolioSnapshot,
     Position,
+    PositionSummary,
     Price,
     ShelfEntry,
 )
-from src.core.valuation import _cash_value_in_base, build_simulated_state
+from src.core.valuation import (
+    _allocation_by_attribute_metrics,
+    _position_allocation_maps,
+    _safe_total_value,
+    _valued_position_summaries,
+    _cash_value_in_base,
+    build_simulated_state,
+)
 from tests.shared.factories import fx, market_data_snapshot
 
 
@@ -63,6 +72,92 @@ def test_cash_value_in_base_suppresses_missing_cash_fx_log_without_log() -> None
     )
 
     assert value == Decimal("0")
+
+
+def test_valued_position_summaries_records_missing_price_and_fx_gaps() -> None:
+    portfolio = PortfolioSnapshot(
+        portfolio_id="p1",
+        base_currency="USD",
+        positions=[
+            Position(instrument_id="EUR_STOCK", quantity=Decimal("2")),
+            Position(instrument_id="MISSING_PRICE", quantity=Decimal("1")),
+        ],
+        cash_balances=[],
+    )
+    market_data = MarketDataSnapshot(
+        prices=[Price(instrument_id="EUR_STOCK", price=Decimal("50"), currency="EUR")]
+    )
+    dq_log: dict[str, list[str]] = {}
+
+    summaries, total_value = _valued_position_summaries(
+        portfolio=portfolio,
+        market_data=market_data,
+        options=EngineOptions(),
+        dq_log=dq_log,
+    )
+
+    assert [summary.instrument_id for summary in summaries] == ["EUR_STOCK", "MISSING_PRICE"]
+    assert total_value == Decimal("0")
+    assert dq_log == {
+        "price_missing": ["MISSING_PRICE"],
+        "fx_missing": ["EUR/USD"],
+    }
+
+
+def test_position_allocation_maps_apply_shelf_asset_class_and_attributes() -> None:
+    summaries = [
+        PositionSummary(
+            instrument_id="Tech_A",
+            quantity=Decimal("1"),
+            instrument_currency="USD",
+            value_in_instrument_ccy=Money(amount=Decimal("40"), currency="USD"),
+            value_in_base_ccy=Money(amount=Decimal("40"), currency="USD"),
+            weight=Decimal("0"),
+        ),
+        PositionSummary(
+            instrument_id="Bond_C",
+            quantity=Decimal("1"),
+            instrument_currency="USD",
+            value_in_instrument_ccy=Money(amount=Decimal("60"), currency="USD"),
+            value_in_base_ccy=Money(amount=Decimal("60"), currency="USD"),
+            weight=Decimal("0"),
+        ),
+    ]
+    shelf = [
+        ShelfEntry(
+            instrument_id="Tech_A",
+            status="APPROVED",
+            asset_class="EQUITY",
+            attributes={"sector": "TECH"},
+        ),
+        ShelfEntry(
+            instrument_id="Bond_C",
+            status="APPROVED",
+            asset_class="FIXED_INCOME",
+            attributes={"sector": "FI"},
+        ),
+    ]
+
+    by_asset_class, by_attribute = _position_allocation_maps(
+        position_summaries=summaries,
+        shelf=shelf,
+    )
+    metrics = _allocation_by_attribute_metrics(
+        allocation_by_attribute=by_attribute,
+        total_value=Decimal("100"),
+        base_ccy="USD",
+    )
+
+    assert by_asset_class == {
+        "EQUITY": Decimal("40"),
+        "FIXED_INCOME": Decimal("60"),
+    }
+    assert summaries[0].asset_class == "EQUITY"
+    assert metrics["sector"][0].key == "TECH"
+    assert metrics["sector"][0].weight == Decimal("0.4")
+    assert metrics["sector"][1].key == "FI"
+    assert metrics["sector"][1].weight == Decimal("0.6")
+    assert _safe_total_value(Decimal("0")) == Decimal("1")
 
 
 def test_valuation_service_aggregates_attributes():

--- a/tests/unit/dpm/engine/test_policy_pack_resolution.py
+++ b/tests/unit/dpm/engine/test_policy_pack_resolution.py
@@ -263,6 +263,44 @@ def test_policy_pack_catalog_parse_skips_non_string_and_blank_ids(monkeypatch):
     assert policy_pack_module.parse_policy_pack_catalog('{"ignored":"input"}') == {}
 
 
+def test_policy_pack_definition_payload_normalizes_defaults():
+    payload = policy_pack_module._policy_pack_definition_payload(
+        policy_pack_id="  dpm_standard_v1  ",
+        definition={"turnover_policy": {"max_turnover_pct": "0.05"}},
+    )
+
+    assert payload is not None
+    policy_pack_id, model_payload = payload
+    assert policy_pack_id == "dpm_standard_v1"
+    assert model_payload == {
+        "policy_pack_id": "dpm_standard_v1",
+        "version": "1",
+        "turnover_policy": {"max_turnover_pct": "0.05"},
+        "tax_policy": {},
+        "settlement_policy": {},
+        "constraint_policy": {},
+        "workflow_policy": {},
+        "idempotency_policy": {},
+    }
+
+
+def test_parse_policy_pack_definition_returns_none_for_invalid_rows():
+    assert (
+        policy_pack_module._parse_policy_pack_definition(
+            policy_pack_id="bad",
+            definition={"turnover_policy": {"max_turnover_pct": "not-decimal"}},
+        )
+        is None
+    )
+    assert (
+        policy_pack_module._parse_policy_pack_definition(
+            policy_pack_id=123,
+            definition={"version": "1"},
+        )
+        is None
+    )
+
+
 def test_policy_pack_resolve_definition_missing_or_none():
     resolution_none = resolve_effective_policy_pack(
         policy_packs_enabled=True,

--- a/tests/unit/dpm/engine/test_policy_pack_resolution.py
+++ b/tests/unit/dpm/engine/test_policy_pack_resolution.py
@@ -2,8 +2,13 @@ from decimal import Decimal
 
 import src.core.rebalance.policy_packs as policy_pack_module
 from src.core.rebalance.policy_packs import (
+    DpmPolicyPackDefinition,
+    DpmPolicyPackTaxPolicy,
+    DpmPolicyPackTurnoverPolicy,
+    DpmPolicyPackWorkflowPolicy,
     apply_policy_pack_to_engine_options,
     parse_policy_pack_catalog,
+    policy_pack_engine_option_updates,
     resolve_effective_policy_pack,
     resolve_policy_pack_definition,
     resolve_policy_pack_replay_enabled,
@@ -203,6 +208,35 @@ def test_policy_pack_apply_workflow_overrides():
     assert effective_options.enable_workflow_gates is False
     assert effective_options.workflow_requires_mandate_approval is True
     assert effective_options.mandate_approval_already_obtained is True
+
+
+def test_policy_pack_engine_option_updates_returns_only_configured_overrides():
+    updates = policy_pack_engine_option_updates(
+        policy_pack=DpmPolicyPackDefinition(
+            policy_pack_id="dpm_standard_v1",
+            version="1",
+            turnover_policy=DpmPolicyPackTurnoverPolicy(max_turnover_pct=Decimal("0.07")),
+            tax_policy=DpmPolicyPackTaxPolicy(enable_tax_awareness=True),
+            workflow_policy=DpmPolicyPackWorkflowPolicy(
+                workflow_requires_mandate_approval=True,
+            ),
+        )
+    )
+
+    assert updates == {
+        "max_turnover_pct": Decimal("0.07"),
+        "enable_tax_awareness": True,
+        "workflow_requires_mandate_approval": True,
+    }
+
+
+def test_policy_pack_engine_option_updates_empty_without_overrides():
+    assert (
+        policy_pack_engine_option_updates(
+            policy_pack=DpmPolicyPackDefinition(policy_pack_id="dpm_standard_v1", version="1")
+        )
+        == {}
+    )
 
 
 def test_policy_pack_resolve_replay_enabled_override_and_fallback():

--- a/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
+++ b/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import httpx
 import pytest
 
@@ -6,7 +8,9 @@ from src.infrastructure.core_sourcing.client import (
     DpmCoreResolverConfig,
     DpmCoreResolverError,
     DpmCoreResolverUnavailableError,
+    _map_core_snapshot_row,
     _portfolio_snapshot_from_core_snapshot,
+    _portfolio_positions_and_cash_from_core_rows,
     _required_currency_pairs,
 )
 
@@ -231,6 +235,44 @@ def test_core_snapshot_transform_uses_reporting_currency_and_skips_blank_rows() 
     assert snapshot.base_currency == "EUR"
     assert [position.instrument_id for position in snapshot.positions] == ["EQ_EU"]
     assert snapshot.cash_balances[0].currency == "USD"
+
+
+def test_core_snapshot_row_mapper_returns_none_for_blank_identifier() -> None:
+    assert _map_core_snapshot_row({"quantity": "99"}, base_currency="USD") is None
+
+
+def test_core_snapshot_row_mapper_preserves_position_market_value_currency() -> None:
+    mapped_row = _map_core_snapshot_row(
+        {
+            "security_id": "EQ_US",
+            "quantity": "12.5",
+            "currency": "usd",
+            "market_value_local": "1234.56",
+        },
+        base_currency="SGD",
+    )
+
+    assert mapped_row is not None
+    assert mapped_row.position is not None
+    assert mapped_row.position.instrument_id == "EQ_US"
+    assert mapped_row.position.quantity == Decimal("12.5")
+    assert mapped_row.position.market_value is not None
+    assert mapped_row.position.market_value.amount == Decimal("1234.56")
+    assert mapped_row.position.market_value.currency == "USD"
+
+
+def test_core_snapshot_rows_aggregate_cash_by_currency() -> None:
+    positions, cash_by_currency = _portfolio_positions_and_cash_from_core_rows(
+        [
+            {"instrument_id": "CASH_USD", "quantity": "10", "currency": "USD"},
+            {"instrument_id": "CASH_USD_2", "quantity": "15", "currency": "USD"},
+            {"instrument_id": "EQ_EU", "quantity": "2", "currency": "EUR"},
+        ],
+        base_currency="SGD",
+    )
+
+    assert [position.instrument_id for position in positions] == ["EQ_EU"]
+    assert cash_by_currency == {"USD": Decimal("25")}
 
 
 def test_required_currency_pairs_ignores_base_currency_and_missing_market_values() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_command_center.py
+++ b/tests/unit/dpm/mandates/test_mandate_command_center.py
@@ -3,6 +3,9 @@ from datetime import date, datetime, timezone
 from src.api.services.mandate_command_center import (
     attention_buckets,
     build_command_center_summary,
+    command_center_completeness,
+    command_center_health_distribution,
+    command_center_partial_reasons,
     command_center_supportability_state,
     latest_command_center_run,
     recommended_actions,
@@ -283,6 +286,43 @@ def test_build_command_center_summary_projects_empty_state_without_run() -> None
     assert summary.supportability.reason == "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
 
 
+def test_command_center_health_distribution_filters_selected_state() -> None:
+    assert command_center_health_distribution(
+        latest_run=_run(),
+        health_state="PENDING_REVIEW",
+    ) == {"PENDING_REVIEW": 1}
+    assert command_center_health_distribution(
+        latest_run=None,
+        health_state="READY",
+    ) == {"READY": 0}
+
+
+def test_command_center_partial_reasons_name_discovery_limit_and_missing_run() -> None:
+    assert command_center_partial_reasons(
+        latest_run=None,
+        portfolio_manager_id=None,
+        book_id=None,
+        active_exception_count=10,
+        limit=10,
+    ) == [
+        "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS",
+        "PM_BOOK_DISCOVERY_NOT_YET_SOURCED",
+        "ATTENTION_QUEUE_LIMIT_REACHED",
+    ]
+
+
+def test_command_center_completeness_classifies_empty_partial_and_complete() -> None:
+    assert command_center_completeness(latest_run=None, partial_reasons=[]) == "EMPTY"
+    assert (
+        command_center_completeness(
+            latest_run=_run(),
+            partial_reasons=["PM_BOOK_DISCOVERY_NOT_YET_SOURCED"],
+        )
+        == "PARTIAL"
+    )
+    assert command_center_completeness(latest_run=_run(), partial_reasons=[]) == "COMPLETE"
+
+
 def test_mandate_command_center_exports_only_projection_helpers() -> None:
     from src.api.services import mandate_command_center
 
@@ -290,6 +330,9 @@ def test_mandate_command_center_exports_only_projection_helpers() -> None:
     assert mandate_command_center.__all__ == [
         "attention_buckets",
         "build_command_center_summary",
+        "command_center_completeness",
+        "command_center_health_distribution",
+        "command_center_partial_reasons",
         "command_center_supportability_state",
         "latest_command_center_run",
         "recommended_actions",

--- a/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
+++ b/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
@@ -13,6 +13,7 @@ from src.core.construction.vocabulary import ConstructionMethod, ConstructionMet
 from src.core.models import Money
 from src.core.outcomes.snapshots import (
     DpmExpectedSnapshotAssemblyError,
+    _proof_pack_state,
     assemble_expected_outcome_snapshot,
 )
 from src.core.proof_packs.models import (
@@ -179,6 +180,14 @@ def _proof_pack(
         created_by="lotus-manage",
         correlation_id="corr-outcome-001",
     )
+
+
+def test_proof_pack_state_maps_supported_statuses_and_unknown_status_fail_closed() -> None:
+    assert _proof_pack_state("READY") == "READY"
+    assert _proof_pack_state("PENDING_REVIEW") == "PENDING_REVIEW"
+    assert _proof_pack_state("DEGRADED") == "DEGRADED"
+    assert _proof_pack_state("BLOCKED") == "BLOCKED"
+    assert _proof_pack_state("STALE_UNBOUNDED_STATUS") == "BLOCKED"
 
 
 def _wave(

--- a/tests/unit/dpm/portfolio_memory/test_search_page.py
+++ b/tests/unit/dpm/portfolio_memory/test_search_page.py
@@ -10,7 +10,11 @@ from src.core.portfolio_memory.models import (
     DpmPortfolioMemory,
     DpmPortfolioMemoryEvent,
     DpmPortfolioMemorySourceRef,
+    _validate_search_item_counts,
+    _validate_search_item_latest_event_metadata,
+    _validate_search_item_latest_matching_event_metadata,
     _validate_search_item_metadata,
+    _validate_search_item_sorted_aggregates,
     _validate_search_page_pagination,
 )
 from src.core.portfolio_memory.search_page import (
@@ -205,6 +209,51 @@ def test_validate_search_item_metadata_accepts_empty_search_item_metadata() -> N
         latest_matching_event_source_id=None,
         latest_matching_event_content_hash=None,
     )
+
+
+def test_validate_search_item_count_helper_rejects_matching_count_above_event_count() -> None:
+    with pytest.raises(ValueError, match="matching_event_count must not exceed"):
+        _validate_search_item_counts(
+            event_count=1,
+            event_type_counts={"WAVE_HANDOFF_READY": 1},
+            matching_event_count=2,
+        )
+
+
+def test_validate_search_item_sorted_aggregate_helper_rejects_duplicate_reasons() -> None:
+    with pytest.raises(ValueError, match="reason_codes must be sorted and unique"):
+        _validate_search_item_sorted_aggregates(
+            source_systems=["lotus-manage"],
+            reason_codes=["READY_FOR_OPERATIONS_REVIEW", "READY_FOR_OPERATIONS_REVIEW"],
+        )
+
+
+def test_validate_search_item_latest_event_helper_rejects_empty_item_with_latest_event() -> None:
+    with pytest.raises(ValueError, match="empty search items must not carry latest event metadata"):
+        _validate_search_item_latest_event_metadata(
+            event_count=0,
+            supportability_state="EMPTY",
+            event_type_counts={},
+            source_systems=[],
+            reason_codes=[],
+            latest_event_time="2026-05-31T10:00:00+00:00",
+            latest_event_type=None,
+        )
+
+
+def test_validate_search_item_latest_matching_helper_rejects_missing_identity() -> None:
+    with pytest.raises(ValueError, match="matching events must carry latest matching"):
+        _validate_search_item_latest_matching_event_metadata(
+            matching_event_count=1,
+            latest_matching_event_time="2026-05-31T10:00:00+00:00",
+            latest_matching_event_type="WAVE_HANDOFF_READY",
+            latest_matching_event_id="memory:search:handoff",
+            latest_matching_event_identity=None,
+            latest_matching_event_source_system="lotus-manage",
+            latest_matching_event_source_type="DPM_WAVE_INTERNAL_OPERATIONS_HANDOFF",
+            latest_matching_event_source_id="handoff-001",
+            latest_matching_event_content_hash=None,
+        )
 
 
 def test_validate_search_item_metadata_rejects_mismatched_aggregates_and_ordering() -> None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -947,6 +947,109 @@ def test_builder_covers_trade_tax_approval_and_defensive_source_edges() -> None:
         )
 
 
+def test_proof_pack_build_context_prefers_explicit_correlation_then_falls_back_to_run() -> None:
+    result = _ready_rebalance_result()
+    run = _run_record(result=result)
+    selection = ConstructionAlternativeSelection(
+        selection_id="sel_context_corr",
+        alternative_set_id="cas_context_corr",
+        alternative_id="alt_context_corr",
+        selected_at=CREATED_AT,
+        actor_id="pm_001",
+        reason_code="MODEL_DRIFT_REVIEW",
+        correlation_id="corr-selection-context",
+    )
+
+    explicit = builder_module._proof_pack_build_context(
+        source_type="REBALANCE_RUN",
+        run=run,
+        alternative_set=None,
+        selected_alternative=None,
+        selection=selection,
+        correlation_id="corr-explicit-context",
+        created_at=CREATED_AT,
+        mandate_twin=None,
+        mandate_health=None,
+        direct_regime_stress_context=None,
+    )
+    selected = builder_module._proof_pack_build_context(
+        source_type="REBALANCE_RUN",
+        run=run,
+        alternative_set=None,
+        selected_alternative=None,
+        selection=selection,
+        correlation_id=None,
+        created_at=CREATED_AT,
+        mandate_twin=None,
+        mandate_health=None,
+        direct_regime_stress_context=None,
+    )
+    run_fallback = builder_module._proof_pack_build_context(
+        source_type="REBALANCE_RUN",
+        run=run,
+        alternative_set=None,
+        selected_alternative=None,
+        selection=None,
+        correlation_id=None,
+        created_at=CREATED_AT,
+        mandate_twin=None,
+        mandate_health=None,
+        direct_regime_stress_context=None,
+    )
+
+    assert explicit.correlation_id == "corr-explicit-context"
+    assert selected.correlation_id == "corr-selection-context"
+    assert run_fallback.correlation_id == result.correlation_id
+
+
+def test_proof_pack_build_context_attaches_direct_regime_source_hashes_and_refs() -> None:
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+    alternative_set = build_alternative_set(
+        alternative_set_id="cas_context_direct_regime",
+        portfolio_id="pf_proof_pack_1",
+        as_of="2026-05-03",
+        alternatives=[alternative],
+    ).model_copy(update={"generated_at": CREATED_AT})
+
+    context = builder_module._proof_pack_build_context(
+        source_type="SELECTED_ALTERNATIVE",
+        run=_run_record(result=result),
+        alternative_set=alternative_set,
+        selected_alternative=alternative,
+        selection=None,
+        correlation_id=None,
+        created_at=CREATED_AT,
+        mandate_twin=None,
+        mandate_health=None,
+        direct_regime_stress_context=AuthoritativeRegimeStressContext(
+            supportability_status="READY",
+            source_system="lotus-risk",
+            scenario_pack_id="CIO_REGIME_CONTEXT_Q3",
+            worst_case_loss_pct=Decimal("0.0700"),
+            maximum_allowed_loss_pct=Decimal("0.1200"),
+            cio_approval_ref="CIO-APPROVAL-CONTEXT-Q3",
+            effective_from=date(2026, 7, 1),
+            reason_codes=["REGIME_SCENARIO_WITHIN_POLICY"],
+        ),
+    )
+
+    assert context.proof_pack_id == (
+        f"dpp_{alternative_set.alternative_set_id}_{alternative.alternative_id}"
+    )
+    assert context.portfolio_id == "pf_proof_pack_1"
+    assert context.source_hashes["regime_stress_context"].startswith("sha256:")
+    assert context.source_analytics["regime_stress"].facts["scenario_pack_id"] == (
+        "CIO_REGIME_CONTEXT_Q3"
+    )
+    assert any(
+        ref.source_system == "lotus-risk"
+        and ref.source_type == "RegimeScenarioPackEvaluation"
+        and ref.source_id == "CIO_REGIME_CONTEXT_Q3"
+        for ref in context.source_refs
+    )
+
+
 def test_proof_pack_hash_is_deterministic_for_equivalent_inputs() -> None:
     mandate_twin = _mandate_twin()
     kwargs = {

--- a/tests/unit/dpm/waves/test_campaign_definition_repository.py
+++ b/tests/unit/dpm/waves/test_campaign_definition_repository.py
@@ -42,6 +42,8 @@ from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionCandidate,
     DpmBulkReviewCampaignDefinitionGovernance,
+    _validate_lifecycle_fields_absent,
+    _validate_required_lifecycle_value,
     bulk_review_campaign_definition_hash,
 )
 from src.core.waves.campaign_repository import DpmBulkReviewCampaignDefinitionConflictError
@@ -265,6 +267,20 @@ def test_campaign_definition_lifecycle_helpers_preserve_reason_codes() -> None:
                 "retired_by": "ops",
             }
         )._validate_superseded_lifecycle()
+
+
+def test_lifecycle_required_value_helper_rejects_missing_and_blank_values() -> None:
+    for value in [None, "  "]:
+        with pytest.raises(ValueError, match="LIFECYCLE_VALUE_REQUIRED"):
+            _validate_required_lifecycle_value(value, reason_code="LIFECYCLE_VALUE_REQUIRED")
+
+
+def test_lifecycle_absent_fields_helper_rejects_present_values() -> None:
+    with pytest.raises(ValueError, match="LIFECYCLE_FIELDS_FORBIDDEN"):
+        _validate_lifecycle_fields_absent(
+            [None, "ops"],
+            reason_code="LIFECYCLE_FIELDS_FORBIDDEN",
+        )
 
 
 def test_in_memory_campaign_definition_repository_filters_and_conflicts() -> None:

--- a/tests/unit/dpm/waves/test_campaign_maker_checker_control_helpers.py
+++ b/tests/unit/dpm/waves/test_campaign_maker_checker_control_helpers.py
@@ -1,0 +1,106 @@
+import pytest
+
+from src.core.waves.campaign_maker_checker_controls import _validate_control_action
+
+
+@pytest.mark.parametrize(
+    (
+        "control_action",
+        "control_outcome",
+        "submitter_actor_id",
+        "reviewer_actor_id",
+        "required_reviewer_role",
+    ),
+    [
+        ("SUBMITTED_FOR_REVIEW", "PENDING", "maker-1", None, None),
+        ("REVIEWER_ASSIGNED", "PENDING", None, "checker-1", "senior_reviewer"),
+        ("REVIEW_COMPLETED", "PASSED", "maker-1", "checker-1", None),
+        ("REVIEW_COMPLETED", "FAILED", "maker-1", "checker-1", None),
+        ("CONTROL_EXCEPTION_RAISED", "EXCEPTION_OPEN", None, None, None),
+        ("CONTROL_EXCEPTION_RESOLVED", "EXCEPTION_RESOLVED", None, None, None),
+    ],
+)
+def test_validate_control_action_accepts_valid_action_outcome_pairs(
+    control_action: str,
+    control_outcome: str,
+    submitter_actor_id: str | None,
+    reviewer_actor_id: str | None,
+    required_reviewer_role: str | None,
+) -> None:
+    _validate_control_action(
+        control_action=control_action,
+        control_outcome=control_outcome,
+        submitter_actor_id=submitter_actor_id,
+        reviewer_actor_id=reviewer_actor_id,
+        required_reviewer_role=required_reviewer_role,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "control_action",
+        "control_outcome",
+        "submitter_actor_id",
+        "reviewer_actor_id",
+        "required_reviewer_role",
+        "expected_error",
+    ),
+    [
+        (
+            "SUBMITTED_FOR_REVIEW",
+            "PASSED",
+            "maker-1",
+            None,
+            None,
+            "BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_SUBMISSION_OUTCOME_INVALID",
+        ),
+        (
+            "REVIEWER_ASSIGNED",
+            "PENDING",
+            None,
+            "checker-1",
+            None,
+            "BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_REVIEWER_REQUIRED",
+        ),
+        (
+            "REVIEW_COMPLETED",
+            "PASSED",
+            "actor-1",
+            "actor-1",
+            None,
+            "BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_ACTOR_SEPARATION_REQUIRED",
+        ),
+        (
+            "CONTROL_EXCEPTION_RAISED",
+            "PENDING",
+            None,
+            None,
+            None,
+            "BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_EXCEPTION_OUTCOME_INVALID",
+        ),
+        (
+            "CONTROL_EXCEPTION_RESOLVED",
+            "EXCEPTION_OPEN",
+            None,
+            None,
+            None,
+            "BULK_REVIEW_CAMPAIGN_MAKER_CHECKER_EXCEPTION_RESOLUTION_INVALID",
+        ),
+    ],
+)
+def test_validate_control_action_rejects_invalid_action_outcome_pairs(
+    control_action: str,
+    control_outcome: str,
+    submitter_actor_id: str | None,
+    reviewer_actor_id: str | None,
+    required_reviewer_role: str | None,
+    expected_error: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected_error):
+        _validate_control_action(
+            control_action=control_action,
+            control_outcome=control_outcome,
+            submitter_actor_id=submitter_actor_id,
+            reviewer_actor_id=reviewer_actor_id,
+            required_reviewer_role=required_reviewer_role,
+        )

--- a/tests/unit/dpm/waves/test_wave_construction_selection.py
+++ b/tests/unit/dpm/waves/test_wave_construction_selection.py
@@ -3,6 +3,7 @@ import pytest
 from src.api.services import wave_construction_selection
 from src.api.services.wave_construction_selection import select_construction_alternative_for_wave
 from src.api.services.wave_errors import DpmWaveLookupError
+from src.core.construction.repository import ConstructionAlternativeNotFoundError
 
 
 class _ConstructionService:
@@ -47,7 +48,7 @@ def test_select_construction_alternative_for_wave_maps_selection_failures(
     monkeypatch,
 ) -> None:
     service = _ConstructionService()
-    service.error = LookupError("alternative missing")
+    service.error = ConstructionAlternativeNotFoundError("alternative missing")
     monkeypatch.setattr(wave_construction_selection, "construction_service", service)
 
     with pytest.raises(DpmWaveLookupError) as exc_info:
@@ -63,6 +64,25 @@ def test_select_construction_alternative_for_wave_maps_selection_failures(
 
     assert exc_info.value.code == "DPM_CONSTRUCTION_ALTERNATIVE_NOT_FOUND"
     assert exc_info.value.message == "alternative missing"
+
+
+def test_select_construction_alternative_for_wave_does_not_hide_unexpected_failures(
+    monkeypatch,
+) -> None:
+    service = _ConstructionService()
+    service.error = RuntimeError("repository write side effect failed")
+    monkeypatch.setattr(wave_construction_selection, "construction_service", service)
+
+    with pytest.raises(RuntimeError, match="repository write side effect failed"):
+        select_construction_alternative_for_wave(
+            repository="repository",
+            alternative_set_id="alt_set_001",
+            alternative_id="alt_balanced",
+            actor_id="pm_001",
+            reason_code="PM_SELECTED",
+            comment=None,
+            correlation_id="corr_wave_select",
+        )
 
 
 def test_wave_construction_selection_exports_public_surface() -> None:

--- a/tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py
+++ b/tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py
@@ -5,6 +5,11 @@ from datetime import date
 import pytest
 
 from src.api.services.wave_core_portfolio_universe_resolution import (
+    _PortfolioUniverseResolutionRequest,
+    _candidate_portfolio_payloads,
+    _portfolio_universe_candidate_page_ref,
+    _resolve_candidate_pages,
+    _selection_basis_payload,
     resolve_core_dpm_portfolio_universe_candidates,
 )
 from src.api.services.wave_errors import (
@@ -170,6 +175,76 @@ def test_resolve_core_dpm_portfolio_universe_candidates_paginates_and_attaches_s
     assert resolver.calls[1]["page_token"] == "page-2"
     assert candidates[0]["source_refs"][0]["source_type"] == "DpmPortfolioUniverseCandidate"
     assert candidates[0]["source_refs"][1]["source_type"] == "DPM_PORTFOLIO_UNIVERSE_CANDIDATE"
+
+
+def test_resolve_candidate_pages_passes_bounded_page_tokens() -> None:
+    page_0 = _candidate_page(next_page_token="page-2", returned_candidate_count=1)
+    page_1 = _candidate_page(
+        next_page_token=None,
+        returned_candidate_count=1,
+        candidates=[
+            _candidate_row(
+                portfolio_id="PB_SG_GLOBAL_BAL_002",
+                mandate_id="MANDATE_PB_SG_GLOBAL_BAL_002",
+                binding_version=4,
+                source_record_id="mandate-binding-002",
+            )
+        ],
+    )
+    resolver = _UniverseResolver([page_0, page_1])
+
+    pages = _resolve_candidate_pages(
+        resolver=resolver,
+        request=_PortfolioUniverseResolutionRequest(
+            as_of_date=date(2026, 5, 10),
+            tenant_id="default",
+            booking_center_code="Singapore",
+            model_portfolio_ids=["MODEL_PB_SG_GLOBAL_BAL_DPM"],
+            include_inactive_mandates=False,
+            campaign_candidate_page_size=1,
+            correlation_id="corr-universe-001",
+        ),
+    )
+
+    assert pages == [page_0, page_1]
+    assert resolver.calls[0]["page_token"] is None
+    assert resolver.calls[1]["page_token"] == "page-2"
+    assert resolver.calls[1]["page_size"] == 1
+
+
+def test_candidate_portfolio_payloads_preserve_page_and_candidate_source_refs() -> None:
+    page = _candidate_page()
+    candidate = page.candidates[0]
+
+    payloads = _candidate_portfolio_payloads(
+        candidates=[candidate],
+        universe_ref=_portfolio_universe_candidate_page_ref(page=page),
+        selection_basis=_selection_basis_payload(page),
+    )
+
+    assert len(payloads) == 1
+    assert payloads[0]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert payloads[0]["mandate_id"] == "MANDATE_PB_SG_GLOBAL_BAL_001"
+    assert payloads[0]["portfolio_type"] == "DISCRETIONARY"
+
+    page_ref, candidate_ref = payloads[0]["source_refs"]
+    assert page_ref == {
+        "source_system": "lotus-core",
+        "source_type": "DpmPortfolioUniverseCandidate",
+        "source_id": "snapshot-001",
+        "source_version": "v1",
+        "content_hash": "sha256:portfolio-universe",
+        "supportability_state": "READY",
+    }
+    assert candidate_ref["source_type"] == "DPM_PORTFOLIO_UNIVERSE_CANDIDATE"
+    assert candidate_ref["source_id"] == "mandate-binding-001"
+    assert candidate_ref["source_version"] == "3"
+    assert candidate_ref["selection_basis"] == {
+        "basis_type": "EFFECTIVE_DISCRETIONARY_MANDATE_BINDING",
+        "source_table": "portfolio_mandate_bindings",
+        "included_when": [],
+        "downstream_boundary": "Candidate membership is not execution authority.",
+    }
 
 
 def test_resolve_core_dpm_portfolio_universe_candidates_rejects_duplicate_candidates() -> None:

--- a/tests/unit/dpm/waves/test_wave_selection_item.py
+++ b/tests/unit/dpm/waves/test_wave_selection_item.py
@@ -1,7 +1,9 @@
+import pytest
 from pytest import MonkeyPatch
 
 from src.api.services import wave_selection_item
 from src.api.services.wave_selection_item import with_selection_and_proof_pack
+from src.core.proof_packs import ProofPackSourceValidationError
 from src.core.proof_packs.models import DpmPreTradeProofPack
 from src.core.waves import DpmRebalanceWaveItem
 
@@ -81,7 +83,7 @@ def test_selection_records_degraded_proof_pack_generation_failure(
     monkeypatch: MonkeyPatch,
 ) -> None:
     def _generate(**_kwargs: object) -> DpmPreTradeProofPack:
-        raise RuntimeError("proof pack unavailable")
+        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_NOT_FOUND")
 
     monkeypatch.setattr(
         wave_selection_item.proof_pack_service,
@@ -96,7 +98,23 @@ def test_selection_records_degraded_proof_pack_generation_failure(
     assert updated.reason_codes == ["CONSTRUCTION_ALTERNATIVE_SELECTED"]
     assert updated.diagnostics["proof_pack_state"] == "DEGRADED"
     assert updated.diagnostics["proof_pack_reason_code"] == "PROOF_PACK_GENERATION_FAILED"
-    assert updated.diagnostics["proof_pack_error"] == "RuntimeError"
+    assert updated.diagnostics["proof_pack_error"] == "ProofPackSourceValidationError"
+
+
+def test_selection_does_not_hide_unexpected_proof_pack_generation_failure(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def _generate(**_kwargs: object) -> DpmPreTradeProofPack:
+        raise RuntimeError("proof pack repository side effect failed")
+
+    monkeypatch.setattr(
+        wave_selection_item.proof_pack_service,
+        "generate_proof_pack_from_selected_alternative",
+        _generate,
+    )
+
+    with pytest.raises(RuntimeError, match="proof pack repository side effect failed"):
+        _select()
 
 
 def test_wave_selection_item_exports_only_selection_builder() -> None:

--- a/tests/unit/dpm/waves/test_wave_simulation_item.py
+++ b/tests/unit/dpm/waves/test_wave_simulation_item.py
@@ -1,9 +1,11 @@
+import pytest
 from pytest import MonkeyPatch
 
 from src.api.request_models import RebalanceRequest
 from src.api.services import wave_simulation_item
 from src.api.services.wave_simulation_item import DpmWaveSimulationInput, simulate_item
 from src.core.construction.models import ConstructionAlternative, ConstructionAlternativeSet
+from src.core.construction.repository import ConstructionIdempotencyConflictError
 from src.core.construction.vocabulary import ConstructionMethodStatus
 from src.core.waves import DpmRebalanceWaveItem
 
@@ -122,7 +124,7 @@ def test_simulate_item_blocks_construction_generation_failure(
     monkeypatch: MonkeyPatch,
 ) -> None:
     def _generate(**_kwargs: object) -> ConstructionAlternativeSet:
-        raise RuntimeError("construction unavailable")
+        raise ConstructionIdempotencyConflictError("CONSTRUCTION_IDEMPOTENCY_KEY_CONFLICT")
 
     monkeypatch.setattr(
         wave_simulation_item.construction_service,
@@ -146,8 +148,32 @@ def test_simulate_item_blocks_construction_generation_failure(
         "existing": "value",
         "source_owner": "lotus-manage-construction",
         "required_action": "REVIEW_CONSTRUCTION_INPUTS",
-        "construction_error": "RuntimeError",
+        "construction_error": "ConstructionIdempotencyConflictError",
     }
+
+
+def test_simulate_item_does_not_hide_unexpected_construction_generation_failure(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    def _generate(**_kwargs: object) -> ConstructionAlternativeSet:
+        raise RuntimeError("construction repository side effect failed")
+
+    monkeypatch.setattr(
+        wave_simulation_item.construction_service,
+        "generate_construction_alternative_set",
+        _generate,
+    )
+
+    with pytest.raises(RuntimeError, match="construction repository side effect failed"):
+        simulate_item(
+            item=_item(),
+            correlation_id="corr-simulate",
+            item_inputs={"PB_SG_SIMULATE": _request()},
+            methods=None,
+            construction_repository=object(),  # type: ignore[arg-type]
+            run_service=object(),  # type: ignore[arg-type]
+            risk_authority_client=None,
+        )
 
 
 def test_wave_simulation_item_exports_only_simulation_item_contract() -> None:


### PR DESCRIPTION
## Summary

This PR continues the enterprise backend hardening program for `lotus-manage` with 50 small, auditable commits on a non-squash branch. It focuses on modularity, service-boundary discipline, direct helper tests, API quality evidence, and measurable before/after quality reporting.

Major changes:

- Added/refreshed the refactor health, quality scorecard, complexity, architecture, and API governance report foundation.
- Extracted focused helpers across construction, source-product context mapping, proof packs, PM operating quality, mandate command-center, wave orchestration, core sourcing, target generation, valuation, tax budget, settlement, and campaign lifecycle logic.
- Added direct service/helper tests for extracted behavior instead of relying only on router-level or broad API tests.
- Preserved behavior while keeping orchestration boundaries in the existing public functions and moving deterministic mapping/policy math into smaller helpers.
- Updated `docs/architecture/CODEBASE-REVIEW-LEDGER.md` through `BACKEND-REVIEW-20260605-635` with scope, action, evidence, and no-wiki-change decisions.

## Before / After Scorecard

From `quality/refactor_health_report.md`:

| Metric | origin/main | current branch | Delta |
| --- | ---: | ---: | ---: |
| Python files | 796 | 798 | +2 |
| Total Python LOC | 153392 | 155953 | +2561 |
| Test functions | 2078 | 2141 | +63 |
| Service boundary findings | 0 | 0 | +0 |
| Router infrastructure imports | 0 | 0 | +0 |

OpenAPI completeness remains fully governed:

| Metric | Current |
| --- | ---: |
| Operations | 135 |
| Missing summary | 0 |
| Missing description | 0 |
| Missing tags | 0 |
| Missing 4xx/5xx response | 0 |
| Missing examples marker | 0 |

Complexity evidence:

- Repeatedly refreshed `quality/complexity_report.md` after source slices.
- The latest measured top source hotspot moved to `generate_fx_and_simulate` after removing these previously reported hotspots from the top source list:
  - `generate_targets_heuristic`
  - `_portfolio_snapshot_from_core_snapshot`
  - `_validate_superseded_lifecycle`
  - `external_treasury_currency_overlay_context`
  - plus earlier PM-quality, proof-pack, settlement, tax-budget, valuation, and wave/source-context hotspots.

Quality scorecard posture:

- Active gates: Ruff lint/format, mypy, unit tests, OpenAPI quality, API vocabulary validation.
- Clean service-boundary scans maintained.
- Remaining explicit backlog: convert more report-only quality baselines into regression-blocking thresholds; deepen runtime observability/security scoring; continue source hotspot reduction.

## Validation Evidence

Local full gate:

- `make check` passed.
- Unit result inside `make check`: `2309 passed in 40.65s`.

Additional pre-PR checks:

- `git fetch origin --prune` passed.
- `git branch -r --no-merged origin/main` returned only `origin/feat/manage-backend-readiness-refactor-20260604-2`.
- Wiki drift check passed with `DiffCount 0`:
  - `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage`
- Latest branch head GitHub checks before PR creation were green:
  - `Remote Feature Lane` success
  - `Quality Baseline` success

Representative per-slice gates also passed throughout the branch:

- `python -m ruff check <touched files>`
- `python -m ruff format --check <touched files>`
- `python -m mypy --config-file mypy.ini <touched src files>`
- focused pytest for changed behavior
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan: `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"`

## Wiki / Documentation Decision

No wiki publication is required for this PR. The branch updates repo-local quality evidence and the codebase review ledger only; it does not change operator-facing wiki truth, public API contract semantics, or runtime instructions.

## Risks and Follow-Up Backlog

- This is a broad refactor branch by design, although split into 50 small commits. Review should focus on behavior preservation and extracted-helper boundaries.
- Complexity/dead-code/dependency-architecture tools are still partly report-only. Follow-up should graduate stable detectors to fail-new-regression gates.
- Security depth remains partially active: `make security-audit` exists, while `bandit` and `pip-audit` remain report-only in the baseline.
- Observability contract validation is active, but runtime observability scoring should be deepened in a later slice.
- Next measured source hotspots include `generate_fx_and_simulate`, `apply_group_constraints`, proof-pack section payloads, and universe/source analytics helpers.