### PR TITLE
chore: sync enterprise backend refactoring standard

### DIFF
--- a/docs/architecture/ENTERPRISE_BACKEND_REFACTORING_INSTRUCTIONS.md
+++ b/docs/architecture/ENTERPRISE_BACKEND_REFACTORING_INSTRUCTIONS.md
@@ -1,28 +1,31 @@
-# Lotus Enterprise Backend Refactoring Instructions
+# Enterprise Backend Refactoring Instructions
 
 Use this file as the detailed refactoring instruction pack for any Lotus backend application.
 
-The Codex Goal prompt must name the target application and instruct the agent to follow this file fully.
-
-This instruction pack is application-independent. Apply it to the named target app only.
+The Codex Goal prompt should name the target application and instruct the agent to follow this file fully.
 
 ---
 
-# 1. Mission
+## 0. Scope and Preconditions
 
-Refactor the target Lotus backend application into a modular, reusable, maintainable, performant, secure, observable, enterprise-grade, production-ready, bank-buyable backend application.
+Before editing, confirm:
 
-The goal is not cosmetic cleanup.
+- Repo governance for the target app (AGENTS.md, repository engineering context, and local conventions).
+- Target stack (language/runtime, web framework, persistence, auth mechanisms, deployment model).
+- Branching rule:
+  - For `lotus-risk`, use branch work anchored to `feat` if that repo policy requires it.
+  - For all other Lotus backend repos in active mode, branch from and target `main` by default.
+- Baseline evidence to compare against:
+  - build/test status,
+  - quality baseline reports,
+  - endpoint inventory and API trust/contract artifacts.
+- Any durable-truth area affected (RFC, API contract, wiki, context, runbooks): plan stranded-truth reconciliation before final closure.
 
-The goal is to make the application:
+---
 
-- easier to understand
-- safer to change
-- easier to test
-- easier to operate
-- easier to support in production
-- easier to explain to developers, business users, operations, sales, and enterprise clients
-- suitable for enterprise adoption and long-term maintainability
+## 1. Mission
+
+Refactor the target Lotus backend application into a modular, reusable, maintainable, performant, secure, observable, enterprise-grade, production-ready, bank-buyable application.
 
 The application must align with:
 
@@ -33,101 +36,70 @@ The application must align with:
 - production support expectations
 - secure software delivery practices
 - implementation-backed documentation expectations
-- Codex-assisted development safety expectations
 
-Refactoring must preserve existing behavior unless a behavior change is intentional, tested, documented, and clearly explained.
+The goal is not cosmetic cleanup. The goal is to make the application easier to understand, safer to change, easier to operate, easier to test, easier to explain, and suitable for enterprise adoption.
+
+Primary acceptance target: every refactor slice must improve these three dimensions together:
+
+- reliability and risk posture,
+- developer maintainability and execution speed,
+- production supportability and incident readiness.
 
 ---
 
-# 2. Execution Principles
+## 2. Working Rules
 
 Work on a feature branch.
 
-Use small, meaningful commits.
-
-Target roughly 40 to 60 well-scoped commits, unless the repository is too small or too large for that number to make sense.
+Use small, meaningful commits. Target roughly 25–50 well-scoped commits.
 
 Preserve normal commit history because the final PR will use a non-squash merge strategy.
 
-Each commit should have a clear purpose and should keep the application buildable and testable as much as practical.
+Each commit should have a clear purpose and should keep the application buildable and testable as much as possible.
 
-Prefer incremental improvement over large rewrites.
+Avoid large mechanical rewrites unless they create clear architectural value.
 
-Avoid large mechanical rewrites unless they create clear architectural value and are easy to review.
+Preserve existing behavior unless intentionally changing it.
 
-Do not mix unrelated concerns in one commit.
+When behavior changes, document the reason, update tests, and explain the impact in the PR.
 
-Do not perform broad renaming, formatting, folder moves, and business refactoring in the same commit unless unavoidable.
+Keep branch policy strict:
 
