### PR TITLE
Refactor tenant policy and assignment replay helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19322,3 +19322,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal tenant policy-pack resolver
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-793: Campaign assignment transition replay helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/waves/campaign_assignment_tasks.py`,
+  `tests/unit/dpm/waves/test_campaign_discovery.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_optional_transition_replay_fields_match` was the top current source-complexity
+  hotspot and combined optional assignee, escalation-tier, SLA-posture, and due-date comparison
+  rules for idempotent assignment task transition replay in one predicate.
+- Action: extracted field-specific replay predicates for assignees, escalation tier, SLA posture,
+  and due date while preserving the existing transition-ref replay/conflict behavior. Added direct
+  helper tests for normalized assignee matching, assignee mismatch, unspecified optional fields,
+  mismatched escalation tier, mismatched SLA posture, and mismatched due date. Refreshed
+  current-state quality reports and preserved the stable baseline artifact; the refreshed
+  complexity report shows `_optional_transition_replay_fields_match` dropped out of the top
+  current source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_tasks.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q` (74 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal campaign assignment task
+  idempotency helper maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19291,3 +19291,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal risk outcome source
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-792: Tenant policy-pack map parser helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/rebalance/tenant_policy_packs.py`,
+  `tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `parse_tenant_policy_pack_map` was the top current source-complexity hotspot and mixed
+  optional configuration normalization, JSON decoding, map-shape validation, row validation, and
+  tenant/policy-pack id normalization in one resolver-support helper.
+- Action: extracted JSON map loading and tenant-policy-pack row normalization helpers while
+  preserving fail-closed invalid configuration behavior and the existing static resolver contract.
+  Added direct helper tests for empty/invalid/non-object JSON, valid map loading, string-pair
+  normalization, and invalid row rejection. Refreshed current-state quality reports and preserved
+  the stable baseline artifact; the refreshed complexity report shows
+  `parse_tenant_policy_pack_map` dropped out of the top current source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/tenant_policy_packs.py tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py`,
+  `python -m ruff format --check src/core/rebalance/tenant_policy_packs.py tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/tenant_policy_packs.py`,
+  `python -m pytest tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py -q` (7 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal tenant policy-pack resolver
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T09:49:04+00:00`
+- Generated at: `2026-06-12T10:01:11+00:00`
 
-- Current ref: `8c5ffc6e`
+- Current ref: `cdfb20f6`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | parse_tenant_policy_pack_map | src/core/rebalance/tenant_policy_packs.py | 9 | 20 |
-| 2 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
-| 3 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
-| 4 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
-| 5 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
-| 6 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 7 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 8 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
-| 9 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
-| 10 | setup_observability | src/api/observability.py | 8 | 98 |
+| 1 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
+| 2 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
+| 3 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
+| 4 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
+| 5 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 6 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 7 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
+| 8 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
+| 9 | setup_observability | src/api/observability.py | 8 | 98 |
+| 10 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T10:01:11+00:00`
+- Generated at: `2026-06-12T10:04:26+00:00`
 
-- Current ref: `cdfb20f6`
+- Current ref: `ba65f13c`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _optional_transition_replay_fields_match | src/core/waves/campaign_assignment_tasks.py | 9 | 19 |
-| 2 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
-| 3 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
-| 4 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
-| 5 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 6 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 7 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
-| 8 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
-| 9 | setup_observability | src/api/observability.py | 8 | 98 |
-| 10 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 1 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
+| 2 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
+| 3 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
+| 4 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 5 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 6 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
+| 7 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
+| 8 | setup_observability | src/api/observability.py | 8 | 98 |
+| 9 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 10 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T10:01:11+00:00`
+- Generated at: `2026-06-12T10:04:26+00:00`
 
-- Current ref: `cdfb20f6`
+- Current ref: `ba65f13c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T09:49:04+00:00`
+- Generated at: `2026-06-12T10:01:11+00:00`
 
-- Current ref: `8c5ffc6e`
+- Current ref: `cdfb20f6`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T10:01:11+00:00`
+- Generated at: `2026-06-12T10:04:26+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `cdfb20f6`
+- Current ref: `ba65f13c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 164895 | 164933 | +38 |
+| Total Python LOC | 164895 | 164994 | +99 |
 | Test functions | 2346 | 2349 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
@@ -57,7 +57,7 @@
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2237 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2137 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T09:49:04+00:00`
+- Generated at: `2026-06-12T10:01:11+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `8c5ffc6e`
+- Current ref: `cdfb20f6`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 164743 | 164895 | +152 |
-| Test functions | 2344 | 2346 | +2 |
+| Total Python LOC | 164895 | 164933 | +38 |
+| Test functions | 2346 | 2349 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -41,7 +41,7 @@
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2152 |
+| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2237 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |

--- a/src/core/rebalance/tenant_policy_packs.py
+++ b/src/core/rebalance/tenant_policy_packs.py
@@ -1,5 +1,5 @@
 import json
-from typing import Optional, Protocol
+from typing import Any, Optional, Protocol
 
 
 class DpmTenantPolicyPackResolver(Protocol):
@@ -25,25 +25,39 @@ class StaticMapDpmTenantPolicyPackResolver:
 
 
 def parse_tenant_policy_pack_map(mapping_json: Optional[str]) -> dict[str, str]:
+    raw_mapping = _load_tenant_policy_pack_json_map(mapping_json)
+    if raw_mapping is None:
+        return {}
+    mapping: dict[str, str] = {}
+    for tenant_id, policy_pack_id in raw_mapping.items():
+        row = _tenant_policy_pack_mapping_row(tenant_id=tenant_id, policy_pack_id=policy_pack_id)
+        if row is not None:
+            normalized_tenant_id, normalized_policy_pack_id = row
+            mapping[normalized_tenant_id] = normalized_policy_pack_id
+    return mapping
+
+
+def _load_tenant_policy_pack_json_map(mapping_json: Optional[str]) -> dict[str, Any] | None:
     normalized_json = (mapping_json or "").strip()
     if not normalized_json:
-        return {}
+        return None
     try:
         raw = json.loads(normalized_json)
     except json.JSONDecodeError:
-        return {}
-    if not isinstance(raw, dict):
-        return {}
-    mapping: dict[str, str] = {}
-    for tenant_id, policy_pack_id in raw.items():
-        if not isinstance(policy_pack_id, str):
-            continue
-        normalized_tenant_id = _normalize_optional_value(tenant_id)
-        normalized_policy_pack_id = _normalize_optional_value(policy_pack_id)
-        if normalized_tenant_id is None or normalized_policy_pack_id is None:
-            continue
-        mapping[normalized_tenant_id] = normalized_policy_pack_id
-    return mapping
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _tenant_policy_pack_mapping_row(
+    *, tenant_id: Any, policy_pack_id: Any
+) -> tuple[str, str] | None:
+    if not isinstance(tenant_id, str) or not isinstance(policy_pack_id, str):
+        return None
+    normalized_tenant_id = _normalize_optional_value(tenant_id)
+    normalized_policy_pack_id = _normalize_optional_value(policy_pack_id)
+    if normalized_tenant_id is None or normalized_policy_pack_id is None:
+        return None
+    return normalized_tenant_id, normalized_policy_pack_id
 
 
 def build_tenant_policy_pack_resolver(

--- a/src/core/waves/campaign_assignment_tasks.py
+++ b/src/core/waves/campaign_assignment_tasks.py
@@ -619,17 +619,55 @@ def _optional_transition_replay_fields_match(
     sla_posture: CampaignAssignmentSlaPosture | None,
     due_at: datetime | None,
 ) -> bool:
-    if assigned_actor_ids is not None and transition.assigned_actor_ids != _normalize_actor_ids(
-        assigned_actor_ids
-    ):
-        return False
-    if escalation_tier is not None and transition.escalation_tier != escalation_tier:
-        return False
-    if sla_posture is not None and transition.sla_posture != sla_posture:
-        return False
-    if due_at is not None and transition.due_at != due_at:
-        return False
-    return True
+    return (
+        _transition_assignees_replay_match(
+            transition=transition,
+            assigned_actor_ids=assigned_actor_ids,
+        )
+        and _transition_escalation_tier_replay_match(
+            transition=transition,
+            escalation_tier=escalation_tier,
+        )
+        and _transition_sla_posture_replay_match(
+            transition=transition,
+            sla_posture=sla_posture,
+        )
+        and _transition_due_at_replay_match(transition=transition, due_at=due_at)
+    )
+
+
+def _transition_assignees_replay_match(
+    *,
+    transition: DpmBulkReviewCampaignDefinitionAssignmentTaskTransition,
+    assigned_actor_ids: list[str] | None,
+) -> bool:
+    if assigned_actor_ids is None:
+        return True
+    return transition.assigned_actor_ids == _normalize_actor_ids(assigned_actor_ids)
+
+
+def _transition_escalation_tier_replay_match(
+    *,
+    transition: DpmBulkReviewCampaignDefinitionAssignmentTaskTransition,
+    escalation_tier: CampaignAssignmentEscalationTier | None,
+) -> bool:
+    return escalation_tier is None or transition.escalation_tier == escalation_tier
+
+
+def _transition_sla_posture_replay_match(
+    *,
+    transition: DpmBulkReviewCampaignDefinitionAssignmentTaskTransition,
+    sla_posture: CampaignAssignmentSlaPosture | None,
+) -> bool:
+    return sla_posture is None or transition.sla_posture == sla_posture
+
+
+def _transition_due_at_replay_match(
+    *,
+    transition: DpmBulkReviewCampaignDefinitionAssignmentTaskTransition,
+    due_at: datetime | None,
+) -> bool:
+    return due_at is None or transition.due_at == due_at
 
 
 def _source_ref_payloads(source_refs: list[DpmWaveSourceRef]) -> list[dict[str, object]]:

--- a/tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py
+++ b/tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py
@@ -1,5 +1,7 @@
 from src.core.rebalance.tenant_policy_packs import (
     build_tenant_policy_pack_resolver,
+    _load_tenant_policy_pack_json_map,
+    _tenant_policy_pack_mapping_row,
     parse_tenant_policy_pack_map,
 )
 
@@ -14,6 +16,28 @@ def test_parse_tenant_policy_pack_map_invalid_inputs():
 def test_parse_tenant_policy_pack_map_skips_invalid_rows():
     mapping = parse_tenant_policy_pack_map('{"tenant_1":"pack_1"," ":"pack_2","tenant_3":3}')
     assert mapping == {"tenant_1": "pack_1"}
+
+
+def test_load_tenant_policy_pack_json_map_returns_only_json_objects():
+    assert _load_tenant_policy_pack_json_map(None) is None
+    assert _load_tenant_policy_pack_json_map(" ") is None
+    assert _load_tenant_policy_pack_json_map("{bad-json}") is None
+    assert _load_tenant_policy_pack_json_map("[]") is None
+    assert _load_tenant_policy_pack_json_map('{"tenant_1":"pack_1"}') == {"tenant_1": "pack_1"}
+
+
+def test_tenant_policy_pack_mapping_row_normalizes_valid_string_pairs():
+    assert _tenant_policy_pack_mapping_row(tenant_id=" tenant_1 ", policy_pack_id=" pack_1 ") == (
+        "tenant_1",
+        "pack_1",
+    )
+
+
+def test_tenant_policy_pack_mapping_row_rejects_invalid_values():
+    assert _tenant_policy_pack_mapping_row(tenant_id=1, policy_pack_id="pack_1") is None
+    assert _tenant_policy_pack_mapping_row(tenant_id="tenant_1", policy_pack_id=1) is None
+    assert _tenant_policy_pack_mapping_row(tenant_id=" ", policy_pack_id="pack_1") is None
+    assert _tenant_policy_pack_mapping_row(tenant_id="tenant_1", policy_pack_id=" ") is None
 
 
 def test_build_resolver_disabled_returns_none():

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -57,7 +57,11 @@ from src.core.waves.campaign_assignment_tasks import (
     _optional_transition_replay_fields_match,
     _required_transition_replay_fields,
     _source_ref_payloads,
+    _transition_assignees_replay_match,
+    _transition_due_at_replay_match,
+    _transition_escalation_tier_replay_match,
     _transition_next_assignees,
+    _transition_sla_posture_replay_match,
     _transition_task_fields,
     _validate_transition_field_requirements,
     _validate_transition_allowed,
@@ -1712,6 +1716,25 @@ def test_campaign_assignment_transition_replay_helpers_project_comparison_fields
         escalation_tier=None,
         sla_posture=None,
         due_at=None,
+    )
+    assert _transition_assignees_replay_match(
+        transition=transition,
+        assigned_actor_ids=[" pm_001 ", "pm_001"],
+    )
+    assert not _transition_assignees_replay_match(
+        transition=transition,
+        assigned_actor_ids=["pm_002"],
+    )
+    assert _transition_escalation_tier_replay_match(transition=transition, escalation_tier=None)
+    assert not _transition_escalation_tier_replay_match(
+        transition=transition, escalation_tier="OPS"
+    )
+    assert _transition_sla_posture_replay_match(transition=transition, sla_posture=None)
+    assert not _transition_sla_posture_replay_match(transition=transition, sla_posture="ATTENTION")
+    assert _transition_due_at_replay_match(transition=transition, due_at=None)
+    assert not _transition_due_at_replay_match(
+        transition=transition,
+        due_at=datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc),
     )
 
 


### PR DESCRIPTION
## Summary
- Extract tenant policy-pack parser helpers for JSON map loading and tenant-policy-pack row normalization.
- Extract campaign assignment transition replay helpers for optional assignee, escalation-tier, SLA-posture, and due-date comparisons.
- Refresh current-state refactor health, scorecard, complexity report, and codebase review ledger entries BACKEND-REVIEW-20260612-792 and BACKEND-REVIEW-20260612-793.

## Quality Evidence
- `python -m ruff check src/core/rebalance/tenant_policy_packs.py tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py`
- `python -m ruff format --check src/core/rebalance/tenant_policy_packs.py tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py`
- `python -m mypy --config-file mypy.ini src/core/rebalance/tenant_policy_packs.py`
- `python -m pytest tests/unit/dpm/engine/test_tenant_policy_pack_resolver.py -q` (7 passed)
- `python -m ruff check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`
- `python -m ruff format --check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`
- `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_tasks.py`
- `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q` (74 passed)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- Service leakage scan returned no matches.
- `make check` (2522 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Measurable Improvement
- `quality/complexity_report.md` no longer lists `parse_tenant_policy_pack_map` or `_optional_transition_replay_fields_match` in the top current source hotspots.
- Next reported source hotspot is `_ensure_schema_documentation` in `src/api/openapi_enrichment.py`.

## Behavior / Docs / Wiki
- Behavior preserved; changes are helper extractions with direct regression tests.
- No README/wiki/operator truth change required.