### PR TITLE
Refactor OpenAPI and performance attribution helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19416,3 +19416,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal portfolio-memory search
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-796: OpenAPI HTTP operation iteration helpers
+
+- Date: 2026-06-12
+- Scope: `src/api/openapi_enrichment.py`,
+  `tests/unit/api/test_openapi_enrichment_helpers.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_schema_http_operations` was the top current source-complexity hotspot and combined
+  OpenAPI path-map validation, path-method filtering, HTTP method filtering, and operation-shape
+  filtering in one iterator.
+- Action: extracted schema path-method iteration and per-path HTTP operation filtering helpers
+  while preserving the existing OpenAPI enrichment behavior for non-dict paths, non-string path
+  keys, non-HTTP methods, and non-dict operation fragments. Added direct helper tests for
+  path-method filtering and operation-method filtering. Refreshed current-state quality reports
+  and preserved the stable baseline artifact; the refreshed complexity report shows
+  `_schema_http_operations` dropped out of the top current source-complexity list without
+  introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`,
+  `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q` (24 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal OpenAPI enrichment helper
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19447,3 +19447,35 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal OpenAPI enrichment helper
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-797: Performance attribution selector helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/outcomes/performance_sources.py`,
+  `tests/unit/core/test_performance_realized_outcome_sources.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_attribution_level` and `_attribution_currency` were the top current
+  source-complexity hotspots and duplicated source-owned attribution entry selection, malformed
+  payload tolerance, selector matching, and fallback selector normalization.
+- Action: extracted a shared attribution-entry selector with focused selector-match and
+  selector-resolution helpers while preserving existing level and currency attribution behavior.
+  Added direct helper tests for requested selector matching, malformed/non-list attribution
+  payloads, no-match fallbacks, selector-match truth, and unknown selector fallback. Refreshed
+  current-state quality reports and preserved the stable baseline artifact; the refreshed
+  complexity report shows `_attribution_level`, `_attribution_currency`, and the extracted
+  selector helpers are out of the top current source-complexity list.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/performance_sources.py tests/unit/core/test_performance_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/performance_sources.py tests/unit/core/test_performance_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/performance_sources.py`,
+  `python -m pytest tests/unit/core/test_performance_realized_outcome_sources.py -q` (29 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal performance attribution source
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T10:20:02+00:00`
+- Generated at: `2026-06-12T10:30:45+00:00`
 
-- Current ref: `bc8534ec`
+- Current ref: `b54aeffd`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _schema_http_operations | src/api/openapi_enrichment.py | 9 | 16 |
-| 2 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 3 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 4 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
-| 5 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
-| 6 | setup_observability | src/api/observability.py | 8 | 98 |
-| 7 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
-| 8 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
-| 9 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
-| 10 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 1 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 2 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
+| 3 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
+| 4 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
+| 5 | setup_observability | src/api/observability.py | 8 | 98 |
+| 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 7 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 8 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 9 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 10 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T10:30:45+00:00`
+- Generated at: `2026-06-12T10:34:56+00:00`
 
-- Current ref: `b54aeffd`
+- Current ref: `d472d7e3`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _attribution_level | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 2 | _attribution_currency | src/core/outcomes/performance_sources.py | 9 | 14 |
-| 3 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
-| 4 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
-| 5 | setup_observability | src/api/observability.py | 8 | 98 |
-| 6 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
-| 7 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
-| 8 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
-| 9 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
-| 10 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 1 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
+| 2 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
+| 3 | setup_observability | src/api/observability.py | 8 | 98 |
+| 4 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 5 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 6 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 7 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 8 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 9 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 10 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T10:20:02+00:00`
+- Generated at: `2026-06-12T10:30:45+00:00`
 