-When behavior changes, document:
+- do not push directly to protected branches,
+- isolate one repository per Codex run,
+- do not mix non-orthogonal refactors in one PR unless clearly related.
 
-- what changed
-- why it changed
-- who or what is impacted
-- what tests prove the new behavior
-- whether migration or client communication is required
-
-Use the repository's existing conventions where they are good.
-
-Improve conventions where they are weak, inconsistent, unsafe, or not enterprise-ready.
+Before closing, include branch name, target branch, and validation evidence in PR metadata.
 
 ---
 
-# 3. Codex Safety Rules
-
-Codex must not optimize for speed over correctness.
-
-Codex must not hide uncertainty.
-
-Codex must not silently remove behavior.
-
-Codex must not delete code only because it looks unused unless evidence supports removal.
-
-Codex must not introduce new dependencies without clear justification.
-
-Codex must not introduce framework, persistence, infrastructure, or transport leakage into domain/application logic.
-
-Codex must not weaken tests to make CI pass.
-
-Codex must not lower quality thresholds to make CI pass without documenting why.
-
-Codex must not replace meaningful business behavior with placeholders, stubs, fake implementations, or TODO-only code.
-
-Codex must not document capabilities that are not implemented.
-
-Codex must not expose secrets, tokens, credentials, client data, internal stack traces, or sensitive data in logs, docs, examples, tests, or error responses.
-
-Codex must not create a large final PR without progressive commits and measurable evidence.
-
-When in doubt, prefer a smaller, safer change with clear evidence.
-
----
-
-# 4. Refactoring Focus Areas
+## 3. Refactoring Focus
 
 Improve the application across these areas:
 
 - remove dead code and unused paths
 - split monolithic files into clear modules
-- reduce duplication across routers, controllers, services, DTOs, mappers, validators, middleware, clients, repositories, tests, and configuration
+- reduce duplication across routers, controllers, services, DTOs, mappers, validators, middleware, clients, repositories, and tests
 - improve domain modeling and private banking vocabulary
 - improve API design, versioning, routing, pagination, filtering, sorting, and error handling
-- complete OpenAPI with summaries, descriptions, examples, tags, operation IDs, request models, response models, and error models
-- keep business logic out of routers, controllers, middleware, infrastructure, persistence models, and downstream adapters
+- complete OpenAPI with descriptions, examples, tags, operation IDs, request models, response models, and error models
+- keep business logic out of routers, controllers, middleware, infrastructure, and persistence layers
 - improve service boundaries, dependency flow, orchestration boundaries, and separation of concerns
 - strengthen validation, idempotency, correlation IDs, auditability, lineage, and traceability
-- improve structured logging, metrics, tracing hooks, health checks, readiness checks, and operational diagnostics
+- improve structured logging, metrics, tracing, health checks, readiness checks, and operational diagnostics
 - optimize latency, batching, pagination, caching, connection pooling, timeout handling, retry behavior, and downstream access patterns
-- harden security, authentication, authorization, sensitive-data handling, secrets handling, configuration, CORS, secure headers, and API abuse protection
-- improve resilience with timeouts, retries, bounded failure behavior, graceful degradation, and consistent downstream error mapping
+- harden security, authentication, authorization, sensitive-data handling, secrets handling, configuration, CORS, headers, and API abuse protection
+- improve resilience with timeouts, retries, circuit-breaker-style boundaries, graceful degradation, and consistent downstream error mapping
 - improve tests with meaningful unit, integration, contract, API, middleware, security, regression, and end-to-end coverage
-- update README, architecture docs, API catalog, RFCs, operational runbooks, supported-features material, and wiki-ready documentation
-
-Prioritize changes that produce measurable improvement and reduce long-term ownership risk.
+- update README, wiki, RFC, architecture diagrams, API catalog, operational runbooks, and supported-features material
+- enforce deterministic behavior for breaking changes through migration/deprecation strategies
+- improve data ownership, schema migration safety, and rollback strategy
+- standardize dependency lifecycle, lockfile hygiene, and reproducible install strategy
+- strengthen idempotency semantics and replay safety for state-changing flows
 
 ---
 
