### PR TITLE
Harden manage source hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -18960,3 +18960,43 @@ and improves internal transaction-cost source posture maintainability only.
   `python scripts/engineering_health_report.py` and
   `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260612-781: Campaign approval-decision helpers extracted
+
+- Date: 2026-06-12
+- Scope: `src/core/waves/campaign_definition_approval_decisions.py` and
+  `tests/unit/dpm/waves/test_campaign_definition_repository.py`.
+- Finding: `record_bulk_review_campaign_definition_approval_decision` was the next current
+  source-complexity hotspot and mixed active-definition checks, request-field normalization,
+  required-field validation, decision construction, idempotent replay detection, conflict
+  detection, and append-only definition rebuilding in one function.
+- Action: extracted private helpers for active-definition validation, normalized approval-decision
+  input, required text validation, existing decision lookup, and append-only rebuilding. Added
+  direct helper tests for trimmed request fields, blank decision-ref rejection, active-definition
+  validation, existing decision lookup, and append behavior while preserving existing append-only
+  behavior coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_definition_approval_decisions.py tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `python -m ruff format --check src/core/waves/campaign_definition_approval_decisions.py tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_definition_approval_decisions.py`,
+  and `python -m pytest tests/unit/dpm/waves/test_campaign_definition_repository.py -q` (51 passed).
+- Wiki decision: no wiki source change required; this is internal campaign approval-decision
+  maintainability refactoring.
+
+## BACKEND-REVIEW-20260612-782: Campaign approval-decision reports refreshed
+
+- Date: 2026-06-12
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports needed to reflect the campaign approval-decision helper
+  extraction after `BACKEND-REVIEW-20260612-781`.
+- Action: regenerated current-state refactor reports and restored stable baseline/rule artifacts.
+  The refreshed complexity report shows `record_bulk_review_campaign_definition_approval_decision`
+  dropped out of the top current source-complexity list; in-memory rebalance-run listing helpers
+  are now the next source hotspot family.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py` and
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -18867,3 +18867,58 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260612-777: Source hotspot helper extractions continued
+
+- Date: 2026-06-12
+- Scope: `src/core/waves/campaign_definition_lifecycle.py`,
+  `src/core/outcomes/risk_sources.py`, `src/core/portfolio_memory/handoffs.py`,
+  `tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `tests/unit/core/test_risk_realized_outcome_sources.py`, and
+  `tests/unit/dpm/portfolio_memory/test_handoffs.py`.
+- Finding: the next source-complexity hotspots mixed pure validation and projection logic into
+  orchestration methods: campaign supersession replacement validation and lineage payload
+  rebuilding, concentration realized-source reason-code/snapshot projection, and portfolio-memory
+  report-context count/rank/governance validation.
+- Action: kept repository orchestration and source-owned value selection in their existing owners
+  while extracting focused helpers for campaign supersession validation, concentration source
+  snapshot assembly, and portfolio-memory handoff consistency checks. Added direct helper tests for
+  replacement-version normalization, active replacement validation, supersession lineage payloads,
+  concentration reason-code coverage, not-supported concentration value suppression, and
+  portfolio-memory event-ref count/rank/governance policy validation.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_definition_lifecycle.py src/core/outcomes/risk_sources.py src/core/portfolio_memory/handoffs.py tests/unit/dpm/waves/test_campaign_definition_repository.py tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/dpm/portfolio_memory/test_handoffs.py`,
+  `python -m ruff format --check src/core/waves/campaign_definition_lifecycle.py src/core/outcomes/risk_sources.py src/core/portfolio_memory/handoffs.py tests/unit/dpm/waves/test_campaign_definition_repository.py tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/dpm/portfolio_memory/test_handoffs.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_definition_lifecycle.py src/core/outcomes/risk_sources.py src/core/portfolio_memory/handoffs.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_definition_repository.py tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/dpm/portfolio_memory/test_handoffs.py -q`
+  (107 passed),
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal core helper and validation
+  maintainability refactoring.
+
+## BACKEND-REVIEW-20260612-778: Source hotspot reports refreshed
+
+- Date: 2026-06-12
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports still pointed at the pre-slice source hotspot posture, so
+  they did not reflect the campaign lifecycle, concentration source, and portfolio-memory handoff
+  helper extractions.
+- Action: regenerated current-state refactor reports after the helper extractions. Preserved
+  `quality/baseline_report.md`, `quality/architecture_rules.md`, and
+  `quality/api_governance_rules.md` so the branch baseline and rule docs remain stable. The
+  refreshed complexity report shows the three targeted hotspots dropped out of the top current
+  source-complexity list, with proof-pack source analytics now the next source hotspot family.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -18922,3 +18922,41 @@ and improves internal transaction-cost source posture maintainability only.
   `git diff --check`,
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260612-779: Proof-pack source analytics helpers extracted
+
+- Date: 2026-06-12
+- Scope: `src/core/proof_packs/source_analytics.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Finding: `_risk_source_analytics` and `_performance_source_analytics` were the next current
+  source-complexity hotspots and duplicated inline reason-code fallback, source-ref assembly,
+  source fact projection, and optional metric filtering.
+- Action: extracted shared authority reason-code and source-ref helpers plus focused risk and
+  performance facts/metrics projectors. Preserved source-owned analytics behavior and added direct
+  helper tests for degraded reason fallback, metric filtering, fact projection, and source-ref
+  construction.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/source_analytics.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/source_analytics.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/source_analytics.py`,
+  and `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` (72 passed).
+- Wiki decision: no wiki source change required; this is internal proof-pack source analytics
+  maintainability refactoring.
+
+## BACKEND-REVIEW-20260612-780: Proof-pack source analytics reports refreshed
+
+- Date: 2026-06-12
+- Scope: `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: current-state quality reports needed to reflect the proof-pack source analytics helper
+  extraction after `BACKEND-REVIEW-20260612-779`.
+- Action: regenerated current-state refactor reports and restored stable baseline/rule artifacts.
+  The refreshed complexity report shows `_performance_source_analytics` and
+  `_risk_source_analytics` dropped out of the top current source-complexity list; campaign approval
+  decision recording is now the next source hotspot.
+- Status: hardened.
+- Evidence:
+  `python scripts/engineering_health_report.py` and
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T08:32:38+00:00`
+- Generated at: `2026-06-12T08:36:49+00:00`
 
