### PR TITLE
Refactor manage hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19063,3 +19063,36 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal realized-source mapping
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-785: Solver fallback helper extraction
+
+- Date: 2026-06-12
+- Scope: `src/core/target_generation.py`,
+  `tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_solve_with_fallbacks` was the next current source-complexity hotspot and combined
+  installed-solver discovery, solver availability filtering, solve invocation, compatibility
+  fallback exception handling, status normalization, and optimal-status detection in one loop.
+- Action: extracted installed-solver discovery, availability checks, individual solve-attempt
+  status handling, and optimal-status detection into focused helpers while preserving solver order,
+  compatibility fallback behavior, and latest-status reporting. Added direct helper tests for
+  unavailable installed-solver discovery, try-all availability semantics, compatibility kwarg
+  rejection, successful status normalization, and optimal-status classification. Refreshed
+  current-state quality reports and preserved stable baseline/rule artifacts; the refreshed
+  complexity report shows `_solve_with_fallbacks` dropped out of the top current source-complexity
+  list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m mypy --config-file mypy.ini src/core/target_generation.py`,
+  `python -m pytest tests/unit/core/test_target_generation_solver_fallbacks.py -q` (15 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal solver fallback maintainability
+  refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19000,3 +19000,35 @@ and improves internal transaction-cost source posture maintainability only.
   `python scripts/engineering_health_report.py` and
   `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this updates repo-local refactor evidence only.
