### PR TITLE
Refactor supportability and remediation helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19510,3 +19510,33 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal portfolio-memory supportability
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-799: Outcome-review remediation route mapper
+
+- Date: 2026-06-12
+- Scope: `src/api/routers/outcome_review_supportability_routes.py`,
+  `tests/unit/api/test_outcome_reviews_api.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_remediation_routes` was the top current source-complexity hotspot and combined
+  reason-code classification, remediation-route selection, deduplication, and sorting inside one
+  outcome-review supportability router helper.
+- Action: extracted a reason-code-to-remediation-route mapper and a source-owner remediation
+  predicate while preserving the existing sorted unique remediation route response. Added direct
+  tests for risk, performance, execution, realized source, cash/tax source-owner, and no-route
+  reason behavior. Refreshed current-state quality reports and preserved the stable baseline
+  artifact; the refreshed complexity report shows `_remediation_routes` dropped out of the top
+  current source-complexity list without introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/outcome_review_supportability_routes.py tests/unit/api/test_outcome_reviews_api.py`,
+  `python -m ruff format --check src/api/routers/outcome_review_supportability_routes.py tests/unit/api/test_outcome_reviews_api.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/outcome_review_supportability_routes.py`,
+  `python -m pytest tests/unit/api/test_outcome_reviews_api.py -q` (6 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal outcome-review supportability
+  route-mapping maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19479,3 +19479,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal performance attribution source
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-798: Portfolio-memory source supportability predicates
+
+- Date: 2026-06-12
+- Scope: `src/core/portfolio_memory/supportability.py`,
+  `tests/unit/dpm/portfolio_memory/test_governance_supportability.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `source_supportability_state` was a top current source-complexity hotspot and combined
+  blocked, degraded, and pending-review source-state classification rules in one portfolio-memory
+  supportability mapper.
+- Action: extracted explicit blocked, degraded, and pending-review source-state predicates while
+  preserving the existing fail-closed portfolio-memory supportability mapping. Added direct tests
+  for each predicate classification and non-match behavior. Refreshed current-state quality reports
+  and preserved the stable baseline artifact; the refreshed complexity report shows
+  `source_supportability_state` dropped out of the top current source-complexity list without
+  introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/portfolio_memory/supportability.py tests/unit/dpm/portfolio_memory/test_governance_supportability.py`,
+  `python -m ruff format --check src/core/portfolio_memory/supportability.py tests/unit/dpm/portfolio_memory/test_governance_supportability.py`,
+  `python -m mypy --config-file mypy.ini src/core/portfolio_memory/supportability.py`,
+  `python -m pytest tests/unit/dpm/portfolio_memory/test_governance_supportability.py -q` (5 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal portfolio-memory supportability
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T10:46:23+00:00`
+- Generated at: `2026-06-12T10:49:00+00:00`
 
-- Current ref: `35600357`
+- Current ref: `78e4a966`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
-| 2 | setup_observability | src/api/observability.py | 8 | 98 |
-| 3 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
-| 4 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
-| 5 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
-| 6 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
-| 7 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
-| 8 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 9 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 10 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 1 | setup_observability | src/api/observability.py | 8 | 98 |
+| 2 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 3 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 4 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 5 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 6 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 7 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 8 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 9 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 10 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T10:34:56+00:00`
+- Generated at: `2026-06-12T10:46:23+00:00`
 
-- Current ref: `d472d7e3`
+- Current ref: `35600357`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -33,15 +33,15 @@
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
 | 1 | _remediation_routes | src/api/routers/outcome_review_supportability_routes.py | 9 | 12 |
-| 2 | source_supportability_state | src/core/portfolio_memory/supportability.py | 9 | 9 |
-| 3 | setup_observability | src/api/observability.py | 8 | 98 |
-| 4 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
-| 5 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
-| 6 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
-| 7 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
-| 8 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
-| 9 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 10 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 2 | setup_observability | src/api/observability.py | 8 | 98 |
+| 3 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 4 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 5 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 6 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 7 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 8 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 9 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 10 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T10:34:56+00:00`
+- Generated at: `2026-06-12T10:46:23+00:00`
 