-- Current ref: `f688bb15`
+- Current ref: `8b87deca`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _performance_source_analytics | src/core/proof_packs/source_analytics.py | 9 | 50 |
-| 2 | _risk_source_analytics | src/core/proof_packs/source_analytics.py | 9 | 49 |
-| 3 | record_bulk_review_campaign_definition_approval_decision | src/core/waves/campaign_definition_approval_decisions.py | 9 | 44 |
-| 4 | list_operations | src/infrastructure/rebalance_runs/in_memory.py | 9 | 39 |
-| 5 | list_runs | src/infrastructure/rebalance_runs/in_memory.py | 9 | 37 |
-| 6 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
-| 7 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
-| 8 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
-| 9 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
-| 10 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
+| 1 | record_bulk_review_campaign_definition_approval_decision | src/core/waves/campaign_definition_approval_decisions.py | 9 | 44 |
+| 2 | list_operations | src/infrastructure/rebalance_runs/in_memory.py | 9 | 39 |
+| 3 | list_runs | src/infrastructure/rebalance_runs/in_memory.py | 9 | 37 |
+| 4 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
+| 5 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
+| 6 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
+| 7 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
+| 8 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
+| 9 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
+| 10 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-05T11:41:04+00:00`
+- Generated at: `2026-06-12T08:32:38+00:00`
 
-- Current ref: `e204b141`
+- Current ref: `f688bb15`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | supersede_bulk_review_campaign_definition | src/core/waves/campaign_definition_lifecycle.py | 9 | 60 |
-| 2 | realized_concentration_source_from_concentration_response | src/core/outcomes/risk_sources.py | 9 | 55 |
-| 3 | validate_bounded_event_ref_metadata | src/core/portfolio_memory/handoffs.py | 9 | 53 |
-| 4 | _performance_source_analytics | src/core/proof_packs/source_analytics.py | 9 | 50 |
-| 5 | _risk_source_analytics | src/core/proof_packs/source_analytics.py | 9 | 49 |
-| 6 | record_bulk_review_campaign_definition_approval_decision | src/core/waves/campaign_definition_approval_decisions.py | 9 | 44 |
-| 7 | list_operations | src/infrastructure/rebalance_runs/in_memory.py | 9 | 39 |
-| 8 | list_runs | src/infrastructure/rebalance_runs/in_memory.py | 9 | 37 |
-| 9 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
-| 10 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
+| 1 | _performance_source_analytics | src/core/proof_packs/source_analytics.py | 9 | 50 |
+| 2 | _risk_source_analytics | src/core/proof_packs/source_analytics.py | 9 | 49 |
+| 3 | record_bulk_review_campaign_definition_approval_decision | src/core/waves/campaign_definition_approval_decisions.py | 9 | 44 |
+| 4 | list_operations | src/infrastructure/rebalance_runs/in_memory.py | 9 | 39 |
+| 5 | list_runs | src/infrastructure/rebalance_runs/in_memory.py | 9 | 37 |
+| 6 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
+| 7 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
+| 8 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
+| 9 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
+| 10 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T08:36:49+00:00`
+- Generated at: `2026-06-12T08:40:21+00:00`
 
-- Current ref: `8b87deca`
+- Current ref: `74f189dc`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | record_bulk_review_campaign_definition_approval_decision | src/core/waves/campaign_definition_approval_decisions.py | 9 | 44 |
-| 2 | list_operations | src/infrastructure/rebalance_runs/in_memory.py | 9 | 39 |
-| 3 | list_runs | src/infrastructure/rebalance_runs/in_memory.py | 9 | 37 |
-| 4 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
-| 5 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
-| 6 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
-| 7 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
-| 8 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
-| 9 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
-| 10 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
+| 1 | list_operations | src/infrastructure/rebalance_runs/in_memory.py | 9 | 39 |
+| 2 | list_runs | src/infrastructure/rebalance_runs/in_memory.py | 9 | 37 |
+| 3 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
+| 4 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
+| 5 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
+| 6 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
+| 7 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
+| 8 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
+| 9 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
+| 10 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T08:32:38+00:00`
+- Generated at: `2026-06-12T08:36:49+00:00`
 
-- Current ref: `f688bb15`
+- Current ref: `8b87deca`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T08:36:49+00:00`
+- Generated at: `2026-06-12T08:40:21+00:00`
 
-- Current ref: `8b87deca`
+- Current ref: `74f189dc`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-05T11:41:04+00:00`
+- Generated at: `2026-06-12T08:32:38+00:00`
 
-- Current ref: `e204b141`
+- Current ref: `f688bb15`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-05T11:41:04+00:00`
+- Generated at: `2026-06-12T08:32:38+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `e204b141`
+- Current ref: `f688bb15`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 806 | 811 | +5 |
-| Total Python LOC | 161062 | 163248 | +2186 |
-| Test functions | 2259 | 2307 | +48 |
+| Python files | 811 | 812 | +1 |
+| Total Python LOC | 163248 | 163613 | +365 |
+| Test functions | 2307 | 2318 | +11 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -55,7 +55,7 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2225 |
+| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2305 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
 | 8 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2071 |
 | 9 | src/core/dpm_source_context.py | 1886 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T08:36:49+00:00`
+- Generated at: `2026-06-12T08:40:21+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `8b87deca`
+- Current ref: `74f189dc`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 811 | 812 | +1 |
-| Total Python LOC | 163248 | 163741 | +493 |
-| Test functions | 2307 | 2320 | +13 |
+| Total Python LOC | 163248 | 163878 | +630 |
+| Test functions | 2307 | 2322 | +15 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -55,7 +55,7 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2305 |
+| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2152 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
 | 9 | src/core/dpm_source_context.py | 1886 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T08:32:38+00:00`
+- Generated at: `2026-06-12T08:36:49+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f688bb15`
+- Current ref: `8b87deca`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 811 | 812 | +1 |
-| Total Python LOC | 163248 | 163613 | +365 |
-| Test functions | 2307 | 2318 | +11 |
+| Total Python LOC | 163248 | 163741 | +493 |
+| Test functions | 2307 | 2320 | +13 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -56,8 +56,8 @@
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2305 |
-| 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
-| 8 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2071 |
+| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2152 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |
 

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -208,32 +208,17 @@ def realized_concentration_source_from_concentration_response(
             f"lotus-risk concentration response is missing a numeric {measure} value"
         )
 