-- Current ref: `bc8534ec`
+- Current ref: `b54aeffd`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T10:30:45+00:00`
+- Generated at: `2026-06-12T10:34:56+00:00`
 
-- Current ref: `b54aeffd`
+- Current ref: `d472d7e3`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T10:20:02+00:00`
+- Generated at: `2026-06-12T10:30:45+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `bc8534ec`
+- Current ref: `b54aeffd`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 164994 | 165129 | +135 |
-| Test functions | 2349 | 2352 | +3 |
+| Total Python LOC | 165129 | 165164 | +35 |
+| Test functions | 2352 | 2353 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T10:30:45+00:00`
+- Generated at: `2026-06-12T10:34:56+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `b54aeffd`
+- Current ref: `d472d7e3`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 165129 | 165164 | +35 |
-| Test functions | 2352 | 2353 | +1 |
+| Total Python LOC | 165129 | 165230 | +101 |
+| Test functions | 2352 | 2355 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -511,19 +511,30 @@ def _ensure_operation_documentation(schema: dict[str, Any], service_name: str) -
 def _schema_http_operations(
     schema: dict[str, Any],
 ) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    for path, methods in _schema_path_methods(schema):
+        yield from _path_http_operations(path=path, methods=methods)
+
+
+def _schema_path_methods(schema: dict[str, Any]) -> Iterator[tuple[str, dict[str, Any]]]:
     paths = schema.get("paths", {})
     if not isinstance(paths, dict):
         return
     for path, methods in paths.items():
         if not isinstance(path, str) or not isinstance(methods, dict):
             continue
-        for method, operation in methods.items():
-            if (
-                isinstance(method, str)
-                and _is_http_operation_method(method)
-                and isinstance(operation, dict)
-            ):
-                yield path, method, operation
+        yield path, methods
+
+
+def _path_http_operations(
+    *, path: str, methods: dict[str, Any]
+) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    for method, operation in methods.items():
+        if (
+            isinstance(method, str)
+            and _is_http_operation_method(method)
+            and isinstance(operation, dict)
+        ):
+            yield path, method, operation
 
 
 def _ensure_operation_default_docs(

--- a/src/core/outcomes/performance_sources.py
+++ b/src/core/outcomes/performance_sources.py
@@ -505,15 +505,11 @@ def _attribution_level(
     period_result: dict[str, Any],
     level_dimension: str | None,
 ) -> tuple[dict[str, Any], str]:
-    levels = period_result.get("levels")
-    if not isinstance(levels, list):
-        return {}, level_dimension or "unknown"
-    for level in levels:
-        level_mapping = _read_mapping(level)
-        dimension = _read_text(level_mapping.get("dimension"))
-        if level_dimension is None or dimension == level_dimension:
-            return level_mapping, dimension or level_dimension or "unknown"
-    return {}, level_dimension or "unknown"
+    return _selected_attribution_entry(
+        entries=period_result.get("levels"),
+        selector_field="dimension",
+        requested_selector=level_dimension,
+    )
 
 
 def _attribution_currency(
@@ -521,15 +517,38 @@ def _attribution_currency(
     period_result: dict[str, Any],
     currency: str | None,
 ) -> tuple[dict[str, Any], str]:
-    currency_results = period_result.get("currency_attribution")
-    if not isinstance(currency_results, list):
-        return {}, currency or "unknown"
-    for currency_result in currency_results:
-        result_mapping = _read_mapping(currency_result)
-        currency_code = _read_text(result_mapping.get("currency"))
-        if currency is None or currency_code == currency:
-            return result_mapping, currency_code or currency or "unknown"
-    return {}, currency or "unknown"
+    return _selected_attribution_entry(
+        entries=period_result.get("currency_attribution"),
+        selector_field="currency",
+        requested_selector=currency,
+    )
+
+
+def _selected_attribution_entry(
+    *,
+    entries: Any,
+    selector_field: str,
+    requested_selector: str | None,
+) -> tuple[dict[str, Any], str]:
+    if not isinstance(entries, list):
+        return {}, requested_selector or "unknown"
+    for entry in entries:
+        entry_mapping = _read_mapping(entry)
+        selector = _read_text(entry_mapping.get(selector_field))
+        if _attribution_selector_matches(selector=selector, requested_selector=requested_selector):
+            return entry_mapping, _resolved_attribution_selector(
+                selector=selector,
+                requested_selector=requested_selector,
+            )
+    return {}, _resolved_attribution_selector(selector=None, requested_selector=requested_selector)
+
+
+def _attribution_selector_matches(*, selector: str | None, requested_selector: str | None) -> bool:
+    return requested_selector is None or selector == requested_selector
+
+
+def _resolved_attribution_selector(*, selector: str | None, requested_selector: str | None) -> str:
+    return selector or requested_selector or "unknown"
 
 
 def _performance_source_posture(

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -17,12 +17,14 @@ from src.api.openapi_enrichment import (
     _number_example_for_key,
     _operation_has_error_response,
     _operation_tag_for_path,
+    _path_http_operations,
     _ref_example_from_schema,
     _schema_component_schemas,
     _schema_declared_example,
     _schema_documentable_properties,
     _schema_format_example,
     _schema_http_operations,
+    _schema_path_methods,
     _schema_type_example,
     _SEMANTIC_DESCRIPTION_RULES,
     _semantic_description_for_context,
@@ -421,6 +423,28 @@ def test_openapi_enrichment_schema_http_operations_filters_schema_fragments() ->
 
     assert list(_schema_http_operations(schema)) == [("/api/v1/custom", "get", operation)]
     assert list(_schema_http_operations({"paths": []})) == []
+    assert list(_schema_path_methods(schema)) == [
+        ("/api/v1/custom", {"get": operation, "trace": {"responses": {}}}),
+        ("/bad-operation", {"post": []}),
+    ]
+    assert list(_schema_path_methods({"paths": []})) == []
+
+
+def test_openapi_enrichment_path_http_operations_filters_methods() -> None:
+    get_operation = {"responses": {"200": {"description": "ok"}}}
+    post_operation = {"responses": {"201": {"description": "created"}}}
+    methods = {
+        "get": get_operation,
+        "post": post_operation,
+        "trace": {"responses": {}},
+        42: {"responses": {}},
+        "delete": [],
+    }
+
+    assert list(_path_http_operations(path="/api/v1/custom", methods=methods)) == [
+        ("/api/v1/custom", "get", get_operation),
+        ("/api/v1/custom", "post", post_operation),
+    ]
 
 
 def test_openapi_enrichment_schema_documentable_properties_filters_fragments() -> None:

--- a/tests/unit/core/test_performance_realized_outcome_sources.py
+++ b/tests/unit/core/test_performance_realized_outcome_sources.py
@@ -352,6 +352,53 @@ def test_attribution_adapter_wraps_source_owned_currency_effect() -> None:
     assert "PERFORMANCE_ATTRIBUTION_CURRENCY_USD" in source.reason_codes
 
 
+def test_selected_attribution_entry_matches_requested_selector() -> None:
+    asset_class = {"dimension": "asset_class", "total_effect_pct": 0.47}
+    sector = {"dimension": "sector", "total_effect_pct": 0.21}
+
+    entry, selector = perf_sources._selected_attribution_entry(
+        entries=[asset_class, sector],
+        selector_field="dimension",
+        requested_selector="sector",
+    )
+
+    assert entry == sector
+    assert selector == "sector"
+
+
+def test_selected_attribution_entry_uses_fallback_for_malformed_payloads() -> None:
+    assert perf_sources._selected_attribution_entry(
+        entries={"dimension": "asset_class"},
+        selector_field="dimension",
+        requested_selector="asset_class",
+    ) == ({}, "asset_class")
+    assert perf_sources._selected_attribution_entry(
+        entries=[{"dimension": ""}],
+        selector_field="dimension",
+        requested_selector=None,
+    ) == ({"dimension": ""}, "unknown")
+    assert perf_sources._selected_attribution_entry(
+        entries=[{"dimension": "asset_class"}],
+        selector_field="dimension",
+        requested_selector="sector",
+    ) == ({}, "sector")
+    assert perf_sources._attribution_selector_matches(
+        selector="sector",
+        requested_selector="sector",
+    )
+    assert not perf_sources._attribution_selector_matches(
+        selector="asset_class",
+        requested_selector="sector",
+    )
+    assert (
+        perf_sources._resolved_attribution_selector(
+            selector=None,
+            requested_selector=None,
+        )
+        == "unknown"
+    )
+
+
 def test_source_owned_attribution_can_make_rfc42_performance_dimension_ready() -> None:
     source = realized_attribution_source_from_attribution_response(_attribution_response())
 


### PR DESCRIPTION
## Summary
- Extract OpenAPI HTTP operation iteration helpers from `_schema_http_operations` with direct helper coverage.
- Extract shared performance attribution selector helpers for level/currency attribution lookup with direct fallback/malformed-payload coverage.
- Refresh current-state quality reports and add ledger entries `BACKEND-REVIEW-20260612-796` and `BACKEND-REVIEW-20260612-797`.

## Quality evidence
- `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`
- `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q` (24 passed)
- `python -m ruff check src/core/outcomes/performance_sources.py tests/unit/core/test_performance_realized_outcome_sources.py`
- `python -m ruff format --check src/core/outcomes/performance_sources.py tests/unit/core/test_performance_realized_outcome_sources.py`
- `python -m mypy --config-file mypy.ini src/core/outcomes/performance_sources.py`
- `python -m pytest tests/unit/core/test_performance_realized_outcome_sources.py -q` (29 passed)
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan returned no matches
- `make check` (2528 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- wiki drift check: `DiffCount 0`

## Measurable outcome
- `_schema_http_operations`, `_attribution_level`, and `_attribution_currency` are no longer listed in the top current source-complexity hotspots.
- Next source hotspots now start with `_remediation_routes` and `source_supportability_state`.

## Wiki
No wiki publication required; this PR changes internal backend helper structure, direct tests, current quality reports, and the codebase review ledger only.