### PR TITLE
Refactor OpenAPI and portfolio memory filter helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19353,3 +19353,35 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal campaign assignment task
   idempotency helper maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-794: OpenAPI schema documentation helpers
+
+- Date: 2026-06-12
+- Scope: `src/api/openapi_enrichment.py`,
+  `tests/unit/api/test_openapi_enrichment_helpers.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_ensure_schema_documentation` was the top current source-complexity hotspot and mixed
+  component/schema/property filtering with description and example mutation for OpenAPI schema
+  enrichment.
+- Action: extracted documentable schema-property iteration, component schema extraction, model
+  property filtering, and property documentation mutation helpers while preserving the existing
+  enrichment behavior for non-standard schema fragments, declared descriptions, and declared
+  examples. Added direct helper tests for fragment filtering, component-schema extraction,
+  model-property filtering, generated descriptions/examples, and preserving existing property
+  documentation. Refreshed current-state quality reports and preserved the stable baseline
+  artifact; the refreshed complexity report shows `_ensure_schema_documentation` dropped out of the
+  top current source-complexity list without introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`,
+  `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q` (23 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal OpenAPI enrichment helper
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19385,3 +19385,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal OpenAPI enrichment helper
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-795: Portfolio-memory search filter predicates
+
+- Date: 2026-06-12
+- Scope: `src/core/portfolio_memory/search_filters.py`,
+  `tests/unit/dpm/portfolio_memory/test_search_filters.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `event_matches_search_filters` was the top current source-complexity hotspot and
+  combined event type, supportability state, represented source-system, and represented
+  source-type matching inside one portfolio-memory search predicate.
+- Action: extracted field-specific event type, supportability, source-system, and source-type
+  match predicates while preserving the existing search filter behavior across event-local source
+  fields, source refs, and artifact refs. Added direct helper tests for optional filters, matched
+  and mismatched event type, matched and mismatched supportability state, and source facet
+  inclusion/exclusion. Refreshed current-state quality reports and preserved the stable baseline
+  artifact; the refreshed complexity report shows `event_matches_search_filters` dropped out of
+  the top current source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/portfolio_memory/search_filters.py tests/unit/dpm/portfolio_memory/test_search_filters.py`,
+  `python -m ruff format --check src/core/portfolio_memory/search_filters.py tests/unit/dpm/portfolio_memory/test_search_filters.py`,
+  `python -m mypy --config-file mypy.ini src/core/portfolio_memory/search_filters.py`,
+  `python -m pytest tests/unit/dpm/portfolio_memory/test_search_filters.py -q` (6 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal portfolio-memory search
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T10:04:26+00:00`
+- Generated at: `2026-06-12T10:17:03+00:00`
 
-- Current ref: `ba65f13c`
+- Current ref: `9b292948`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _ensure_schema_documentation | src/api/openapi_enrichment.py | 9 | 18 |
-| 2 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
-| 3 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
-| 4 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 5 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 6 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
-| 7 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
-| 8 | setup_observability | src/api/observability.py | 8 | 98 |
-| 9 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
-| 10 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 1 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
+| 2 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
+| 3 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 4 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 5 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
+| 6 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
+| 7 | setup_observability | src/api/observability.py | 8 | 98 |
+| 8 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 9 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 10 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T10:17:03+00:00`
+- Generated at: `2026-06-12T10:20:02+00:00`
 
-- Current ref: `9b292948`
+- Current ref: `bc8534ec`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | event_matches_search_filters | src/core/portfolio_memory/search_filters.py | 9 | 17 |
-| 2 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
-| 3 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 4 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 5 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
-| 6 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
-| 7 | setup_observability | src/api/observability.py | 8 | 98 |
-| 8 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
-| 9 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
-| 10 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 1 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
+| 2 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 3 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 4 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
+| 5 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
+| 6 | setup_observability | src/api/observability.py | 8 | 98 |
+| 7 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 8 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 9 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 10 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T10:04:26+00:00`
+- Generated at: `2026-06-12T10:17:03+00:00`
 