-# 5. Architecture Principles
+## 4. Architecture Principles
 
 Use clear layered architecture.
 
@@ -146,130 +118,23 @@ Rules:
 - routers/controllers call application services or use cases only
 - routers/controllers must not call repositories, database clients, HTTP clients, Kafka clients, Redis clients, file clients, or downstream adapters directly
 - middleware must stay thin, reusable, and free of business logic
-- domain logic must not depend on FastAPI, framework objects, infrastructure clients, persistence models, API DTOs, transport DTOs, or external service response models
-- application logic must not depend on FastAPI, framework request objects, persistence models, concrete infrastructure clients, or transport DTOs
+- domain and application logic must not depend on FastAPI, framework objects, infrastructure clients, persistence models, or transport DTOs
 - infrastructure must sit behind ports/adapters
 - API DTOs must not leak into domain logic
 - persistence models must not leak into API responses or domain logic
-- downstream response models must not leak into domain logic
-- mappers must be explicit and testable
 - downstream errors must map to consistent platform errors
 - errors should follow RFC 7807/problem-details style where applicable
 - every request must support or propagate correlation ID
 - relevant mutations must be auditable
 - idempotent operations must define explicit idempotency behavior
 - logs must be structured and must not leak sensitive data
-
-The core business logic should be testable without FastAPI, real databases, Kafka, Redis, cloud services, or real downstream APIs.
-
----
-
-# 6. Layer Responsibilities
-
-## API Layer
-
-Responsible for:
-
-- route definitions
-- HTTP method and path
-- request DTOs
-- response DTOs
-- status codes
-- headers
-- query parameters
-- path parameters
-- authentication context extraction
-- API-level validation
-- mapping API DTOs to application commands
-- mapping application results to API responses
-
-Not responsible for:
-
-- business decisions
-- database access
-- downstream HTTP calls
-- Kafka publishing
-- Redis access
-- file access
-- complex orchestration
-- domain calculations
-
-## Application Layer
-
-Responsible for:
-
-- use case orchestration
-- transaction/workflow coordination
-- calling domain logic
-- calling ports
-- coordinating persistence through repository ports
-- coordinating downstream access through client ports
-- idempotency workflow
-- audit workflow
-- application-level error mapping
-
-Not responsible for:
-
-- HTTP details
-- API DTOs
-- persistence schema details
-- concrete client implementation
-- framework objects
-
-## Domain Layer
-
-Responsible for:
-
-- business models
-- value objects
-- policies
-- business rules
-- calculations
-- validations
-- state transitions
-- private banking vocabulary
-
-Not responsible for:
-
-- FastAPI
-- Pydantic API DTOs
-- SQLAlchemy/ORM models
-- database details
-- HTTP clients
-- Kafka clients
-- Redis clients
-- file clients
-- cloud clients
-
-## Ports
-
-Responsible for:
-
-- defining external capabilities required by the application
-- repository interfaces
-- downstream client interfaces
-- event publisher interfaces
-- audit interfaces
-- idempotency store interfaces
-- clock/UUID/provider interfaces where useful for testability
-
-## Infrastructure
-
-Responsible for:
-
-- concrete repository implementations
-- database access
-- downstream HTTP clients
-- Kafka/EventHub producers/consumers
-- Redis/cache clients
-- file/cloud storage clients
-- external service DTO mapping
-- infrastructure-specific error handling
-- configuration of concrete adapters
+- enforce boundary violations through automated checks (import-linter, dependency maps, package boundaries)
+- keep orchestrator code out of domain entities/value objects
+- isolate config/feature flag readers from business logic for deterministic behavior
 
 ---
 
-# 7. API Governance
+## 5. API Governance
 
 Improve APIs so they are consistent, explainable, and enterprise-ready.
 
@@ -283,94 +148,63 @@ Every endpoint should have:
 - operation ID
 - request model
 - response model
