### PR TITLE
Refactor observability and mandate twin helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19573,3 +19573,35 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal API observability setup
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-801: Mandate digital twin source projection helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/mandates.py`, `tests/unit/dpm/core/test_mandate_health.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `compile_mandate_digital_twin_from_core` was a top current source-complexity hotspot
+  and mixed mandate twin orchestration with cash-band constraint mapping, active restriction
+  filtering, sustainability strategy selection, active preference-note projection, lineage
+  assembly, and final model construction.
+- Action: extracted pure mandate twin constraint and preference projection helpers while preserving
+  the compile function as the orchestration boundary. Added direct tests that pin cash reserve band
+  behavior, active-only restricted-instrument projection, sustainability strategy selection, and
+  active-only preference notes. Refreshed current-state quality reports and preserved the stable
+  baseline artifact; the refreshed complexity report shows `compile_mandate_digital_twin_from_core`
+  dropped out of the top current source-complexity list without introducing a replacement hotspot
+  from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py`,
+  `python -m ruff format --check src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py`,
+  `python -m mypy --config-file mypy.ini src/core/mandates.py`,
+  `python -m pytest tests/unit/dpm/core/test_mandate_health.py -q` (38 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal mandate twin projection
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19540,3 +19540,36 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal outcome-review supportability
   route-mapping maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-800: Observability setup orchestration helpers
+
+- Date: 2026-06-12
+- Scope: `src/api/observability.py`,
+  `tests/unit/app/middleware/test_observability.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `setup_observability` was the top current source-complexity hotspot and combined root
+  logger setup, Prometheus metrics route registration, request trace-id parsing, request
+  middleware implementation, metric recording, structured access logging, context reset, and
+  response header enrichment inside one registration function.
+- Action: extracted root JSON logging setup, HTTP metrics baseline initialization, the metrics
+  endpoint, W3C traceparent trace-id parsing, and the request observability middleware while
+  preserving existing correlation/request/trace response headers, security headers, metrics
+  exposition, access logging, and exception reraising behavior. Added direct tests for valid
+  traceparent preservation, malformed traceparent replacement, and metrics endpoint response
+  content. Refreshed current-state quality reports and preserved the stable baseline artifact; the
+  refreshed complexity report shows `setup_observability` dropped out of the top current
+  source-complexity list without introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/observability.py tests/unit/app/middleware/test_observability.py tests/unit/api/test_observability_exception_path.py tests/unit/dpm/api/test_observability_api.py`,
+  `python -m ruff format --check src/api/observability.py tests/unit/app/middleware/test_observability.py tests/unit/api/test_observability_exception_path.py tests/unit/dpm/api/test_observability_api.py`,
+  `python -m mypy --config-file mypy.ini src/api/observability.py`,
+  `python -m pytest tests/unit/app/middleware/test_observability.py tests/unit/api/test_observability_exception_path.py tests/unit/dpm/api/test_observability_api.py -q` (21 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal API observability setup
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T11:00:31+00:00`
+- Generated at: `2026-06-12T11:05:42+00:00`
 
-- Current ref: `81e9426a`
+- Current ref: `ff0487d6`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
-| 2 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
-| 3 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
-| 4 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
-| 5 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
-| 6 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 7 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 8 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 9 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 10 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 1 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 2 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 3 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 4 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 5 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 6 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 7 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 8 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 9 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 10 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T10:49:00+00:00`
+- Generated at: `2026-06-12T11:00:31+00:00`
 
-- Current ref: `78e4a966`
+- Current ref: `81e9426a`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | setup_observability | src/api/observability.py | 8 | 98 |
-| 2 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
-| 3 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
-| 4 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
-| 5 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
-| 6 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
-| 7 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 8 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 9 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 10 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 1 | compile_mandate_digital_twin_from_core | src/core/mandates.py | 8 | 89 |
+| 2 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
+| 3 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 4 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 5 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 6 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 7 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 8 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 9 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 10 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T10:49:00+00:00`
+- Generated at: `2026-06-12T11:00:31+00:00`
 