-- Current ref: `ba65f13c`
+- Current ref: `9b292948`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T10:17:03+00:00`
+- Generated at: `2026-06-12T10:20:02+00:00`
 
-- Current ref: `9b292948`
+- Current ref: `bc8534ec`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T10:04:26+00:00`
+- Generated at: `2026-06-12T10:17:03+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `ba65f13c`
+- Current ref: `9b292948`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 164895 | 164994 | +99 |
-| Test functions | 2346 | 2349 | +3 |
+| Total Python LOC | 164994 | 165086 | +92 |
+| Test functions | 2349 | 2351 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -42,7 +42,7 @@
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2237 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2114 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2137 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T10:17:03+00:00`
+- Generated at: `2026-06-12T10:20:02+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `9b292948`
+- Current ref: `bc8534ec`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 164994 | 165086 | +92 |
-| Test functions | 2349 | 2351 | +2 |
+| Total Python LOC | 164994 | 165129 | +135 |
+| Test functions | 2349 | 2352 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -563,23 +563,52 @@ def _operation_has_error_response(responses: dict[str, Any]) -> bool:
 
 
 def _ensure_schema_documentation(schema: dict[str, Any]) -> None:
-    components = schema.get("components", {})
-    schemas = components.get("schemas", {})
-    if not isinstance(schemas, dict):
+    for model_name, prop_name, prop_schema in _schema_documentable_properties(schema):
+        _ensure_property_documentation(
+            model_name=model_name,
+            prop_name=prop_name,
+            prop_schema=prop_schema,
+        )
+
+
+def _schema_documentable_properties(
+    schema: dict[str, Any],
+) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    schemas = _schema_component_schemas(schema)
+    if schemas is None:
         return
     for model_name, model_schema in schemas.items():
-        if not isinstance(model_schema, dict):
-            continue
-        properties = model_schema.get("properties", {})
-        if not isinstance(properties, dict):
-            continue
-        for prop_name, prop_schema in properties.items():
-            if not isinstance(prop_schema, dict):
-                continue
-            if not prop_schema.get("description"):
-                prop_schema["description"] = _infer_description(model_name, prop_name, prop_schema)
-            if "example" not in prop_schema:
-                prop_schema["example"] = _infer_example(prop_name, prop_schema)
+        yield from _model_documentable_properties(model_name=model_name, model_schema=model_schema)
+
+
+def _schema_component_schemas(schema: dict[str, Any]) -> dict[str, Any] | None:
+    components = schema.get("components", {})
+    if not isinstance(components, dict):
+        return None
+    schemas = components.get("schemas", {})
+    return schemas if isinstance(schemas, dict) else None
+
+
+def _model_documentable_properties(
+    *, model_name: Any, model_schema: Any
+) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    if not isinstance(model_name, str) or not isinstance(model_schema, dict):
+        return
+    properties = model_schema.get("properties", {})
+    if not isinstance(properties, dict):
+        return
+    for prop_name, prop_schema in properties.items():
+        if isinstance(prop_name, str) and isinstance(prop_schema, dict):
+            yield model_name, prop_name, prop_schema
+
+
+def _ensure_property_documentation(
+    *, model_name: str, prop_name: str, prop_schema: dict[str, Any]
+) -> None:
+    if not prop_schema.get("description"):
+        prop_schema["description"] = _infer_description(model_name, prop_name, prop_schema)
+    if "example" not in prop_schema:
+        prop_schema["example"] = _infer_example(prop_name, prop_schema)
 
 
 def enrich_openapi_schema(schema: dict[str, Any], *, service_name: str) -> dict[str, Any]:

--- a/src/core/portfolio_memory/search_filters.py
+++ b/src/core/portfolio_memory/search_filters.py
@@ -25,15 +25,37 @@ def event_matches_search_filters(
     source_system: str | None,
     source_type: str | None,
 ) -> bool:
-    if event_type is not None and event.event_type != event_type:
-        return False
-    if supportability_state is not None and event.supportability_state != supportability_state:
-        return False
-    if source_system is not None and source_system not in event_source_systems(event):
-        return False
-    if source_type is not None and source_type not in event_source_types(event):
-        return False
-    return True
+    return (
+        _event_type_matches(event=event, event_type=event_type)
+        and _event_supportability_matches(
+            event=event,
+            supportability_state=supportability_state,
+        )
+        and _event_source_system_matches(event=event, source_system=source_system)
+        and _event_source_type_matches(event=event, source_type=source_type)
+    )
+
+
+def _event_type_matches(*, event: DpmPortfolioMemoryEvent, event_type: str | None) -> bool:
+    return event_type is None or event.event_type == event_type
+
+
+def _event_supportability_matches(
+    *,
+    event: DpmPortfolioMemoryEvent,
+    supportability_state: PortfolioMemorySupportabilityState | None,
+) -> bool:
+    return supportability_state is None or event.supportability_state == supportability_state
+
+
+def _event_source_system_matches(
+    *, event: DpmPortfolioMemoryEvent, source_system: str | None
+) -> bool:
+    return source_system is None or source_system in event_source_systems(event)
+
+
+def _event_source_type_matches(*, event: DpmPortfolioMemoryEvent, source_type: str | None) -> bool:
+    return source_type is None or source_type in event_source_types(event)
 
 
 def event_source_systems(event: DpmPortfolioMemoryEvent) -> set[str]:

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -8,15 +8,19 @@ from src.api.openapi_enrichment import (
     _ensure_operation_default_docs,
     _ensure_operation_default_error_response,
     _ensure_operation_examples,
+    _ensure_property_documentation,
     _infer_description,
     _infer_example,
     _is_error_status_code,
     _is_http_operation_method,
+    _model_documentable_properties,
     _number_example_for_key,
     _operation_has_error_response,
     _operation_tag_for_path,
     _ref_example_from_schema,
+    _schema_component_schemas,
     _schema_declared_example,
+    _schema_documentable_properties,
     _schema_format_example,
     _schema_http_operations,
     _schema_type_example,
@@ -417,6 +421,65 @@ def test_openapi_enrichment_schema_http_operations_filters_schema_fragments() ->
 
     assert list(_schema_http_operations(schema)) == [("/api/v1/custom", "get", operation)]
     assert list(_schema_http_operations({"paths": []})) == []
+
+
+def test_openapi_enrichment_schema_documentable_properties_filters_fragments() -> None:
+    good_property = {"type": "string"}
+    schema = {
+        "components": {
+            "schemas": {
+                "Payload": {"properties": {"customId": good_property, 42: {"type": "string"}}},
+                "Broken": [],
+                99: {"properties": {"ignored": {"type": "string"}}},
+                "NoProperties": {"properties": []},
+                "MixedProperties": {"properties": {"bad": []}},
+            }
+        }
+    }
+
+    assert list(_schema_documentable_properties(schema)) == [("Payload", "customId", good_property)]
+    assert list(_schema_documentable_properties({"components": []})) == []
+    assert _schema_component_schemas(schema) == schema["components"]["schemas"]
+    assert _schema_component_schemas({"components": []}) is None
+    assert list(
+        _model_documentable_properties(
+            model_name="Payload",
+            model_schema={"properties": {"customId": good_property, 42: {}}},
+        )
+    ) == [("Payload", "customId", good_property)]
+    assert list(_model_documentable_properties(model_name=42, model_schema={})) == []
+    assert (
+        list(_model_documentable_properties(model_name="Payload", model_schema={"properties": []}))
+        == []
+    )
+
+
+def test_openapi_enrichment_property_documentation_preserves_existing_values() -> None:
+    existing = {
+        "type": "string",
+        "description": "Existing description.",
+        "example": "existing-example",
+    }
+    generated = {"type": "string"}
+
+    _ensure_property_documentation(
+        model_name="Payload",
+        prop_name="customId",
+        prop_schema=existing,
+    )
+    _ensure_property_documentation(
+        model_name="Payload",
+        prop_name="customId",
+        prop_schema=generated,
+    )
+
+    assert existing == {
+        "type": "string",
+        "description": "Existing description.",
+        "example": "existing-example",
+    }
+    assert generated["description"] == "Unique custom identifier."
+    assert generated["example"] == "CUSTOM_001"
 
 
 def test_openapi_enrichment_metrics_helper_adds_prometheus_and_error_examples() -> None:

--- a/tests/unit/dpm/portfolio_memory/test_search_filters.py
+++ b/tests/unit/dpm/portfolio_memory/test_search_filters.py
@@ -8,6 +8,10 @@ from src.core.portfolio_memory.search_filters import (
     event_matches_search_filters,
     event_source_systems,
     event_source_types,
+    _event_source_system_matches,
+    _event_source_type_matches,
+    _event_supportability_matches,
+    _event_type_matches,
     normalize_portfolio_memory_search_filter,
 )
 
@@ -73,6 +77,23 @@ def test_event_matches_search_filters_across_source_facets() -> None:
         source_system="lotus-report",
         source_type="REPORT_INPUT",
     )
+
+
+def test_event_search_filter_predicates_match_optional_fields_and_facets() -> None:
+    event = _event()
+
+    assert _event_type_matches(event=event, event_type=None)
+    assert _event_type_matches(event=event, event_type="WAVE_EVENT")
+    assert not _event_type_matches(event=event, event_type="OUTCOME_REVIEW_CREATED")
+    assert _event_supportability_matches(event=event, supportability_state=None)
+    assert _event_supportability_matches(event=event, supportability_state="READY")
+    assert not _event_supportability_matches(event=event, supportability_state="BLOCKED")
+    assert _event_source_system_matches(event=event, source_system=None)
+    assert _event_source_system_matches(event=event, source_system="lotus-core")
+    assert not _event_source_system_matches(event=event, source_system="lotus-risk")
+    assert _event_source_type_matches(event=event, source_type=None)
+    assert _event_source_type_matches(event=event, source_type="REPORT_INPUT")
+    assert not _event_source_type_matches(event=event, source_type="RiskMetricsReport")
     assert not event_matches_search_filters(
         event=event,
         event_type="OUTCOME_REVIEW_CREATED",


### PR DESCRIPTION
## Summary
- Extract OpenAPI schema documentation helpers for component schema filtering, model-property filtering, and property documentation mutation.
- Extract portfolio-memory search filter predicates for event type, supportability, represented source-system, and represented source-type matching.
- Refresh current-state refactor health, scorecard, complexity report, and codebase review ledger entries BACKEND-REVIEW-20260612-794 and BACKEND-REVIEW-20260612-795.

## Quality Evidence
- `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`
- `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q` (23 passed)
- `python -m ruff check src/core/portfolio_memory/search_filters.py tests/unit/dpm/portfolio_memory/test_search_filters.py`
- `python -m ruff format --check src/core/portfolio_memory/search_filters.py tests/unit/dpm/portfolio_memory/test_search_filters.py`
- `python -m mypy --config-file mypy.ini src/core/portfolio_memory/search_filters.py`
- `python -m pytest tests/unit/dpm/portfolio_memory/test_search_filters.py -q` (6 passed)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- Service leakage scan returned no matches.
- `make check` (2525 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Measurable Improvement
- `quality/complexity_report.md` no longer lists `_ensure_schema_documentation` or `event_matches_search_filters` in the top current source hotspots.
- Next reported source hotspot is `_schema_http_operations` in `src/api/openapi_enrichment.py`.

## Behavior / Docs / Wiki
- Behavior preserved; changes are helper extractions with direct regression tests.
- No README/wiki/operator truth change required.