-- useful request examples
-- useful response examples
+- useful request and response examples
 - standard error responses
 - documented validation behavior
 - documented correlation ID behavior
 - documented idempotency behavior where relevant
-- documented pagination/filtering/sorting where relevant
-- security/authentication declaration where relevant
+- documented paging stability and sort ordering
+- documented backward-compatibility policy and deprecation notices
+- documented authz and audit impact
 
 Standardize:
 
 - pagination
 - filtering
 - sorting
-- error format
 - status codes
 - versioning
 - deprecation strategy
 - internal versus public endpoints
-- health endpoint
-- readiness endpoint
-- liveness endpoint
-- metrics endpoint
-- OpenAPI tag structure
-- API examples
+- health, readiness, liveness, and metrics endpoints
+- endpoint certification expectations against repository ledger/wiki truth where it exists
+- request strictness and unsupported-query behavior
 
-Problem-details responses should be consistent.
-
-Typical error shape should include:
-
-- type
-- title
-- status
-- detail
-- instance where applicable
-- correlation ID
-- application error code where useful
-- safe contextual metadata where useful
-
-Do not expose internal exception messages, stack traces, downstream raw errors, secrets, credentials, or sensitive client data.
+For public endpoints, keep backward compatibility rules explicit and codify migration windows.
 
 ---
 
-# 8. Observability and Operations
+## 6. Observability and Operations
 
 Improve operational readiness.
 
 The application should support:
 
 - structured JSON logging
-- correlation ID in request logs
-- correlation ID in response headers
-- correlation ID propagation to downstream calls
-- correlation ID propagation to events/messages where applicable
-- safe logging without secrets, tokens, credentials, personal data, or client-sensitive data
+- correlation ID in logs and responses
+- safe logging without secrets, tokens, personal data, or client-sensitive data
 - request metrics
 - latency metrics
 - downstream call metrics
 - error metrics
-- business-operation metrics where useful
+- saturation metrics for queues, pools, thread/execution workers, and storage connectors
+- business-outcome metrics for critical financial workflows
 - health checks
 - readiness checks
 - liveness checks
 - tracing hooks where practical
 - clear operational diagnostics
-- meaningful startup behavior
-- meaningful shutdown behavior
-- timeout visibility
-- retry visibility
-- dependency health visibility
+- meaningful startup and shutdown behavior
 - runbook documentation
+- explicit SLIs/SLOs and alert thresholds
+- dashboards and alerting rules bound to implemented metrics
+- startup dependency graphs and dependency timeout behavior
 
-Logs should be useful for production support but must not leak sensitive information.
-
-Operational documentation should explain:
-
-- how to run locally
-- how to configure
-- how to diagnose failures
-- how to interpret health/readiness
-- how to trace a request with correlation ID
-- what downstream dependencies exist
-- what common failures mean
-- what alerts or metrics matter
+Operational evidence should include failure-path expectations and recovery behavior, not only success-path monitoring.
 
 ---
 
-# 9. Security
+## 7. Security
 
 Harden the application.
 
@@ -378,7 +212,6 @@ Check and improve:
 
 - authentication boundaries
 - authorization boundaries
-- service-to-service trust boundaries
 - secrets handling
 - environment-based configuration
 - safe defaults
@@ -386,139 +219,63 @@ Check and improve:
 - secure headers where applicable
 - CORS policy
 - input validation
-- output sanitization where relevant
 - dependency vulnerabilities
 - insecure Python patterns
-- unsafe deserialization
-- command execution risks
-- path traversal risks
-- SQL/NoSQL injection risks
-- SSRF risks in downstream calls
 - downstream error leakage
 - logs for sensitive-data exposure
-- negative/security test coverage
+- test coverage for negative/security cases
+- secret scanning and credential leakage prevention in CI
+- container and image trust posture
+- identity and access control model clarity
 
-Do not expose:
+Do not expose tokens, secrets, credentials, internal stack traces, or sensitive client data.
 