-- Current ref: `d472d7e3`
+- Current ref: `35600357`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T10:46:23+00:00`
+- Generated at: `2026-06-12T10:49:00+00:00`
 
-- Current ref: `35600357`
+- Current ref: `78e4a966`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T10:46:23+00:00`
+- Generated at: `2026-06-12T10:49:00+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `35600357`
+- Current ref: `78e4a966`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 165230 | 165272 | +42 |
-| Test functions | 2355 | 2356 | +1 |
+| Total Python LOC | 165230 | 165306 | +76 |
+| Test functions | 2355 | 2357 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T10:34:56+00:00`
+- Generated at: `2026-06-12T10:46:23+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `d472d7e3`
+- Current ref: `35600357`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 165129 | 165230 | +101 |
-| Test functions | 2352 | 2355 | +3 |
+| Total Python LOC | 165230 | 165272 | +42 |
+| Test functions | 2355 | 2356 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/routers/outcome_review_supportability_routes.py
+++ b/src/api/routers/outcome_review_supportability_routes.py
@@ -102,12 +102,23 @@ def _supportability_response(
 def _remediation_routes(review: DpmPostTradeOutcomeReview) -> list[str]:
     routes: set[str] = set()
     for reason in review.supportability.reason_codes:
-        if "RISK" in reason:
-            routes.add("lotus-risk:refresh-post-trade-risk-source")
-        elif "PERFORMANCE" in reason:
-            routes.add("lotus-performance:refresh-post-trade-performance-source")
-        elif "EXECUTION" in reason:
-            routes.add("execution-owner:certify-fill-and-order-evidence")
-        elif "SOURCE" in reason or "CASH" in reason or "FX" in reason or "TAX" in reason:
-            routes.add("source-owner:refresh-realized-outcome-source")
+        route = _remediation_route_for_reason(reason)
+        if route is not None:
+            routes.add(route)
     return sorted(routes)
+
+
+def _remediation_route_for_reason(reason: str) -> str | None:
+    if "RISK" in reason:
+        return "lotus-risk:refresh-post-trade-risk-source"
+    if "PERFORMANCE" in reason:
+        return "lotus-performance:refresh-post-trade-performance-source"
+    if "EXECUTION" in reason:
+        return "execution-owner:certify-fill-and-order-evidence"
+    if _is_realized_source_remediation_reason(reason):
+        return "source-owner:refresh-realized-outcome-source"
+    return None
+
+
+def _is_realized_source_remediation_reason(reason: str) -> bool:
+    return "SOURCE" in reason or "CASH" in reason or "FX" in reason or "TAX" in reason

--- a/src/core/portfolio_memory/supportability.py
+++ b/src/core/portfolio_memory/supportability.py
@@ -25,13 +25,38 @@ def portfolio_memory_state(
 
 def source_supportability_state(source_state: str | None) -> PortfolioMemorySupportabilityState:
     normalized = (source_state or "").upper()
-    if "BLOCK" in normalized or normalized in {"FAILED", "REJECTED", "CANCELLED"}:
+    if _source_state_is_blocked(normalized):
         return "BLOCKED"
-    if "DEGRADED" in normalized or "BREACHED" in normalized or "PARTIAL" in normalized:
+    if _source_state_is_degraded(normalized):
         return "DEGRADED"
-    if "REVIEW" in normalized or normalized in {"CREATED", "DRAFT", "PREVIEWED", "CANDIDATE"}:
+    if _source_state_requires_review(normalized):
         return "PENDING_REVIEW"
     return "READY"
+
+
+def _source_state_is_blocked(normalized_source_state: str) -> bool:
+    return "BLOCK" in normalized_source_state or normalized_source_state in {
+        "FAILED",
+        "REJECTED",
+        "CANCELLED",
+    }
+
+
+def _source_state_is_degraded(normalized_source_state: str) -> bool:
+    return (
+        "DEGRADED" in normalized_source_state
+        or "BREACHED" in normalized_source_state
+        or "PARTIAL" in normalized_source_state
+    )
+
+
+def _source_state_requires_review(normalized_source_state: str) -> bool:
+    return "REVIEW" in normalized_source_state or normalized_source_state in {
+        "CREATED",
+        "DRAFT",
+        "PREVIEWED",
+        "CANDIDATE",
+    }
 
 
 def monitoring_exception_state(

--- a/tests/unit/api/test_outcome_reviews_api.py
+++ b/tests/unit/api/test_outcome_reviews_api.py
@@ -9,6 +9,10 @@ from src.api.dependencies import (
     get_wave_repository,
 )
 from src.api.main import app
+from src.api.routers.outcome_review_supportability_routes import (
+    _is_realized_source_remediation_reason,
+    _remediation_route_for_reason,
+)
 from src.core.outcomes import (
     DpmOutcomeDimensionInput,
     DpmOutcomeMetricValue,
@@ -424,6 +428,25 @@ def test_outcome_review_supportability_routes_source_owner_remediation() -> None
         ]
     finally:
         app.dependency_overrides.clear()
+
+
+def test_outcome_review_remediation_reason_mapper_returns_operator_routes() -> None:
+    assert _remediation_route_for_reason("RISK_SOURCE_UNAVAILABLE") == (
+        "lotus-risk:refresh-post-trade-risk-source"
+    )
+    assert _remediation_route_for_reason("PERFORMANCE_SOURCE_UNAVAILABLE") == (
+        "lotus-performance:refresh-post-trade-performance-source"
+    )
+    assert _remediation_route_for_reason("EXECUTION_EVIDENCE_BLOCKED") == (
+        "execution-owner:certify-fill-and-order-evidence"
+    )
+    assert _remediation_route_for_reason("FX_SOURCE_STALE") == (
+        "source-owner:refresh-realized-outcome-source"
+    )
+    assert _remediation_route_for_reason("OUTCOME_REVIEW_READY") is None
+    assert _is_realized_source_remediation_reason("CASH_RECONCILIATION_STALE")
+    assert _is_realized_source_remediation_reason("TAX_SOURCE_UNAVAILABLE")
+    assert not _is_realized_source_remediation_reason("OUTCOME_REVIEW_READY")
 
 
 def test_outcome_review_supportability_exposes_external_execution_boundary() -> None:

--- a/tests/unit/dpm/portfolio_memory/test_governance_supportability.py
+++ b/tests/unit/dpm/portfolio_memory/test_governance_supportability.py
@@ -6,6 +6,9 @@ from src.core.portfolio_memory.governance import (
 )
 from src.core.portfolio_memory.models import DpmPortfolioMemoryEvent
 from src.core.portfolio_memory.supportability import (
+    _source_state_is_blocked,
+    _source_state_is_degraded,
+    _source_state_requires_review,
     assignment_sla_state,
     assignment_task_state,
     maker_checker_state,
@@ -84,3 +87,17 @@ def test_portfolio_memory_supportability_mapping_is_fail_closed() -> None:
     assert assignment_task_state("CANCELLED", "ON_TRACK") == "BLOCKED"
     assert assignment_task_state("OPEN", "ON_TRACK") == "PENDING_REVIEW"
     assert maker_checker_state("EXCEPTION_OPEN") == "DEGRADED"
+
+
+def test_source_supportability_state_predicates_classify_source_posture() -> None:
+    assert _source_state_is_blocked("PERMISSION_BLOCKED")
+    assert _source_state_is_blocked("FAILED")
+    assert not _source_state_is_blocked("READY")
+
+    assert _source_state_is_degraded("SLA_BREACHED")
+    assert _source_state_is_degraded("PARTIAL")
+    assert not _source_state_is_degraded("READY")
+
+    assert _source_state_requires_review("REVIEW_REQUIRED")
+    assert _source_state_requires_review("DRAFT")
+    assert not _source_state_requires_review("READY")


### PR DESCRIPTION
## Summary
- Extract portfolio-memory source supportability classification predicates with focused governance-supportability tests.
- Extract outcome-review remediation reason route mapping helpers with direct API test coverage.
- Refresh current-state quality reports and add ledger entries `BACKEND-REVIEW-20260612-798` and `BACKEND-REVIEW-20260612-799`.

## Quality evidence
- `python -m ruff check src/core/portfolio_memory/supportability.py tests/unit/dpm/portfolio_memory/test_governance_supportability.py`
- `python -m ruff format --check src/core/portfolio_memory/supportability.py tests/unit/dpm/portfolio_memory/test_governance_supportability.py`
- `python -m mypy --config-file mypy.ini src/core/portfolio_memory/supportability.py`
- `python -m pytest tests/unit/dpm/portfolio_memory/test_governance_supportability.py -q` (5 passed)
- `python -m ruff check src/api/routers/outcome_review_supportability_routes.py tests/unit/api/test_outcome_reviews_api.py`
- `python -m ruff format --check src/api/routers/outcome_review_supportability_routes.py tests/unit/api/test_outcome_reviews_api.py`
- `python -m mypy --config-file mypy.ini src/api/routers/outcome_review_supportability_routes.py`
- `python -m pytest tests/unit/api/test_outcome_reviews_api.py -q` (6 passed)
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan returned no matches
- `make check` (2530 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- wiki drift check: `DiffCount 0`

## Measurable outcome
- `source_supportability_state` and `_remediation_routes` are no longer listed in the top current source-complexity hotspots.
- Current top source hotspots now start with `setup_observability`, `compile_mandate_digital_twin_from_core`, and `_decision_timeline`.

## Wiki
No wiki publication required; this PR changes internal helper structure, direct tests, current quality reports, and the codebase review ledger only.