### PR TITLE
Refactor proof pack and outcome comparison hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19769,3 +19769,37 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal proof-pack Markdown
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-807: Outcome dimension comparison helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/outcomes/comparison.py`,
+  `tests/unit/core/test_outcome_comparison.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `compare_outcome_dimension` was the top current source-complexity hotspot after the
+  proof-pack Markdown slice and mixed source-reference collection, source-supportability
+  short-circuiting, mandatory-value validation, variance-pressure calculation, threshold
+  state/reason selection, and result assembly in one function.
+- Action: extracted pure source-reference, mandatory-value, and variance-pressure state/reason
+  helpers while preserving the public comparison contract, source-supportability fail-closed
+  behavior, tolerance semantics, degraded-source handling, supportability payloads, and
+  calculation trace. Added direct helper tests for source-ref ordering, missing expected/realized
+  values, hard breaches, and degraded evidence classification. Refreshed current-state quality
+  reports and preserved the stable baseline artifact; the refreshed complexity report shows
+  `compare_outcome_dimension` dropped out of the top current source-complexity list without
+  introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py`,
+  `python -m ruff format --check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/comparison.py`,
+  `python -m pytest tests/unit/core/test_outcome_comparison.py -q` (13 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal outcome comparison
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19737,3 +19737,35 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal expected outcome snapshot
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-806: Proof-pack Markdown renderer helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/proof_packs/markdown.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_markdown.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `render_proof_pack_markdown` was the top current source-complexity hotspot and mixed
+  decision summary rendering, supportability counts, section matrix rows, timeline rows,
+  evidence-gap output, and integrity/source-hash output in one function.
+- Action: extracted deterministic Markdown section helpers while preserving the public renderer,
+  human-readable output shape, stable section ordering, sorted supportability/source-hash output,
+  evidence-gap omission behavior, and table escaping. Added direct helper tests for sorted
+  supportability lines, omitted empty evidence gaps, and sorted integrity source hashes. Refreshed
+  current-state quality reports and preserved the stable baseline artifact; the refreshed
+  complexity report shows `render_proof_pack_markdown` dropped out of the top current
+  source-complexity list without introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/markdown.py tests/unit/dpm/proof_packs/test_proof_pack_markdown.py`,
+  `python -m ruff format --check src/core/proof_packs/markdown.py tests/unit/dpm/proof_packs/test_proof_pack_markdown.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/markdown.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_markdown.py -q` (5 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal proof-pack Markdown
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T14:11:53+00:00`
+- Generated at: `2026-06-12T14:22:55+00:00`
 
-- Current ref: `6276a5dc`
+- Current ref: `9cac4fbe`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | render_proof_pack_markdown | src/core/proof_packs/markdown.py | 8 | 72 |
-| 2 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 3 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 4 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 5 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 6 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 7 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 8 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 9 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 10 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 1 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
+| 2 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 3 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 4 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 5 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 6 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 7 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 8 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 9 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 10 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T14:22:55+00:00`
+- Generated at: `2026-06-12T14:26:08+00:00`
 
-- Current ref: `9cac4fbe`
+- Current ref: `5ee0517c`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | compare_outcome_dimension | src/core/outcomes/comparison.py | 8 | 69 |
-| 2 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 3 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 4 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 5 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 6 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 7 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 8 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 9 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 10 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 1 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
+| 2 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 3 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 4 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 5 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 6 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 7 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 8 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 9 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 10 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T14:22:55+00:00`
+- Generated at: `2026-06-12T14:26:08+00:00`
 
-- Current ref: `9cac4fbe`
+- Current ref: `5ee0517c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T14:11:53+00:00`
+- Generated at: `2026-06-12T14:22:55+00:00`
 
-- Current ref: `6276a5dc`
+- Current ref: `9cac4fbe`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T14:22:55+00:00`
+- Generated at: `2026-06-12T14:26:08+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `9cac4fbe`
+- Current ref: `5ee0517c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 165982 | 166037 | +55 |
-| Test functions | 2372 | 2375 | +3 |
+| Total Python LOC | 165982 | 166096 | +114 |
+| Test functions | 2372 | 2378 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T14:11:53+00:00`
+- Generated at: `2026-06-12T14:22:55+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `6276a5dc`
+- Current ref: `9cac4fbe`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 812 | 813 | +1 |
-| Total Python LOC | 165736 | 165982 | +246 |
-| Test functions | 2368 | 2372 | +4 |
+| Python files | 813 | 813 | +0 |
+| Total Python LOC | 165982 | 166037 | +55 |
+| Test functions | 2372 | 2375 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/outcomes/comparison.py
+++ b/src/core/outcomes/comparison.py
@@ -67,33 +67,28 @@ def compare_outcome_dimension(
 ) -> DpmOutcomeDimensionResult:
     """Compare one outcome dimension without source clients or persistence."""
 
-    source_refs = [
-        *dimension_input.expected.source_refs,
-        *dimension_input.realized.source_refs,
-    ]
+    source_refs = _dimension_source_refs(dimension_input)
     supportability_state = _source_supportability_state(dimension_input)
     if supportability_state == "NOT_SUPPORTED":
-        reason = _not_supported_reason(dimension_input.dimension)
         return _result(
             dimension_input,
             state="NOT_SUPPORTED",
-            reason_code=reason,
+            reason_code=_not_supported_reason(dimension_input.dimension),
             source_refs=source_refs,
             explanation="No certified source-owner contract supports this outcome dimension.",
         )
     if supportability_state == "BLOCKED":
-        reason = _blocked_reason(dimension_input.dimension)
         return _result(
             dimension_input,
             state="BLOCKED",
-            reason_code=reason,
+            reason_code=_blocked_reason(dimension_input.dimension),
             source_refs=source_refs,
             explanation="Mandatory source evidence is missing, conflicting, or invalid.",
         )
 
     expected = dimension_input.expected.value
     realized = dimension_input.realized.value
-    if expected is None or realized is None:
+    if _dimension_values_missing(dimension_input):
         return _result(
             dimension_input,
             state="BLOCKED",
@@ -101,6 +96,8 @@ def compare_outcome_dimension(
             source_refs=source_refs,
             explanation="Expected and realized values are mandatory for deterministic comparison.",
         )
+    assert expected is not None
+    assert realized is not None
 
     variance = realized - expected
     pressure = _variance_pressure(
@@ -109,18 +106,11 @@ def compare_outcome_dimension(
         variance=variance,
         dimension_input=dimension_input,
     )
-    if pressure > dimension_input.tolerance.hard:
-        state: OutcomeDimensionState = "BREACHED"
-        reason_code = _pending_reason(dimension_input.dimension)
-    elif pressure > dimension_input.tolerance.soft:
-        state = "PENDING_REVIEW"
-        reason_code = _pending_reason(dimension_input.dimension)
-    elif supportability_state == "DEGRADED":
-        state = "DEGRADED"
-        reason_code = "SOURCE_EVIDENCE_INCOMPLETE"
-    else:
-        state = "READY"
-        reason_code = _ready_reason(dimension_input.dimension)
+    state, reason_code = _dimension_state_and_reason(
+        dimension_input=dimension_input,
+        supportability_state=supportability_state,
+        pressure=pressure,
+    )
 
     return _result(
         dimension_input,
@@ -131,6 +121,34 @@ def compare_outcome_dimension(
         pressure=pressure,
         explanation=_dimension_explanation(state, reason_code, pressure),
     )
+
+
+def _dimension_source_refs(
+    dimension_input: DpmOutcomeDimensionInput,
+) -> list[DpmOutcomeSourceRef]:
+    return [
+        *dimension_input.expected.source_refs,
+        *dimension_input.realized.source_refs,
+    ]
+
+
+def _dimension_values_missing(dimension_input: DpmOutcomeDimensionInput) -> bool:
+    return dimension_input.expected.value is None or dimension_input.realized.value is None
+
+
+def _dimension_state_and_reason(
+    *,
+    dimension_input: DpmOutcomeDimensionInput,
+    supportability_state: OutcomeDimensionState,
+    pressure: Decimal,
+) -> tuple[OutcomeDimensionState, str]:
+    if pressure > dimension_input.tolerance.hard:
+        return "BREACHED", _pending_reason(dimension_input.dimension)
+    if pressure > dimension_input.tolerance.soft:
+        return "PENDING_REVIEW", _pending_reason(dimension_input.dimension)
+    if supportability_state == "DEGRADED":
+        return "DEGRADED", "SOURCE_EVIDENCE_INCOMPLETE"
+    return "READY", _ready_reason(dimension_input.dimension)
 
 
 def _variance_pressure(

--- a/src/core/proof_packs/markdown.py
+++ b/src/core/proof_packs/markdown.py
@@ -6,7 +6,17 @@ from src.core.proof_packs.models import DpmPreTradeProofPack, DpmProofPackSectio
 def render_proof_pack_markdown(proof_pack: DpmPreTradeProofPack) -> str:
     """Render a human-readable proof-pack summary without changing evidence truth."""
 
-    lines = [
+    lines = _decision_summary_lines(proof_pack)
+    lines.extend(_supportability_lines(proof_pack))
+    lines.extend(_section_matrix_lines(proof_pack))
+    lines.extend(_timeline_lines(proof_pack))
+    lines.extend(_evidence_gap_lines(proof_pack))
+    lines.extend(_integrity_lines(proof_pack))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _decision_summary_lines(proof_pack: DpmPreTradeProofPack) -> list[str]:
+    return [
         f"# Pre-Trade Proof Pack {proof_pack.proof_pack_id}",
         "",
         "## Decision Summary",
@@ -20,61 +30,71 @@ def render_proof_pack_markdown(proof_pack: DpmPreTradeProofPack) -> str:
         f"- Created by: `{proof_pack.created_by}`",
         f"- Recommended action: `{proof_pack.decision_summary.recommended_action}`",
         f"- Rationale: {proof_pack.decision_summary.business_rationale}",
+    ]
+
+
+def _supportability_lines(proof_pack: DpmPreTradeProofPack) -> list[str]:
+    lines = [
         "",
         "## Supportability",
         "",
         "| State | Count |",
         "| --- | ---: |",
     ]
-    for state, count in sorted(proof_pack.supportability.section_state_counts.items()):
-        lines.append(f"| `{state}` | {count} |")
-
     lines.extend(
-        [
-            "",
-            "## Section Matrix",
-            "",
-            "| Section | State | Summary | Reason codes |",
-            "| --- | --- | --- | --- |",
-        ]
+        f"| `{state}` | {count} |"
+        for state, count in sorted(proof_pack.supportability.section_state_counts.items())
     )
-    for section in proof_pack.sections:
-        lines.append(_section_row(section))
+    return lines
 
-    lines.extend(
-        [
-            "",
-            "## Timeline",
-            "",
-            "| Time | Event | Actor | Status | Reason codes |",
-            "| --- | --- | --- | --- | --- |",
-        ]
-    )
-    for event in proof_pack.decision_timeline.events:
-        lines.append(
+
+def _section_matrix_lines(proof_pack: DpmPreTradeProofPack) -> list[str]:
+    return [
+        "",
+        "## Section Matrix",
+        "",
+        "| Section | State | Summary | Reason codes |",
+        "| --- | --- | --- | --- |",
+        *(_section_row(section) for section in proof_pack.sections),
+    ]
+
+
+def _timeline_lines(proof_pack: DpmPreTradeProofPack) -> list[str]:
+    return [
+        "",
+        "## Timeline",
+        "",
+        "| Time | Event | Actor | Status | Reason codes |",
+        "| --- | --- | --- | --- | --- |",
+        *(
             "| "
             f"`{event.event_time}` | `{event.event_type}` | `{event.actor}` | "
             f"`{event.status}` | {_codes(event.reason_codes)} |"
-        )
+            for event in proof_pack.decision_timeline.events
+        ),
+    ]
 
-    if proof_pack.supportability.reason_codes:
-        lines.extend(["", "## Evidence Gaps", ""])
-        for code in proof_pack.supportability.reason_codes:
-            lines.append(f"- `{code}`")
 
-    lines.extend(
-        [
-            "",
-            "## Integrity",
-            "",
-            f"- Content hash: `{proof_pack.content_hash}`",
-            "- Source hashes:",
-        ]
-    )
-    for key, value in sorted(proof_pack.source_hashes.items()):
-        lines.append(f"  - `{key}`: `{value}`")
+def _evidence_gap_lines(proof_pack: DpmPreTradeProofPack) -> list[str]:
+    if not proof_pack.supportability.reason_codes:
+        return []
+    return [
+        "",
+        "## Evidence Gaps",
+        "",
+        *(f"- `{code}`" for code in proof_pack.supportability.reason_codes),
+    ]
 
-    return "\n".join(lines).rstrip() + "\n"
+
+def _integrity_lines(proof_pack: DpmPreTradeProofPack) -> list[str]:
+    return [
+        "",
+        "## Integrity",
+        "",
+        f"- Content hash: `{proof_pack.content_hash}`",
+        "- Source hashes:",
+        *(f"  - `{key}`: `{value}`" for key, value in sorted(proof_pack.source_hashes.items())),
+    ]
 
 
 def _section_row(section: DpmProofPackSection) -> str:

--- a/tests/unit/core/test_outcome_comparison.py
+++ b/tests/unit/core/test_outcome_comparison.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 import pytest
 from pydantic import ValidationError
 
+import src.core.outcomes.comparison as outcome_comparison
 from src.core.outcomes import (
     DpmOutcomeDimensionInput,
     DpmOutcomeMetricValue,
@@ -149,6 +150,46 @@ def test_not_supported_dimension_cannot_become_ready_even_when_values_exist() ->
     assert result.state == "NOT_SUPPORTED"
     assert result.reason_code == "RISK_OUTCOME_NOT_SUPPORTED"
     assert result.variance is None
+
+
+def test_dimension_source_refs_combine_expected_and_realized_refs() -> None:
+    refs = outcome_comparison._dimension_source_refs(
+        _dimension(expected="0.1200", realized="0.1180")
+    )
+
+    assert [ref.source_system for ref in refs] == ["lotus-manage", "lotus-performance"]
+
+
+def test_dimension_values_missing_detects_expected_or_realized_gaps() -> None:
+    assert outcome_comparison._dimension_values_missing(_dimension(expected=None)) is True
+    assert outcome_comparison._dimension_values_missing(_dimension(realized=None)) is True
+    assert (
+        outcome_comparison._dimension_values_missing(
+            _dimension(expected="0.1200", realized="0.1180")
+        )
+        is False
+    )
+
+
+def test_dimension_state_and_reason_classifies_pressure_and_degraded_sources() -> None:
+    breached_state, breached_reason = outcome_comparison._dimension_state_and_reason(
+        dimension_input=_dimension(dimension="COST", expected="100.00", realized="111.00"),
+        supportability_state="READY",
+        pressure=Decimal("11.00"),
+    )
+    degraded_state, degraded_reason = outcome_comparison._dimension_state_and_reason(
+        dimension_input=_dimension(
+            dimension="DRIFT_REDUCTION",
+            expected="0.1200",
+            realized="0.1190",
+            realized_state="DEGRADED",
+        ),
+        supportability_state="DEGRADED",
+        pressure=Decimal("0"),
+    )
+
+    assert (breached_state, breached_reason) == ("BREACHED", "COST_ABOVE_ESTIMATE")
+    assert (degraded_state, degraded_reason) == ("DEGRADED", "SOURCE_EVIDENCE_INCOMPLETE")
 
 
 def test_review_rollup_prioritizes_blocked_then_breached_then_degraded() -> None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_markdown.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_markdown.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 from src.core.models import EngineOptions, RebalanceResult
+from src.core.proof_packs import markdown as proof_pack_markdown
 from src.core.proof_packs import build_proof_pack_from_run, render_proof_pack_markdown
 from src.core.rebalance.engine import run_simulation
 from src.core.rebalance_runs.models import DpmRunRecord
@@ -92,3 +93,37 @@ def test_markdown_summary_has_stable_section_order() -> None:
     ai_index = markdown.index("| `ai_refs` |")
 
     assert decision_index < mandate_index < ai_index
+
+
+def test_markdown_supportability_lines_are_sorted() -> None:
+    lines = proof_pack_markdown._supportability_lines(_proof_pack())
+
+    assert lines[:5] == [
+        "",
+        "## Supportability",
+        "",
+        "| State | Count |",
+        "| --- | ---: |",
+    ]
+    assert lines[5:] == sorted(lines[5:])
+
+
+def test_markdown_evidence_gap_lines_are_omitted_when_no_reason_codes() -> None:
+    proof_pack = _proof_pack().model_copy(
+        update={
+            "supportability": _proof_pack().supportability.model_copy(update={"reason_codes": []})
+        }
+    )
+
+    assert proof_pack_markdown._evidence_gap_lines(proof_pack) == []
+
+
+def test_markdown_integrity_lines_sort_source_hashes() -> None:
+    proof_pack = _proof_pack().model_copy(
+        update={"source_hashes": {"zeta": "sha256:z", "alpha": "sha256:a"}}
+    )
+
+    assert proof_pack_markdown._integrity_lines(proof_pack)[-2:] == [
+        "  - `alpha`: `sha256:a`",
+        "  - `zeta`: `sha256:z`",
+    ]


### PR DESCRIPTION
## Summary
- extracted deterministic proof-pack Markdown section renderers while preserving output shape and ordering
- extracted outcome dimension comparison helpers for source refs, missing values, and pressure-based state/reason selection
- refreshed refactor health, scorecard, and complexity reports; ledger entries added through BACKEND-REVIEW-20260612-807

## Validation
- python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_markdown.py -q (5 passed)
- python -m pytest tests/unit/core/test_outcome_comparison.py -q (13 passed)
- python -m ruff check touched files
- python -m ruff format --check touched files
- python -m mypy --config-file mypy.ini touched src files
- python scripts/engineering_health_report.py; restored stable baseline/non-evidence generated reports
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- git diff --check
- service leakage scan returned no matches
- make check (2551 passed)
- git fetch origin --prune
- git branch -r --no-merged origin/main (no output)
- wiki drift check: DiffCount 0

## Wiki
No wiki source change required; this is internal maintainability refactoring with repo-local quality evidence.