### PR TITLE
Refactor proof-pack timeline and persistence helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19605,3 +19605,35 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal mandate twin projection
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-802: Proof-pack decision timeline event helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_decision_timeline` was the top current source-complexity hotspot and combined
+  source-event projection, selected-alternative fallback handling, workflow-decision event mapping,
+  proof-pack generated event creation, event ranking, and chronological sorting in one helper.
+- Action: extracted pure decision timeline event helpers for source events, run creation,
+  alternative-set generation, selected alternatives, workflow decisions, proof-pack generation, and
+  event sorting while preserving the public proof-pack timeline output. Added direct tests for
+  same-timestamp event ordering, selected-alternative fallback actor/time behavior, and workflow
+  review evidence projection. Refreshed current-state quality reports and preserved the stable
+  baseline artifact; the refreshed complexity report shows `_decision_timeline` dropped out of the
+  top current source-complexity list without introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` (77 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal proof-pack timeline
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19637,3 +19637,36 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal proof-pack timeline
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-803: Proof-pack Postgres persistence row helpers
+
+- Date: 2026-06-12
+- Scope: `src/infrastructure/proof_packs/postgres.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `save_proof_pack` was the top current source-complexity hotspot and combined immutable
+  content-hash conflict checks, idempotency conflict checks, proof-pack row serialization,
+  section-row serialization, SQL execution, and transaction commit behavior inside one persistence
+  method.
+- Action: extracted pure conflict guard helpers plus proof-pack and section insert-parameter
+  builders while preserving the existing SQL statements, `ON CONFLICT` behavior, fake-Postgres
+  round-trip behavior, and transaction commit boundary. Added direct tests for insert-parameter
+  storage contracts and conflict error-code preservation. Refreshed current-state quality reports
+  and preserved the stable baseline artifact; the refreshed complexity report shows
+  `save_proof_pack` dropped out of the top current source-complexity list without introducing a
+  replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/proof_packs/postgres.py tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py`,
+  `python -m ruff format --check src/infrastructure/proof_packs/postgres.py tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/proof_packs/postgres.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py -q` (8 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal proof-pack persistence
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T11:18:33+00:00`
+- Generated at: `2026-06-12T11:21:33+00:00`
 
-- Current ref: `01c1b462`
+- Current ref: `cf901a3c`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
-| 2 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
-| 3 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
-| 4 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 5 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 6 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 7 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 8 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 9 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 10 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 1 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 2 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 3 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 4 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 5 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 6 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 7 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 8 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 9 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 10 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T11:05:42+00:00`
+- Generated at: `2026-06-12T11:18:33+00:00`
 
-- Current ref: `ff0487d6`
+- Current ref: `01c1b462`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _decision_timeline | src/core/proof_packs/builder.py | 8 | 89 |
-| 2 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
-| 3 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
-| 4 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
-| 5 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 6 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 7 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 8 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 9 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 10 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 1 | save_proof_pack | src/infrastructure/proof_packs/postgres.py | 8 | 89 |
+| 2 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
+| 3 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 4 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 5 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 6 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 7 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 8 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 9 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 10 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T11:05:42+00:00`
+- Generated at: `2026-06-12T11:18:33+00:00`
 
-- Current ref: `ff0487d6`
+- Current ref: `01c1b462`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T11:18:33+00:00`
+- Generated at: `2026-06-12T11:21:33+00:00`
 
-- Current ref: `01c1b462`
+- Current ref: `cf901a3c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T11:18:33+00:00`
+- Generated at: `2026-06-12T11:21:33+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `01c1b462`
+- Current ref: `cf901a3c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 165462 | 165621 | +159 |
-| Test functions | 2362 | 2365 | +3 |
+| Total Python LOC | 165462 | 165736 | +274 |
+| Test functions | 2362 | 2368 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T11:05:42+00:00`
+- Generated at: `2026-06-12T11:18:33+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `ff0487d6`
+- Current ref: `01c1b462`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 812 | +0 |
-| Total Python LOC | 165306 | 165462 | +156 |
-| Test functions | 2357 | 2362 | +5 |
+| Total Python LOC | 165462 | 165621 | +159 |
+| Test functions | 2362 | 2365 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -56,7 +56,7 @@
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2237 |
+| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2327 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2137 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -1306,82 +1306,151 @@ def _decision_timeline(
     workflow_decisions: list[DpmRunWorkflowDecisionRecord],
     created_by: str,
 ) -> DpmProofPackDecisionTimeline:
-    events: list[DpmProofPackDecisionTimelineEvent] = []
-    if run is not None:
-        events.append(
-            DpmProofPackDecisionTimelineEvent(
-                event_id=f"{run.rebalance_run_id}:run_created",
-                event_type="REBALANCE_RUN_CREATED",
-                event_time=run.created_at.isoformat(),
-                actor="lotus-manage",
-                source_system="lotus-manage",
-                status=str(run.result_json.get("status", "UNKNOWN")),
-                reason_codes=[],
-            )
-        )
-    if alternative_set is not None:
-        events.append(
-            DpmProofPackDecisionTimelineEvent(
-                event_id=f"{alternative_set.alternative_set_id}:generated",
-                event_type="ALTERNATIVE_SET_GENERATED",
-                event_time=alternative_set.generated_at.isoformat(),
-                actor="lotus-manage",
-                source_system="lotus-manage",
-                status=str(alternative_set.status),
-                reason_codes=[],
-            )
-        )
-    if selected_alternative is not None:
-        events.append(
-            DpmProofPackDecisionTimelineEvent(
-                event_id=f"{selected_alternative.alternative_id}:selected",
-                event_type="SELECTED_ALTERNATIVE",
-                event_time=selection.selected_at.isoformat() if selection else generated_at,
-                actor=selection.actor_id if selection else created_by,
-                source_system="lotus-manage",
-                status=str(selected_alternative.method_status),
-                reason_codes=[selection.reason_code] if selection else [],
-            )
-        )
-    for decision in workflow_decisions:
-        events.append(
-            DpmProofPackDecisionTimelineEvent(
-                event_id=f"{decision.decision_id}:workflow_decision",
-                event_type="WORKFLOW_DECISION",
-                event_time=decision.decided_at.isoformat(),
-                actor=decision.actor_id,
-                source_system="lotus-manage",
-                status=str(decision.action),
-                reason_codes=[decision.reason_code],
-            )
-        )
+    events = _source_decision_timeline_events(
+        run=run,
+        alternative_set=alternative_set,
+        selected_alternative=selected_alternative,
+        selection=selection,
+        generated_at=generated_at,
+        created_by=created_by,
+    )
+    events.extend(_workflow_decision_timeline_events(workflow_decisions))
     events.append(
-        DpmProofPackDecisionTimelineEvent(
-            event_id=f"{proof_pack_id}:generated",
-            event_type="PROOF_PACK_GENERATED",
-            event_time=generated_at,
-            actor=created_by,
-            source_system="lotus-manage",
-            status=source_type,
-            reason_codes=[],
+        _proof_pack_generated_timeline_event(
+            proof_pack_id=proof_pack_id,
+            generated_at=generated_at,
+            source_type=source_type,
+            created_by=created_by,
         )
     )
-    event_rank = {
-        "REBALANCE_RUN_CREATED": 0,
-        "ALTERNATIVE_SET_GENERATED": 1,
-        "SELECTED_ALTERNATIVE": 2,
-        "WORKFLOW_DECISION": 3,
-        "PROOF_PACK_GENERATED": 4,
-    }
     return DpmProofPackDecisionTimeline(
-        events=sorted(
-            events,
-            key=lambda event: (
-                event.event_time,
-                event_rank.get(event.event_type, 99),
-                event.event_id,
-            ),
+        events=sorted(events, key=_decision_timeline_event_sort_key)
+    )
+
+
+def _source_decision_timeline_events(
+    *,
+    run: DpmRunRecord | None,
+    alternative_set: ConstructionAlternativeSet | None,
+    selected_alternative: ConstructionAlternative | None,
+    selection: ConstructionAlternativeSelection | None,
+    generated_at: str,
+    created_by: str,
+) -> list[DpmProofPackDecisionTimelineEvent]:
+    events: list[DpmProofPackDecisionTimelineEvent] = []
+    if run is not None:
+        events.append(_run_created_timeline_event(run))
+    if alternative_set is not None:
+        events.append(_alternative_set_generated_timeline_event(alternative_set))
+    if selected_alternative is not None:
+        events.append(
+            _selected_alternative_timeline_event(
+                selected_alternative=selected_alternative,
+                selection=selection,
+                generated_at=generated_at,
+                created_by=created_by,
+            )
         )
+    return events
+
+
+def _run_created_timeline_event(
+    run: DpmRunRecord,
+) -> DpmProofPackDecisionTimelineEvent:
+    return DpmProofPackDecisionTimelineEvent(
+        event_id=f"{run.rebalance_run_id}:run_created",
+        event_type="REBALANCE_RUN_CREATED",
+        event_time=run.created_at.isoformat(),
+        actor="lotus-manage",
+        source_system="lotus-manage",
+        status=str(run.result_json.get("status", "UNKNOWN")),
+        reason_codes=[],
+    )
+
+
+def _alternative_set_generated_timeline_event(
+    alternative_set: ConstructionAlternativeSet,
+) -> DpmProofPackDecisionTimelineEvent:
+    return DpmProofPackDecisionTimelineEvent(
+        event_id=f"{alternative_set.alternative_set_id}:generated",
+        event_type="ALTERNATIVE_SET_GENERATED",
+        event_time=alternative_set.generated_at.isoformat(),
+        actor="lotus-manage",
+        source_system="lotus-manage",
+        status=str(alternative_set.status),
+        reason_codes=[],
+    )
+
+
+def _selected_alternative_timeline_event(
+    *,
+    selected_alternative: ConstructionAlternative,
+    selection: ConstructionAlternativeSelection | None,
+    generated_at: str,
+    created_by: str,
+) -> DpmProofPackDecisionTimelineEvent:
+    return DpmProofPackDecisionTimelineEvent(
+        event_id=f"{selected_alternative.alternative_id}:selected",
+        event_type="SELECTED_ALTERNATIVE",
+        event_time=selection.selected_at.isoformat() if selection else generated_at,
+        actor=selection.actor_id if selection else created_by,
+        source_system="lotus-manage",
+        status=str(selected_alternative.method_status),
+        reason_codes=[selection.reason_code] if selection else [],
+    )
+
+
+def _workflow_decision_timeline_events(
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
+) -> list[DpmProofPackDecisionTimelineEvent]:
+    return [
+        DpmProofPackDecisionTimelineEvent(
+            event_id=f"{decision.decision_id}:workflow_decision",
+            event_type="WORKFLOW_DECISION",
+            event_time=decision.decided_at.isoformat(),
+            actor=decision.actor_id,
+            source_system="lotus-manage",
+            status=str(decision.action),
+            reason_codes=[decision.reason_code],
+        )
+        for decision in workflow_decisions
+    ]
+
+
+def _proof_pack_generated_timeline_event(
+    *,
+    proof_pack_id: str,
+    generated_at: str,
+    source_type: ProofPackSourceType,
+    created_by: str,
+) -> DpmProofPackDecisionTimelineEvent:
+    return DpmProofPackDecisionTimelineEvent(
+        event_id=f"{proof_pack_id}:generated",
+        event_type="PROOF_PACK_GENERATED",
+        event_time=generated_at,
+        actor=created_by,
+        source_system="lotus-manage",
+        status=source_type,
+        reason_codes=[],
+    )
+
+
+_DECISION_TIMELINE_EVENT_RANK = {
+    "REBALANCE_RUN_CREATED": 0,
+    "ALTERNATIVE_SET_GENERATED": 1,
+    "SELECTED_ALTERNATIVE": 2,
+    "WORKFLOW_DECISION": 3,
+    "PROOF_PACK_GENERATED": 4,
+}
+
+
+def _decision_timeline_event_sort_key(
+    event: DpmProofPackDecisionTimelineEvent,
+) -> tuple[str, int, str]:
+    return (
+        event.event_time,
+        _DECISION_TIMELINE_EVENT_RANK.get(event.event_type, 99),
+        event.event_id,
     )
 
 

--- a/src/infrastructure/proof_packs/postgres.py
+++ b/src/infrastructure/proof_packs/postgres.py
@@ -8,6 +8,7 @@ from typing import Any
 from src.core.common.capabilities import has_psycopg
 from src.core.proof_packs.models import (
     DpmPreTradeProofPack,
+    DpmProofPackSection,
     DpmProofPackRetentionMetadata,
     DpmProofPackStoredRef,
 )
@@ -42,8 +43,10 @@ class PostgresDpmProofPackRepository:
                 """,
                 (proof_pack.proof_pack_id,),
             ).fetchone()
-            if existing is not None and existing["content_hash"] != proof_pack.content_hash:
-                raise DpmProofPackConflictError("DPM_PROOF_PACK_IMMUTABLE_CONFLICT")
+            _raise_on_existing_proof_pack_conflict(
+                existing=existing,
+                proof_pack=proof_pack,
+            )
             if idempotency_key is not None:
                 existing_idempotency = connection.execute(
                     """
@@ -53,11 +56,10 @@ class PostgresDpmProofPackRepository:
                     """,
                     (idempotency_key,),
                 ).fetchone()
-                if (
-                    existing_idempotency is not None
-                    and existing_idempotency["proof_pack_id"] != proof_pack.proof_pack_id
-                ):
-                    raise DpmProofPackConflictError("DPM_PROOF_PACK_IDEMPOTENCY_CONFLICT")
+                _raise_on_idempotency_conflict(
+                    existing_idempotency=existing_idempotency,
+                    proof_pack=proof_pack,
+                )
 
             connection.execute(
                 """
@@ -76,18 +78,10 @@ class PostgresDpmProofPackRepository:
                 ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (proof_pack_id) DO NOTHING
                 """,
-                (
-                    proof_pack.proof_pack_id,
-                    proof_pack.portfolio_id,
-                    proof_pack.mandate_id,
-                    proof_pack.source_type,
-                    proof_pack.status,
-                    proof_pack.content_hash,
-                    idempotency_key,
-                    RETENTION_POLICY_PRE_TRADE_PROOF_PACK,
-                    retention_expires_at.isoformat() if retention_expires_at else None,
-                    dump_model_json(proof_pack),
-                    proof_pack.created_at.isoformat(),
+                _proof_pack_insert_params(
+                    proof_pack=proof_pack,
+                    idempotency_key=idempotency_key,
+                    retention_expires_at=retention_expires_at,
                 ),
             )
             for section in proof_pack.sections:
@@ -104,14 +98,9 @@ class PostgresDpmProofPackRepository:
                     ) VALUES (%s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (proof_pack_id, section_id) DO NOTHING
                     """,
-                    (
-                        proof_pack.proof_pack_id,
-                        section.section_id,
-                        section.section_type,
-                        section.state,
-                        section.content_hash,
-                        dump_model_json(section),
-                        section.generated_at,
+                    _proof_pack_section_insert_params(
+                        proof_pack=proof_pack,
+                        section=section,
                     ),
                 )
             connection.commit()
@@ -262,6 +251,64 @@ def _payload(row: Any) -> str | dict[str, Any]:
     if not isinstance(payload, str):
         return json.dumps(payload, default=str)
     return payload
+
+
+def _raise_on_existing_proof_pack_conflict(
+    *,
+    existing: Any,
+    proof_pack: DpmPreTradeProofPack,
+) -> None:
+    if existing is not None and existing["content_hash"] != proof_pack.content_hash:
+        raise DpmProofPackConflictError("DPM_PROOF_PACK_IMMUTABLE_CONFLICT")
+
+
+def _raise_on_idempotency_conflict(
+    *,
+    existing_idempotency: Any,
+    proof_pack: DpmPreTradeProofPack,
+) -> None:
+    if (
+        existing_idempotency is not None
+        and existing_idempotency["proof_pack_id"] != proof_pack.proof_pack_id
+    ):
+        raise DpmProofPackConflictError("DPM_PROOF_PACK_IDEMPOTENCY_CONFLICT")
+
+
+def _proof_pack_insert_params(
+    *,
+    proof_pack: DpmPreTradeProofPack,
+    idempotency_key: str | None,
+    retention_expires_at: datetime | None,
+) -> tuple[Any, ...]:
+    return (
+        proof_pack.proof_pack_id,
+        proof_pack.portfolio_id,
+        proof_pack.mandate_id,
+        proof_pack.source_type,
+        proof_pack.status,
+        proof_pack.content_hash,
+        idempotency_key,
+        RETENTION_POLICY_PRE_TRADE_PROOF_PACK,
+        retention_expires_at.isoformat() if retention_expires_at else None,
+        dump_model_json(proof_pack),
+        proof_pack.created_at.isoformat(),
+    )
+
+
+def _proof_pack_section_insert_params(
+    *,
+    proof_pack: DpmPreTradeProofPack,
+    section: DpmProofPackSection,
+) -> tuple[Any, ...]:
+    return (
+        proof_pack.proof_pack_id,
+        section.section_id,
+        section.section_type,
+        section.state,
+        section.content_hash,
+        dump_model_json(section),
+        section.generated_at,
+    )
 
 
 def _import_psycopg() -> tuple[Any, Any]:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -782,6 +782,96 @@ def test_selected_alternative_section_payload_projects_method_trace() -> None:
     assert reason_codes == []
 
 
+def test_decision_timeline_orders_source_workflow_and_generated_events() -> None:
+    result = _ready_rebalance_result()
+    run = _run_record(result=result)
+    alternative = build_rebalance_result_alternative(result=result)
+    alternative_set = build_alternative_set(
+        alternative_set_id="cas_timeline_order",
+        portfolio_id="pf_proof_pack_1",
+        as_of="2026-05-03",
+        alternatives=[alternative],
+    ).model_copy(update={"generated_at": CREATED_AT})
+    selection = ConstructionAlternativeSelection(
+        selection_id="sel_timeline_order",
+        alternative_set_id=alternative_set.alternative_set_id,
+        alternative_id=alternative.alternative_id,
+        selected_at=CREATED_AT,
+        actor_id="pm_001",
+        reason_code="MODEL_DRIFT_REVIEW",
+    )
+    decision = DpmRunWorkflowDecisionRecord(
+        decision_id="dwd_timeline_order",
+        run_id=run.rebalance_run_id,
+        action="APPROVE",
+        reason_code="REVIEW_APPROVED",
+        comment="Evidence reviewed.",
+        actor_id="reviewer_001",
+        decided_at=CREATED_AT,
+        correlation_id="corr-timeline-order",
+    )
+
+    timeline = builder_module._decision_timeline(
+        proof_pack_id="dpp_timeline_order",
+        generated_at=CREATED_AT.isoformat(),
+        source_type="SELECTED_ALTERNATIVE",
+        run=run,
+        alternative_set=alternative_set,
+        selected_alternative=alternative,
+        selection=selection,
+        workflow_decisions=[decision],
+        created_by="pm_001",
+    )
+
+    assert [event.event_type for event in timeline.events] == [
+        "REBALANCE_RUN_CREATED",
+        "ALTERNATIVE_SET_GENERATED",
+        "SELECTED_ALTERNATIVE",
+        "WORKFLOW_DECISION",
+        "PROOF_PACK_GENERATED",
+    ]
+
+
+def test_selected_alternative_timeline_event_falls_back_to_creator_without_selection() -> None:
+    alternative = build_rebalance_result_alternative(result=_ready_rebalance_result())
+
+    event = builder_module._selected_alternative_timeline_event(
+        selected_alternative=alternative,
+        selection=None,
+        generated_at=CREATED_AT.isoformat(),
+        created_by="pm_fallback",
+    )
+
+    assert event.event_id == f"{alternative.alternative_id}:selected"
+    assert event.event_time == CREATED_AT.isoformat()
+    assert event.actor == "pm_fallback"
+    assert event.status == alternative.method_status
+    assert event.reason_codes == []
+
+
+def test_workflow_decision_timeline_events_project_review_evidence() -> None:
+    decision = DpmRunWorkflowDecisionRecord(
+        decision_id="dwd_timeline_review",
+        run_id="rr_timeline_review",
+        action="REJECT",
+        reason_code="REMEDIATION_REQUIRED",
+        comment="Fix source evidence.",
+        actor_id="reviewer_002",
+        decided_at=CREATED_AT,
+        correlation_id="corr-timeline-review",
+    )
+
+    events = builder_module._workflow_decision_timeline_events([decision])
+
+    assert len(events) == 1
+    assert events[0].event_id == "dwd_timeline_review:workflow_decision"
+    assert events[0].event_type == "WORKFLOW_DECISION"
+    assert events[0].event_time == CREATED_AT.isoformat()
+    assert events[0].actor == "reviewer_002"
+    assert events[0].status == "REJECT"
+    assert events[0].reason_codes == ["REMEDIATION_REQUIRED"]
+
+
 def test_source_readiness_section_payload_blocks_missing_run() -> None:
     state, summary, facts, metrics, reason_codes = builder_module._source_readiness_section_payload(
         result=None

--- a/tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py
@@ -163,6 +163,74 @@ def test_postgres_proof_pack_payload_normalizes_dict_and_non_string_rows() -> No
     assert postgres_module._payload({"payload_json": 3}) == "3"
 
 
+def test_postgres_proof_pack_insert_params_preserve_storage_contract() -> None:
+    proof_pack = _proof_pack()
+
+    params = postgres_module._proof_pack_insert_params(
+        proof_pack=proof_pack,
+        idempotency_key="idem-proof-pack-postgres",
+        retention_expires_at=RETENTION_EXPIRES_AT,
+    )
+
+    assert params[:9] == (
+        proof_pack.proof_pack_id,
+        proof_pack.portfolio_id,
+        proof_pack.mandate_id,
+        proof_pack.source_type,
+        proof_pack.status,
+        proof_pack.content_hash,
+        "idem-proof-pack-postgres",
+        RETENTION_POLICY_PRE_TRADE_PROOF_PACK,
+        RETENTION_EXPIRES_AT.isoformat(),
+    )
+    assert json.loads(str(params[9]))["proof_pack_id"] == proof_pack.proof_pack_id
+    assert params[10] == proof_pack.created_at.isoformat()
+
+
+def test_postgres_proof_pack_section_insert_params_preserve_section_contract() -> None:
+    proof_pack = _proof_pack()
+    section = proof_pack.sections[0]
+
+    params = postgres_module._proof_pack_section_insert_params(
+        proof_pack=proof_pack,
+        section=section,
+    )
+
+    assert params[:5] == (
+        proof_pack.proof_pack_id,
+        section.section_id,
+        section.section_type,
+        section.state,
+        section.content_hash,
+    )
+    assert json.loads(str(params[5]))["section_id"] == section.section_id
+    assert params[6] == section.generated_at
+
+
+def test_postgres_proof_pack_conflict_helpers_preserve_error_codes() -> None:
+    proof_pack = _proof_pack(reason="Initial rationale.")
+    mutated = _proof_pack(reason="Changed rationale.")
+
+    postgres_module._raise_on_existing_proof_pack_conflict(
+        existing={"content_hash": proof_pack.content_hash},
+        proof_pack=proof_pack,
+    )
+    postgres_module._raise_on_idempotency_conflict(
+        existing_idempotency={"proof_pack_id": proof_pack.proof_pack_id},
+        proof_pack=proof_pack,
+    )
+    with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IMMUTABLE_CONFLICT"):
+        postgres_module._raise_on_existing_proof_pack_conflict(
+            existing={"content_hash": proof_pack.content_hash},
+            proof_pack=mutated,
+        )
+    with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IDEMPOTENCY_CONFLICT"):
+        postgres_module._raise_on_idempotency_conflict(
+            existing_idempotency={"proof_pack_id": proof_pack.proof_pack_id},
+            proof_pack=proof_pack.model_copy(update={"proof_pack_id": "dpp_other"}),
+        )
+
+
 def test_postgres_proof_pack_repository_conflict_paths(
     fake_repository: tuple[PostgresDpmProofPackRepository, _FakeConnection],
 ) -> None:


### PR DESCRIPTION
## Summary
- Refactor proof-pack decision timeline assembly into focused event projection and sort helpers while preserving generated timeline behavior.
- Refactor proof-pack Postgres persistence save support into pure conflict guards and insert-row parameter builders while preserving SQL, conflict, and transaction behavior.
- Add direct helper tests and update codebase review ledger plus current quality reports.

## Evidence
- `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` (77 passed)
- `python -m ruff check src/infrastructure/proof_packs/postgres.py tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py`
- `python -m ruff format --check src/infrastructure/proof_packs/postgres.py tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py`
- `python -m mypy --config-file mypy.ini src/infrastructure/proof_packs/postgres.py`
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py -q` (8 passed)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan returned no matches
- `make check` (2541 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Wiki
No wiki source change required; these are internal proof-pack maintainability refactors and repo-local quality evidence updates.