+
+## BACKEND-REVIEW-20260612-783: In-memory rebalance-run listing helpers extracted
+
+- Date: 2026-06-12
+- Scope: `src/infrastructure/rebalance_runs/in_memory.py`,
+  `tests/unit/dpm/supportability/test_dpm_run_repository_backends.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: in-memory `list_runs` and `list_operations` were the top current source-complexity
+  hotspots and duplicated optional filter checks, descending ordering, cursor lookup, unknown-cursor
+  handling, and next-cursor calculation inside repository methods.
+- Action: extracted private run and operation filter dataclasses, shared cursor-page logic, and
+  focused list helpers while leaving repository locking and deepcopy boundaries in
+  `InMemoryDpmRunRepository`. Added direct helper tests for filter combinations, newest-first
+  ordering, cursor pagination, and unknown-cursor empty-page behavior. Refreshed current-state
+  quality reports and preserved stable baseline/rule artifacts; the refreshed complexity report
+  shows `list_runs` and `list_operations` dropped out of the top current source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/rebalance_runs/in_memory.py tests/unit/dpm/supportability/test_dpm_run_repository_backends.py`,
+  `python -m ruff format --check src/infrastructure/rebalance_runs/in_memory.py tests/unit/dpm/supportability/test_dpm_run_repository_backends.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/rebalance_runs/in_memory.py`,
+  `python -m pytest tests/unit/dpm/supportability/test_dpm_run_repository_backends.py -q`
+  (41 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal in-memory repository
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19032,3 +19032,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal in-memory repository
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-784: Realized outcome metric source helpers extracted
+
+- Date: 2026-06-12
+- Scope: `src/core/outcomes/realized_sources.py`,
+  `tests/unit/core/test_realized_outcome_sources.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_metric_from_sources` was the next current source-complexity hotspot and mixed missing
+  source handling, conflicting source-owner value detection, source-state mapping, blocked/not
+  supported value suppression, missing ready-value blocking, and metric construction in one helper.
+- Action: extracted source-value conflict detection, single-source metric construction,
+  state-aware value selection, and missing-ready-value detection into direct pure helpers. Added
+  focused tests for conflict detection, blocked/not-supported value suppression, and state-specific
+  missing-value behavior while preserving existing realized outcome snapshot contract tests.
+  Refreshed current-state quality reports and preserved stable baseline/rule artifacts; the
+  refreshed complexity report shows `_metric_from_sources` dropped out of the top current
+  source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/realized_sources.py tests/unit/core/test_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/realized_sources.py tests/unit/core/test_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/realized_sources.py`,
+  `python -m pytest tests/unit/core/test_realized_outcome_sources.py -q` (14 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal realized-source mapping
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T08:55:09+00:00`
+- Generated at: `2026-06-12T08:58:03+00:00`
 
-- Current ref: `cb77ef64`
+- Current ref: `c6d5c5c9`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
-| 2 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
-| 3 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
-| 4 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
-| 5 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
-| 6 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
-| 7 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
-| 8 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
-| 9 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
-| 10 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
+| 1 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
+| 2 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
+| 3 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
+| 4 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
+| 5 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
+| 6 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
+| 7 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
+| 8 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
+| 9 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
+| 10 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T08:40:21+00:00`
+- Generated at: `2026-06-12T08:55:09+00:00`
 
-- Current ref: `74f189dc`
+- Current ref: `cb77ef64`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | list_operations | src/infrastructure/rebalance_runs/in_memory.py | 9 | 39 |
-| 2 | list_runs | src/infrastructure/rebalance_runs/in_memory.py | 9 | 37 |
-| 3 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
-| 4 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
-| 5 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
-| 6 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
-| 7 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
-| 8 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
-| 9 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
-| 10 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
+| 1 | _metric_from_sources | src/core/outcomes/realized_sources.py | 9 | 35 |
+| 2 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
+| 3 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
+| 4 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
+| 5 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
+| 6 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
+| 7 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
+| 8 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
+| 9 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
+| 10 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T08:58:03+00:00`
+- Generated at: `2026-06-12T09:00:33+00:00`
 
-- Current ref: `c6d5c5c9`
+- Current ref: `6adb7e7a`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _solve_with_fallbacks | src/core/target_generation.py | 9 | 32 |
-| 2 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
-| 3 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
-| 4 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
-| 5 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
-| 6 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
-| 7 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
-| 8 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
-| 9 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
-| 10 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
+| 1 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
+| 2 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
+| 3 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
+| 4 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
+| 5 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
+| 6 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
+| 7 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
+| 8 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
+| 9 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
+| 10 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T08:55:09+00:00`
+- Generated at: `2026-06-12T08:58:03+00:00`
 
-- Current ref: `cb77ef64`
+- Current ref: `c6d5c5c9`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T08:58:03+00:00`
+- Generated at: `2026-06-12T09:00:33+00:00`
 
-- Current ref: `c6d5c5c9`
+- Current ref: `6adb7e7a`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T08:40:21+00:00`
+- Generated at: `2026-06-12T08:55:09+00:00`
 
-- Current ref: `74f189dc`
+- Current ref: `cb77ef64`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T08:55:09+00:00`
+- Generated at: `2026-06-12T08:58:03+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `cb77ef64`
+- Current ref: `c6d5c5c9`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 163878 | 164156 | +278 |
-| Test functions | 2322 | 2324 | +2 |
+| Total Python LOC | 163878 | 164243 | +365 |
+| Test functions | 2322 | 2327 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T08:58:03+00:00`
+- Generated at: `2026-06-12T09:00:33+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `c6d5c5c9`
+- Current ref: `6adb7e7a`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 163878 | 164243 | +365 |
-| Test functions | 2322 | 2327 | +5 |
+| Total Python LOC | 163878 | 164311 | +433 |
+| Test functions | 2322 | 2330 | +8 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T08:40:21+00:00`
+- Generated at: `2026-06-12T08:55:09+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `74f189dc`
+- Current ref: `cb77ef64`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 811 | 812 | +1 |
-| Total Python LOC | 163248 | 163878 | +630 |
-| Test functions | 2307 | 2322 | +15 |
+| Python files | 812 | 812 | +0 |
+| Total Python LOC | 163878 | 164156 | +278 |
+| Test functions | 2322 | 2324 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -40,9 +40,9 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2225 |
-| 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
-| 8 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2071 |
+| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
+| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2152 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |
 

--- a/src/core/outcomes/realized_sources.py
+++ b/src/core/outcomes/realized_sources.py
@@ -1,6 +1,7 @@
 """Realized source snapshot adapter for RFC-0042."""
 
 from collections import Counter
+from decimal import Decimal
 
 from src.core.outcomes.models import (
     DpmOutcomeMetricValue,
@@ -78,15 +79,29 @@ def _metric_from_sources(
 ) -> DpmOutcomeMetricValue:
     if not snapshots:
         return _missing_metric(dimension=dimension, review_window=review_window)
-    if len(snapshots) > 1:
-        values = {snapshot.value for snapshot in snapshots}
-        if len(values) > 1:
-            return _conflicting_metric(dimension=dimension, snapshots=snapshots)
-    snapshot = snapshots[0]
+    if _has_conflicting_source_values(snapshots):
+        return _conflicting_metric(dimension=dimension, snapshots=snapshots)
+    return _single_source_metric(
+        dimension=dimension,
+        review_window=review_window,
+        snapshot=snapshots[0],
+    )
+
+
+def _has_conflicting_source_values(snapshots: list[DpmRealizedSourceSnapshot]) -> bool:
+    return len({snapshot.value for snapshot in snapshots}) > 1
+
+
+def _single_source_metric(
+    *,
+    dimension: OutcomeDimension,
+    review_window: DpmOutcomeReviewWindow,
+    snapshot: DpmRealizedSourceSnapshot,
+) -> DpmOutcomeMetricValue:
     state = _state_from_source(snapshot)
     reason_code = _reason_code(dimension=dimension, snapshot=snapshot, state=state)
-    value = snapshot.value if state not in {"BLOCKED", "NOT_SUPPORTED"} else None
-    if state == "READY" and value is None:
+    value = _source_value_for_state(snapshot=snapshot, state=state)
+    if _ready_source_value_is_missing(state=state, value=value):
         state = "BLOCKED"
         reason_code = _blocked_reason(dimension)
     return DpmOutcomeMetricValue(
@@ -105,6 +120,24 @@ def _metric_from_sources(
             explanation=_supportability_explanation(snapshot=snapshot, state=state),
         ),
     )
+
+
+def _source_value_for_state(
+    *,
+    snapshot: DpmRealizedSourceSnapshot,
+    state: OutcomeDimensionState,
+) -> Decimal | None:
+    if state in {"BLOCKED", "NOT_SUPPORTED"}:
+        return None
+    return snapshot.value
+
+
+def _ready_source_value_is_missing(
+    *,
+    state: OutcomeDimensionState,
+    value: Decimal | None,
+) -> bool:
+    return state == "READY" and value is None
 
 
 def _missing_metric(

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -57,36 +57,65 @@ def _build_solver_attempts(cp: Any) -> tuple[tuple[Any, tuple[dict[str, Any], ..
 
 def _solve_with_fallbacks(prob: Any, cp: Any) -> tuple[bool, str | None]:
     latest_status: str | None = None
-    installed: set[str] = set()
-    try:
-        installed = {str(s) for s in cp.installed_solvers()}
-    except (AttributeError, TypeError, ValueError):
-        installed = set()
+    installed = _installed_solver_names(cp)
 
     for solver_name, kwargs_attempts in _build_solver_attempts(cp):
-        if installed and str(solver_name) not in installed:
+        if not _solver_is_available(solver_name=solver_name, installed=installed):
             continue
 
         for solve_kwargs in kwargs_attempts:
-            try:
-                prob.solve(
-                    solver=solver_name,
-                    verbose=False,
-                    warm_start=False,
-                    **solve_kwargs,
-                )
-            except TypeError:
-                # Binding rejected one or more kwargs; try compatibility profile.
-                continue
-            except (cp.SolverError, ValueError):
-                # Runtime/configuration failure; still try compatibility profile.
+            attempt_status = _solve_attempt_status(
+                prob=prob,
+                cp=cp,
+                solver_name=solver_name,
+                solve_kwargs=solve_kwargs,
+            )
+            if attempt_status is None:
                 continue
 
-            latest_status = str(prob.status).lower()
-            if latest_status in _SOLVER_STATUS_OPTIMAL:
+            latest_status = attempt_status
+            if _solver_status_is_optimal(latest_status):
                 return True, latest_status
 
     return False, latest_status
+
+
+def _installed_solver_names(cp: Any) -> set[str]:
+    try:
+        return {str(solver_name) for solver_name in cp.installed_solvers()}
+    except (AttributeError, TypeError, ValueError):
+        return set()
+
+
+def _solver_is_available(*, solver_name: Any, installed: set[str]) -> bool:
+    return not installed or str(solver_name) in installed
+
+
+def _solve_attempt_status(
+    *,
+    prob: Any,
+    cp: Any,
+    solver_name: Any,
+    solve_kwargs: dict[str, Any],
+) -> str | None:
+    try:
+        prob.solve(
+            solver=solver_name,
+            verbose=False,
+            warm_start=False,
+            **solve_kwargs,
+        )
+    except TypeError:
+        # Binding rejected one or more kwargs; try compatibility profile.
+        return None
+    except (cp.SolverError, ValueError):
+        # Runtime/configuration failure; still try compatibility profile.
+        return None
+    return str(prob.status).lower()
+
+
+def _solver_status_is_optimal(status: str) -> bool:
+    return status in _SOLVER_STATUS_OPTIMAL
 
 
 def _solver_failure_reason(latest_status: str | None) -> str:

--- a/src/infrastructure/rebalance_runs/in_memory.py
+++ b/src/infrastructure/rebalance_runs/in_memory.py
@@ -1,9 +1,10 @@
 import json
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from threading import Lock
-from typing import Any, Optional
+from typing import Any, Optional, TypeVar
 
 from src.core.rebalance_runs.models import (
     DpmAsyncOperationRecord,
@@ -15,6 +16,8 @@ from src.core.rebalance_runs.models import (
     DpmSupportabilitySummaryData,
 )
 from src.core.rebalance_runs.repository import DpmRunRepository, DpmRunRepositoryConflictError
+
+_T = TypeVar("_T")
 
 
 @dataclass(frozen=True)
@@ -36,6 +39,140 @@ class _WorkflowDecisionFilters:
     reason_code: str | None
     decided_from: datetime | None
     decided_to: datetime | None
+
+
+@dataclass(frozen=True)
+class _RunListFilters:
+    created_from: datetime | None
+    created_to: datetime | None
+    status: str | None
+    request_hash: str | None
+    portfolio_id: str | None
+
+
+@dataclass(frozen=True)
+class _OperationListFilters:
+    created_from: datetime | None
+    created_to: datetime | None
+    operation_type: str | None
+    status: str | None
+    correlation_id: str | None
+
+
+def _optional_datetime_is_on_or_after(
+    actual: datetime,
+    lower_bound: datetime | None,
+) -> bool:
+    return lower_bound is None or actual >= lower_bound
+
+
+def _optional_datetime_is_on_or_before(
+    actual: datetime,
+    upper_bound: datetime | None,
+) -> bool:
+    return upper_bound is None or actual <= upper_bound
+
+
+def _run_matches_filters(run: DpmRunRecord, filters: _RunListFilters) -> bool:
+    return all(
+        (
+            _optional_datetime_is_on_or_after(run.created_at, filters.created_from),
+            _optional_datetime_is_on_or_before(run.created_at, filters.created_to),
+            _optional_value_matches(str(run.result_json.get("status", "")), filters.status),
+            _optional_value_matches(run.request_hash, filters.request_hash),
+            _optional_value_matches(run.portfolio_id, filters.portfolio_id),
+        )
+    )
+
+
+def _operation_matches_filters(
+    operation: DpmAsyncOperationRecord,
+    filters: _OperationListFilters,
+) -> bool:
+    return all(
+        (
+            _optional_datetime_is_on_or_after(operation.created_at, filters.created_from),
+            _optional_datetime_is_on_or_before(operation.created_at, filters.created_to),
+            _optional_value_matches(operation.operation_type, filters.operation_type),
+            _optional_value_matches(operation.status, filters.status),
+            _optional_value_matches(operation.correlation_id, filters.correlation_id),
+        )
+    )
+
+
+def _sorted_filtered_runs(
+    runs: Sequence[DpmRunRecord],
+    filters: _RunListFilters,
+) -> list[DpmRunRecord]:
+    return sorted(
+        (run for run in runs if _run_matches_filters(run, filters)),
+        key=lambda item: (item.created_at, item.rebalance_run_id),
+        reverse=True,
+    )
+
+
+def _sorted_filtered_operations(
+    operations: Sequence[DpmAsyncOperationRecord],
+    filters: _OperationListFilters,
+) -> list[DpmAsyncOperationRecord]:
+    return sorted(
+        (operation for operation in operations if _operation_matches_filters(operation, filters)),
+        key=lambda item: (item.created_at, item.operation_id),
+        reverse=True,
+    )
+
+
+def _cursor_page(
+    rows: Sequence[_T],
+    *,
+    limit: int,
+    cursor: str | None,
+    identity: Callable[[_T], str],
+) -> tuple[list[_T], str | None]:
+    page_source = list(rows)
+    if cursor is not None:
+        cursor_index = next(
+            (index for index, row in enumerate(page_source) if identity(row) == cursor),
+            None,
+        )
+        if cursor_index is None:
+            return [], None
+        page_source = page_source[cursor_index + 1 :]
+    page = page_source[:limit]
+    next_cursor = identity(page[-1]) if len(page_source) > limit else None
+    return page, next_cursor
+
+
+def _list_runs_filtered(
+    *,
+    runs: Sequence[DpmRunRecord],
+    filters: _RunListFilters,
+    limit: int,
+    cursor: str | None,
+) -> tuple[list[DpmRunRecord], str | None]:
+    rows = _sorted_filtered_runs(runs, filters)
+    return _cursor_page(
+        rows,
+        limit=limit,
+        cursor=cursor,
+        identity=lambda row: row.rebalance_run_id,
+    )
+
+
+def _list_operations_filtered(
+    *,
+    operations: Sequence[DpmAsyncOperationRecord],
+    filters: _OperationListFilters,
+    limit: int,
+    cursor: str | None,
+) -> tuple[list[DpmAsyncOperationRecord], str | None]:
+    rows = _sorted_filtered_operations(operations, filters)
+    return _cursor_page(
+        rows,
+        limit=limit,
+        cursor=cursor,
+        identity=lambda row: row.operation_id,
+    )
 
 
 def _expired_runs(
@@ -325,30 +462,18 @@ class InMemoryDpmRunRepository(DpmRunRepository):
         cursor: Optional[str],
     ) -> tuple[list[DpmRunRecord], Optional[str]]:
         with self._lock:
-            rows = list(self._runs.values())
-            if created_from is not None:
-                rows = [row for row in rows if row.created_at >= created_from]
-            if created_to is not None:
-                rows = [row for row in rows if row.created_at <= created_to]
-            if status is not None:
-                rows = [row for row in rows if str(row.result_json.get("status", "")) == status]
-            if request_hash is not None:
-                rows = [row for row in rows if row.request_hash == request_hash]
-            if portfolio_id is not None:
-                rows = [row for row in rows if row.portfolio_id == portfolio_id]
-            rows = sorted(
-                rows, key=lambda item: (item.created_at, item.rebalance_run_id), reverse=True
+            page, next_cursor = _list_runs_filtered(
+                runs=list(self._runs.values()),
+                filters=_RunListFilters(
+                    created_from=created_from,
+                    created_to=created_to,
+                    status=status,
+                    request_hash=request_hash,
+                    portfolio_id=portfolio_id,
+                ),
+                limit=limit,
+                cursor=cursor,
             )
-            if cursor is not None:
-                cursor_index = next(
-                    (index for index, row in enumerate(rows) if row.rebalance_run_id == cursor),
-                    None,
-                )
-                if cursor_index is None:
-                    return [], None
-                rows = rows[cursor_index + 1 :]
-            page = rows[:limit]
-            next_cursor = page[-1].rebalance_run_id if len(rows) > limit else None
             return [deepcopy(row) for row in page], next_cursor
 
     def save_run_artifact(self, *, rebalance_run_id: str, artifact_json: dict[str, Any]) -> None:
@@ -430,32 +555,18 @@ class InMemoryDpmRunRepository(DpmRunRepository):
         cursor: Optional[str],
     ) -> tuple[list[DpmAsyncOperationRecord], Optional[str]]:
         with self._lock:
-            rows = list(self._operations.values())
-            if created_from is not None:
-                rows = [row for row in rows if row.created_at >= created_from]
-            if created_to is not None:
-                rows = [row for row in rows if row.created_at <= created_to]
-            if operation_type is not None:
-                rows = [row for row in rows if row.operation_type == operation_type]
-            if status is not None:
-                rows = [row for row in rows if row.status == status]
-            if correlation_id is not None:
-                rows = [row for row in rows if row.correlation_id == correlation_id]
-            rows = sorted(
-                rows,
-                key=lambda item: (item.created_at, item.operation_id),
-                reverse=True,
+            page, next_cursor = _list_operations_filtered(
+                operations=list(self._operations.values()),
+                filters=_OperationListFilters(
+                    created_from=created_from,
+                    created_to=created_to,
+                    operation_type=operation_type,
+                    status=status,
+                    correlation_id=correlation_id,
+                ),
+                limit=limit,
+                cursor=cursor,
             )
-            if cursor is not None:
-                cursor_index = next(
-                    (index for index, row in enumerate(rows) if row.operation_id == cursor),
-                    None,
-                )
-                if cursor_index is None:
-                    return [], None
-                rows = rows[cursor_index + 1 :]
-            page = rows[:limit]
-            next_cursor = page[-1].operation_id if len(rows) > limit else None
             return [deepcopy(row) for row in page], next_cursor
 
     def purge_expired_operations(self, *, ttl_seconds: int, now: datetime) -> int:

--- a/tests/unit/core/test_realized_outcome_sources.py
+++ b/tests/unit/core/test_realized_outcome_sources.py
@@ -5,6 +5,7 @@ from src.core.outcomes import (
     DpmRealizedSourceSnapshot,
     assemble_realized_outcome_snapshot,
 )
+from src.core.outcomes import realized_sources as realized_source_helpers
 
 
 def _window() -> DpmOutcomeReviewWindow:
@@ -148,6 +149,20 @@ def test_conflicting_source_owner_values_block_dimension() -> None:
     assert {ref.source_id for ref in cost.source_refs} == {"core_cost_001", "core_cost_002"}
 
 
+def test_realized_source_conflict_helper_detects_value_disagreement_only() -> None:
+    matching = [
+        _source(dimension="COST", source_id="core_cost_001", value="126.50"),
+        _source(dimension="COST", source_id="core_cost_002", value="126.50"),
+    ]
+    conflicting = [
+        _source(dimension="COST", source_id="core_cost_001", value="126.50"),
+        _source(dimension="COST", source_id="core_cost_002", value="127.10"),
+    ]
+
+    assert realized_source_helpers._has_conflicting_source_values(matching) is False
+    assert realized_source_helpers._has_conflicting_source_values(conflicting) is True
+
+
 def test_malformed_source_blocks_without_using_partial_value() -> None:
     snapshot = assemble_realized_outcome_snapshot(
         portfolio_id="PB_SG_GLOBAL_BAL_001",
@@ -170,6 +185,24 @@ def test_malformed_source_blocks_without_using_partial_value() -> None:
     assert drift.supportability.reason_codes[0] == "SOURCE_EVIDENCE_INCOMPLETE"
 
 
+def test_realized_source_value_helper_suppresses_blocked_and_not_supported_values() -> None:
+    source = _source(dimension="RISK_REDUCTION", value="0.0100")
+
+    assert (
+        str(realized_source_helpers._source_value_for_state(snapshot=source, state="READY"))
+        == "0.0100"
+    )
+    assert (
+        realized_source_helpers._source_value_for_state(snapshot=source, state="DEGRADED")
+        == source.value
+    )
+    assert realized_source_helpers._source_value_for_state(snapshot=source, state="BLOCKED") is None
+    assert (
+        realized_source_helpers._source_value_for_state(snapshot=source, state="NOT_SUPPORTED")
+        is None
+    )
+
+
 def test_ready_source_without_value_blocks_dimension() -> None:
     snapshot = assemble_realized_outcome_snapshot(
         portfolio_id="PB_SG_GLOBAL_BAL_001",
@@ -188,6 +221,27 @@ def test_ready_source_without_value_blocks_dimension() -> None:
     assert snapshot.supportability.state == "BLOCKED"
     assert drift.supportability.state == "BLOCKED"
     assert drift.supportability.reason_codes[0] == "SOURCE_EVIDENCE_INCOMPLETE"
+
+
+def test_realized_source_missing_ready_value_helper_is_state_specific() -> None:
+    assert realized_source_helpers._ready_source_value_is_missing(
+        state="READY",
+        value=None,
+    )
+    assert (
+        realized_source_helpers._ready_source_value_is_missing(
+            state="DEGRADED",
+            value=None,
+        )
+        is False
+    )
+    assert (
+        realized_source_helpers._ready_source_value_is_missing(
+            state="READY",
+            value=_source(dimension="COST").value,
+        )
+        is False
+    )
 
 
 def test_source_owner_not_supported_degrades_mixed_snapshot_without_value() -> None:

--- a/tests/unit/core/test_target_generation_solver_fallbacks.py
+++ b/tests/unit/core/test_target_generation_solver_fallbacks.py
@@ -5,8 +5,12 @@ import pytest
 
 from src.core.models import DiagnosticsData, EngineOptions, ModelPortfolio, ModelTarget, ShelfEntry
 from src.core.target_generation import (
+    _installed_solver_names,
     _load_solver_modules,
+    _solve_attempt_status,
     _solve_with_fallbacks,
+    _solver_is_available,
+    _solver_status_is_optimal,
     build_target_trace,
     generate_targets_solver,
 )
@@ -166,6 +170,41 @@ def test_solve_with_fallbacks_skips_uninstalled_solver_and_tries_compatibility_k
     assert solved is True
     assert latest_status == "optimal"
     assert [solver for solver, _ in problem.calls] == ["SCS", "SCS"]
+
+
+def test_installed_solver_helper_returns_empty_set_when_discovery_is_unavailable() -> None:
+    class _CpWithoutInstalledSolvers:
+        pass
+
+    assert _installed_solver_names(_CpFallbackStub) == {"SCS"}
+    assert _installed_solver_names(_CpWithoutInstalledSolvers) == set()
+
+
+def test_solver_availability_helper_treats_empty_installed_set_as_try_all() -> None:
+    assert _solver_is_available(solver_name="OSQP", installed=set())
+    assert _solver_is_available(solver_name="SCS", installed={"SCS"})
+    assert _solver_is_available(solver_name="OSQP", installed={"SCS"}) is False
+
+
+def test_solve_attempt_status_handles_success_and_compatibility_failures() -> None:
+    problem = _ProblemStub()
+
+    rejected = _solve_attempt_status(
+        prob=problem,
+        cp=_CpFallbackStub,
+        solver_name="SCS",
+        solve_kwargs={"time_limit_secs": 0.5},
+    )
+    solved = _solve_attempt_status(
+        prob=problem,
+        cp=_CpFallbackStub,
+        solver_name="SCS",
+        solve_kwargs={},
+    )
+
+    assert rejected is None
+    assert solved == "optimal"
+    assert _solver_status_is_optimal(solved)
 
 
 def test_load_solver_modules_records_error_when_dependencies_are_absent(monkeypatch) -> None:

--- a/tests/unit/dpm/supportability/test_dpm_run_repository_backends.py
+++ b/tests/unit/dpm/supportability/test_dpm_run_repository_backends.py
@@ -19,8 +19,12 @@ from src.infrastructure.rebalance_runs import (
     SqliteDpmRunRepository,
 )
 from src.infrastructure.rebalance_runs.in_memory import (
+    _OperationListFilters,
+    _RunListFilters,
     _expired_run_identities,
     _expired_runs,
+    _list_operations_filtered,
+    _list_runs_filtered,
     _purge_expired_idempotency_history,
     _purge_expired_lineage_edges,
 )
@@ -336,6 +340,83 @@ def test_repository_list_runs_request_hash_filter_contract(repository):
     assert matching_cursor is None
 
 
+def test_in_memory_run_list_helper_filters_sorts_and_pages() -> None:
+    now = datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc)
+    runs = [
+        DpmRunRecord(
+            rebalance_run_id="rr_in_memory_list_1",
+            correlation_id="corr_in_memory_list_1",
+            request_hash="sha256:req-list-1",
+            idempotency_key=None,
+            portfolio_id="pf_in_memory_list_1",
+            created_at=now,
+            result_json={"rebalance_run_id": "rr_in_memory_list_1", "status": "READY"},
+        ),
+        DpmRunRecord(
+            rebalance_run_id="rr_in_memory_list_2",
+            correlation_id="corr_in_memory_list_2",
+            request_hash="sha256:req-list-2",
+            idempotency_key=None,
+            portfolio_id="pf_in_memory_list_2",
+            created_at=now + timedelta(minutes=1),
+            result_json={"rebalance_run_id": "rr_in_memory_list_2", "status": "BLOCKED"},
+        ),
+        DpmRunRecord(
+            rebalance_run_id="rr_in_memory_list_3",
+            correlation_id="corr_in_memory_list_3",
+            request_hash="sha256:req-list-3",
+            idempotency_key=None,
+            portfolio_id="pf_in_memory_list_2",
+            created_at=now + timedelta(minutes=2),
+            result_json={"rebalance_run_id": "rr_in_memory_list_3", "status": "BLOCKED"},
+        ),
+    ]
+
+    page, cursor = _list_runs_filtered(
+        runs=runs,
+        filters=_RunListFilters(
+            created_from=now + timedelta(seconds=30),
+            created_to=None,
+            status="BLOCKED",
+            request_hash=None,
+            portfolio_id="pf_in_memory_list_2",
+        ),
+        limit=1,
+        cursor=None,
+    )
+    page_two, cursor_two = _list_runs_filtered(
+        runs=runs,
+        filters=_RunListFilters(
+            created_from=now + timedelta(seconds=30),
+            created_to=None,
+            status="BLOCKED",
+            request_hash=None,
+            portfolio_id="pf_in_memory_list_2",
+        ),
+        limit=1,
+        cursor=cursor,
+    )
+    missing_page, missing_cursor = _list_runs_filtered(
+        runs=runs,
+        filters=_RunListFilters(
+            created_from=None,
+            created_to=None,
+            status=None,
+            request_hash=None,
+            portfolio_id=None,
+        ),
+        limit=10,
+        cursor="rr_missing",
+    )
+
+    assert [run.rebalance_run_id for run in page] == ["rr_in_memory_list_3"]
+    assert cursor == "rr_in_memory_list_3"
+    assert [run.rebalance_run_id for run in page_two] == ["rr_in_memory_list_2"]
+    assert cursor_two is None
+    assert missing_page == []
+    assert missing_cursor is None
+
+
 def test_repository_list_operations_filter_and_cursor_contract(repository):
     now = datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc)
     repository.create_operation(
@@ -402,6 +483,92 @@ def test_repository_list_operations_filter_and_cursor_contract(repository):
     )
     assert [operation.operation_id for operation in page_two] == ["dop_repo_list_1"]
     assert cursor_two is None
+
+
+def test_in_memory_operation_list_helper_filters_sorts_and_pages() -> None:
+    now = datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc)
+    operations = [
+        DpmAsyncOperationRecord(
+            operation_id="dop_in_memory_list_1",
+            operation_type="ANALYZE_SCENARIOS",
+            status="SUCCEEDED",
+            correlation_id="corr_in_memory_list_1",
+            created_at=now,
+            started_at=now,
+            finished_at=now + timedelta(seconds=1),
+            result_json={"ok": True},
+            error_json=None,
+            request_json=None,
+        ),
+        DpmAsyncOperationRecord(
+            operation_id="dop_in_memory_list_2",
+            operation_type="ANALYZE_SCENARIOS",
+            status="PENDING",
+            correlation_id="corr_in_memory_list_2",
+            created_at=now + timedelta(minutes=1),
+            started_at=None,
+            finished_at=None,
+            result_json=None,
+            error_json=None,
+            request_json={"scenarios": {}},
+        ),
+        DpmAsyncOperationRecord(
+            operation_id="dop_in_memory_list_3",
+            operation_type="ANALYZE_SCENARIOS",
+            status="PENDING",
+            correlation_id="corr_in_memory_list_3",
+            created_at=now + timedelta(minutes=2),
+            started_at=None,
+            finished_at=None,
+            result_json=None,
+            error_json=None,
+            request_json={"scenarios": {}},
+        ),
+    ]
+
+    page, cursor = _list_operations_filtered(
+        operations=operations,
+        filters=_OperationListFilters(
+            created_from=now + timedelta(seconds=30),
+            created_to=None,
+            operation_type="ANALYZE_SCENARIOS",
+            status="PENDING",
+            correlation_id=None,
+        ),
+        limit=1,
+        cursor=None,
+    )
+    page_two, cursor_two = _list_operations_filtered(
+        operations=operations,
+        filters=_OperationListFilters(
+            created_from=now + timedelta(seconds=30),
+            created_to=None,
+            operation_type="ANALYZE_SCENARIOS",
+            status="PENDING",
+            correlation_id=None,
+        ),
+        limit=1,
+        cursor=cursor,
+    )
+    missing_page, missing_cursor = _list_operations_filtered(
+        operations=operations,
+        filters=_OperationListFilters(
+            created_from=None,
+            created_to=None,
+            operation_type=None,
+            status=None,
+            correlation_id=None,
+        ),
+        limit=10,
+        cursor="dop_missing",
+    )
+
+    assert [operation.operation_id for operation in page] == ["dop_in_memory_list_3"]
+    assert cursor == "dop_in_memory_list_3"
+    assert [operation.operation_id for operation in page_two] == ["dop_in_memory_list_2"]
+    assert cursor_two is None
+    assert missing_page == []
+    assert missing_cursor is None
 
 
 def test_repository_list_operations_time_window_and_invalid_cursor_contract(repository):


### PR DESCRIPTION
## Summary
- Extracted in-memory rebalance-run listing filters and cursor pagination helpers, with direct helper tests.
- Extracted realized outcome source metric helpers for conflict detection, state-aware value suppression, and missing ready-value handling.
- Extracted solver fallback helpers for installed-solver discovery, availability checks, solve-attempt status normalization, and optimal-status detection.
- Updated `docs/architecture/CODEBASE-REVIEW-LEDGER.md` through `BACKEND-REVIEW-20260612-785` and refreshed current quality reports.

## Evidence
- `python -m ruff check src/infrastructure/rebalance_runs/in_memory.py tests/unit/dpm/supportability/test_dpm_run_repository_backends.py`
- `python -m ruff format --check src/infrastructure/rebalance_runs/in_memory.py tests/unit/dpm/supportability/test_dpm_run_repository_backends.py`
- `python -m mypy --config-file mypy.ini src/infrastructure/rebalance_runs/in_memory.py`
- `python -m pytest tests/unit/dpm/supportability/test_dpm_run_repository_backends.py -q` (41 passed)
- `python -m ruff check src/core/outcomes/realized_sources.py tests/unit/core/test_realized_outcome_sources.py`
- `python -m ruff format --check src/core/outcomes/realized_sources.py tests/unit/core/test_realized_outcome_sources.py`
- `python -m mypy --config-file mypy.ini src/core/outcomes/realized_sources.py`
- `python -m pytest tests/unit/core/test_realized_outcome_sources.py -q` (14 passed)
- `python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`
- `python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`
- `python -m mypy --config-file mypy.ini src/core/target_generation.py`
- `python -m pytest tests/unit/core/test_target_generation_solver_fallbacks.py -q` (15 passed)
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- Service leakage scan returned no matches: `rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"`
- `make check` (2503 passed)
- `git fetch origin --prune && git branch -r --no-merged origin/main` (no unmerged remote branches)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (`DiffCount 0`)

## Risk / Scope
- Internal helper extraction only; no API, persistence, OpenAPI, vocabulary, or wiki truth change.
- Current complexity report shows `list_runs`, `list_operations`, `_metric_from_sources`, and `_solve_with_fallbacks` dropped out of the top current source-complexity list.