-- Current ref: `78e4a966`
+- Current ref: `81e9426a`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T11:00:31+00:00`
+- Generated at: `2026-06-12T11:05:42+00:00`
 
-- Current ref: `81e9426a`
+- Current ref: `ff0487d6`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T11:00:31+00:00`
+- Generated at: `2026-06-12T11:05:42+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `81e9426a`
+- Current ref: `ff0487d6`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 165306 | 165339 | +33 |
-| Test functions | 2357 | 2360 | +3 |
+| Total Python LOC | 165306 | 165462 | +156 |
+| Test functions | 2357 | 2362 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T10:49:00+00:00`
+- Generated at: `2026-06-12T11:00:31+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `78e4a966`
+- Current ref: `81e9426a`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 165230 | 165306 | +76 |
-| Test functions | 2355 | 2357 | +2 |
+| Total Python LOC | 165306 | 165339 | +33 |
+| Test functions | 2357 | 2360 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -241,6 +241,20 @@ class JsonFormatter(logging.Formatter):
 
 
 def setup_observability(app: FastAPI) -> None:
+    _configure_root_json_logging()
+    _initialize_http_metrics_baseline()
+    app.get(
+        "/metrics",
+        tags=["Monitoring"],
+        summary="Metrics",
+        operation_id="metrics_metrics_get",
+        responses={503: {"description": "Metrics exposition unavailable."}},
+        response_description="Prometheus text exposition for lotus-manage metrics.",
+    )(_metrics_endpoint)
+    app.middleware("http")(_request_observability_middleware)
+
+
+def _configure_root_json_logging() -> None:
     root_logger = logging.getLogger()
     if root_logger.hasHandlers():
         root_logger.handlers.clear()
@@ -248,72 +262,46 @@ def setup_observability(app: FastAPI) -> None:
     handler = logging.StreamHandler()
     handler.setFormatter(JsonFormatter())
     root_logger.addHandler(handler)
+
+
+def _initialize_http_metrics_baseline() -> None:
     HTTP_REQUESTS_TOTAL.labels(method="GET", endpoint="/metrics", status_family="2xx")
 
-    @app.get(
-        "/metrics",
-        tags=["Monitoring"],
-        summary="Metrics",
-        operation_id="metrics_metrics_get",
-        responses={503: {"description": "Metrics exposition unavailable."}},
-        response_description="Prometheus text exposition for lotus-manage metrics.",
-    )
-    def _metrics() -> Response:
-        return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
-    @app.middleware("http")
-    async def _request_observability_middleware(
-        request: Request, call_next: Callable[[Request], Awaitable[Response]]
-    ) -> Response:
-        logger = logging.getLogger("http.access")
-        started = time.perf_counter()
+def _metrics_endpoint() -> Response:
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
-        correlation_id = request.headers.get("X-Correlation-Id") or f"corr_{uuid4().hex[:12]}"
-        request_id = request.headers.get("X-Request-Id") or f"req_{uuid4().hex[:12]}"
-        traceparent = request.headers.get("traceparent", "")
-        trace_id = uuid4().hex
-        if traceparent:
-            parts = traceparent.split("-")
-            if len(parts) >= 4 and len(parts[1]) == 32:
-                trace_id = parts[1]
 
-        correlation_token = correlation_id_var.set(correlation_id)
-        request_token = request_id_var.set(request_id)
-        trace_token = trace_id_var.set(trace_id)
-        try:
-            response = await call_next(request)
-        except Exception:
-            latency_ms = round((time.perf_counter() - started) * 1000, 2)
-            endpoint = _route_template(request)
-            HTTP_REQUESTS_TOTAL.labels(
-                method=request.method,
-                endpoint=endpoint,
-                status_family="5xx",
-            ).inc()
-            logger.info(
-                "request.completed",
-                extra={
-                    "extra_fields": {
-                        "http_method": request.method,
-                        "endpoint": endpoint,
-                        "status_code": 500,
-                        "status_family": "5xx",
-                        "latency_bucket_ms": _latency_bucket_ms(latency_ms),
-                    }
-                },
-            )
-            correlation_id_var.reset(correlation_token)
-            request_id_var.reset(request_token)
-            trace_id_var.reset(trace_token)
-            raise
+def _trace_id_from_traceparent(traceparent: str) -> str:
+    if traceparent:
+        parts = traceparent.split("-")
+        if len(parts) >= 4 and len(parts[1]) == 32:
+            return parts[1]
+    return uuid4().hex
 
+
+async def _request_observability_middleware(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    logger = logging.getLogger("http.access")
+    started = time.perf_counter()
+
+    correlation_id = request.headers.get("X-Correlation-Id") or f"corr_{uuid4().hex[:12]}"
+    request_id = request.headers.get("X-Request-Id") or f"req_{uuid4().hex[:12]}"
+    trace_id = _trace_id_from_traceparent(request.headers.get("traceparent", ""))
+
+    correlation_token = correlation_id_var.set(correlation_id)
+    request_token = request_id_var.set(request_id)
+    trace_token = trace_id_var.set(trace_id)
+    try:
+        response = await call_next(request)
+    except Exception:
         latency_ms = round((time.perf_counter() - started) * 1000, 2)
         endpoint = _route_template(request)
-        status_family = _status_family(response.status_code)
         HTTP_REQUESTS_TOTAL.labels(
             method=request.method,
             endpoint=endpoint,
-            status_family=status_family,
+            status_family="5xx",
         ).inc()
         logger.info(
             "request.completed",
@@ -321,8 +309,8 @@ def setup_observability(app: FastAPI) -> None:
                 "extra_fields": {
                     "http_method": request.method,
                     "endpoint": endpoint,
-                    "status_code": response.status_code,
-                    "status_family": status_family,
+                    "status_code": 500,
+                    "status_family": "5xx",
                     "latency_bucket_ms": _latency_bucket_ms(latency_ms),
                 }
             },
@@ -330,14 +318,39 @@ def setup_observability(app: FastAPI) -> None:
         correlation_id_var.reset(correlation_token)
         request_id_var.reset(request_token)
         trace_id_var.reset(trace_token)
+        raise
 
-        response_correlation_id = response.headers.get("X-Correlation-Id", correlation_id)
-        response.headers["X-Correlation-Id"] = response_correlation_id
-        response.headers["X-Request-Id"] = request_id
-        response.headers["X-Trace-Id"] = trace_id
-        apply_observability_headers(response)
-        response.headers["traceparent"] = f"00-{trace_id}-0000000000000001-01"
-        return response
+    latency_ms = round((time.perf_counter() - started) * 1000, 2)
+    endpoint = _route_template(request)
+    status_family = _status_family(response.status_code)
+    HTTP_REQUESTS_TOTAL.labels(
+        method=request.method,
+        endpoint=endpoint,
+        status_family=status_family,
+    ).inc()
+    logger.info(
+        "request.completed",
+        extra={
+            "extra_fields": {
+                "http_method": request.method,
+                "endpoint": endpoint,
+                "status_code": response.status_code,
+                "status_family": status_family,
+                "latency_bucket_ms": _latency_bucket_ms(latency_ms),
+            }
+        },
+    )
+    correlation_id_var.reset(correlation_token)
+    request_id_var.reset(request_token)
+    trace_id_var.reset(trace_token)
+
+    response_correlation_id = response.headers.get("X-Correlation-Id", correlation_id)
+    response.headers["X-Correlation-Id"] = response_correlation_id
+    response.headers["X-Request-Id"] = request_id
+    response.headers["X-Trace-Id"] = trace_id
+    apply_observability_headers(response)
+    response.headers["traceparent"] = f"00-{trace_id}-0000000000000001-01"
+    return response
 
 
 def record_action_register_supportability(

--- a/src/core/mandates.py
+++ b/src/core/mandates.py
@@ -748,6 +748,53 @@ def _benchmark_assignment_source_record_id(
     )
 
 
+def _mandate_twin_constraint_set(
+    *,
+    mandate: DpmCoreMandateBindingResponse,
+    client_restriction_profile: Optional[DpmCoreClientRestrictionProfileResponse],
+) -> DpmMandateConstraintSet:
+    cash_reserve_weight = mandate.rebalance_bands.cash_reserve_weight or Decimal("0")
+    constraints = DpmMandateConstraintSet(
+        cash_band_min_weight=cash_reserve_weight,
+        cash_band_max_weight=max(cash_reserve_weight, Decimal("0.10")),
+        turnover_budget=Decimal("0.15"),
+    )
+    if client_restriction_profile is not None:
+        constraints.restricted_instruments = _active_restricted_instruments(
+            client_restriction_profile
+        )
+    return constraints
+
+
+def _active_restricted_instruments(
+    client_restriction_profile: DpmCoreClientRestrictionProfileResponse,
+) -> list[str]:
+    return sorted(
+        {
+            instrument_id
+            for restriction in client_restriction_profile.restrictions
+            if restriction.restriction_status.upper() == "ACTIVE"
+            for instrument_id in restriction.instrument_ids
+        }
+    )
+
+
+def _mandate_twin_preferences(
+    sustainability_preference_profile: Optional[DpmCoreSustainabilityPreferenceProfileResponse],
+) -> DpmMandatePreferences:
+    preferences = DpmMandatePreferences()
+    if sustainability_preference_profile is not None:
+        preferences.sustainability_strategy = _sustainability_strategy(
+            sustainability_preference_profile
+        )
+        preferences.bespoke_notes = [
+            preference.preference_code
+            for preference in sustainability_preference_profile.preferences
+            if preference.preference_status.upper() == "ACTIVE"
+        ]
+    return preferences
+
+
 def compile_mandate_digital_twin_from_core(
     *,
     mandate: DpmCoreMandateBindingResponse,
@@ -776,31 +823,11 @@ def compile_mandate_digital_twin_from_core(
         planned_withdrawal_schedule=planned_withdrawal_schedule,
         benchmark_assignment=benchmark_assignment,
     )
-    cash_reserve_weight = mandate.rebalance_bands.cash_reserve_weight or Decimal("0")
-    constraints = DpmMandateConstraintSet(
-        cash_band_min_weight=cash_reserve_weight,
-        cash_band_max_weight=max(cash_reserve_weight, Decimal("0.10")),
-        turnover_budget=Decimal("0.15"),
+    constraints = _mandate_twin_constraint_set(
+        mandate=mandate,
+        client_restriction_profile=client_restriction_profile,
     )
-    if client_restriction_profile is not None:
-        constraints.restricted_instruments = sorted(
-            {
-                instrument_id
-                for restriction in client_restriction_profile.restrictions
-                if restriction.restriction_status.upper() == "ACTIVE"
-                for instrument_id in restriction.instrument_ids
-            }
-        )
-    preferences = DpmMandatePreferences()
-    if sustainability_preference_profile is not None:
-        preferences.sustainability_strategy = _sustainability_strategy(
-            sustainability_preference_profile
-        )
-        preferences.bespoke_notes = [
-            preference.preference_code
-            for preference in sustainability_preference_profile.preferences
-            if preference.preference_status.upper() == "ACTIVE"
-        ]
+    preferences = _mandate_twin_preferences(sustainability_preference_profile)
     source_lineage = _build_digital_twin_source_lineage(
         mandate=mandate,
         model_targets=model_targets,

--- a/tests/unit/app/middleware/test_observability.py
+++ b/tests/unit/app/middleware/test_observability.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
-from src.api.observability import setup_observability
+from src.api.observability import _metrics_endpoint, _trace_id_from_traceparent, setup_observability
 from src.api.response_headers import apply_observability_headers
 
 
@@ -49,3 +49,23 @@ def test_observability_middleware_injects_correlation_and_hardening_headers() ->
     assert response.headers["X-Request-Id"]
     assert response.headers["X-Trace-Id"]
     assert response.headers["traceparent"].startswith("00-")
+
+
+def test_trace_id_from_traceparent_preserves_valid_w3c_trace_id() -> None:
+    trace_id = "0123456789abcdef0123456789abcdef"
+
+    assert _trace_id_from_traceparent(f"00-{trace_id}-0000000000000001-01") == trace_id
+
+
+def test_trace_id_from_traceparent_replaces_malformed_traceparent() -> None:
+    trace_id = _trace_id_from_traceparent("00-short-0000000000000001-01")
+
+    assert len(trace_id) == 32
+    assert trace_id != "short"
+
+
+def test_metrics_endpoint_returns_prometheus_text_response() -> None:
+    response = _metrics_endpoint()
+
+    assert response.media_type.startswith("text/plain")
+    assert b"http_requests" in response.body

--- a/tests/unit/dpm/core/test_mandate_health.py
+++ b/tests/unit/dpm/core/test_mandate_health.py
@@ -32,7 +32,9 @@ from src.core.mandates import (
     _benchmark_assignment_source_lineage,
     _benchmark_assignment_source_record_id,
     _build_digital_twin_source_lineage,
+    _mandate_twin_constraint_set,
     _mandate_binding_profile_gap_codes,
+    _mandate_twin_preferences,
     _mandate_optional_source_product_gap_codes,
     _mandate_source_schedule_gap_codes,
     _mandate_twin_field_gap_codes,
@@ -178,78 +180,82 @@ def _market_data_coverage(**overrides: object) -> DpmCoreMarketDataCoverageWindo
     return DpmCoreMarketDataCoverageWindowResponse.model_validate(payload)
 
 
-def _client_restriction_profile() -> DpmCoreClientRestrictionProfileResponse:
-    return DpmCoreClientRestrictionProfileResponse.model_validate(
-        {
-            "product_name": "ClientRestrictionProfile",
-            "product_version": "v1",
-            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-            "client_id": "CIF_SG_000184",
-            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
-            "as_of_date": "2026-05-03",
-            "restrictions": [
-                {
-                    "restriction_scope": "INSTRUMENT",
-                    "restriction_code": "CLIENT_RESTRICTED_SECURITY",
-                    "restriction_status": "ACTIVE",
-                    "restriction_source": "CLIENT_PROFILE",
-                    "applies_to_buy": True,
-                    "applies_to_sell": False,
-                    "instrument_ids": ["EQ_US_AAPL"],
-                    "asset_classes": [],
-                    "issuer_ids": [],
-                    "country_codes": [],
-                    "effective_from": "2026-04-01",
-                    "restriction_version": 1,
-                }
-            ],
-            "supportability": {
-                "state": "READY",
-                "reason": "CLIENT_RESTRICTION_PROFILE_READY",
-                "restriction_count": 1,
-                "missing_data_families": [],
-            },
-            "lineage": {"contract_version": "ClientRestrictionProfile:v1"},
-            "data_quality_status": "READY",
-            "latest_evidence_timestamp": "2026-05-03T01:05:00Z",
-        }
-    )
+def _client_restriction_profile(
+    **overrides: object,
+) -> DpmCoreClientRestrictionProfileResponse:
+    payload: dict[str, object] = {
+        "product_name": "ClientRestrictionProfile",
+        "product_version": "v1",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "client_id": "CIF_SG_000184",
+        "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-05-03",
+        "restrictions": [
+            {
+                "restriction_scope": "INSTRUMENT",
+                "restriction_code": "CLIENT_RESTRICTED_SECURITY",
+                "restriction_status": "ACTIVE",
+                "restriction_source": "CLIENT_PROFILE",
+                "applies_to_buy": True,
+                "applies_to_sell": False,
+                "instrument_ids": ["EQ_US_AAPL"],
+                "asset_classes": [],
+                "issuer_ids": [],
+                "country_codes": [],
+                "effective_from": "2026-04-01",
+                "restriction_version": 1,
+            }
+        ],
+        "supportability": {
+            "state": "READY",
+            "reason": "CLIENT_RESTRICTION_PROFILE_READY",
+            "restriction_count": 1,
+            "missing_data_families": [],
+        },
+        "lineage": {"contract_version": "ClientRestrictionProfile:v1"},
+        "data_quality_status": "READY",
+        "latest_evidence_timestamp": "2026-05-03T01:05:00Z",
+    }
+    payload.update(overrides)
+    return DpmCoreClientRestrictionProfileResponse.model_validate(payload)
 
 
-def _sustainability_preference_profile() -> DpmCoreSustainabilityPreferenceProfileResponse:
-    return DpmCoreSustainabilityPreferenceProfileResponse.model_validate(
-        {
-            "product_name": "SustainabilityPreferenceProfile",
-            "product_version": "v1",
-            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
-            "client_id": "CIF_SG_000184",
-            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
-            "as_of_date": "2026-05-03",
-            "preferences": [
-                {
-                    "preference_framework": "BANK_SUSTAINABILITY",
-                    "preference_code": "MIN_SUSTAINABLE_ALLOCATION",
-                    "preference_status": "ACTIVE",
-                    "preference_source": "CLIENT_PROFILE",
-                    "minimum_allocation": "0.20",
-                    "applies_to_asset_classes": ["EQUITY"],
-                    "exclusion_codes": ["THERMAL_COAL"],
-                    "positive_tilt_codes": [],
-                    "effective_from": "2026-04-01",
-                    "preference_version": 1,
-                }
-            ],
-            "supportability": {
-                "state": "READY",
-                "reason": "SUSTAINABILITY_PREFERENCE_PROFILE_READY",
-                "preference_count": 1,
-                "missing_data_families": [],
-            },
-            "lineage": {"contract_version": "SustainabilityPreferenceProfile:v1"},
-            "data_quality_status": "READY",
-            "latest_evidence_timestamp": "2026-05-03T01:05:00Z",
-        }
-    )
+def _sustainability_preference_profile(
+    **overrides: object,
+) -> DpmCoreSustainabilityPreferenceProfileResponse:
+    payload: dict[str, object] = {
+        "product_name": "SustainabilityPreferenceProfile",
+        "product_version": "v1",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "client_id": "CIF_SG_000184",
+        "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-05-03",
+        "preferences": [
+            {
+                "preference_framework": "BANK_SUSTAINABILITY",
+                "preference_code": "MIN_SUSTAINABLE_ALLOCATION",
+                "preference_status": "ACTIVE",
+                "preference_source": "CLIENT_PROFILE",
+                "minimum_allocation": "0.20",
+                "applies_to_asset_classes": ["EQUITY"],
+                "exclusion_codes": ["THERMAL_COAL"],
+                "positive_tilt_codes": [],
+                "effective_from": "2026-04-01",
+                "preference_version": 1,
+            }
+        ],
+        "supportability": {
+            "state": "READY",
+            "reason": "SUSTAINABILITY_PREFERENCE_PROFILE_READY",
+            "preference_count": 1,
+            "missing_data_families": [],
+        },
+        "lineage": {"contract_version": "SustainabilityPreferenceProfile:v1"},
+        "data_quality_status": "READY",
+        "latest_evidence_timestamp": "2026-05-03T01:05:00Z",
+    }
+    payload.update(overrides)
+    return DpmCoreSustainabilityPreferenceProfileResponse.model_validate(payload)
 
 
 def _inactive_sustainability_preference_profile() -> DpmCoreSustainabilityPreferenceProfileResponse:
@@ -613,6 +619,96 @@ def test_mandate_twin_field_gap_codes_clear_when_core_products_are_sourced() -> 
         )
         == []
     )
+
+
+def test_mandate_twin_constraint_set_projects_cash_band_and_active_restrictions() -> None:
+    constraints = _mandate_twin_constraint_set(
+        mandate=_mandate_binding(
+            rebalance_bands={
+                "default_band": "0.0250000000",
+                "cash_reserve_weight": "0.1200000000",
+            }
+        ),
+        client_restriction_profile=_client_restriction_profile(
+            restrictions=[
+                {
+                    "restriction_scope": "instrument",
+                    "restriction_code": "NO_SINGLE_NAME_EQUITY",
+                    "restriction_status": "ACTIVE",
+                    "restriction_source": "client_mandate",
+                    "applies_to_buy": True,
+                    "applies_to_sell": False,
+                    "instrument_ids": ["EQ_US_MSFT", "EQ_US_AAPL"],
+                    "asset_classes": [],
+                    "issuer_ids": [],
+                    "country_codes": [],
+                    "effective_from": "2026-04-01",
+                    "restriction_version": 1,
+                    "source_record_id": "restriction-active",
+                },
+                {
+                    "restriction_scope": "instrument",
+                    "restriction_code": "LEGACY_RESTRICTION",
+                    "restriction_status": "INACTIVE",
+                    "restriction_source": "client_mandate",
+                    "applies_to_buy": True,
+                    "applies_to_sell": False,
+                    "instrument_ids": ["EQ_US_TSLA"],
+                    "asset_classes": [],
+                    "issuer_ids": [],
+                    "country_codes": [],
+                    "effective_from": "2025-01-01",
+                    "effective_to": "2026-01-01",
+                    "restriction_version": 1,
+                    "source_record_id": "restriction-inactive",
+                },
+            ]
+        ),
+    )
+
+    assert constraints.cash_band_min_weight == Decimal("0.1200000000")
+    assert constraints.cash_band_max_weight == Decimal("0.1200000000")
+    assert constraints.turnover_budget == Decimal("0.15")
+    assert constraints.restricted_instruments == ["EQ_US_AAPL", "EQ_US_MSFT"]
+
+
+def test_mandate_twin_preferences_project_active_sustainability_preferences() -> None:
+    preferences = _mandate_twin_preferences(
+        _sustainability_preference_profile(
+            preferences=[
+                {
+                    "preference_framework": "BANK_SUSTAINABILITY",
+                    "preference_code": "MIN_SUSTAINABLE_ALLOCATION",
+                    "preference_status": "ACTIVE",
+                    "preference_source": "CLIENT_PROFILE",
+                    "minimum_allocation": "0.3000000000",
+                    "applies_to_asset_classes": ["EQUITY"],
+                    "exclusion_codes": [],
+                    "positive_tilt_codes": [],
+                    "effective_from": "2026-04-01",
+                    "preference_version": 1,
+                    "source_record_id": "sustainability-active",
+                },
+                {
+                    "preference_framework": "BANK_SUSTAINABILITY",
+                    "preference_code": "LEGACY_EXCLUSION",
+                    "preference_status": "INACTIVE",
+                    "preference_source": "CLIENT_PROFILE",
+                    "minimum_allocation": "0.1000000000",
+                    "applies_to_asset_classes": ["EQUITY"],
+                    "exclusion_codes": [],
+                    "positive_tilt_codes": [],
+                    "effective_from": "2025-01-01",
+                    "effective_to": "2026-01-01",
+                    "preference_version": 1,
+                    "source_record_id": "sustainability-inactive",
+                },
+            ]
+        )
+    )
+
+    assert preferences.sustainability_strategy == "BANK_SUSTAINABILITY"
+    assert preferences.bespoke_notes == ["MIN_SUSTAINABLE_ALLOCATION"]
 
 
 def test_build_digital_twin_source_lineage_includes_all_core_products() -> None:


### PR DESCRIPTION
## Summary
- Refactor API observability setup into focused helpers for JSON logging, metrics registration, traceparent handling, and request middleware while preserving headers, metrics, access logging, and exception behavior.
- Refactor mandate digital twin source projection into pure constraint and preference helpers while keeping compile orchestration in `compile_mandate_digital_twin_from_core`.
- Add direct helper tests and refresh codebase review ledger plus current quality reports.

## Evidence
- `python -m ruff check src/api/observability.py tests/unit/app/middleware/test_observability.py tests/unit/api/test_observability_exception_path.py tests/unit/dpm/api/test_observability_api.py`
- `python -m ruff format --check src/api/observability.py tests/unit/app/middleware/test_observability.py tests/unit/api/test_observability_exception_path.py tests/unit/dpm/api/test_observability_api.py`
- `python -m mypy --config-file mypy.ini src/api/observability.py`
- `python -m pytest tests/unit/app/middleware/test_observability.py tests/unit/api/test_observability_exception_path.py tests/unit/dpm/api/test_observability_api.py -q` (21 passed)
- `python -m ruff check src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py`
- `python -m ruff format --check src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py`
- `python -m mypy --config-file mypy.ini src/core/mandates.py`
- `python -m pytest tests/unit/dpm/core/test_mandate_health.py -q` (38 passed)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan returned no matches
- `make check` (2535 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Wiki
No wiki source change required; these are internal backend maintainability refactors and repo-local quality evidence updates.