-- tokens
-- secrets
-- credentials
-- internal stack traces
-- raw downstream errors
-- sensitive client data
-- personal data
-- private account information
-- full request/response bodies where they may contain sensitive data
+Required security posture checks:
 
-New dependencies must be justified and checked for:
-
-- purpose
-- license
-- maintenance status
-- security vulnerabilities
-- overlap with existing dependencies
-- runtime/container impact
+- threat-model for trust boundaries and abuse cases
+- RBAC/ABAC enforcement validation for protected flows
+- least-privilege service credentials
+- data-classification review for PII-like and market-sensitive identifiers
+- encryption requirements for transit and rest where applicable
+- security dependency and supply-chain scans with fail-on-regression policy
 
 ---
 
-# 10. Resilience and Reliability
-
-Improve production resilience.
-
-Check and improve:
-
-- explicit downstream timeouts
-- bounded retries
-- retry backoff
-- no infinite retry loops
-- consistent timeout configuration
-- consistent error mapping
-- graceful degradation where appropriate
-- duplicate message handling
-- idempotent mutation behavior
-- idempotent event processing where applicable
-- transaction boundaries
-- partial-failure behavior
-- startup dependency behavior
-- shutdown behavior
-- connection pooling
-- resource cleanup
-- concurrency safety
-- race-condition risks
-- poison message handling where applicable
-- dead-letter behavior where applicable
-
-For idempotent operations, define and test:
-
-- same idempotency key with same payload
-- same idempotency key with different payload
-- concurrent requests with same key
-- operation in progress
-- operation completed
-- operation failed
-- retention/expiry behavior
-
----
-
-# 11. Testing Expectations
+## 8. Testing Expectations
 
 Improve tests so they protect behavior, architecture, and production readiness.
 
 Add or strengthen:
 
-- unit tests for domain logic
-- unit tests for value objects
-- unit tests for application services/use cases
+- unit tests for domain logic and application services
 - integration tests for infrastructure/adapters where practical
-- repository tests where practical
-- downstream client tests with mocked responses
 - contract/API tests
 - router/controller tests
 - middleware tests
 - error-handling tests
 - security tests
 - regression tests for existing supported features
-- health/readiness/liveness tests
+- health/readiness tests
 - correlation ID propagation tests
 - RFC 7807/problem-details tests
 - downstream failure tests
-- timeout/retry tests
 - sensitive-data masking tests
 - idempotency tests where relevant
-- audit tests where relevant
-- OpenAPI generation tests
-- architecture boundary tests
 - performance smoke tests where practical
+- concurrency and retry-safety tests for state changes
+- migration/recovery tests where persistence behavior is changed
+- chaos-style dependency failure tests for key upstream/downstream paths
+- contract compatibility tests for API schema drift
 
-Tests should be meaningful, not coverage fillers.
+Tests should be meaningful, not just coverage fillers.
 
-Do not weaken or delete tests to make refactoring easier.
-
-If a test is obsolete, explain why and replace it with a better test.
-
-Use golden regression tests for business-critical calculations and behavior.
-
-For portfolio, performance, buying-power, advisory, or reporting apps, preserve and expand tests around:
-
-- money and Decimal precision
-- FX handling
-- date/time boundaries
-- timezone behavior
-- valuation dates
-- cashflow timing
-- cost calculation
-- TWR/MWR/performance calculations where relevant
-- contribution/attribution where relevant
-- benchmark behavior where relevant
-- buying power and collateral behavior where relevant
-- idempotency and duplicate event behavior
-- backdated or correction events where relevant
+For every behavior-sensitive change, include positive, negative, and backward-compatibility regression coverage.
 
 ---
 
-# 12. Quality Gates and Measurement
+## 9. Quality Gates and Measurement
 
-Add measurable quality gates so refactoring progress is tangible in CI and PR evidence.
+Add measurable quality gates so refactoring progress is tangible in CI.
 
 Before major refactoring, create a baseline report covering:
 
@@ -534,7 +291,6 @@ Before major refactoring, create a baseline report covering:
 - test count
 - line coverage
 - branch coverage
