### PR TITLE
Refactor outcome review and tax source helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19128,3 +19128,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal in-memory outcome review
   repository maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-787: Core realized-tax currency total helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/outcomes/core_sources.py`,
+  `tests/unit/core/test_core_realized_outcome_sources.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_select_currency_total` was the next current source-complexity hotspot and mixed
+  response-shape validation, currency normalization, per-row mapping, case-insensitive matching,
+  missing-currency errors, and ambiguous multi-currency errors in one helper.
+- Action: extracted currency-filter normalization, source-row loading, row matching, and selection
+  validation helpers while preserving the realized-tax adapter contract and source-owned lotus-core
+  evidence semantics. Added direct helper tests for case-insensitive matching, no-filter behavior,
+  missing requested currency errors, and ambiguous multi-currency errors. Refreshed current-state
+  quality reports and preserved stable baseline/rule artifacts; the refreshed complexity report
+  shows `_select_currency_total` dropped out of the top current source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/core_sources.py tests/unit/core/test_core_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/core_sources.py tests/unit/core/test_core_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/core_sources.py`,
+  `python -m pytest tests/unit/core/test_core_realized_outcome_sources.py` (46 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal realized-tax source mapping
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19096,3 +19096,35 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal solver fallback maintainability
   refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-786: In-memory outcome review persistence helpers
+
+- Date: 2026-06-12
+- Scope: `src/infrastructure/outcomes/in_memory.py`,
+  `tests/unit/infrastructure/test_outcome_review_repository.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: in-memory `save_outcome_review` was the next current source-complexity hotspot and
+  mixed immutable content-hash conflict checks, idempotency-key registration, retention metadata
+  projection, review persistence, and append-only event de-duplication in one repository method.
+- Action: extracted focused helper rules for review identity conflicts, idempotency registration,
+  retention metadata construction, and missing-event appends while preserving repository locking,
+  deepcopy boundaries, and storage ownership. Added direct helper tests for immutable conflict
+  rejection, idempotency conflict rejection, retention expiry serialization, and append-only event
+  copying. Refreshed current-state quality reports and preserved stable baseline/rule artifacts;
+  the refreshed complexity report shows `save_outcome_review` dropped out of the top current
+  source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/outcomes/in_memory.py tests/unit/infrastructure/test_outcome_review_repository.py`,
+  `python -m ruff format --check src/infrastructure/outcomes/in_memory.py tests/unit/infrastructure/test_outcome_review_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/outcomes/in_memory.py`,
+  `python -m pytest tests/unit/infrastructure/test_outcome_review_repository.py` (19 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal in-memory outcome review
+  repository maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T09:13:47+00:00`
+- Generated at: `2026-06-12T09:17:05+00:00`
 
-- Current ref: `8f53cb06`
+- Current ref: `3810a8ed`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
-| 2 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
-| 3 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
-| 4 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
-| 5 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
-| 6 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
-| 7 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
-| 8 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
-| 9 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
-| 10 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
+| 1 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
+| 2 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
+| 3 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
+| 4 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
+| 5 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
+| 6 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
+| 7 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
+| 8 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
+| 9 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
+| 10 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T09:00:33+00:00`
+- Generated at: `2026-06-12T09:13:47+00:00`
 
-- Current ref: `6adb7e7a`
+- Current ref: `8f53cb06`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | save_outcome_review | src/infrastructure/outcomes/in_memory.py | 9 | 28 |
-| 2 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
-| 3 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
-| 4 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
-| 5 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
-| 6 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
-| 7 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
-| 8 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
-| 9 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
-| 10 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
+| 1 | _select_currency_total | src/core/outcomes/core_sources.py | 9 | 27 |
+| 2 | _validate_search_page_pagination | src/core/portfolio_memory/models.py | 9 | 27 |
+| 3 | apply_security_trade_to_portfolio | src/core/common/simulation_shared.py | 9 | 26 |
+| 4 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
+| 5 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
+| 6 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
+| 7 | _validate_search_item_latest_event_metadata | src/core/portfolio_memory/models.py | 9 | 23 |
+| 8 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
+| 9 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
+| 10 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T09:00:33+00:00`
+- Generated at: `2026-06-12T09:13:47+00:00`
 
-- Current ref: `6adb7e7a`
+- Current ref: `8f53cb06`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T09:13:47+00:00`
+- Generated at: `2026-06-12T09:17:05+00:00`
 
-- Current ref: `8f53cb06`
+- Current ref: `3810a8ed`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T09:13:47+00:00`
+- Generated at: `2026-06-12T09:17:05+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `8f53cb06`
+- Current ref: `3810a8ed`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 164311 | 164410 | +99 |
-| Test functions | 2330 | 2334 | +4 |
+| Total Python LOC | 164311 | 164470 | +159 |
+| Test functions | 2330 | 2336 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T09:00:33+00:00`
+- Generated at: `2026-06-12T09:13:47+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `6adb7e7a`
+- Current ref: `8f53cb06`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 163878 | 164311 | +433 |
-| Test functions | 2322 | 2330 | +8 |
+| Total Python LOC | 164311 | 164410 | +99 |
+| Test functions | 2330 | 2334 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/outcomes/core_sources.py
+++ b/src/core/outcomes/core_sources.py
@@ -490,28 +490,57 @@ def _select_currency_total(
     response: dict[str, Any],
     currency: str | None,
 ) -> dict[str, Any]:
+    normalized_currency = _normalized_currency_filter(currency)
+    matches = [
+        total
+        for total in _currency_total_rows(response)
+        if _currency_total_matches(total, normalized_currency)
+    ]
+    _raise_on_invalid_currency_total_selection(
+        matches=matches,
+        normalized_currency=normalized_currency,
+        requested_currency=currency,
+    )
+    return matches[0]
+
+
+def _normalized_currency_filter(currency: str | None) -> str | None:
+    return currency.upper() if isinstance(currency, str) else None
+
+
+def _currency_total_rows(response: dict[str, Any]) -> list[dict[str, Any]]:
     totals = response.get("currency_totals")
     if not isinstance(totals, list) or not totals:
         raise CoreOutcomeSourceError(
             "lotus-core realized-tax summary response is missing currency_totals"
         )
-    normalized_currency = currency.upper() if isinstance(currency, str) else None
-    matches = [
-        _read_mapping(total)
-        for total in totals
-        if normalized_currency is None
-        or (_read_text(_read_mapping(total).get("currency")) or "").upper() == normalized_currency
-    ]
+    return [_read_mapping(total) for total in totals]
+
+
+def _currency_total_matches(
+    total: dict[str, Any],
+    normalized_currency: str | None,
+) -> bool:
+    if normalized_currency is None:
+        return True
+    return (_read_text(total.get("currency")) or "").upper() == normalized_currency
+
+
+def _raise_on_invalid_currency_total_selection(
+    *,
+    matches: list[dict[str, Any]],
+    normalized_currency: str | None,
+    requested_currency: str | None,
+) -> None:
     if not matches:
         raise CoreOutcomeSourceError(
-            f"lotus-core realized-tax summary response is missing currency {currency}"
+            f"lotus-core realized-tax summary response is missing currency {requested_currency}"
         )
     if normalized_currency is None and len(matches) != 1:
         raise CoreOutcomeSourceError(
             "lotus-core realized-tax summary response has multiple currencies; "
             "currency must be supplied"
         )
-    return matches[0]
 
 
 def _find_cash_movement_bucket(

--- a/src/infrastructure/outcomes/in_memory.py
+++ b/src/infrastructure/outcomes/in_memory.py
@@ -41,27 +41,17 @@ class InMemoryDpmOutcomeReviewRepository(DpmOutcomeReviewRepository):
         retention_expires_at: datetime | None,
     ) -> None:
         with self._lock:
-            existing = self._reviews.get(review.outcome_review_id)
-            if existing is not None and existing.content_hash != review.content_hash:
-                raise DpmOutcomeReviewConflictError("DPM_OUTCOME_REVIEW_IMMUTABLE_CONFLICT")
-            if review.idempotency_key:
-                existing_id = self._idempotency_index.get(review.idempotency_key)
-                if existing_id is not None and existing_id != review.outcome_review_id:
-                    raise DpmOutcomeReviewConflictError("DPM_OUTCOME_REVIEW_IDEMPOTENCY_CONFLICT")
-                self._idempotency_index[review.idempotency_key] = review.outcome_review_id
+            _raise_on_outcome_review_identity_conflict(self._reviews, review)
+            _register_outcome_review_idempotency(self._idempotency_index, review)
             self._reviews[review.outcome_review_id] = deepcopy(review)
-            self._retention[review.outcome_review_id] = DpmOutcomeRetentionMetadata(
-                outcome_review_id=review.outcome_review_id,
-                retention_policy=review.retention_policy,
-                retention_expires_at=retention_expires_at.isoformat()
-                if retention_expires_at
-                else None,
-                legal_hold_state=review.legal_hold_state,
+            self._retention[review.outcome_review_id] = _retention_metadata_for_review(
+                review=review,
+                retention_expires_at=retention_expires_at,
             )
-            events = self._events.setdefault(review.outcome_review_id, [])
-            for event in review.events:
-                if not any(existing_event.event_id == event.event_id for existing_event in events):
-                    events.append(deepcopy(event))
+            _append_missing_outcome_events(
+                self._events.setdefault(review.outcome_review_id, []),
+                review.events,
+            )
 
     def get_outcome_review(
         self,
@@ -129,6 +119,52 @@ class InMemoryDpmOutcomeReviewRepository(DpmOutcomeReviewRepository):
         with self._lock:
             events = self._events.get(outcome_review_id, [])
             return deepcopy(sorted(events, key=lambda event: (event.event_time, event.event_id)))
+
+
+def _raise_on_outcome_review_identity_conflict(
+    reviews: dict[str, DpmPostTradeOutcomeReview],
+    review: DpmPostTradeOutcomeReview,
+) -> None:
+    existing = reviews.get(review.outcome_review_id)
+    if existing is not None and existing.content_hash != review.content_hash:
+        raise DpmOutcomeReviewConflictError("DPM_OUTCOME_REVIEW_IMMUTABLE_CONFLICT")
+
+
+def _register_outcome_review_idempotency(
+    idempotency_index: dict[str, str],
+    review: DpmPostTradeOutcomeReview,
+) -> None:
+    if review.idempotency_key is None:
+        return
+    existing_id = idempotency_index.get(review.idempotency_key)
+    if existing_id is not None and existing_id != review.outcome_review_id:
+        raise DpmOutcomeReviewConflictError("DPM_OUTCOME_REVIEW_IDEMPOTENCY_CONFLICT")
+    idempotency_index[review.idempotency_key] = review.outcome_review_id
+
+
+def _retention_metadata_for_review(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    retention_expires_at: datetime | None,
+) -> DpmOutcomeRetentionMetadata:
+    return DpmOutcomeRetentionMetadata(
+        outcome_review_id=review.outcome_review_id,
+        retention_policy=review.retention_policy,
+        retention_expires_at=retention_expires_at.isoformat() if retention_expires_at else None,
+        legal_hold_state=review.legal_hold_state,
+    )
+
+
+def _append_missing_outcome_events(
+    existing_events: list[DpmOutcomeEvent],
+    candidate_events: Iterable[DpmOutcomeEvent],
+) -> None:
+    existing_event_ids = {event.event_id for event in existing_events}
+    for event in candidate_events:
+        if event.event_id in existing_event_ids:
+            continue
+        existing_events.append(deepcopy(event))
+        existing_event_ids.add(event.event_id)
 
 
 def _outcome_review_matches_filters(

--- a/tests/unit/core/test_core_realized_outcome_sources.py
+++ b/tests/unit/core/test_core_realized_outcome_sources.py
@@ -15,6 +15,10 @@ from src.core.outcomes import (
 from src.core.outcomes.core_sources import (
     _cash_movement_bucket_matches,
     _cash_movement_buckets,
+    _currency_total_matches,
+    _currency_total_rows,
+    _normalized_currency_filter,
+    _raise_on_invalid_currency_total_selection,
     _transaction_cashflow_value,
     _transaction_fx_pnl_value,
 )
@@ -1022,6 +1026,33 @@ def test_realized_tax_summary_adapter_rejects_ambiguous_currency_totals() -> Non
 
     with pytest.raises(CoreOutcomeSourceError, match="currency must be supplied"):
         realized_tax_summary_source_from_realized_tax_summary_response(response)
+
+
+def test_realized_tax_summary_currency_total_helpers_match_requested_currency() -> None:
+    rows = _currency_total_rows(_realized_tax_summary_response())
+
+    assert _normalized_currency_filter("usd") == "USD"
+    assert _normalized_currency_filter(None) is None
+    assert _currency_total_matches(rows[0], "USD")
+    assert not _currency_total_matches(rows[0], "SGD")
+
+
+def test_realized_tax_summary_currency_total_helper_rejects_invalid_selection() -> None:
+    with pytest.raises(CoreOutcomeSourceError, match="missing currency SGD"):
+        _raise_on_invalid_currency_total_selection(
+            matches=[],
+            normalized_currency="SGD",
+            requested_currency="SGD",
+        )
+    with pytest.raises(CoreOutcomeSourceError, match="currency must be supplied"):
+        _raise_on_invalid_currency_total_selection(
+            matches=[
+                {"currency": "USD", "total_tax_amount": "1"},
+                {"currency": "SGD", "total_tax_amount": "2"},
+            ],
+            normalized_currency=None,
+            requested_currency=None,
+        )
 
 
 def test_realized_tax_summary_adapter_rejects_missing_reporting_total() -> None:

--- a/tests/unit/infrastructure/test_outcome_review_repository.py
+++ b/tests/unit/infrastructure/test_outcome_review_repository.py
@@ -20,9 +20,13 @@ from src.core.outcomes.models import DpmOutcomeDimensionInput
 from src.core.outcomes.repository import DpmOutcomeReviewConflictError
 from src.infrastructure.outcomes import InMemoryDpmOutcomeReviewRepository
 from src.infrastructure.outcomes.in_memory import (
+    _OutcomeReviewFilters,
+    _append_missing_outcome_events,
     _list_outcome_reviews,
     _outcome_review_matches_filters,
-    _OutcomeReviewFilters,
+    _raise_on_outcome_review_identity_conflict,
+    _register_outcome_review_idempotency,
+    _retention_metadata_for_review,
 )
 from src.infrastructure.outcomes.postgres import (
     PostgresDpmOutcomeReviewRepository,
@@ -339,6 +343,65 @@ def test_outcome_review_list_helper_filters_sorts_and_pages() -> None:
     )
 
     assert [review.outcome_review_id for review in listed] == ["dor_newer"]
+
+
+def test_outcome_review_identity_helper_rejects_content_hash_change() -> None:
+    review = _review()
+
+    with pytest.raises(DpmOutcomeReviewConflictError, match="IMMUTABLE"):
+        _raise_on_outcome_review_identity_conflict(
+            {review.outcome_review_id: review},
+            review.model_copy(update={"content_hash": "sha256:different"}),
+        )
+
+
+def test_outcome_review_idempotency_helper_registers_once_per_review() -> None:
+    review = _review()
+    idempotency_index: dict[str, str] = {}
+
+    _register_outcome_review_idempotency(idempotency_index, review)
+    _register_outcome_review_idempotency(idempotency_index, review)
+
+    assert idempotency_index == {"idem_001": "dor_001"}
+    with pytest.raises(DpmOutcomeReviewConflictError, match="IDEMPOTENCY"):
+        _register_outcome_review_idempotency(
+            idempotency_index,
+            _review(outcome_review_id="dor_002", content_hash="sha256:review-2"),
+        )
+
+
+def test_outcome_review_retention_helper_serializes_expiry() -> None:
+    retention = _retention_metadata_for_review(
+        review=_review(),
+        retention_expires_at=datetime(2033, 5, 6, tzinfo=timezone.utc),
+    )
+
+    assert retention.outcome_review_id == "dor_001"
+    assert retention.retention_policy == "DPM_OUTCOME_REVIEW_7Y"
+    assert retention.retention_expires_at == "2033-05-06T00:00:00+00:00"
+    assert retention.legal_hold_state == "NONE"
+
+
+def test_outcome_review_event_helper_appends_missing_events_once() -> None:
+    review = _review()
+    existing_events = [review.events[0]]
+    refreshed = DpmOutcomeEvent(
+        event_id="dor_001_refreshed",
+        event_type="OUTCOME_REVIEW_SOURCE_REFRESHED",
+        event_time="2026-05-06T01:30:00Z",
+        actor="system",
+        outcome_review_id="dor_001",
+        state="READY",
+        reason_codes=["SOURCE_REFRESHED"],
+    )
+
+    _append_missing_outcome_events(existing_events, [review.events[0], refreshed])
+
+    assert [event.event_id for event in existing_events] == [
+        "dor_001_created",
+        "dor_001_refreshed",
+    ]
+    assert existing_events[1] is not refreshed
 
 
 def test_in_memory_outcome_repository_returns_deep_copies() -> None:


### PR DESCRIPTION
## Summary
- extract in-memory outcome review persistence helpers for identity conflicts, idempotency registration, retention metadata, and append-only event handling
- extract realized-tax currency-total selection helpers for normalization, row loading, matching, and invalid-selection errors
- refresh current-state quality reports and update CODEBASE-REVIEW-LEDGER through BACKEND-REVIEW-20260612-787

## Local validation
- python -m pytest tests/unit/infrastructure/test_outcome_review_repository.py (19 passed)
- python -m pytest tests/unit/core/test_core_realized_outcome_sources.py (46 passed)
- python -m ruff check touched files
- python -m ruff format --check touched files
- python -m mypy --config-file mypy.ini touched source files
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- git diff --check
- service leakage scan returned no matches
- make check (2509 passed)
- git fetch origin --prune
- git branch -r --no-merged origin/main (no output)
- wiki drift check: DiffCount 0

## Wiki decision
No wiki source change required; this PR contains internal backend helper extractions and repo-local quality evidence only.