### PR TITLE
Refactor manage hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19705,3 +19705,35 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal rebalance batch execution
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-805: Expected outcome snapshot assembly helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/outcomes/snapshots.py`,
+  `tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `assemble_expected_outcome_snapshot` was the top current source-complexity hotspot after
+  the rebalance batch slice and still mixed validated artifact orchestration with final snapshot
+  identity field projection and calculation-trace payload construction.
+- Action: extracted pure expected-snapshot identity and calculation-trace helpers while preserving
+  proof-pack linkage validation, wave/handoff validation, source-lineage assembly, supportability
+  roll-up, expected-value construction, source hashes, and section hashes. Added direct tests for
+  artifact identifier projection and calculation-trace source posture. Refreshed current-state
+  quality reports and preserved the stable baseline artifact; the refreshed complexity report
+  shows `assemble_expected_outcome_snapshot` dropped out of the top current source-complexity list
+  without introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m ruff format --check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/snapshots.py`,
+  `python -m pytest tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py -q` (17 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal expected outcome snapshot
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19670,3 +19670,38 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal proof-pack persistence
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-804: Rebalance batch scenario execution helpers
+
+- Date: 2026-06-12
+- Scope: `src/api/services/rebalance_batch_execution.py`,
+  `src/api/services/rebalance_batch_scenario_execution.py`,
+  `tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `execute_batch_scenarios` was the top current source-complexity hotspot and combined
+  batch iteration, scenario option validation, policy-pack application, deterministic request and
+  correlation identity, engine invocation, source-lineage enrichment, supportability recording,
+  comparison metrics, failure mapping, and observability in one service function.
+- Action: extracted deterministic scenario execution identifiers, scenario option validation, and
+  valid-scenario execution into a focused service helper while preserving the public batch
+  orchestration contract, failure semantics, supportability write inputs, source-lineage handling,
+  and comparison metrics. Added direct tests for deterministic scenario identities and the
+  successful scenario execution/supportability path. Refreshed current-state quality reports and
+  preserved the stable baseline artifact; the refreshed complexity report shows
+  `execute_batch_scenarios` dropped out of the top current source-complexity list without
+  introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/rebalance_batch_execution.py src/api/services/rebalance_batch_scenario_execution.py tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  `python -m ruff format --check src/api/services/rebalance_batch_execution.py src/api/services/rebalance_batch_scenario_execution.py tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/rebalance_batch_execution.py src/api/services/rebalance_batch_scenario_execution.py`,
+  `python -m pytest tests/unit/api/test_runtime_request_model_and_service_edges.py -q` (41
+  passed), `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal rebalance batch execution
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T14:08:25+00:00`
+- Generated at: `2026-06-12T14:11:53+00:00`
 
-- Current ref: `8877c92e`
+- Current ref: `6276a5dc`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
-| 2 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 3 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 4 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 5 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 6 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 7 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 8 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 9 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 10 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 1 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 2 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 3 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 4 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 5 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 6 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 7 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 8 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 9 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 10 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T11:21:33+00:00`
+- Generated at: `2026-06-12T14:08:25+00:00`
 
-- Current ref: `cf901a3c`
+- Current ref: `8877c92e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 8 | 81 |
-| 2 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
-| 3 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 4 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 5 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 6 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 7 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 8 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 9 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 10 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 1 | assemble_expected_outcome_snapshot | src/core/outcomes/snapshots.py | 8 | 78 |
+| 2 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
+| 3 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 4 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 5 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 6 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 7 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 8 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 9 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 10 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T11:21:33+00:00`
+- Generated at: `2026-06-12T14:08:25+00:00`
 
-- Current ref: `cf901a3c`
+- Current ref: `8877c92e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T14:08:25+00:00`
+- Generated at: `2026-06-12T14:11:53+00:00`
 
-- Current ref: `8877c92e`
+- Current ref: `6276a5dc`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T14:08:25+00:00`
+- Generated at: `2026-06-12T14:11:53+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `8877c92e`
+- Current ref: `6276a5dc`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 812 | 813 | +1 |
-| Total Python LOC | 165736 | 165865 | +129 |
-| Test functions | 2368 | 2370 | +2 |
+| Total Python LOC | 165736 | 165982 | +246 |
+| Test functions | 2368 | 2372 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T11:21:33+00:00`
+- Generated at: `2026-06-12T14:08:25+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `cf901a3c`
+- Current ref: `8877c92e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 812 | 812 | +0 |
-| Total Python LOC | 165462 | 165736 | +274 |
-| Test functions | 2362 | 2368 | +6 |
+| Python files | 812 | 813 | +1 |
+| Total Python LOC | 165736 | 165865 | +129 |
+| Test functions | 2368 | 2370 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -41,7 +41,7 @@
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2237 |
+| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2327 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2137 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |

--- a/src/api/services/rebalance_batch_execution.py
+++ b/src/api/services/rebalance_batch_execution.py
@@ -1,5 +1,4 @@
 import logging
-from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -7,25 +6,22 @@ from pydantic import ValidationError
 
 from src.api.observability import record_execution_call
 from src.api.services.rebalance_batch_analysis import (
-    build_comparison_metric,
     resolve_base_snapshot_ids,
     to_invalid_options_error,
 )
-from src.api.services.rebalance_source_lineage import apply_source_lineage, source_input_mode
+from src.api.services.rebalance_batch_scenario_execution import (
+    RecordForSupportFn,
+    RunSimulationFn,
+    execute_valid_batch_scenario,
+    validate_batch_scenario_options,
+)
+from src.api.services.rebalance_source_lineage import source_input_mode
 from src.core.dpm_source_context import DpmResolvedSourceContext
 from src.core.models import (
     BatchRebalanceRequest,
     BatchRebalanceResult,
-    EngineOptions,
-    RebalanceResult,
 )
-from src.core.rebalance.policy_packs import (
-    DpmPolicyPackDefinition,
-    apply_policy_pack_to_engine_options,
-)
-
-RunSimulationFn = Callable[..., RebalanceResult]
-RecordForSupportFn = Callable[..., object]
+from src.core.rebalance.policy_packs import DpmPolicyPackDefinition
 
 
 def execute_batch_scenarios(
@@ -47,46 +43,25 @@ def execute_batch_scenarios(
     for scenario_name in sorted(request.scenarios.keys()):
         scenario = request.scenarios[scenario_name]
         try:
-            options = EngineOptions.model_validate(scenario.options)
+            options = validate_batch_scenario_options(scenario)
         except ValidationError as exc:
             failed_scenarios[scenario_name] = to_invalid_options_error(exc)
             continue
 
         try:
-            effective_options = apply_policy_pack_to_engine_options(
+            scenario_result, scenario_metric = execute_valid_batch_scenario(
+                request=request,
+                scenario_name=scenario_name,
                 options=options,
-                policy_pack=policy_definition,
-            )
-            scenario_correlation_id = (
-                f"{correlation_id}:{scenario_name}"
-                if correlation_id
-                else f"{batch_id}:{scenario_name}"
-            )
-            request_hash = f"{batch_id}:{scenario_name}"
-            scenario_result = run_simulation_fn(
-                portfolio=request.portfolio_snapshot,
-                market_data=request.market_data_snapshot,
-                model=request.model_portfolio,
-                shelf=request.shelf_entries,
-                options=effective_options,
-                request_hash=request_hash,
-                correlation_id=scenario_correlation_id,
-            )
-            scenario_result = apply_source_lineage(
-                result=scenario_result,
+                batch_id=batch_id,
+                correlation_id=correlation_id,
+                policy_definition=policy_definition,
                 source_context=source_context,
-            )
-            record_for_support(
-                result=scenario_result,
-                request_hash=request_hash,
-                portfolio_id=request.portfolio_snapshot.portfolio_id,
-                idempotency_key=None,
+                run_simulation_fn=run_simulation_fn,
+                record_for_support=record_for_support,
             )
             results[scenario_name] = scenario_result
-            comparison_metrics[scenario_name] = build_comparison_metric(
-                scenario_result=scenario_result,
-                base_currency=request.portfolio_snapshot.base_currency,
-            )
+            comparison_metrics[scenario_name] = scenario_metric
         except (ValidationError, RuntimeError, ValueError) as exc:
             current_logger.exception("Scenario execution failed")
             failed_scenarios[scenario_name] = f"SCENARIO_EXECUTION_ERROR: {type(exc).__name__}"

--- a/src/api/services/rebalance_batch_scenario_execution.py
+++ b/src/api/services/rebalance_batch_scenario_execution.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Optional
+
+from src.api.services.rebalance_batch_analysis import build_comparison_metric
+from src.api.services.rebalance_source_lineage import apply_source_lineage
+from src.core.dpm_source_context import DpmResolvedSourceContext
+from src.core.models import (
+    BatchRebalanceRequest,
+    BatchScenarioMetric,
+    EngineOptions,
+    RebalanceResult,
+    SimulationScenario,
+)
+from src.core.rebalance.policy_packs import (
+    DpmPolicyPackDefinition,
+    apply_policy_pack_to_engine_options,
+)
+
+RunSimulationFn = Callable[..., RebalanceResult]
+RecordForSupportFn = Callable[..., object]
+
+
+@dataclass(frozen=True)
+class BatchScenarioExecutionIds:
+    request_hash: str
+    correlation_id: str
+
+
+def build_batch_scenario_execution_ids(
+    *,
+    batch_id: str,
+    scenario_name: str,
+    correlation_id: Optional[str],
+) -> BatchScenarioExecutionIds:
+    scenario_suffix = f"{batch_id}:{scenario_name}"
+    return BatchScenarioExecutionIds(
+        request_hash=scenario_suffix,
+        correlation_id=(f"{correlation_id}:{scenario_name}" if correlation_id else scenario_suffix),
+    )
+
+
+def validate_batch_scenario_options(scenario: SimulationScenario) -> EngineOptions:
+    return EngineOptions.model_validate(scenario.options)
+
+
+def execute_valid_batch_scenario(
+    *,
+    request: BatchRebalanceRequest,
+    scenario_name: str,
+    options: EngineOptions,
+    batch_id: str,
+    correlation_id: Optional[str],
+    policy_definition: Optional[DpmPolicyPackDefinition],
+    source_context: Optional[DpmResolvedSourceContext],
+    run_simulation_fn: RunSimulationFn,
+    record_for_support: RecordForSupportFn,
+) -> tuple[RebalanceResult, BatchScenarioMetric]:
+    effective_options = apply_policy_pack_to_engine_options(
+        options=options,
+        policy_pack=policy_definition,
+    )
+    execution_ids = build_batch_scenario_execution_ids(
+        batch_id=batch_id,
+        scenario_name=scenario_name,
+        correlation_id=correlation_id,
+    )
+    scenario_result = run_simulation_fn(
+        portfolio=request.portfolio_snapshot,
+        market_data=request.market_data_snapshot,
+        model=request.model_portfolio,
+        shelf=request.shelf_entries,
+        options=effective_options,
+        request_hash=execution_ids.request_hash,
+        correlation_id=execution_ids.correlation_id,
+    )
+    scenario_result = apply_source_lineage(
+        result=scenario_result,
+        source_context=source_context,
+    )
+    record_for_support(
+        result=scenario_result,
+        request_hash=execution_ids.request_hash,
+        portfolio_id=request.portfolio_snapshot.portfolio_id,
+        idempotency_key=None,
+    )
+    return (
+        scenario_result,
+        build_comparison_metric(
+            scenario_result=scenario_result,
+            base_currency=request.portfolio_snapshot.base_currency,
+        ),
+    )
+
+
+__all__ = [
+    "BatchScenarioExecutionIds",
+    "execute_valid_batch_scenario",
+    "build_batch_scenario_execution_ids",
+    "validate_batch_scenario_options",
+]

--- a/src/core/outcomes/snapshots.py
+++ b/src/core/outcomes/snapshots.py
@@ -1,5 +1,7 @@
 """Expected outcome snapshot assembly for RFC-0042."""
 
+from dataclasses import dataclass
+
 from src.core.construction.models import (
     ConstructionAlternative,
     ConstructionAlternativeSelection,
@@ -20,6 +22,19 @@ from src.core.waves.models import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWav
 
 class DpmExpectedSnapshotAssemblyError(ValueError):
     """Raised when expected outcome evidence is missing or inconsistent."""
+
+
+@dataclass(frozen=True)
+class DpmExpectedSnapshotIdentity:
+    portfolio_id: str
+    mandate_id: str | None
+    rebalance_run_id: str | None
+    alternative_set_id: str
+    selected_alternative_id: str
+    proof_pack_id: str
+    wave_id: str | None
+    wave_item_id: str | None
+    operations_handoff_ref_id: str | None
 
 
 _PROOF_PACK_OUTCOME_STATES: dict[str, OutcomeDimensionState] = {
@@ -76,16 +91,25 @@ def assemble_expected_outcome_snapshot(
         wave_item=wave_item,
         handoff=handoff,
     )
+    identity = build_expected_snapshot_identity(
+        alternative_set=alternative_set,
+        selection=selection,
+        selected_alternative=selected_alternative,
+        proof_pack=proof_pack,
+        wave=wave,
+        wave_item=wave_item,
+        handoff=handoff,
+    )
     return DpmExpectedOutcomeSnapshot(
-        portfolio_id=alternative_set.portfolio_id,
-        mandate_id=proof_pack.mandate_id,
-        rebalance_run_id=selected_alternative.rebalance_run_id or proof_pack.rebalance_run_id,
-        alternative_set_id=alternative_set.alternative_set_id,
-        selected_alternative_id=selection.alternative_id,
-        proof_pack_id=proof_pack.proof_pack_id,
-        wave_id=wave.wave_id if wave else None,
-        wave_item_id=wave_item.wave_item_id if wave_item else None,
-        operations_handoff_ref_id=handoff.handoff_ref_id if handoff else None,
+        portfolio_id=identity.portfolio_id,
+        mandate_id=identity.mandate_id,
+        rebalance_run_id=identity.rebalance_run_id,
+        alternative_set_id=identity.alternative_set_id,
+        selected_alternative_id=identity.selected_alternative_id,
+        proof_pack_id=identity.proof_pack_id,
+        wave_id=identity.wave_id,
+        wave_item_id=identity.wave_item_id,
+        operations_handoff_ref_id=identity.operations_handoff_ref_id,
         expected_values=expected_values,
         supportability=supportability,
         source_lineage=_source_lineage(
@@ -98,16 +122,54 @@ def assemble_expected_outcome_snapshot(
         ),
         source_hashes=proof_pack.source_hashes,
         section_hashes=_section_hashes(proof_pack),
-        calculation_trace={
-            "source": "RFC-0039_SELECTED_ALTERNATIVE_WITH_RFC-0040_PROOF_PACK",
-            "selected_method": str(selected_alternative.method),
-            "selected_method_status": str(selected_alternative.method_status),
-            "proof_pack_status": proof_pack.status,
-            "wave_item_state": wave_item.state if wave_item else None,
-            "handoff_reason_code": handoff.reason_code if handoff else None,
-            "defaulted_expected_values": [],
-        },
+        calculation_trace=build_expected_snapshot_calculation_trace(
+            selected_alternative=selected_alternative,
+            proof_pack=proof_pack,
+            wave_item=wave_item,
+            handoff=handoff,
+        ),
     )
+
+
+def build_expected_snapshot_identity(
+    *,
+    alternative_set: ConstructionAlternativeSet,
+    selection: ConstructionAlternativeSelection,
+    selected_alternative: ConstructionAlternative,
+    proof_pack: DpmPreTradeProofPack,
+    wave: DpmRebalanceWave | None,
+    wave_item: DpmRebalanceWaveItem | None,
+    handoff: DpmWaveHandoffRef | None,
+) -> DpmExpectedSnapshotIdentity:
+    return DpmExpectedSnapshotIdentity(
+        portfolio_id=alternative_set.portfolio_id,
+        mandate_id=proof_pack.mandate_id,
+        rebalance_run_id=selected_alternative.rebalance_run_id or proof_pack.rebalance_run_id,
+        alternative_set_id=alternative_set.alternative_set_id,
+        selected_alternative_id=selection.alternative_id,
+        proof_pack_id=proof_pack.proof_pack_id,
+        wave_id=wave.wave_id if wave else None,
+        wave_item_id=wave_item.wave_item_id if wave_item else None,
+        operations_handoff_ref_id=handoff.handoff_ref_id if handoff else None,
+    )
+
+
+def build_expected_snapshot_calculation_trace(
+    *,
+    selected_alternative: ConstructionAlternative,
+    proof_pack: DpmPreTradeProofPack,
+    wave_item: DpmRebalanceWaveItem | None,
+    handoff: DpmWaveHandoffRef | None,
+) -> dict[str, object]:
+    return {
+        "source": "RFC-0039_SELECTED_ALTERNATIVE_WITH_RFC-0040_PROOF_PACK",
+        "selected_method": str(selected_alternative.method),
+        "selected_method_status": str(selected_alternative.method_status),
+        "proof_pack_status": proof_pack.status,
+        "wave_item_state": wave_item.state if wave_item else None,
+        "handoff_reason_code": handoff.reason_code if handoff else None,
+        "defaulted_expected_values": [],
+    }
 
 
 def _select_alternative(

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -15,6 +15,7 @@ import src.api.services.rebalance_async_operation_runner as async_runner
 import src.api.services.rebalance_async_submission as async_submission
 import src.api.services.rebalance_async_submission_payload as async_submission_payload
 import src.api.services.rebalance_batch_execution as batch_execution
+import src.api.services.rebalance_batch_scenario_execution as batch_scenario_execution
 import src.api.services.rebalance_idempotency_replay as idempotency_replay
 import src.api.services.rebalance_policy_pack_execution as policy_pack_execution
 import src.api.services.rebalance_request_envelope_resolution as envelope_resolution
@@ -819,6 +820,56 @@ def test_rebalance_batch_execution_reports_invalid_options_without_running_engin
     assert set(result.failed_scenarios) == {"invalid_case"}
     assert result.failed_scenarios["invalid_case"].startswith("INVALID_OPTIONS:")
     assert result.warnings == ["PARTIAL_BATCH_FAILURE"]
+
+
+def test_batch_scenario_execution_ids_are_deterministic() -> None:
+    assert batch_scenario_execution.build_batch_scenario_execution_ids(
+        batch_id="batch_test",
+        scenario_name="baseline",
+        correlation_id="corr_batch",
+    ) == batch_scenario_execution.BatchScenarioExecutionIds(
+        request_hash="batch_test:baseline",
+        correlation_id="corr_batch:baseline",
+    )
+    assert batch_scenario_execution.build_batch_scenario_execution_ids(
+        batch_id="batch_test",
+        scenario_name="baseline",
+        correlation_id=None,
+    ) == batch_scenario_execution.BatchScenarioExecutionIds(
+        request_hash="batch_test:baseline",
+        correlation_id="batch_test:baseline",
+    )
+
+
+def test_batch_scenario_execution_runs_engine_and_records_supportability() -> None:
+    batch_payload = valid_api_payload()
+    batch_payload.pop("options")
+    batch_payload["scenarios"] = {"baseline": {"options": {}}}
+    request = BatchRebalanceRequest.model_validate(batch_payload)
+    support_calls: list[dict] = []
+
+    scenario_result, metric = batch_scenario_execution.execute_valid_batch_scenario(
+        request=request,
+        scenario_name="baseline",
+        options=batch_scenario_execution.validate_batch_scenario_options(
+            request.scenarios["baseline"]
+        ),
+        batch_id="batch_test",
+        correlation_id="corr_batch",
+        policy_definition=None,
+        source_context=None,
+        run_simulation_fn=run_simulation,
+        record_for_support=lambda **kwargs: support_calls.append(kwargs),
+    )
+
+    assert scenario_result.correlation_id == "corr_batch:baseline"
+    assert scenario_result.lineage.request_hash == "batch_test:baseline"
+    assert scenario_result.lineage.input_mode == "stateless"
+    assert metric.status == scenario_result.status
+    assert metric.gross_turnover_notional_base.currency == request.portfolio_snapshot.base_currency
+    assert support_calls[0]["request_hash"] == "batch_test:baseline"
+    assert support_calls[0]["portfolio_id"] == request.portfolio_snapshot.portfolio_id
+    assert support_calls[0]["idempotency_key"] is None
 
 
 def test_rebalance_sync_execution_runs_engine_and_records_supportability() -> None:

--- a/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
+++ b/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
@@ -15,6 +15,8 @@ from src.core.outcomes.snapshots import (
     DpmExpectedSnapshotAssemblyError,
     _proof_pack_state,
     assemble_expected_outcome_snapshot,
+    build_expected_snapshot_calculation_trace,
+    build_expected_snapshot_identity,
 )
 from src.core.proof_packs.models import (
     DpmPreTradeProofPack,
@@ -237,6 +239,59 @@ def _wave(
         ),
         handoff_refs=[handoff],
     )
+
+
+def test_expected_snapshot_identity_helper_resolves_artifact_ids() -> None:
+    alternative_set = _alternative_set()
+    selection = _selection()
+    selected_alternative = alternative_set.alternatives[0]
+    proof_pack = _proof_pack()
+    wave = _wave()
+    wave_item = wave.items[0]
+    handoff = wave.handoff_refs[0]
+
+    identity = build_expected_snapshot_identity(
+        alternative_set=alternative_set,
+        selection=selection,
+        selected_alternative=selected_alternative,
+        proof_pack=proof_pack,
+        wave=wave,
+        wave_item=wave_item,
+        handoff=handoff,
+    )
+
+    assert identity.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert identity.mandate_id == "MANDATE_PB_SG_GLOBAL_BAL_001"
+    assert identity.rebalance_run_id == "rr_outcome_001"
+    assert identity.alternative_set_id == "cas_outcome_001"
+    assert identity.selected_alternative_id == "alt_selected"
+    assert identity.proof_pack_id == "dpp_outcome_001"
+    assert identity.wave_id == "dwv_outcome_001"
+    assert identity.wave_item_id == "dwi_outcome_001"
+    assert identity.operations_handoff_ref_id == "dwh_outcome_001"
+
+
+def test_expected_snapshot_calculation_trace_helper_records_source_posture() -> None:
+    alternative_set = _alternative_set(method_status=ConstructionMethodStatus.PENDING_REVIEW)
+    proof_pack = _proof_pack(status="PENDING_REVIEW")
+    wave = _wave(item_state="REVIEW_REQUIRED")
+
+    trace = build_expected_snapshot_calculation_trace(
+        selected_alternative=alternative_set.alternatives[0],
+        proof_pack=proof_pack,
+        wave_item=wave.items[0],
+        handoff=wave.handoff_refs[0],
+    )
+
+    assert trace == {
+        "source": "RFC-0039_SELECTED_ALTERNATIVE_WITH_RFC-0040_PROOF_PACK",
+        "selected_method": str(ConstructionMethod.HEURISTIC_EXPLAINABLE),
+        "selected_method_status": str(ConstructionMethodStatus.PENDING_REVIEW),
+        "proof_pack_status": "PENDING_REVIEW",
+        "wave_item_state": "REVIEW_REQUIRED",
+        "handoff_reason_code": "READY_FOR_OPERATIONS_REVIEW",
+        "defaulted_expected_values": [],
+    }
 
 
 def test_expected_snapshot_preserves_construction_proof_pack_wave_and_handoff_lineage() -> None:


### PR DESCRIPTION
## Summary
- extracted rebalance batch scenario execution helpers for deterministic scenario IDs, option validation, engine invocation, lineage, supportability recording, and comparison metrics
- extracted expected outcome snapshot identity and calculation-trace helpers
- refreshed refactor health, scorecard, and complexity reports; ledger entries added through BACKEND-REVIEW-20260612-805

## Validation
- python -m pytest tests/unit/api/test_runtime_request_model_and_service_edges.py -q (41 passed)
- python -m pytest tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py -q (17 passed)
- python -m ruff check touched files
- python -m ruff format --check touched files
- python -m mypy --config-file mypy.ini touched src files
- python scripts/engineering_health_report.py; restored stable baseline/non-evidence generated reports
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- git diff --check
- service leakage scan returned no matches
- make check (2532 passed, 13 skipped)
- git fetch origin --prune
- git branch -r --no-merged origin/main (no output)
- wiki drift check: DiffCount 0

## Wiki
No wiki source change required; this is internal maintainability refactoring with repo-local quality evidence.