-- diff coverage where available
 - dead-code candidates
 - dependency issues
 - security findings
@@ -545,7 +301,9 @@ Before major refactoring, create a baseline report covering:
 - middleware complexity
 - documentation gaps
 - observability gaps
-- container/deployment gaps where applicable
+- policy enforcement gaps
+- resilience gaps
+- backward-compatibility break risks
 
 Create a before/after scorecard and update it during the refactor.
 
@@ -561,28 +319,27 @@ Recommended files:
 - `quality/architecture_rules.md`
 - `quality/api_governance_rules.md`
 - `quality/ci_quality_gates.md`
-- `quality/security_findings.md`
-- `quality/refactor_decisions.md`
+- `quality/enterprise_readiness_checklist.md`
+- `quality/ops_slo_contract.md`
 
 Recommended tools where applicable:
 
 - `ruff` for linting and formatting
 - `mypy` or `pyright` for type checking
 - `pytest`, `pytest-cov`, and `coverage.py` for tests and coverage
-- `diff-cover` for changed-code coverage
-- `radon` for complexity and maintainability reporting
-- `xenon` for complexity enforcement
-- `vulture` for dead-code detection
+- `radon` or `xenon` for complexity and maintainability
+- `vulture` for dead code
 - `deptry` for dependency hygiene
-- `bandit` for Python security scanning
-- `pip-audit` or `osv-scanner` for dependency vulnerability scanning
+- `bandit` for security scanning
+- `pip-audit` for dependency vulnerability scanning
 - `spectral` for OpenAPI governance
-- `import-linter` or equivalent for architecture boundaries
+- `import-linter` for architecture boundaries
 - `interrogate` for docstring coverage
 - optional: `schemathesis` for OpenAPI/property-based API testing
 - optional: `pytest-benchmark` for performance checks
 - optional: `locust` or `k6` for load/performance testing
-- optional: `hadolint`, `trivy`, `grype`, `syft`, or equivalent for container and supply-chain checks
+- optional: `grype`, `trivy`, or `snyk` for supply-chain scanning
+- optional: `semgrep` for policy/rule pattern enforcement
 
 Use progressive CI gating:
 
@@ -591,50 +348,11 @@ Use progressive CI gating:
 3. enforce agreed thresholds
 4. enforce strict enterprise-readiness gates
 
-Do not make CI weaker to complete the refactor.
+Each gate should include deterministic pass criteria in `quality/ci_quality_gates.md`.
 
 ---
 
-# 13. Required Evidence After Each Meaningful Refactoring Step
-
-For each meaningful refactoring commit or small group of commits, record evidence in the commit message, PR notes, or `quality/refactor_health_report.md`.
-
-Evidence should include where applicable:
-
-- tests run
-- number of tests passed
-- focused test suites run
-- Ruff lint result
-- Ruff format result
-- type-check result
-- Radon/Xenon complexity result
-- before/after complexity for touched hotspots
-- coverage or diff coverage result
-- dependency check result
-- security check result
-- OpenAPI/Spectral result
-- architecture boundary check result
-- known limitations or deferred work
-
-Example evidence format:
-
-```text
-Evidence:
-- pytest tests/unit/application/test_create_proposal.py: 18 passed
-- ruff check src/app/application src/app/domain: passed
-- ruff format --check src/app/application src/app/domain: passed
-- pyright: passed
-- radon: CreateProposalUseCase.execute improved from C (13) to B (7)
-- architecture boundary check: passed
-```
-
-Evidence must be specific, not generic.
-
-Avoid statements like "all good" or "quality improved" without proof.
-
----
-
-# 14. Documentation Expectations
+## 10. Documentation Expectations
 
 Treat documentation as part of the product.
 
@@ -649,8 +367,13 @@ Update or create:
 - `docs/supported-features.md`
 - `docs/configuration.md`
 - `docs/local-development.md`
