### PR TITLE
Refactor proof pack and risk source posture helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19257,3 +19257,37 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal proof-pack payload
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-791: Risk source posture supportability helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/outcomes/risk_sources.py`,
+  `tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_rolling_source_posture` and `_historical_attribution_source_posture` were the top
+  current source-complexity hotspots and duplicated supportability-state precedence, degraded-value
+  quality selection, and rolling-context unavailable checks inside source-owned risk outcome
+  adapters.
+- Action: introduced shared risk source posture type aliases, extracted supportability posture,
+  rolling context availability, and degraded-value quality helpers, and kept the historical
+  attribution fail-closed ordering where period errors block before stale supportability posture.
+  Added direct helper tests for unsupported, permission-blocked, stale, ready, rolling context
+  unavailable, partial/unavailable degraded values, and the stale-plus-period-error precedence
+  boundary. Refreshed current-state quality reports and preserved the stable baseline artifact; the
+  refreshed complexity report shows both targeted risk-source posture helpers dropped out of the top
+  current source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`,
+  `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py -q` (53 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal risk outcome source
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19226,3 +19226,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal shared simulation helper
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-790: Proof-pack approval posture helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_approval_requirements_section_payload` was the top current source-complexity hotspot
+  and mixed workflow decision ordering, gate fact serialization, approval state precedence, metric
+  assembly, and reason-code projection inside one proof-pack section payload helper.
+- Action: extracted focused approval workflow fact, approval state, gate fact, and reason-code
+  helpers while preserving the proof-pack section payload contract and existing run/gate precedence
+  behavior. Added direct helper tests for gate-required pending review, blocked precedence, ordered
+  workflow decision facts, gate serialization, and reason-code projection. Refreshed current-state
+  quality reports and preserved the stable baseline artifact; the refreshed complexity report shows
+  `_approval_requirements_section_payload` dropped out of the top current source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` (74 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal proof-pack payload
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T09:32:43+00:00`
+- Generated at: `2026-06-12T09:45:19+00:00`
 
-- Current ref: `187aca72`
+- Current ref: `65fbc366`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _approval_requirements_section_payload | src/core/proof_packs/builder.py | 9 | 25 |
-| 2 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
-| 3 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
-| 4 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
-| 5 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
-| 6 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
-| 7 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
-| 8 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
-| 9 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 10 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 1 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
+| 2 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
+| 3 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
+| 4 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
+| 5 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
+| 6 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
+| 7 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
+| 8 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 9 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 10 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T09:45:19+00:00`
+- Generated at: `2026-06-12T09:49:04+00:00`
 
-- Current ref: `65fbc366`
+- Current ref: `8c5ffc6e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _rolling_source_posture | src/core/outcomes/risk_sources.py | 9 | 24 |
-| 2 | _historical_attribution_source_posture | src/core/outcomes/risk_sources.py | 9 | 23 |
-| 3 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
-| 4 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
-| 5 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
-| 6 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
-| 7 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
-| 8 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 9 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 10 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
+| 1 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
+| 2 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
+| 3 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
+| 4 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
+| 5 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
+| 6 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 7 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 8 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
+| 9 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
+| 10 | setup_observability | src/api/observability.py | 8 | 98 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T09:45:19+00:00`
+- Generated at: `2026-06-12T09:49:04+00:00`
 
-- Current ref: `65fbc366`
+- Current ref: `8c5ffc6e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T09:32:43+00:00`
+- Generated at: `2026-06-12T09:45:19+00:00`
 
-- Current ref: `187aca72`
+- Current ref: `65fbc366`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T09:45:19+00:00`
+- Generated at: `2026-06-12T09:49:04+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `65fbc366`
+- Current ref: `8c5ffc6e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 164743 | 164849 | +106 |
+| Total Python LOC | 164743 | 164895 | +152 |
 | Test functions | 2344 | 2346 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T09:32:43+00:00`
+- Generated at: `2026-06-12T09:45:19+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `187aca72`
+- Current ref: `65fbc366`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 164470 | 164743 | +273 |
-| Test functions | 2336 | 2344 | +8 |
+| Total Python LOC | 164743 | 164849 | +106 |
+| Test functions | 2344 | 2346 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -56,7 +56,7 @@
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2152 |
+| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2237 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -73,6 +73,18 @@ class RiskOutcomeSourceError(ValueError):
     """Raised when a lotus-risk response cannot produce bounded outcome evidence."""
 
 
+_RiskSourceState = Literal["READY", "DEGRADED", "BLOCKED", "NOT_SUPPORTED"]
+_RiskSourceQuality = Literal[
+    "COMPLETE",
+    "STALE",
+    "UNAVAILABLE",
+    "PARTIAL",
+    "MISSING",
+    "NOT_SUPPORTED",
+]
+_RiskSourcePosture = tuple[_RiskSourceState, _RiskSourceQuality]
+
+
 def realized_risk_source_from_risk_metrics_report(
     response: dict[str, Any],
     *,
@@ -718,24 +730,14 @@ def _rolling_source_posture(
     supportability_state: str,
     value: Decimal | None,
     context_reason: str,
-) -> tuple[
-    Literal["READY", "DEGRADED", "BLOCKED", "NOT_SUPPORTED"],
-    Literal["COMPLETE", "STALE", "UNAVAILABLE", "PARTIAL", "MISSING", "NOT_SUPPORTED"],
-]:
-    if supportability_state == "unsupported":
-        return "NOT_SUPPORTED", "NOT_SUPPORTED"
-    if supportability_state == "permission_blocked":
-        return "BLOCKED", "MISSING"
-    if supportability_state == "stale":
-        return "DEGRADED", "STALE"
-    if (
-        context_reason.endswith("_BENCHMARK_UNAVAILABLE")
-        or context_reason.endswith("_RISK_FREE_UNAVAILABLE")
-        or context_reason.endswith("_NO_ALIGNED_OBSERVATIONS")
-    ):
+) -> _RiskSourcePosture:
+    supportability_posture = _supportability_source_posture(supportability_state)
+    if supportability_posture is not None:
+        return supportability_posture
+    if _rolling_context_unavailable(context_reason):
         return "DEGRADED", "UNAVAILABLE"
     if supportability_state != "ready":
-        return "DEGRADED", "PARTIAL" if value is not None else "UNAVAILABLE"
+        return "DEGRADED", _quality_for_degraded_value(value)
     return "READY", "COMPLETE"
 
 
@@ -745,23 +747,46 @@ def _historical_attribution_source_posture(
     value: Decimal | None,
     period_error: str | None,
     quality_flags: list[Any],
-) -> tuple[
-    Literal["READY", "DEGRADED", "BLOCKED", "NOT_SUPPORTED"],
-    Literal["COMPLETE", "STALE", "UNAVAILABLE", "PARTIAL", "MISSING", "NOT_SUPPORTED"],
-]:
+) -> _RiskSourcePosture:
+    supportability_posture = _supportability_source_posture(
+        supportability_state, include_stale=False
+    )
+    if supportability_posture is not None:
+        return supportability_posture
+    if period_error is not None:
+        return "BLOCKED", "MISSING"
+    supportability_posture = _supportability_source_posture(supportability_state)
+    if supportability_posture is not None:
+        return supportability_posture
+    if supportability_state != "ready":
+        return "DEGRADED", _quality_for_degraded_value(value)
+    if quality_flags:
+        return "DEGRADED", _quality_for_degraded_value(value)
+    return "READY", "COMPLETE"
+
+
+def _supportability_source_posture(
+    supportability_state: str, *, include_stale: bool = True
+) -> _RiskSourcePosture | None:
     if supportability_state == "unsupported":
         return "NOT_SUPPORTED", "NOT_SUPPORTED"
     if supportability_state == "permission_blocked":
         return "BLOCKED", "MISSING"
-    if period_error is not None:
-        return "BLOCKED", "MISSING"
-    if supportability_state == "stale":
+    if include_stale and supportability_state == "stale":
         return "DEGRADED", "STALE"
-    if supportability_state != "ready":
-        return "DEGRADED", "PARTIAL" if value is not None else "UNAVAILABLE"
-    if quality_flags:
-        return "DEGRADED", "PARTIAL" if value is not None else "UNAVAILABLE"
-    return "READY", "COMPLETE"
+    return None
+
+
+def _rolling_context_unavailable(context_reason: str) -> bool:
+    return (
+        context_reason.endswith("_BENCHMARK_UNAVAILABLE")
+        or context_reason.endswith("_RISK_FREE_UNAVAILABLE")
+        or context_reason.endswith("_NO_ALIGNED_OBSERVATIONS")
+    )
+
+
+def _quality_for_degraded_value(value: Decimal | None) -> _RiskSourceQuality:
+    return "PARTIAL" if value is not None else "UNAVAILABLE"
 
 
 def _is_issuer_concentration_measure(measure: ConcentrationOutcomeMeasure) -> bool:

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -34,7 +34,7 @@ from src.core.proof_packs.source_analytics import (
 from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthSnapshot
 from src.core.rebalance_runs.artifact import build_dpm_run_artifact
 from src.core.rebalance_runs.models import DpmRunRecord, DpmRunWorkflowDecisionRecord
-from src.core.models import RebalanceResult
+from src.core.models import GateDecision, RebalanceResult
 
 PROOF_PACK_VERSION = "1.0"
 
@@ -771,25 +771,46 @@ def _approval_requirements_section_payload(
     workflow_decisions: list[DpmRunWorkflowDecisionRecord],
 ) -> _SectionPayload:
     gate = result.gate_decision
-    workflow_facts = [
-        decision.model_dump(mode="json")
-        for decision in sorted(workflow_decisions, key=lambda item: item.decided_at)
-    ]
-    approval_state: ProofPackSectionState = "READY"
-    if result.status == "PENDING_REVIEW" or (gate and gate.gate.endswith("REQUIRED")):
-        approval_state = "PENDING_REVIEW"
-    if result.status == "BLOCKED" or (gate and gate.gate == "BLOCKED"):
-        approval_state = "BLOCKED"
+    workflow_facts = _approval_workflow_decision_facts(workflow_decisions)
     return (
-        approval_state,
+        _approval_section_state(result=result, gate=gate),
         "Approval posture captured from run status and gate decision.",
         {
-            "gate_decision": gate.model_dump(mode="json") if gate else None,
+            "gate_decision": _approval_gate_fact(gate),
             "workflow_decisions": workflow_facts,
         },
         {"workflow_decision_count": len(workflow_facts)},
-        [reason.reason_code for reason in gate.reasons] if gate else [],
+        _approval_reason_codes(gate),
     )
+
+
+def _approval_workflow_decision_facts(
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
+) -> list[dict[str, Any]]:
+    return [
+        decision.model_dump(mode="json")
+        for decision in sorted(workflow_decisions, key=lambda item: item.decided_at)
+    ]
+
+
+def _approval_section_state(
+    *, result: RebalanceResult, gate: GateDecision | None
+) -> ProofPackSectionState:
+    if result.status == "BLOCKED" or (gate is not None and gate.gate == "BLOCKED"):
+        return "BLOCKED"
+    if result.status == "PENDING_REVIEW" or (gate is not None and gate.gate.endswith("REQUIRED")):
+        return "PENDING_REVIEW"
+    return "READY"
+
+
+def _approval_gate_fact(gate: GateDecision | None) -> dict[str, Any] | None:
+    return gate.model_dump(mode="json") if gate is not None else None
+
+
+def _approval_reason_codes(gate: GateDecision | None) -> list[str]:
+    if gate is None:
+        return []
+    return [reason.reason_code for reason in gate.reasons]
 
 
 def _mandate_context_section_payload(

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -23,11 +23,14 @@ from src.core.outcomes.risk_sources import (
     _historical_attribution_value,
     _metric_unit,
     _primary_reason,
+    _quality_for_degraded_value,
     _relative_drawdown_value,
     _risk_source_posture,
+    _rolling_context_unavailable,
     _rolling_context_reason,
     _rolling_source_posture,
     _rolling_window_result,
+    _supportability_source_posture,
     _decimal_value,
 )
 from tests.unit.core.test_realized_outcome_sources import _window
@@ -1408,6 +1411,18 @@ def test_concentration_drawdown_and_rolling_posture_edges_are_source_safe() -> N
         value=Decimal("1"),
         context_reason="RISK_ROLLING_BENCHMARK_UNAVAILABLE",
     ) == ("DEGRADED", "UNAVAILABLE")
+    assert _supportability_source_posture("unsupported") == (
+        "NOT_SUPPORTED",
+        "NOT_SUPPORTED",
+    )
+    assert _supportability_source_posture("permission_blocked") == ("BLOCKED", "MISSING")
+    assert _supportability_source_posture("stale") == ("DEGRADED", "STALE")
+    assert _supportability_source_posture("stale", include_stale=False) is None
+    assert _supportability_source_posture("ready") is None
+    assert _rolling_context_unavailable("RISK_ROLLING_NO_ALIGNED_OBSERVATIONS")
+    assert not _rolling_context_unavailable("RISK_ROLLING_CONTEXT_NOT_REQUIRED")
+    assert _quality_for_degraded_value(Decimal("1")) == "PARTIAL"
+    assert _quality_for_degraded_value(None) == "UNAVAILABLE"
 
 
 def test_rolling_and_historical_attribution_helper_edges_are_explicit() -> None:
@@ -1472,6 +1487,12 @@ def test_historical_attribution_posture_and_decimal_errors_are_fail_closed() -> 
         period_error=None,
         quality_flags=[],
     ) == ("DEGRADED", "STALE")
+    assert _historical_attribution_source_posture(
+        supportability_state="stale",
+        value=Decimal("1"),
+        period_error="period unavailable",
+        quality_flags=[],
+    ) == ("BLOCKED", "MISSING")
     assert _historical_attribution_source_posture(
         supportability_state="degraded",
         value=None,

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -18,7 +18,16 @@ from src.core.construction import (
     build_alternative_set,
     build_rebalance_result_alternative,
 )
-from src.core.models import EngineOptions, ExcludedInstrument, Money, RebalanceResult, TaxImpact
+from src.core.models import (
+    EngineOptions,
+    ExcludedInstrument,
+    GateDecision,
+    GateDecisionSummary,
+    GateReason,
+    Money,
+    RebalanceResult,
+    TaxImpact,
+)
 from src.core.mandates import (
     DpmMandateDigitalTwin,
     DpmMandateHealthInput,
@@ -499,6 +508,82 @@ def test_approval_requirements_section_payload_blocks_for_blocked_run() -> None:
     assert facts["workflow_decisions"] == []
     assert metrics == {"workflow_decision_count": 0}
     assert reason_codes == []
+
+
+def test_approval_section_state_uses_gate_required_review_and_blocked_precedence() -> None:
+    result = _ready_rebalance_result()
+    review_gate = GateDecision(
+        gate="MANDATE_APPROVAL_REQUIRED",
+        recommended_next_step="REQUEST_MANDATE_APPROVAL",
+        reasons=[],
+        summary=GateDecisionSummary(
+            hard_fail_count=0,
+            soft_fail_count=1,
+            new_high_suitability_count=0,
+            new_medium_suitability_count=0,
+        ),
+    )
+    blocked_gate = review_gate.model_copy(
+        update={"gate": "BLOCKED", "recommended_next_step": "FIX_INPUT"}
+    )
+
+    assert (
+        builder_module._approval_section_state(result=result, gate=review_gate) == "PENDING_REVIEW"
+    )
+    assert builder_module._approval_section_state(result=result, gate=blocked_gate) == "BLOCKED"
+    assert (
+        builder_module._approval_section_state(
+            result=result.model_copy(update={"status": "BLOCKED"}),
+            gate=review_gate,
+        )
+        == "BLOCKED"
+    )
+
+
+def test_approval_support_helpers_serialize_ordered_facts_and_reason_codes() -> None:
+    result = _ready_rebalance_result()
+    later = DpmRunWorkflowDecisionRecord(
+        decision_id="dwd_later",
+        run_id=result.rebalance_run_id,
+        action="APPROVE",
+        reason_code="LATER",
+        actor_id="pm_002",
+        decided_at=datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc),
+        correlation_id="corr-later",
+    )
+    earlier = later.model_copy(
+        update={
+            "decision_id": "dwd_earlier",
+            "reason_code": "EARLIER",
+            "actor_id": "pm_001",
+            "decided_at": datetime(2026, 5, 3, 9, 0, tzinfo=timezone.utc),
+            "correlation_id": "corr-earlier",
+        }
+    )
+    gate = GateDecision(
+        gate="COMPLIANCE_REVIEW_REQUIRED",
+        recommended_next_step="COMPLIANCE_REVIEW",
+        reasons=[
+            GateReason(
+                reason_code="DPM_COMPLIANCE_REVIEW_REQUIRED",
+                severity="HIGH",
+                source="SUITABILITY",
+            )
+        ],
+        summary=GateDecisionSummary(
+            hard_fail_count=0,
+            soft_fail_count=0,
+            new_high_suitability_count=1,
+            new_medium_suitability_count=0,
+        ),
+    )
+
+    facts = builder_module._approval_workflow_decision_facts([later, earlier])
+
+    assert [fact["decision_id"] for fact in facts] == ["dwd_earlier", "dwd_later"]
+    assert builder_module._approval_gate_fact(gate)["gate"] == "COMPLIANCE_REVIEW_REQUIRED"
+    assert builder_module._approval_reason_codes(gate) == ["DPM_COMPLIANCE_REVIEW_REQUIRED"]
+    assert builder_module._approval_reason_codes(None) == []
 
 
 def test_proof_pack_governance_section_payload_orders_workflow_decisions() -> None:


### PR DESCRIPTION
## Summary
- Extract proof-pack approval posture helpers for workflow decision facts, gate facts, approval state precedence, and reason-code projection.
- Extract shared risk-source supportability, rolling-context unavailable, and degraded-value quality helpers while preserving historical attribution fail-closed period-error precedence.
- Refresh current-state refactor health, scorecard, complexity report, and codebase review ledger entries BACKEND-REVIEW-20260612-790 and BACKEND-REVIEW-20260612-791.

## Quality Evidence
- `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` (74 passed)
- `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`
- `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`
- `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`
- `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py -q` (53 passed)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- Service leakage scan returned no matches.
- `make check` (2519 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Measurable Improvement
- `quality/complexity_report.md` no longer lists `_approval_requirements_section_payload`, `_rolling_source_posture`, or `_historical_attribution_source_posture` in the top current source hotspots.
- Next reported source hotspot is `parse_tenant_policy_pack_map` in `src/core/rebalance/tenant_policy_packs.py`.

## Behavior / Docs / Wiki
- Behavior preserved; changes are helper extractions with direct regression tests.
- No README/wiki/operator truth change required.