-    reason_codes = [
-        _primary_reason(source_state),
-        f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
-        f"RISK_REASON_{supportability_reason.upper()}",
-        f"RISK_CONCENTRATION_MEASURE_{measure.upper()}",
-        "RISK_CONCENTRATION_INPUT_MODE_"
-        f"{(_read_text(response.get('input_mode')) or 'UNKNOWN').upper()}",
-    ]
-    if issuer_coverage_status is not None or _is_issuer_concentration_measure(measure):
-        reason_codes.append(
-            f"RISK_CONCENTRATION_ISSUER_COVERAGE_{(issuer_coverage_status or 'unknown').upper()}"
-        )
-
-    return DpmRealizedSourceSnapshot(
-        dimension="RISK_REDUCTION",
-        source_system="lotus-risk",
-        source_type="CONCENTRATION_RESPONSE",
-        source_id=f"{request_fingerprint}:{measure}",
-        value=value if source_state != "NOT_SUPPORTED" else None,
-        unit=_concentration_unit(measure),
+    return _concentration_source_snapshot(
+        request_fingerprint=request_fingerprint,
+        measure=measure,
+        value=value,
         source_state=source_state,
         quality=quality,
-        observed_at=None,
         as_of_date=_read_text(metadata.get("as_of_date")),
-        content_hash=request_fingerprint,
-        reason_codes=reason_codes,
+        supportability_state=supportability_state,
+        supportability_reason=supportability_reason,
+        input_mode=_read_text(response.get("input_mode")),
+        issuer_coverage_status=issuer_coverage_status,
     )
 
 
@@ -512,6 +497,72 @@ def _concentration_value(
         "issuer_coverage_ratio_proposed": issuer.get("coverage_ratio_proposed"),
     }[measure]
     return _decimal_value(value_by_measure) if value_by_measure is not None else None
+
+
+def _concentration_source_snapshot(
+    *,
+    request_fingerprint: str,
+    measure: ConcentrationOutcomeMeasure,
+    value: Decimal | None,
+    source_state: Literal["READY", "DEGRADED", "BLOCKED", "NOT_SUPPORTED"],
+    quality: Literal[
+        "COMPLETE",
+        "STALE",
+        "UNAVAILABLE",
+        "PARTIAL",
+        "MISSING",
+        "NOT_SUPPORTED",
+    ],
+    as_of_date: str | None,
+    supportability_state: str,
+    supportability_reason: str,
+    input_mode: str | None,
+    issuer_coverage_status: str | None,
+) -> DpmRealizedSourceSnapshot:
+    return DpmRealizedSourceSnapshot(
+        dimension="RISK_REDUCTION",
+        source_system="lotus-risk",
+        source_type="CONCENTRATION_RESPONSE",
+        source_id=f"{request_fingerprint}:{measure}",
+        value=value if source_state != "NOT_SUPPORTED" else None,
+        unit=_concentration_unit(measure),
+        source_state=source_state,
+        quality=quality,
+        observed_at=None,
+        as_of_date=as_of_date,
+        content_hash=request_fingerprint,
+        reason_codes=_concentration_reason_codes(
+            source_state=source_state,
+            supportability_state=supportability_state,
+            supportability_reason=supportability_reason,
+            measure=measure,
+            input_mode=input_mode,
+            issuer_coverage_status=issuer_coverage_status,
+        ),
+    )
+
+
+def _concentration_reason_codes(
+    *,
+    source_state: str,
+    supportability_state: str,
+    supportability_reason: str,
+    measure: ConcentrationOutcomeMeasure,
+    input_mode: str | None,
+    issuer_coverage_status: str | None,
+) -> list[str]:
+    reason_codes = [
+        _primary_reason(source_state),
+        f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
+        f"RISK_REASON_{supportability_reason.upper()}",
+        f"RISK_CONCENTRATION_MEASURE_{measure.upper()}",
+        f"RISK_CONCENTRATION_INPUT_MODE_{(input_mode or 'UNKNOWN').upper()}",
+    ]
+    if issuer_coverage_status is not None or _is_issuer_concentration_measure(measure):
+        reason_codes.append(
+            f"RISK_CONCENTRATION_ISSUER_COVERAGE_{(issuer_coverage_status or 'unknown').upper()}"
+        )
+    return reason_codes
 
 
 def _rolling_window_result(

--- a/src/core/portfolio_memory/handoffs.py
+++ b/src/core/portfolio_memory/handoffs.py
@@ -123,56 +123,19 @@ class DpmPortfolioMemoryReportContext(BaseModel):
 
     @model_validator(mode="after")
     def validate_bounded_event_ref_metadata(self) -> "DpmPortfolioMemoryReportContext":
-        expected_returned = len(self.event_refs)
-        if self.event_refs_returned != expected_returned:
-            raise ValueError("event_refs_returned must equal the number of event_refs.")
-
-        expected_omitted = max(0, self.event_count - self.event_refs_returned)
-        if self.event_refs_omitted != expected_omitted:
-            raise ValueError("event_refs_omitted must equal event_count minus event_refs_returned.")
-
-        if self.event_refs_truncated != (self.event_refs_omitted > 0):
-            raise ValueError("event_refs_truncated must match event_refs_omitted posture.")
-
-        expected_ranks = list(range(1, expected_returned + 1))
-        observed_ranks = [event_ref.event_ref_selection_rank for event_ref in self.event_refs]
-        if observed_ranks != expected_ranks:
-            raise ValueError("event_ref_selection_rank values must be contiguous one-based ranks.")
-
-        missing_governance_keys = (
-            PORTFOLIO_MEMORY_REPORT_CONTEXT_REQUIRED_GOVERNANCE_KEYS - self.governance_policy.keys()
+        _validate_event_ref_counts(
+            event_count=self.event_count,
+            event_refs_returned=self.event_refs_returned,
+            event_refs_omitted=self.event_refs_omitted,
+            event_refs_truncated=self.event_refs_truncated,
+            event_ref_count=len(self.event_refs),
         )
-        if missing_governance_keys:
-            raise ValueError(
-                "governance_policy missing required keys: "
-                f"{', '.join(sorted(missing_governance_keys))}."
-            )
-
-        blank_governance_keys = [
-            key for key, value in self.governance_policy.items() if not value.strip()
-        ]
-        if blank_governance_keys:
-            raise ValueError(
-                "governance_policy values must be non-blank for keys: "
-                f"{', '.join(sorted(blank_governance_keys))}."
-            )
-
-        for (
-            event_ref_field,
-            governance_key,
-        ) in PORTFOLIO_MEMORY_REPORT_CONTEXT_EVENT_REF_GOVERNANCE_FIELDS.items():
-            expected_value = self.governance_policy[governance_key]
-            mismatched_refs = [
-                event_ref.event_identity
-                for event_ref in self.event_refs
-                if getattr(event_ref, event_ref_field) != expected_value
-            ]
-            if mismatched_refs:
-                raise ValueError(
-                    "event_refs must match governance_policy."
-                    f"{governance_key} for {event_ref_field}: "
-                    f"{', '.join(mismatched_refs)}."
-                )
+        _validate_event_ref_ranks(self.event_refs)
+        _validate_governance_policy(self.governance_policy)
+        _validate_event_ref_governance(
+            governance_policy=self.governance_policy,
+            event_refs=self.event_refs,
+        )
 
         return self
 
@@ -231,3 +194,70 @@ def _event_ref(
         audit_policy=event.audit_policy,
         access_classification=event.access_classification,
     )
+
+
+def _validate_event_ref_counts(
+    *,
+    event_count: int,
+    event_refs_returned: int,
+    event_refs_omitted: int,
+    event_refs_truncated: bool,
+    event_ref_count: int,
+) -> None:
+    if event_refs_returned != event_ref_count:
+        raise ValueError("event_refs_returned must equal the number of event_refs.")
+
+    expected_omitted = max(0, event_count - event_refs_returned)
+    if event_refs_omitted != expected_omitted:
+        raise ValueError("event_refs_omitted must equal event_count minus event_refs_returned.")
+
+    if event_refs_truncated != (event_refs_omitted > 0):
+        raise ValueError("event_refs_truncated must match event_refs_omitted posture.")
+
+
+def _validate_event_ref_ranks(event_refs: list[DpmPortfolioMemoryReportEventRef]) -> None:
+    expected_ranks = list(range(1, len(event_refs) + 1))
+    observed_ranks = [event_ref.event_ref_selection_rank for event_ref in event_refs]
+    if observed_ranks != expected_ranks:
+        raise ValueError("event_ref_selection_rank values must be contiguous one-based ranks.")
+
+
+def _validate_governance_policy(governance_policy: dict[str, str]) -> None:
+    missing_governance_keys = (
+        PORTFOLIO_MEMORY_REPORT_CONTEXT_REQUIRED_GOVERNANCE_KEYS - governance_policy.keys()
+    )
+    if missing_governance_keys:
+        raise ValueError(
+            "governance_policy missing required keys: "
+            f"{', '.join(sorted(missing_governance_keys))}."
+        )
+
+    blank_governance_keys = [key for key, value in governance_policy.items() if not value.strip()]
+    if blank_governance_keys:
+        raise ValueError(
+            "governance_policy values must be non-blank for keys: "
+            f"{', '.join(sorted(blank_governance_keys))}."
+        )
+
+
+def _validate_event_ref_governance(
+    *,
+    governance_policy: dict[str, str],
+    event_refs: list[DpmPortfolioMemoryReportEventRef],
+) -> None:
+    for (
+        event_ref_field,
+        governance_key,
+    ) in PORTFOLIO_MEMORY_REPORT_CONTEXT_EVENT_REF_GOVERNANCE_FIELDS.items():
+        expected_value = governance_policy[governance_key]
+        mismatched_refs = [
+            event_ref.event_identity
+            for event_ref in event_refs
+            if getattr(event_ref, event_ref_field) != expected_value
+        ]
+        if mismatched_refs:
+            raise ValueError(
+                "event_refs must match governance_policy."
+                f"{governance_key} for {event_ref_field}: "
+                f"{', '.join(mismatched_refs)}."
+            )

--- a/src/core/proof_packs/source_analytics.py
+++ b/src/core/proof_packs/source_analytics.py
@@ -93,45 +93,25 @@ def _risk_source_analytics(source_context: dict[str, Any]) -> ProofPackSourceAna
         return None
     payload = context.model_dump(mode="json", exclude_none=True)
     content_hash = hash_canonical_payload(payload)
-    reason_codes = list(context.reason_codes)
-    if context.supportability_status != ConstructionMethodStatus.READY and not reason_codes:
-        reason_codes.append("DPM_RISK_AUTHORITY_CONTEXT_DEGRADED")
-    source_ref = _source_ref(
-        family="risk",
-        source_system=context.source_system,
-        source_type=context.source_product_name or "RiskMetricsReport",
-        source_id=context.source_id or content_hash,
-        supportability_state=str(context.supportability_status),
-        content_hash=context.content_hash or content_hash,
-    )
     return ProofPackSourceAnalytics(
         family="risk",
         state=_section_state(context.supportability_status),
         summary="Risk impact is attached from source-owned risk authority context.",
-        facts={
-            "source_system": context.source_system,
-            "source_product_name": context.source_product_name or "RiskMetricsReport",
-            "source_product_version": context.source_product_version,
-            "source_id": context.source_id,
-            "issuer_coverage_status": context.issuer_coverage_status,
-        },
-        metrics={
-            key: value
-            for key, value in {
-                "tracking_error": context.tracking_error,
-                "maximum_drawdown": context.maximum_drawdown,
-                "average_drawdown": context.average_drawdown,
-                "stress_loss_pct": context.stress_loss_pct,
-                "stress_contribution_count": context.stress_contribution_count,
-                "attribution_contributor_count": context.attribution_contributor_count,
-                "concentration_breaches": context.concentration_breaches,
-                "concentration_hhi_delta": context.concentration_hhi_delta,
-                "top_position_weight_proposed": context.top_position_weight_proposed,
-            }.items()
-            if value is not None
-        },
-        reason_codes=reason_codes,
-        source_ref=source_ref,
+        facts=_risk_source_facts(context),
+        metrics=_risk_source_metrics(context),
+        reason_codes=_authority_reason_codes(
+            context=context,
+            degraded_reason="DPM_RISK_AUTHORITY_CONTEXT_DEGRADED",
+        ),
+        source_ref=_authority_source_ref(
+            family="risk",
+            source_system=context.source_system,
+            source_type=context.source_product_name or "RiskMetricsReport",
+            source_id=context.source_id,
+            supportability_status=context.supportability_status,
+            content_hash=context.content_hash,
+            fallback_hash=content_hash,
+        ),
         source_hash_key="risk_context",
         content_hash=context.content_hash or content_hash,
     )
@@ -146,47 +126,114 @@ def _performance_source_analytics(
         return None
     payload = context.model_dump(mode="json", exclude_none=True)
     content_hash = hash_canonical_payload(payload)
-    reason_codes = list(context.reason_codes)
-    if context.supportability_status != ConstructionMethodStatus.READY and not reason_codes:
-        reason_codes.append("DPM_PERFORMANCE_CONTEXT_DEGRADED")
-    source_ref = _source_ref(
-        family="performance",
-        source_system=context.source_system,
-        source_type=context.source_product_name or "PerformanceBenchmarkContext",
-        source_id=context.source_id or content_hash,
-        supportability_state=str(context.supportability_status),
-        content_hash=context.content_hash or content_hash,
-    )
     return ProofPackSourceAnalytics(
         family="performance",
         state=_section_state(context.supportability_status),
         summary="Performance context is attached from source-owned performance authority context.",
-        facts={
-            "source_system": context.source_system,
-            "source_product_name": context.source_product_name or "PerformanceBenchmarkContext",
-            "source_product_version": context.source_product_version,
-            "source_id": context.source_id,
-            "benchmark_id": context.benchmark_id,
-        },
-        metrics={
-            key: value
-            for key, value in {
-                "active_return": context.active_return,
-                "benchmark_relative_return": context.benchmark_relative_return,
-                "contribution_total_return": context.contribution_total_return,
-                "attribution_allocation": context.attribution_allocation,
-                "attribution_selection": context.attribution_selection,
-                "attribution_interaction": context.attribution_interaction,
-                "currency_attribution_total": context.currency_attribution_total,
-                "underperformance_flag": context.underperformance_flag,
-            }.items()
-            if value is not None
-        },
-        reason_codes=reason_codes,
-        source_ref=source_ref,
+        facts=_performance_source_facts(context),
+        metrics=_performance_source_metrics(context),
+        reason_codes=_authority_reason_codes(
+            context=context,
+            degraded_reason="DPM_PERFORMANCE_CONTEXT_DEGRADED",
+        ),
+        source_ref=_authority_source_ref(
+            family="performance",
+            source_system=context.source_system,
+            source_type=context.source_product_name or "PerformanceBenchmarkContext",
+            source_id=context.source_id,
+            supportability_status=context.supportability_status,
+            content_hash=context.content_hash,
+            fallback_hash=content_hash,
+        ),
         source_hash_key="performance_context",
         content_hash=context.content_hash or content_hash,
     )
+
+
+def _authority_reason_codes(
+    *,
+    context: AuthoritativeRiskContext | AuthoritativePerformanceContext,
+    degraded_reason: str,
+) -> list[str]:
+    reason_codes = list(context.reason_codes)
+    if context.supportability_status != ConstructionMethodStatus.READY and not reason_codes:
+        reason_codes.append(degraded_reason)
+    return reason_codes
+
+
+def _authority_source_ref(
+    *,
+    family: ProofPackAnalyticsFamily,
+    source_system: str,
+    source_type: str,
+    source_id: str | None,
+    supportability_status: ConstructionMethodStatus,
+    content_hash: str | None,
+    fallback_hash: str,
+) -> DpmProofPackSourceRef:
+    return _source_ref(
+        family=family,
+        source_system=source_system,
+        source_type=source_type,
+        source_id=source_id or fallback_hash,
+        supportability_state=str(supportability_status),
+        content_hash=content_hash or fallback_hash,
+    )
+
+
+def _risk_source_facts(context: AuthoritativeRiskContext) -> dict[str, Any]:
+    return {
+        "source_system": context.source_system,
+        "source_product_name": context.source_product_name or "RiskMetricsReport",
+        "source_product_version": context.source_product_version,
+        "source_id": context.source_id,
+        "issuer_coverage_status": context.issuer_coverage_status,
+    }
+
+
+def _risk_source_metrics(context: AuthoritativeRiskContext) -> dict[str, Any]:
+    return _present_metrics(
+        {
+            "tracking_error": context.tracking_error,
+            "maximum_drawdown": context.maximum_drawdown,
+            "average_drawdown": context.average_drawdown,
+            "stress_loss_pct": context.stress_loss_pct,
+            "stress_contribution_count": context.stress_contribution_count,
+            "attribution_contributor_count": context.attribution_contributor_count,
+            "concentration_breaches": context.concentration_breaches,
+            "concentration_hhi_delta": context.concentration_hhi_delta,
+            "top_position_weight_proposed": context.top_position_weight_proposed,
+        }
+    )
+
+
+def _performance_source_facts(context: AuthoritativePerformanceContext) -> dict[str, Any]:
+    return {
+        "source_system": context.source_system,
+        "source_product_name": context.source_product_name or "PerformanceBenchmarkContext",
+        "source_product_version": context.source_product_version,
+        "source_id": context.source_id,
+        "benchmark_id": context.benchmark_id,
+    }
+
+
+def _performance_source_metrics(context: AuthoritativePerformanceContext) -> dict[str, Any]:
+    return _present_metrics(
+        {
+            "active_return": context.active_return,
+            "benchmark_relative_return": context.benchmark_relative_return,
+            "contribution_total_return": context.contribution_total_return,
+            "attribution_allocation": context.attribution_allocation,
+            "attribution_selection": context.attribution_selection,
+            "attribution_interaction": context.attribution_interaction,
+            "currency_attribution_total": context.currency_attribution_total,
+            "underperformance_flag": context.underperformance_flag,
+        }
+    )
+
+
+def _present_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in metrics.items() if value is not None}
 
 
 def _transaction_cost_source_analytics(

--- a/src/core/waves/campaign_definition_approval_decisions.py
+++ b/src/core/waves/campaign_definition_approval_decisions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Literal
 
@@ -15,6 +16,15 @@ from src.core.waves.models import DpmWaveSourceRef
 from src.core.waves.campaign_page_validation import validate_page_count
 
 CampaignApprovalDecisionType = Literal["APPROVED", "REJECTED", "REQUIRES_REMEDIATION"]
+
+
+@dataclass(frozen=True)
+class _ApprovalDecisionInput:
+    decision_ref: str
+    decided_by: str
+    decision_reason: str
+    correlation_id: str
+    source_refs: list[DpmWaveSourceRef]
 
 
 class DpmBulkReviewCampaignDefinitionApprovalDecisionPage(BaseModel):
@@ -50,33 +60,88 @@ def record_bulk_review_campaign_definition_approval_decision(
     correlation_id: str,
     source_refs: list[DpmWaveSourceRef] | None = None,
 ) -> DpmBulkReviewCampaignDefinition:
-    if definition.status != "ACTIVE":
-        raise ValueError("BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_ACTIVE_REQUIRED")
-    if not decision_ref.strip():
-        raise ValueError("BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_REF_REQUIRED")
-    if not decided_by.strip():
-        raise ValueError("BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_ACTOR_REQUIRED")
-    if not decision_reason.strip():
-        raise ValueError("BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_REASON_REQUIRED")
-    if not correlation_id.strip():
-        raise ValueError("BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_CORRELATION_REQUIRED")
+    _validate_active_campaign_definition(definition)
+    decision_input = _approval_decision_input(
+        decision_ref=decision_ref,
+        decided_by=decided_by,
+        decision_reason=decision_reason,
+        correlation_id=correlation_id,
+        source_refs=source_refs,
+    )
 
     decision = _build_decision(
         definition=definition,
         decision_type=decision_type,
-        decision_ref=decision_ref.strip(),
-        decided_by=decided_by.strip(),
-        decision_reason=decision_reason.strip(),
-        correlation_id=correlation_id.strip(),
-        source_refs=source_refs or [],
+        decision_ref=decision_input.decision_ref,
+        decided_by=decision_input.decided_by,
+        decision_reason=decision_input.decision_reason,
+        correlation_id=decision_input.correlation_id,
+        source_refs=decision_input.source_refs,
     )
-    existing_refs = {existing.decision_ref: existing for existing in definition.approval_decisions}
-    existing = existing_refs.get(decision.decision_ref)
+    existing = _existing_approval_decision(definition=definition, decision=decision)
     if existing is not None:
         if existing.content_hash == decision.content_hash:
             return definition
         raise ValueError("BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_REF_CONFLICT")
 
+    return _append_approval_decision(definition=definition, decision=decision)
+
+
+def _validate_active_campaign_definition(definition: DpmBulkReviewCampaignDefinition) -> None:
+    if definition.status != "ACTIVE":
+        raise ValueError("BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_ACTIVE_REQUIRED")
+
+
+def _approval_decision_input(
+    *,
+    decision_ref: str,
+    decided_by: str,
+    decision_reason: str,
+    correlation_id: str,
+    source_refs: list[DpmWaveSourceRef] | None,
+) -> _ApprovalDecisionInput:
+    return _ApprovalDecisionInput(
+        decision_ref=_required_approval_decision_text(
+            decision_ref,
+            "BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_REF_REQUIRED",
+        ),
+        decided_by=_required_approval_decision_text(
+            decided_by,
+            "BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_ACTOR_REQUIRED",
+        ),
+        decision_reason=_required_approval_decision_text(
+            decision_reason,
+            "BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_REASON_REQUIRED",
+        ),
+        correlation_id=_required_approval_decision_text(
+            correlation_id,
+            "BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_CORRELATION_REQUIRED",
+        ),
+        source_refs=source_refs or [],
+    )
+
+
+def _required_approval_decision_text(value: str, error_code: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(error_code)
+    return normalized
+
+
+def _existing_approval_decision(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+    decision: DpmBulkReviewCampaignDefinitionApprovalDecision,
+) -> DpmBulkReviewCampaignDefinitionApprovalDecision | None:
+    existing_refs = {existing.decision_ref: existing for existing in definition.approval_decisions}
+    return existing_refs.get(decision.decision_ref)
+
+
+def _append_approval_decision(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+    decision: DpmBulkReviewCampaignDefinitionApprovalDecision,
+) -> DpmBulkReviewCampaignDefinition:
     updated = definition.model_copy(
         update={
             "approval_decisions": [*definition.approval_decisions, decision],

--- a/src/core/waves/campaign_definition_lifecycle.py
+++ b/src/core/waves/campaign_definition_lifecycle.py
@@ -75,16 +75,43 @@ def supersede_bulk_review_campaign_definition(
             "BULK_REVIEW_CAMPAIGN_DEFINITION_LIFECYCLE_CONFLICT",
             "Only active campaign definitions can be superseded.",
         )
-    replacement_version = replacement_version.strip()
-    if not replacement_version or replacement_version == campaign_version:
-        raise DpmBulkReviewCampaignDefinitionLifecycleError(
-            "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_VERSION_INVALID",
-            "superseded_by_campaign_version must identify a different version.",
-        )
+    replacement_version = _validated_replacement_version(
+        replacement_version=replacement_version,
+        current_version=campaign_version,
+    )
     replacement = repository.get_definition(
         campaign_id=campaign_id,
         campaign_version=replacement_version,
     )
+    replacement = _validated_active_replacement(replacement)
+    superseded_definition = _superseded_campaign_definition(
+        existing=existing,
+        replacement=replacement,
+        superseded_by=superseded_by,
+        supersession_reason=supersession_reason,
+        correlation_id=correlation_id,
+        superseded_at=superseded_at,
+    )
+    return repository.supersede_definition(definition=superseded_definition)
+
+
+def _validated_replacement_version(
+    *,
+    replacement_version: str,
+    current_version: str,
+) -> str:
+    normalized = replacement_version.strip()
+    if not normalized or normalized == current_version:
+        raise DpmBulkReviewCampaignDefinitionLifecycleError(
+            "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_VERSION_INVALID",
+            "superseded_by_campaign_version must identify a different version.",
+        )
+    return normalized
+
+
+def _validated_active_replacement(
+    replacement: DpmBulkReviewCampaignDefinition | None,
+) -> DpmBulkReviewCampaignDefinition:
     if replacement is None:
         raise DpmBulkReviewCampaignDefinitionLifecycleError(
             "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_NOT_FOUND",
@@ -95,6 +122,18 @@ def supersede_bulk_review_campaign_definition(
             "BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_NOT_ACTIVE",
             "Replacement bulk-review campaign definition must be active.",
         )
+    return replacement
+
+
+def _superseded_campaign_definition(
+    *,
+    existing: DpmBulkReviewCampaignDefinition,
+    replacement: DpmBulkReviewCampaignDefinition,
+    superseded_by: str,
+    supersession_reason: str,
+    correlation_id: str,
+    superseded_at: datetime | None,
+) -> DpmBulkReviewCampaignDefinition:
     superseded_payload = existing.model_dump(mode="python")
     superseded_payload.update(
         {
@@ -109,5 +148,4 @@ def supersede_bulk_review_campaign_definition(
             "content_hash": "",
         }
     )
-    superseded_definition = DpmBulkReviewCampaignDefinition.model_validate(superseded_payload)
-    return repository.supersede_definition(definition=superseded_definition)
+    return DpmBulkReviewCampaignDefinition.model_validate(superseded_payload)

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -13,6 +13,8 @@ from src.core.outcomes import (
 )
 from src.core.outcomes.risk_sources import (
     _absolute_drawdown_value,
+    _concentration_reason_codes,
+    _concentration_source_snapshot,
     _concentration_source_posture,
     _drawdown_source_posture,
     _historical_attribution_contributor,
@@ -672,6 +674,71 @@ def test_concentration_adapter_degrades_issuer_measure_when_coverage_is_partial(
     assert str(source.value) == "3200.0"
     assert snapshot.supportability.state == "DEGRADED"
     assert "RISK_CONCENTRATION_ISSUER_COVERAGE_PARTIAL" in source.reason_codes
+
+
+def test_concentration_reason_codes_include_issuer_coverage_when_source_supplies_status() -> None:
+    assert _concentration_reason_codes(
+        source_state="READY",
+        supportability_state="ready",
+        supportability_reason="calculation_complete",
+        measure="hhi_current",
+        input_mode="stateful",
+        issuer_coverage_status="complete",
+    ) == [
+        "RISK_SOURCE_READY",
+        "RISK_SUPPORTABILITY_READY",
+        "RISK_REASON_CALCULATION_COMPLETE",
+        "RISK_CONCENTRATION_MEASURE_HHI_CURRENT",
+        "RISK_CONCENTRATION_INPUT_MODE_STATEFUL",
+        "RISK_CONCENTRATION_ISSUER_COVERAGE_COMPLETE",
+    ]
+
+
+def test_concentration_reason_codes_project_unknown_coverage_for_issuer_measure() -> None:
+    reason_codes = _concentration_reason_codes(
+        source_state="DEGRADED",
+        supportability_state="ready",
+        supportability_reason="calculation_complete",
+        measure="issuer_coverage_ratio_current",
+        input_mode=None,
+        issuer_coverage_status=None,
+    )
+
+    assert reason_codes == [
+        "RISK_SOURCE_DEGRADED",
+        "RISK_SUPPORTABILITY_READY",
+        "RISK_REASON_CALCULATION_COMPLETE",
+        "RISK_CONCENTRATION_MEASURE_ISSUER_COVERAGE_RATIO_CURRENT",
+        "RISK_CONCENTRATION_INPUT_MODE_UNKNOWN",
+        "RISK_CONCENTRATION_ISSUER_COVERAGE_UNKNOWN",
+    ]
+
+
+def test_concentration_source_snapshot_suppresses_value_for_not_supported_posture() -> None:
+    source = _concentration_source_snapshot(
+        request_fingerprint="sha256:concentration-request",
+        measure="hhi_current",
+        value=Decimal("1345.677131"),
+        source_state="NOT_SUPPORTED",
+        quality="NOT_SUPPORTED",
+        as_of_date="2026-05-06",
+        supportability_state="unsupported",
+        supportability_reason="method_not_supported",
+        input_mode="stateful",
+        issuer_coverage_status=None,
+    )
+
+    assert source.source_id == "sha256:concentration-request:hhi_current"
+    assert source.value is None
+    assert source.unit == "hhi"
+    assert source.as_of_date == "2026-05-06"
+    assert source.reason_codes == [
+        "RISK_SOURCE_NOT_SUPPORTED",
+        "RISK_SUPPORTABILITY_UNSUPPORTED",
+        "RISK_REASON_METHOD_NOT_SUPPORTED",
+        "RISK_CONCENTRATION_MEASURE_HHI_CURRENT",
+        "RISK_CONCENTRATION_INPUT_MODE_STATEFUL",
+    ]
 
 
 def test_concentration_adapter_degrades_issuer_measure_when_coverage_is_missing() -> None:

--- a/tests/unit/dpm/portfolio_memory/test_handoffs.py
+++ b/tests/unit/dpm/portfolio_memory/test_handoffs.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+
+from src.core.portfolio_memory.handoffs import (
+    DpmPortfolioMemoryReportEventRef,
+    _validate_event_ref_counts,
+    _validate_event_ref_governance,
+    _validate_event_ref_ranks,
+    _validate_governance_policy,
+)
+
+
+def _governance_policy() -> dict[str, str]:
+    return {
+        "event_identity_scheme": (
+            "source_system:source_type:source_id:content_hash_or_content_hash_unavailable"
+        ),
+        "retention_policy": "DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
+        "redaction_policy": "NO_RAW_PAYLOADS",
+        "audit_policy": "AUDIT_READ_AND_EXPORT",
+        "access_classification": "CLIENT_CONFIDENTIAL_INTERNAL",
+        "source_authority_policy": (
+            "portfolio memory projects source-owned facts; consumers must not reconstruct truth"
+        ),
+    }
+
+
+def _event_ref(*, rank: int = 1) -> DpmPortfolioMemoryReportEventRef:
+    return DpmPortfolioMemoryReportEventRef(
+        event_identity="lotus-manage:PROOF_PACK:dpp_001:sha256:proof-pack",
+        event_type="PROOF_PACK_CREATED",
+        event_time="2026-05-07T10:00:00Z",
+        event_ref_selection_rank=rank,
+        source_system="lotus-manage",
+        source_type="PROOF_PACK",
+        source_id="dpp_001",
+        content_hash="sha256:proof-pack",
+        retention_policy="DPM_PORTFOLIO_MEMORY_SOURCE_LINEAGE_7Y",
+        redaction_policy="NO_RAW_PAYLOADS",
+        audit_policy="AUDIT_READ_AND_EXPORT",
+        access_classification="CLIENT_CONFIDENTIAL_INTERNAL",
+    )
+
+
+def test_event_ref_counts_accept_consistent_bounded_projection() -> None:
+    _validate_event_ref_counts(
+        event_count=3,
+        event_refs_returned=1,
+        event_refs_omitted=2,
+        event_refs_truncated=True,
+        event_ref_count=1,
+    )
+
+
+def test_event_ref_counts_reject_inconsistent_returned_count() -> None:
+    with pytest.raises(ValueError, match="event_refs_returned must equal"):
+        _validate_event_ref_counts(
+            event_count=3,
+            event_refs_returned=2,
+            event_refs_omitted=1,
+            event_refs_truncated=True,
+            event_ref_count=1,
+        )
+
+
+def test_event_ref_ranks_require_contiguous_one_based_values() -> None:
+    _validate_event_ref_ranks([_event_ref(rank=1)])
+
+    with pytest.raises(ValueError, match="contiguous one-based ranks"):
+        _validate_event_ref_ranks([_event_ref(rank=2)])
+
+
+def test_governance_policy_requires_complete_non_blank_values() -> None:
+    _validate_governance_policy(_governance_policy())
+
+    missing = _governance_policy()
+    missing.pop("source_authority_policy")
+    with pytest.raises(ValueError, match="missing required keys: source_authority_policy"):
+        _validate_governance_policy(missing)
+
+    blank = _governance_policy()
+    blank["audit_policy"] = " "
+    with pytest.raises(ValueError, match="non-blank for keys: audit_policy"):
+        _validate_governance_policy(blank)
+
+
+def test_event_ref_governance_requires_refs_to_match_policy() -> None:
+    _validate_event_ref_governance(
+        governance_policy=_governance_policy(),
+        event_refs=[_event_ref()],
+    )
+
+    mismatched = _event_ref().model_copy(update={"audit_policy": "READ_ONLY"})
+    with pytest.raises(ValueError, match="event_refs must match governance_policy.audit_policy"):
+        _validate_event_ref_governance(
+            governance_policy=_governance_policy(),
+            event_refs=[mismatched],
+        )

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -35,9 +35,15 @@ from src.core.proof_packs.models import DpmProofPackSourceRef
 from src.core.proof_packs.source_analytics import (
     ProofPackAnalyticsFamily,
     ProofPackSourceAnalytics,
+    _authority_reason_codes,
+    _authority_source_ref,
     _missing_regime_stress_governance_evidence,
+    _performance_source_facts,
+    _performance_source_metrics,
     _regime_source_reason_posture,
     _regime_stress_governance_posture_facts,
+    _risk_source_facts,
+    _risk_source_metrics,
     source_analytics_for_alternative,
     source_analytics_for_context,
 )
@@ -1846,6 +1852,81 @@ def test_source_analytics_degraded_and_blocked_context_fallbacks() -> None:
         "REGIME_SCENARIO_CIO_APPROVAL_EVIDENCE_MISSING",
         "REGIME_SCENARIO_EFFECTIVE_PERIOD_EVIDENCE_MISSING",
     ]
+
+
+def test_risk_source_analytics_helpers_project_facts_metrics_and_degraded_reason() -> None:
+    context = AuthoritativeRiskContext(
+        supportability_status="DEGRADED",
+        source_system="lotus-risk",
+        source_product_name="RiskMetricsReport",
+        source_product_version="v1",
+        source_id="risk-context-001",
+        issuer_coverage_status="partial",
+        tracking_error=Decimal("0.034"),
+        maximum_drawdown=Decimal("-0.070"),
+    )
+
+    assert _risk_source_facts(context) == {
+        "source_system": "lotus-risk",
+        "source_product_name": "RiskMetricsReport",
+        "source_product_version": "v1",
+        "source_id": "risk-context-001",
+        "issuer_coverage_status": "partial",
+    }
+    assert _risk_source_metrics(context) == {
+        "tracking_error": Decimal("0.034"),
+        "maximum_drawdown": Decimal("-0.070"),
+    }
+    assert _authority_reason_codes(
+        context=context,
+        degraded_reason="DPM_RISK_AUTHORITY_CONTEXT_DEGRADED",
+    ) == ["DPM_RISK_AUTHORITY_CONTEXT_DEGRADED"]
+
+
+def test_performance_source_analytics_helpers_project_facts_metrics_and_source_ref() -> None:
+    context = AuthoritativePerformanceContext(
+        supportability_status="READY",
+        source_system="lotus-performance",
+        source_product_name="PerformanceBenchmarkContext",
+        source_product_version="v1",
+        source_id="performance-context-001",
+        content_hash="sha256:performance-context",
+        benchmark_id="MSCI_ACWI",
+        active_return=Decimal("0.011"),
+        underperformance_flag=True,
+        reason_codes=["PERFORMANCE_CONTEXT_READY"],
+    )
+
+    assert _performance_source_facts(context) == {
+        "source_system": "lotus-performance",
+        "source_product_name": "PerformanceBenchmarkContext",
+        "source_product_version": "v1",
+        "source_id": "performance-context-001",
+        "benchmark_id": "MSCI_ACWI",
+    }
+    assert _performance_source_metrics(context) == {
+        "active_return": Decimal("0.011"),
+        "underperformance_flag": True,
+    }
+    assert _authority_reason_codes(
+        context=context,
+        degraded_reason="DPM_PERFORMANCE_CONTEXT_DEGRADED",
+    ) == ["PERFORMANCE_CONTEXT_READY"]
+
+    source_ref = _authority_source_ref(
+        family="performance",
+        source_system=context.source_system,
+        source_type=context.source_product_name or "PerformanceBenchmarkContext",
+        source_id=context.source_id,
+        supportability_status=context.supportability_status,
+        content_hash=context.content_hash,
+        fallback_hash="sha256:fallback",
+    )
+
+    assert source_ref.source_system == "lotus-performance"
+    assert source_ref.source_type == "PerformanceBenchmarkContext"
+    assert source_ref.source_id == "performance-context-001"
+    assert source_ref.content_hash == "sha256:performance-context"
 
 
 def test_regime_scenario_pack_missing_governance_evidence_is_pending_review() -> None:

--- a/tests/unit/dpm/waves/test_campaign_definition_repository.py
+++ b/tests/unit/dpm/waves/test_campaign_definition_repository.py
@@ -31,6 +31,11 @@ from src.core.waves.campaign_definition_launch_execution import (
     build_bulk_review_campaign_definition_launch_command,
 )
 from src.core.waves.campaign_definition_approval_decisions import (
+    _append_approval_decision,
+    _approval_decision_input,
+    _build_decision,
+    _existing_approval_decision,
+    _validate_active_campaign_definition,
     build_bulk_review_campaign_definition_approval_decision_page,
     record_bulk_review_campaign_definition_approval_decision,
 )
@@ -576,6 +581,73 @@ def test_campaign_definition_approval_decision_validation_edges() -> None:
         }
         with pytest.raises(ValueError, match=reason_code):
             record_bulk_review_campaign_definition_approval_decision(**request)
+
+
+def test_campaign_approval_decision_helpers_normalize_request_fields() -> None:
+    source_ref = DpmWaveSourceRef(
+        source_system="lotus-manage",
+        source_type="BulkReviewCampaignApprovalMinutes",
+        source_id="minutes-001",
+    )
+    decision_input = _approval_decision_input(
+        decision_ref=" BRC-APPROVAL-2026-05-001 ",
+        decided_by=" cio_ops_committee ",
+        decision_reason=" Approved for bounded DPM campaign launch. ",
+        correlation_id=" corr-campaign-approval-decision-001 ",
+        source_refs=[source_ref],
+    )
+
+    assert decision_input.decision_ref == "BRC-APPROVAL-2026-05-001"
+    assert decision_input.decided_by == "cio_ops_committee"
+    assert decision_input.decision_reason == "Approved for bounded DPM campaign launch."
+    assert decision_input.correlation_id == "corr-campaign-approval-decision-001"
+    assert decision_input.source_refs == [source_ref]
+
+    with pytest.raises(ValueError, match="BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_REF_REQUIRED"):
+        _approval_decision_input(
+            decision_ref=" ",
+            decided_by="cio_ops_committee",
+            decision_reason="Approved for bounded DPM campaign launch.",
+            correlation_id="corr-campaign-approval-decision-001",
+            source_refs=None,
+        )
+
+
+def test_campaign_approval_decision_helpers_detect_active_and_existing_posture() -> None:
+    definition = _definition()
+    _validate_active_campaign_definition(definition)
+    decision = _build_decision(
+        definition=definition,
+        decision_type="APPROVED",
+        decision_ref="BRC-APPROVAL-2026-05-001",
+        decided_by="cio_ops_committee",
+        decision_reason="Approved for bounded DPM campaign launch.",
+        correlation_id="corr-campaign-approval-decision-001",
+        source_refs=[],
+    )
+
+    updated = _append_approval_decision(definition=definition, decision=decision)
+
+    assert _existing_approval_decision(definition=updated, decision=decision) == decision
+    assert updated.approval_decisions == [decision]
+    assert updated.content_hash != definition.content_hash
+
+    retired = DpmBulkReviewCampaignDefinition.model_validate(
+        {
+            **definition.model_dump(mode="python"),
+            "status": "RETIRED",
+            "retired_at": "2026-05-11T08:00:00Z",
+            "retired_by": "ops",
+            "retirement_reason": "Campaign completed.",
+            "retirement_correlation_id": "corr-campaign-definition-retire-001",
+            "content_hash": "",
+        }
+    )
+    with pytest.raises(
+        ValueError,
+        match="BULK_REVIEW_CAMPAIGN_APPROVAL_DECISION_ACTIVE_REQUIRED",
+    ):
+        _validate_active_campaign_definition(retired)
 
 
 def test_campaign_definition_preview_readiness_records_ineligible_and_entitlement_edges() -> None:

--- a/tests/unit/dpm/waves/test_campaign_definition_repository.py
+++ b/tests/unit/dpm/waves/test_campaign_definition_repository.py
@@ -16,6 +16,9 @@ from src.core.waves.campaign_definition_readiness import (
 )
 from src.core.waves.campaign_definition_lifecycle import (
     DpmBulkReviewCampaignDefinitionLifecycleError,
+    _superseded_campaign_definition,
+    _validated_active_replacement,
+    _validated_replacement_version,
     retire_bulk_review_campaign_definition,
     supersede_bulk_review_campaign_definition,
 )
@@ -1367,6 +1370,83 @@ def test_campaign_definition_lifecycle_helpers_are_idempotent_and_fail_closed() 
             supersession_reason="Replacement not active.",
             correlation_id="corr-supersede-not-active-replacement",
         )
+
+
+def test_campaign_supersession_helpers_validate_replacement_version() -> None:
+    assert (
+        _validated_replacement_version(
+            replacement_version=" 2026.06 ",
+            current_version="2026.05",
+        )
+        == "2026.06"
+    )
+
+    with pytest.raises(
+        DpmBulkReviewCampaignDefinitionLifecycleError,
+        match="BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_VERSION_INVALID",
+    ):
+        _validated_replacement_version(
+            replacement_version="2026.05",
+            current_version="2026.05",
+        )
+
+
+def test_campaign_supersession_helpers_require_active_replacement() -> None:
+    active = _definition()
+    assert _validated_active_replacement(active) == active
+
+    with pytest.raises(
+        DpmBulkReviewCampaignDefinitionLifecycleError,
+        match="BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_NOT_FOUND",
+    ):
+        _validated_active_replacement(None)
+
+    with pytest.raises(
+        DpmBulkReviewCampaignDefinitionLifecycleError,
+        match="BULK_REVIEW_CAMPAIGN_SUPERSESSION_REPLACEMENT_NOT_ACTIVE",
+    ):
+        _validated_active_replacement(
+            DpmBulkReviewCampaignDefinition.model_validate(
+                {
+                    **active.model_dump(mode="python"),
+                    "status": "RETIRED",
+                    "retired_at": "2026-05-11T08:00:00Z",
+                    "retired_by": "ops",
+                    "retirement_reason": "Retired replacement.",
+                    "retirement_correlation_id": "corr-retired-replacement",
+                    "content_hash": "",
+                }
+            )
+        )
+
+
+def test_campaign_supersession_helper_builds_superseded_definition_lineage() -> None:
+    existing = _definition()
+    replacement = DpmBulkReviewCampaignDefinition.model_validate(
+        {
+            **_definition(display_name="Refreshed Apple and Tesla holdings review").model_dump(
+                mode="python"
+            ),
+            "campaign_version": "2026.06",
+            "content_hash": "",
+        }
+    )
+
+    superseded = _superseded_campaign_definition(
+        existing=existing,
+        replacement=replacement,
+        superseded_by="ops",
+        supersession_reason="Campaign candidate set refreshed.",
+        correlation_id="corr-supersede-original",
+        superseded_at=datetime(2026, 5, 12, tzinfo=timezone.utc),
+    )
+
+    assert superseded.status == "SUPERSEDED"
+    assert superseded.superseded_by == "ops"
+    assert superseded.superseded_by_campaign_id == replacement.campaign_id
+    assert superseded.superseded_by_campaign_version == "2026.06"
+    assert superseded.superseded_by_content_hash == replacement.content_hash
+    assert superseded.supersession_correlation_id == "corr-supersede-original"
 
 
 def test_in_memory_campaign_definition_repository_rejects_direct_invalid_lifecycle_state() -> None:


### PR DESCRIPTION
## Summary
- Extracted focused helpers from campaign lifecycle supersession, risk concentration source mapping, portfolio-memory report-context validation, proof-pack source analytics, and campaign approval-decision recording.
- Added direct helper tests for each extraction while preserving existing orchestration and source-owned behavior.
- Refreshed codebase review ledger and current-state quality reports through `BACKEND-REVIEW-20260612-782`.

## Evidence
- `python -m ruff check ...` focused touched files: passed
- `python -m ruff format --check ...` focused touched files: passed
- `python -m mypy --config-file mypy.ini ...` focused touched source files: passed
- Focused pytest suites: 107 passed, 72 passed, 51 passed
- `python scripts/openapi_quality_gate.py`: passed
- `python scripts/api_vocabulary_inventory.py --validate-only`: passed
- `git diff --check`: passed
- Service leakage scan: no matches
- `make check`: 2482 passed, 13 skipped
- `git fetch origin --prune`: passed
- `git branch -r --no-merged origin/main`: no unmerged remote branches
- Wiki drift: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`

## Wiki
No wiki source change required; changes are internal source/helper refactors plus repo-local review and quality evidence.