+- `docs/data-classification.md` (or equivalent)
+- `docs/disaster-recovery.md`
 - RFCs where architectural decisions changed
 - wiki-ready diagrams and flow descriptions
+- `wiki/Endpoint-Certification.md` and related wiki operational pages when truth changes
+- `REPOSITORY-ENGINEERING-CONTEXT.md` when repository responsibilities change
+- `AGENTS.md` only when operating contract changes; keep synchronized with platform copy
 
 Documentation should support:
 
@@ -662,68 +385,62 @@ Documentation should support:
 - client pitches
 - future maintainers
 - production support
+- audit and compliance reviewers
 
-Documentation must be implementation-backed.
+Documentation must be implementation-backed. Do not document capabilities that the code does not support.
 
-Do not document capabilities that the code does not support.
+If durable truth changed (API, context, wiki, RFC, deployment/runbook, supported-features), run:
 
-Where the application has limitations, document them honestly.
-
-Where the refactor introduces decisions, document the decision and reasoning.
-
----
-
-# 15. Suggested Commit Sequence
-
-Use this sequence as guidance, adapting to the repository reality.
-
-Do not force the sequence if the repository needs a different safe order.
-
-1. inspect repository structure and identify application boundaries
-2. add or update baseline quality tooling
-3. create baseline quality report
-4. add CI quality workflow in report-only mode
-5. add architecture boundary rules
-6. add OpenAPI governance rules
-7. add controller/router thinness checks where practical
-8. add observability and correlation ID checks
-9. add security and dependency scanning
-10. add type-checking baseline
-11. add or improve coverage reporting
-12. split large modules into coherent packages
-13. extract application services/use cases
-14. extract or refine domain models and value objects
-15. move infrastructure concerns behind ports/adapters
-16. standardize mappers between API/application/domain/persistence
-17. standardize errors and problem-details responses
-18. standardize correlation ID propagation
-19. standardize idempotency behavior where relevant
-20. standardize audit and lineage behavior where relevant
-21. improve validation and request models
-22. improve response models
-23. improve downstream client boundaries
-24. improve retry, timeout, and error mapping behavior
-25. improve logging and metrics
-26. improve health, readiness, and liveness checks
-27. improve OpenAPI descriptions and examples
-28. add or strengthen unit tests
-29. add or strengthen integration tests
-30. add or strengthen API/contract tests
-31. add or strengthen middleware tests
-32. add or strengthen security tests
-33. add or strengthen idempotency tests
-34. add or strengthen performance smoke tests
-35. remove proven dead code
-36. remove unused dependencies
-37. reduce duplication
-38. improve documentation
-39. tighten CI from report-only to regression-blocking
-40. tighten CI to agreed enterprise-readiness thresholds
-41. produce final before/after refactor health report
+1. `git fetch origin --prune`
+2. `git branch -r --no-merged origin/main`
+3. `lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository <repo-name>`
+4. stranded-truth review as required by AGENTS
 
 ---
 
-# 16. PR Requirements
+## 11. Suggested Commit Sequence
+
+Use this sequence as guidance, adapting to the repository reality:
+
+1. add baseline quality tooling and report
+2. add CI quality workflow in report-only mode
+3. add architecture boundary rules
+4. add OpenAPI governance rules
+5. add controller/router thinness checks
+6. add observability and correlation ID checks
+7. add security and dependency scanning
+8. split large modules into coherent packages
+9. extract application services/use cases
+10. extract or refine domain models and value objects
+11. move infrastructure concerns behind ports/adapters
+12. standardize errors and problem-details responses
+13. standardize correlation ID propagation
+14. standardize idempotency behavior where relevant
+15. standardize audit and lineage behavior
+16. improve validation and request models
+17. improve downstream client boundaries
+18. improve retry, timeout, and error mapping behavior
+19. improve logging and metrics
+20. improve health and readiness checks
+21. improve OpenAPI descriptions and examples
+22. add or strengthen unit tests
+23. add or strengthen integration tests
+24. add or strengthen API/contract tests
+25. add or strengthen middleware tests
+26. add or strengthen security tests
+27. add or strengthen performance smoke tests
+28. remove dead code and unused dependencies
+29. reduce duplication
+30. update README, wiki, RFCs, and runbooks
+31. tighten CI from report-only to regression-blocking
+32. tighten CI to enterprise-readiness thresholds
+33. produce final before/after refactor health report
+34. validate governance/docs truth synchronization checks
+35. validate run/rollback readiness for production-facing behavior changes
+
+---
+
+## 12. Final PR Requirements
 
 The final PR must include:
 
@@ -735,70 +452,40 @@ The final PR must include:
 - security improvements
 - observability improvements
 - documentation improvements
-- dependency changes and justification
-- behavior changes, if any
-- migration notes, if any
-- configuration changes, if any
 - known limitations
 - follow-up backlog
-- review focus areas
-
-The PR must include concrete evidence, not just a narrative.
-
-Required PR evidence:
-
-- tests executed and result
-- coverage result
-- lint/format result
-- type-check result
-- complexity/maintainability result
-- dependency hygiene result
-- security scan result
-- OpenAPI governance result where applicable
-- architecture boundary result where applicable
-- before/after hotspot summary
-- known remaining hotspots
+- migration notes if behavior or configuration changed
+- explicit quality gates executed and results
+- enterprise readiness evidence references
+- rollout and rollback guidance
+- references to changed API, mesh, and certification artifacts
 
 ---
 
-# 17. Definition of Done
+## 13. Definition of Done
 
 The refactor is complete only when:
 
 - CI passes
 - scorecard proves measurable improvement
-- architecture boundaries are defined and enforced where practical
-- OpenAPI quality is improved where APIs exist
+- architecture boundaries are enforced
+- OpenAPI quality is improved
 - tests protect important behavior
-- changed code is covered by meaningful tests
-- security checks pass or documented exceptions exist
-- dependency checks pass or documented exceptions exist
-- observability behavior is implemented, documented, and tested where practical
-- correlation ID behavior is implemented and tested
-- error behavior is consistent
-- sensitive-data logging risk is reduced
+- security and dependency checks pass
+- observability behavior is documented and tested
 - documentation is implementation-backed
 - application behavior is preserved unless changes are explicitly documented
 - final PR explains what changed, why it changed, what improved, what risks remain, and what should follow next
+- quality scorecards do not regress on critical governance, resilience, and security checks
+- API, mesh, and operational contract truth is synchronized with repo-local source docs
+- rollout evidence is reproducible from deterministic commands
 
 ---
 
-# 18. Final Agent Instruction
+## 14. Codex Goal Exit Checklist
 
-Refactor with discipline.
-
-Prefer small, evidence-backed improvements.
-
-Keep the application working.
-
-Protect behavior with tests.
-
-Make architecture cleaner without over-engineering.
-
-Do not chase cosmetic perfection.
-
-Do not make broad unsafe rewrites.
-
-Do not claim improvement without measurement.
-
-The final outcome should be a backend application that is measurably cleaner, safer, more testable, more observable, more secure, and easier to own in production.
+- confirm the target branch policy was followed for the repository,
+- confirm each mandatory section above was attempted and evidence attached,
+- confirm no accidental broad cross-repo scope changes,
+- confirm no unresolved `TODO`/`FIXME` without owners and dates,
+- confirm reproducible validation commands are included in PR description.


### PR DESCRIPTION
## Summary

Synchronize the Enterprise Backend Refactoring Instructions across all backend repositories from the canonical source.

## Scope

- docs/architecture/ENTERPRISE_BACKEND_REFACTORING_INSTRUCTIONS.md in backend repos.
- context/playbooks/ENTERPRISE-BACKEND-REFACTORING-INSTRUCTIONS.md canonical copy in lotus-platform.
- Added platform sync script for deterministic propagation.

## Validation

- Hash/contents parity checks across backend repositories.
- Branch-local sync script added to platform.

This change is documentation/process-only and does not alter runtime behavior.