### PR TITLE
Refactor backend source hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19869,3 +19869,36 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal outcome-review Postgres
   persistence maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-810: Turnover-limit selection helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/rebalance/turnover.py`,
+  `tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `apply_turnover_limit` was the top current source-complexity hotspot after the
+  outcome-review persistence slice and mixed turnover budget calculation, proposed turnover
+  aggregation, ranking-key construction, selected-intent accumulation, dropped-intent diagnostics,
+  and warning emission in one function.
+- Action: extracted deterministic turnover budget, proposed-turnover, rank-key, and dropped-intent
+  diagnostic helpers while preserving public engine behavior, score ordering, exact-fit selection,
+  notional-base skip behavior, dropped-intent payloads, and warning emission. Added direct helper
+  tests for budget/proposed turnover, ranking order, and dropped diagnostic materialization.
+  Refreshed current-state quality reports and preserved the stable baseline artifact; the refreshed
+  complexity report shows `apply_turnover_limit` dropped out of the top current source-complexity
+  list without introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/turnover.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py tests/unit/dpm/engine/test_engine_turnover_control.py`,
+  `python -m ruff format --check src/core/rebalance/turnover.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py tests/unit/dpm/engine/test_engine_turnover_control.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/turnover.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_turnover_control.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py -q` (17 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal turnover-limit maintainability
+  refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19836,3 +19836,36 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal PM quality score-run
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-809: Outcome-review Postgres persistence helpers
+
+- Date: 2026-06-12
+- Scope: `src/infrastructure/outcomes/postgres.py`,
+  `tests/unit/infrastructure/test_outcome_review_repository.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `save_outcome_review` was the top current source-complexity hotspot after the
+  PM-quality score-run slice and mixed immutable content-hash checks, idempotency conflict checks,
+  SQL insert parameter assembly, review insert execution, event insertion, and commit handling in
+  one repository method.
+- Action: extracted deterministic immutable-conflict, idempotency-conflict, review insert, and
+  insert-parameter helpers while preserving the repository API, SQL shape, idempotency semantics,
+  retention expiry serialization, event insertion, and commit behavior. Added direct helper tests
+  for insert parameter serialization and fail-closed conflict handling. Refreshed current-state
+  quality reports and preserved the stable baseline artifact; the refreshed complexity report shows
+  `save_outcome_review` dropped out of the top current source-complexity list without introducing a
+  replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/outcomes/postgres.py tests/unit/infrastructure/test_outcome_review_repository.py`,
+  `python -m ruff format --check src/infrastructure/outcomes/postgres.py tests/unit/infrastructure/test_outcome_review_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/outcomes/postgres.py`,
+  `python -m pytest tests/unit/infrastructure/test_outcome_review_repository.py -q` (21 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal outcome-review Postgres
+  persistence maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19803,3 +19803,36 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal outcome comparison
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-808: PM quality score-run materialization helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/pm_quality/scoring.py`,
+  `tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_score_run` was the top current source-complexity hotspot and mixed indicator,
+  book-scope, PM-scope, and governance source-reference aggregation with replay hash-payload
+  assembly and final score-run model construction.
+- Action: extracted deterministic score-run source-reference and hash-payload materialization
+  helpers while preserving the public score-run builder, score-run identifier derivation,
+  content-hash contract, optional scope/governance serialization, source-ref de-duplication, and
+  model construction behavior. Added direct helper tests for cross-scope/governance source-ref
+  collection and optional replay-payload serialization. Refreshed current-state quality reports
+  and preserved the stable baseline artifact; the refreshed complexity report shows `_score_run`
+  dropped out of the top current source-complexity list without introducing a replacement hotspot
+  from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m ruff format --check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m mypy --config-file mypy.ini src/core/pm_quality/scoring.py`,
+  `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py -q` (23 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal PM quality score-run
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T14:38:53+00:00`
+- Generated at: `2026-06-12T14:41:49+00:00`
 
-- Current ref: `c3d40200`
+- Current ref: `eab940bf`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 2 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 3 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 4 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 5 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 6 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 7 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 8 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 9 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 10 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 1 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 2 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 3 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 4 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 5 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 6 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 7 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 8 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 9 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 10 | build_target_trace | src/core/target_generation.py | 8 | 42 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T14:26:08+00:00`
+- Generated at: `2026-06-12T14:38:53+00:00`
 
-- Current ref: `5ee0517c`
+- Current ref: `c3d40200`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _score_run | src/core/pm_quality/scoring.py | 8 | 67 |
-| 2 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
-| 3 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 4 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 5 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 6 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 7 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 8 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 9 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 10 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 1 | save_outcome_review | src/infrastructure/outcomes/postgres.py | 8 | 67 |
+| 2 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
+| 3 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 4 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 5 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 6 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 7 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 8 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 9 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 10 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T14:41:49+00:00`
+- Generated at: `2026-06-12T14:46:07+00:00`
 
-- Current ref: `eab940bf`
+- Current ref: `14eee44f`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | apply_turnover_limit | src/core/rebalance/turnover.py | 8 | 62 |
-| 2 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 3 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 4 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 5 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 6 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 7 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 8 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 9 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 10 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 1 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
+| 2 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 3 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 4 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 5 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 6 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 7 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 8 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 9 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 10 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T14:26:08+00:00`
+- Generated at: `2026-06-12T14:38:53+00:00`
 
-- Current ref: `5ee0517c`
+- Current ref: `c3d40200`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T14:38:53+00:00`
+- Generated at: `2026-06-12T14:41:49+00:00`
 
-- Current ref: `c3d40200`
+- Current ref: `eab940bf`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T14:41:49+00:00`
+- Generated at: `2026-06-12T14:46:07+00:00`
 
-- Current ref: `eab940bf`
+- Current ref: `14eee44f`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T14:26:08+00:00`
+- Generated at: `2026-06-12T14:38:53+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `5ee0517c`
+- Current ref: `c3d40200`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 165982 | 166096 | +114 |
-| Test functions | 2372 | 2378 | +6 |
+| Total Python LOC | 166096 | 166236 | +140 |
+| Test functions | 2378 | 2380 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T14:38:53+00:00`
+- Generated at: `2026-06-12T14:41:49+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `c3d40200`
+- Current ref: `eab940bf`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166096 | 166236 | +140 |
-| Test functions | 2378 | 2380 | +2 |
+| Total Python LOC | 166096 | 166340 | +244 |
+| Test functions | 2378 | 2382 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T14:41:49+00:00`
+- Generated at: `2026-06-12T14:46:07+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `eab940bf`
+- Current ref: `14eee44f`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166096 | 166340 | +244 |
-| Test functions | 2378 | 2382 | +4 |
+| Total Python LOC | 166096 | 166447 | +351 |
+| Test functions | 2378 | 2384 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/pm_quality/scoring.py
+++ b/src/core/pm_quality/scoring.py
@@ -693,35 +693,26 @@ def _score_run(
     generated_by: str,
     correlation_id: str,
 ) -> DpmPmOperatingQualityScoreRun:
-    scope_refs = book_scope_evidence.source_refs if book_scope_evidence is not None else []
-    pm_scope_refs = scope_evidence.source_refs if scope_evidence is not None else []
-    governance_refs = governance_evidence.source_refs if governance_evidence is not None else []
-    source_refs = _dedupe_refs(
-        [ref for result in indicator_results for ref in result.source_refs]
-        + scope_refs
-        + pm_scope_refs
-        + governance_refs
+    source_refs = _score_run_source_refs(
+        indicator_results=indicator_results,
+        book_scope_evidence=book_scope_evidence,
+        scope_evidence=scope_evidence,
+        governance_evidence=governance_evidence,
     )
-    hash_payload = {
-        "pm_id": pm_id,
-        "book_id": book_id,
-        "as_of_date": as_of_date,
-        "policy": policy.model_dump(mode="json"),
-        "state": state,
-        "score": str(score) if score is not None else None,
-        "indicator_results": [result.model_dump(mode="json") for result in indicator_results],
-        "book_scope_evidence": (
-            book_scope_evidence.model_dump(mode="json") if book_scope_evidence is not None else None
-        ),
-        "scope_evidence": (
-            scope_evidence.model_dump(mode="json") if scope_evidence is not None else None
-        ),
-        "governance_evidence": (
-            governance_evidence.model_dump(mode="json") if governance_evidence is not None else None
-        ),
-        "reason_codes": reason_codes,
-        "source_refs": [ref.model_dump(mode="json") for ref in source_refs],
-    }
+    hash_payload = _score_run_hash_payload(
+        pm_id=pm_id,
+        book_id=book_id,
+        as_of_date=as_of_date,
+        policy=policy,
+        state=state,
+        score=score,
+        indicator_results=indicator_results,
+        book_scope_evidence=book_scope_evidence,
+        scope_evidence=scope_evidence,
+        governance_evidence=governance_evidence,
+        reason_codes=reason_codes,
+        source_refs=source_refs,
+    )
     content_hash = _content_hash(hash_payload)
     return DpmPmOperatingQualityScoreRun(
         score_run_id=f"pmq_{uuid5(NAMESPACE_URL, content_hash).hex[:16]}",
@@ -743,6 +734,59 @@ def _score_run(
         generated_by=generated_by,
         correlation_id=correlation_id,
     )
+
+
+def _score_run_source_refs(
+    *,
+    indicator_results: list[DpmPmQualityIndicatorResult],
+    book_scope_evidence: DpmPmQualityBookScopeEvidence | None,
+    scope_evidence: DpmPmQualityScopeEvidence | None,
+    governance_evidence: DpmPmQualityGovernanceEvidence | None,
+) -> list[DpmOutcomeSourceRef]:
+    scope_refs = book_scope_evidence.source_refs if book_scope_evidence is not None else []
+    pm_scope_refs = scope_evidence.source_refs if scope_evidence is not None else []
+    governance_refs = governance_evidence.source_refs if governance_evidence is not None else []
+    return _dedupe_refs(
+        [ref for result in indicator_results for ref in result.source_refs]
+        + scope_refs
+        + pm_scope_refs
+        + governance_refs
+    )
+
+
+def _score_run_hash_payload(
+    *,
+    pm_id: str,
+    book_id: str | None,
+    as_of_date: str,
+    policy: DpmPmOperatingQualityPolicy,
+    state: PmQualityState,
+    score: Decimal | None,
+    indicator_results: list[DpmPmQualityIndicatorResult],
+    book_scope_evidence: DpmPmQualityBookScopeEvidence | None,
+    scope_evidence: DpmPmQualityScopeEvidence | None,
+    governance_evidence: DpmPmQualityGovernanceEvidence | None,
+    reason_codes: list[str],
+    source_refs: list[DpmOutcomeSourceRef],
+) -> dict[str, Any]:
+    return {
+        "pm_id": pm_id,
+        "book_id": book_id,
+        "as_of_date": as_of_date,
+        "policy": policy.model_dump(mode="json"),
+        "state": state,
+        "score": str(score) if score is not None else None,
+        "indicator_results": [result.model_dump(mode="json") for result in indicator_results],
+        "book_scope_evidence": _optional_model_dump(book_scope_evidence),
+        "scope_evidence": _optional_model_dump(scope_evidence),
+        "governance_evidence": _optional_model_dump(governance_evidence),
+        "reason_codes": reason_codes,
+        "source_refs": [ref.model_dump(mode="json") for ref in source_refs],
+    }
+
+
+def _optional_model_dump(model: Any | None) -> dict[str, Any] | None:
+    return model.model_dump(mode="json") if model is not None else None
 
 
 def _fairness_analysis(

--- a/src/core/rebalance/turnover.py
+++ b/src/core/rebalance/turnover.py
@@ -28,29 +28,19 @@ def apply_turnover_limit(
     if options.max_turnover_pct is None:
         return intents
 
-    budget = portfolio_value_base * options.max_turnover_pct
-    proposed = sum(
-        (
-            abs(intent.notional_base.amount)
-            for intent in intents
-            if intent.notional_base is not None
-        ),
-        Decimal("0"),
+    budget = _turnover_budget(
+        portfolio_value_base=portfolio_value_base,
+        max_turnover_pct=options.max_turnover_pct,
     )
+    proposed = _proposed_turnover(intents)
     if proposed <= budget:
         return intents
 
     ranked = sorted(
         intents,
-        key=lambda intent: (
-            -calculate_turnover_score(intent, portfolio_value_base),
-            (
-                abs(intent.notional_base.amount)
-                if intent.notional_base is not None
-                else Decimal("0")
-            ),
-            intent.instrument_id,
-            intent.intent_id,
+        key=lambda intent: _turnover_rank_key(
+            intent=intent,
+            portfolio_value_base=portfolio_value_base,
         ),
     )
 
@@ -60,18 +50,17 @@ def apply_turnover_limit(
         if intent.notional_base is None:
             continue
         notional_abs = abs(intent.notional_base.amount)
-        score = calculate_turnover_score(intent, portfolio_value_base)
         if used + notional_abs <= budget:
             selected.append(intent)
             used += notional_abs
             continue
 
         diagnostics.dropped_intents.append(
-            DroppedIntent(
-                instrument_id=intent.instrument_id,
-                reason="TURNOVER_LIMIT",
-                potential_notional=Money(amount=notional_abs, currency=base_currency),
-                score=score,
+            _dropped_turnover_intent(
+                intent=intent,
+                notional_abs=notional_abs,
+                portfolio_value_base=portfolio_value_base,
+                base_currency=base_currency,
             )
         )
 
@@ -79,3 +68,49 @@ def apply_turnover_limit(
         diagnostics.warnings.append("PARTIAL_REBALANCE_TURNOVER_LIMIT")
 
     return selected
+
+
+def _turnover_budget(*, portfolio_value_base: Decimal, max_turnover_pct: Decimal) -> Decimal:
+    return portfolio_value_base * max_turnover_pct
+
+
+def _proposed_turnover(intents: list[SecurityTradeIntent]) -> Decimal:
+    return sum(
+        (
+            abs(intent.notional_base.amount)
+            for intent in intents
+            if intent.notional_base is not None
+        ),
+        Decimal("0"),
+    )
+
+
+def _turnover_rank_key(
+    *,
+    intent: SecurityTradeIntent,
+    portfolio_value_base: Decimal,
+) -> tuple[Decimal, Decimal, str, str]:
+    notional_abs = (
+        abs(intent.notional_base.amount) if intent.notional_base is not None else Decimal("0")
+    )
+    return (
+        -calculate_turnover_score(intent, portfolio_value_base),
+        notional_abs,
+        intent.instrument_id,
+        intent.intent_id,
+    )
+
+
+def _dropped_turnover_intent(
+    *,
+    intent: SecurityTradeIntent,
+    notional_abs: Decimal,
+    portfolio_value_base: Decimal,
+    base_currency: str,
+) -> DroppedIntent:
+    return DroppedIntent(
+        instrument_id=intent.instrument_id,
+        reason="TURNOVER_LIMIT",
+        potential_notional=Money(amount=notional_abs, currency=base_currency),
+        score=calculate_turnover_score(intent, portfolio_value_base),
+    )

--- a/src/infrastructure/outcomes/postgres.py
+++ b/src/infrastructure/outcomes/postgres.py
@@ -32,62 +32,12 @@ class PostgresDpmOutcomeReviewRepository:
         retention_expires_at: datetime | None,
     ) -> None:
         with closing(self._connect()) as connection:
-            existing = connection.execute(
-                """
-                SELECT content_hash
-                FROM dpm_post_trade_outcome_reviews
-                WHERE outcome_review_id = %s
-                """,
-                (review.outcome_review_id,),
-            ).fetchone()
-            if existing is not None and existing["content_hash"] != review.content_hash:
-                raise DpmOutcomeReviewConflictError("DPM_OUTCOME_REVIEW_IMMUTABLE_CONFLICT")
-            if review.idempotency_key:
-                existing_idempotency = connection.execute(
-                    """
-                    SELECT outcome_review_id
-                    FROM dpm_post_trade_outcome_reviews
-                    WHERE idempotency_key = %s
-                    """,
-                    (review.idempotency_key,),
-                ).fetchone()
-                if (
-                    existing_idempotency is not None
-                    and existing_idempotency["outcome_review_id"] != review.outcome_review_id
-                ):
-                    raise DpmOutcomeReviewConflictError("DPM_OUTCOME_REVIEW_IDEMPOTENCY_CONFLICT")
-            connection.execute(
-                """
-                INSERT INTO dpm_post_trade_outcome_reviews (
-                    outcome_review_id, portfolio_id, mandate_id, rebalance_run_id,
-                    alternative_set_id, selected_alternative_id, proof_pack_id,
-                    wave_id, wave_item_id, state, content_hash, idempotency_key,
-                    retention_policy, retention_expires_at, legal_hold_state, payload_json,
-                    created_at, created_by, correlation_id
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (outcome_review_id) DO NOTHING
-                """,
-                (
-                    review.outcome_review_id,
-                    review.portfolio_id,
-                    review.mandate_id,
-                    review.rebalance_run_id,
-                    review.alternative_set_id,
-                    review.selected_alternative_id,
-                    review.proof_pack_id,
-                    review.wave_id,
-                    review.wave_item_id,
-                    review.state,
-                    review.content_hash,
-                    review.idempotency_key,
-                    review.retention_policy,
-                    retention_expires_at.isoformat() if retention_expires_at else None,
-                    review.legal_hold_state,
-                    dump_model_json(review),
-                    review.created_at.isoformat(),
-                    review.created_by,
-                    review.correlation_id,
-                ),
+            _raise_on_existing_review_conflict(connection=connection, review=review)
+            _raise_on_idempotency_conflict(connection=connection, review=review)
+            _insert_outcome_review(
+                connection=connection,
+                review=review,
+                retention_expires_at=retention_expires_at,
             )
             for event in review.events:
                 _insert_event(connection=connection, event=event)
@@ -218,6 +168,97 @@ class PostgresDpmOutcomeReviewRepository:
     def _init_db(self) -> None:
         with closing(self._connect()) as connection:
             apply_postgres_migrations(connection=connection, namespace="dpm")
+
+
+def _raise_on_existing_review_conflict(
+    *,
+    connection: Any,
+    review: DpmPostTradeOutcomeReview,
+) -> None:
+    existing = connection.execute(
+        """
+        SELECT content_hash
+        FROM dpm_post_trade_outcome_reviews
+        WHERE outcome_review_id = %s
+        """,
+        (review.outcome_review_id,),
+    ).fetchone()
+    if existing is not None and existing["content_hash"] != review.content_hash:
+        raise DpmOutcomeReviewConflictError("DPM_OUTCOME_REVIEW_IMMUTABLE_CONFLICT")
+
+
+def _raise_on_idempotency_conflict(
+    *,
+    connection: Any,
+    review: DpmPostTradeOutcomeReview,
+) -> None:
+    if not review.idempotency_key:
+        return
+    existing_idempotency = connection.execute(
+        """
+        SELECT outcome_review_id
+        FROM dpm_post_trade_outcome_reviews
+        WHERE idempotency_key = %s
+        """,
+        (review.idempotency_key,),
+    ).fetchone()
+    if (
+        existing_idempotency is not None
+        and existing_idempotency["outcome_review_id"] != review.outcome_review_id
+    ):
+        raise DpmOutcomeReviewConflictError("DPM_OUTCOME_REVIEW_IDEMPOTENCY_CONFLICT")
+
+
+def _insert_outcome_review(
+    *,
+    connection: Any,
+    review: DpmPostTradeOutcomeReview,
+    retention_expires_at: datetime | None,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO dpm_post_trade_outcome_reviews (
+            outcome_review_id, portfolio_id, mandate_id, rebalance_run_id,
+            alternative_set_id, selected_alternative_id, proof_pack_id,
+            wave_id, wave_item_id, state, content_hash, idempotency_key,
+            retention_policy, retention_expires_at, legal_hold_state, payload_json,
+            created_at, created_by, correlation_id
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (outcome_review_id) DO NOTHING
+        """,
+        _outcome_review_insert_params(
+            review=review,
+            retention_expires_at=retention_expires_at,
+        ),
+    )
+
+
+def _outcome_review_insert_params(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    retention_expires_at: datetime | None,
+) -> tuple[object, ...]:
+    return (
+        review.outcome_review_id,
+        review.portfolio_id,
+        review.mandate_id,
+        review.rebalance_run_id,
+        review.alternative_set_id,
+        review.selected_alternative_id,
+        review.proof_pack_id,
+        review.wave_id,
+        review.wave_item_id,
+        review.state,
+        review.content_hash,
+        review.idempotency_key,
+        review.retention_policy,
+        retention_expires_at.isoformat() if retention_expires_at else None,
+        review.legal_hold_state,
+        dump_model_json(review),
+        review.created_at.isoformat(),
+        review.created_by,
+        review.correlation_id,
+    )
 
 
 def _insert_event(*, connection: Any, event: DpmOutcomeEvent) -> None:

--- a/tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py
@@ -5,6 +5,7 @@ from src.core.rebalance.engine import (
     _calculate_turnover_score,
     run_simulation,
 )
+from src.core.rebalance import turnover as turnover_module
 from src.core.models import DiagnosticsData, EngineOptions, Money, SecurityTradeIntent
 from tests.shared.assertions import assert_status, security_intents
 from tests.shared.factories import (
@@ -24,6 +25,24 @@ def _diag():
         warnings=[],
         suppressed_intents=[],
         data_quality={"price_missing": [], "fx_missing": [], "shelf_missing": []},
+    )
+
+
+def _security_intent(
+    *,
+    intent_id: str,
+    instrument_id: str,
+    notional_base: Decimal | None,
+) -> SecurityTradeIntent:
+    return SecurityTradeIntent(
+        intent_id=intent_id,
+        instrument_id=instrument_id,
+        side="BUY",
+        quantity=Decimal("1"),
+        notional=Money(amount=Decimal("100"), currency="USD"),
+        notional_base=(
+            Money(amount=notional_base, currency="USD") if notional_base is not None else None
+        ),
     )
 
 
@@ -49,6 +68,59 @@ def test_calculate_turnover_score_returns_zero_when_notional_base_missing():
         notional_base=None,
     )
     assert _calculate_turnover_score(intent, Decimal("1000")) == Decimal("0")
+
+
+def test_turnover_helper_calculates_budget_proposed_and_rank_key():
+    high_score = _security_intent(
+        intent_id="oi_high",
+        instrument_id="B",
+        notional_base=Decimal("200"),
+    )
+    low_notional = _security_intent(
+        intent_id="oi_low",
+        instrument_id="A",
+        notional_base=Decimal("100"),
+    )
+    missing_notional = _security_intent(
+        intent_id="oi_missing",
+        instrument_id="C",
+        notional_base=None,
+    )
+
+    assert turnover_module._turnover_budget(
+        portfolio_value_base=Decimal("1000"),
+        max_turnover_pct=Decimal("0.15"),
+    ) == Decimal("150.00")
+    assert turnover_module._proposed_turnover(
+        [high_score, low_notional, missing_notional]
+    ) == Decimal("300")
+    assert sorted(
+        [low_notional, high_score, missing_notional],
+        key=lambda intent: turnover_module._turnover_rank_key(
+            intent=intent,
+            portfolio_value_base=Decimal("1000"),
+        ),
+    ) == [high_score, low_notional, missing_notional]
+
+
+def test_turnover_drop_helper_records_governed_diagnostic_payload():
+    intent = _security_intent(
+        intent_id="oi_drop",
+        instrument_id="B",
+        notional_base=Decimal("-125"),
+    )
+
+    dropped = turnover_module._dropped_turnover_intent(
+        intent=intent,
+        notional_abs=Decimal("125"),
+        portfolio_value_base=Decimal("1000"),
+        base_currency="USD",
+    )
+
+    assert dropped.instrument_id == "B"
+    assert dropped.reason == "TURNOVER_LIMIT"
+    assert dropped.potential_notional == Money(amount=Decimal("125"), currency="USD")
+    assert dropped.score == Decimal("0.125")
 
 
 def test_apply_turnover_limit_keeps_all_intents_when_within_budget():

--- a/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
+++ b/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
@@ -5,6 +5,7 @@ import pytest
 from src.core.outcomes import DpmOutcomeSourceRef
 from src.core.pm_quality import (
     DpmPmOperatingQualityScoreRun,
+    DpmPmQualityBookScopeEvidence,
     DpmPmQualityFairnessSegmentInput,
     DpmPmQualityFairnessSegmentResult,
     DpmPmOperatingQualityPolicy,
@@ -448,6 +449,101 @@ def test_pm_operating_quality_score_run_uses_configured_policy_and_source_refs()
     ]
     assert any(ref.source_type == "PostTradeOutcomeReview" for ref in score_run.source_refs)
     assert any(ref.source_type == "DPM_OUTCOME_REPORT_INPUT" for ref in score_run.source_refs)
+
+
+def test_pm_quality_score_run_source_ref_helper_collects_scope_and_governance_refs() -> None:
+    indicator_ref = DpmOutcomeSourceRef(
+        source_system="lotus-risk",
+        source_type="PM_SOURCE_QUALITY",
+        source_id="risk-source-001",
+    )
+    book_ref = DpmOutcomeSourceRef(
+        source_system="lotus-core",
+        source_type="PortfolioManagerBookMembership",
+        source_id="book-scope-001",
+    )
+    governance_ref = DpmOutcomeSourceRef(
+        source_system="bank-governance",
+        source_type="PM_QUALITY_POLICY_APPROVAL",
+        source_id="PMQ-APPROVAL-2026-05",
+    )
+    indicator_result = DpmPmQualityIndicatorResult(
+        indicator="SOURCE_QUALITY",
+        score=Decimal("91"),
+        weight=Decimal("100"),
+        state="READY",
+        evidence_count=1,
+        reason_codes=["SOURCE_READY"],
+        source_refs=[indicator_ref, book_ref],
+    )
+    book_scope = DpmPmQualityBookScopeEvidence(
+        source_id="book-scope-001",
+        product_version="v1",
+        supportability_state="READY",
+        returned_portfolio_count=1,
+        source_refs=[book_ref],
+    )
+    scope_evidence = scoring._scope_evidence_from_policy(_scope_policy())
+    governance_evidence = scoring._governance_evidence(
+        policy=_enabled_policy(),
+        as_of_date="2026-05-12",
+        generated_by="ops",
+    ).model_copy(update={"source_refs": [governance_ref]})
+
+    refs = scoring._score_run_source_refs(
+        indicator_results=[indicator_result],
+        book_scope_evidence=book_scope,
+        scope_evidence=scope_evidence,
+        governance_evidence=governance_evidence,
+    )
+
+    assert [ref.source_type for ref in refs] == [
+        "PM_QUALITY_LOOKBACK_WINDOW",
+        "PM_QUALITY_POLICY_APPROVAL",
+        "PM_QUALITY_PEER_GROUP_DEFINITION",
+        "PortfolioManagerBookMembership",
+        "PM_SOURCE_QUALITY",
+    ]
+    assert len([ref for ref in refs if ref.source_id == "book-scope-001"]) == 1
+
+
+def test_pm_quality_score_run_hash_payload_serializes_optional_materialization() -> None:
+    indicator_ref = DpmOutcomeSourceRef(
+        source_system="lotus-risk",
+        source_type="PM_SOURCE_QUALITY",
+        source_id="risk-source-001",
+    )
+    indicator_result = DpmPmQualityIndicatorResult(
+        indicator="SOURCE_QUALITY",
+        score=Decimal("91"),
+        weight=Decimal("100"),
+        state="READY",
+        evidence_count=1,
+        reason_codes=["SOURCE_READY"],
+        source_refs=[indicator_ref],
+    )
+
+    payload = scoring._score_run_hash_payload(
+        pm_id="pm_001",
+        book_id="sg_dpm_book",
+        as_of_date="2026-05-12",
+        policy=_enabled_policy(),
+        state="READY",
+        score=Decimal("91.00"),
+        indicator_results=[indicator_result],
+        book_scope_evidence=None,
+        scope_evidence=None,
+        governance_evidence=None,
+        reason_codes=["PM_QUALITY_WITHIN_POLICY"],
+        source_refs=[indicator_ref],
+    )
+
+    assert payload["score"] == "91.00"
+    assert payload["book_scope_evidence"] is None
+    assert payload["scope_evidence"] is None
+    assert payload["governance_evidence"] is None
+    assert payload["indicator_results"][0]["score"] == "91"
+    assert payload["source_refs"] == [indicator_ref.model_dump(mode="json")]
 
 
 def test_pm_operating_quality_materializes_peer_group_and_lookback_scope() -> None:

--- a/tests/unit/infrastructure/test_outcome_review_repository.py
+++ b/tests/unit/infrastructure/test_outcome_review_repository.py
@@ -31,9 +31,13 @@ from src.infrastructure.outcomes.in_memory import (
 from src.infrastructure.outcomes.postgres import (
     PostgresDpmOutcomeReviewRepository,
     _insert_event,
+    _outcome_review_insert_params,
     _import_psycopg,
     _payload,
+    _raise_on_existing_review_conflict,
+    _raise_on_idempotency_conflict,
 )
+from src.infrastructure.mandates.serialization import dump_model_json
 
 
 class _Cursor:
@@ -463,6 +467,65 @@ def test_postgres_outcome_repository_saves_review_events_and_retention() -> None
         "dor_001",
         "OUTCOME_REVIEW_CREATED",
     )
+
+
+def test_postgres_outcome_review_insert_params_preserve_review_and_retention_fields() -> None:
+    review = _review()
+    retention_expires_at = datetime(2033, 5, 6, tzinfo=timezone.utc)
+
+    params = _outcome_review_insert_params(
+        review=review,
+        retention_expires_at=retention_expires_at,
+    )
+
+    assert params[:12] == (
+        "dor_001",
+        "PB_SG_GLOBAL_BAL_001",
+        "MANDATE_PB_SG_GLOBAL_BAL_001",
+        "rr_001",
+        "cas_001",
+        "alt_min_turnover",
+        "dpp_001",
+        "dwv_001",
+        "dwi_001",
+        "READY",
+        "sha256:review",
+        "idem_001",
+    )
+    assert params[13] == "2033-05-06T00:00:00+00:00"
+    assert params[15] == dump_model_json(review)
+    assert params[16] == "2026-05-06T01:20:00+00:00"
+    assert params[17:] == ("pm_001", "corr_dor_001")
+
+
+def test_postgres_outcome_review_conflict_helpers_fail_closed() -> None:
+    review = _review()
+    immutable_connection = _FakeConnection(
+        cursors=[_Cursor(row={"content_hash": "sha256:different"})]
+    )
+    idempotency_connection = _FakeConnection(
+        cursors=[_Cursor(row={"outcome_review_id": "dor_other"})]
+    )
+    matching_connection = _FakeConnection(
+        cursors=[
+            _Cursor(row={"content_hash": review.content_hash}),
+            _Cursor(row={"outcome_review_id": review.outcome_review_id}),
+        ]
+    )
+
+    with pytest.raises(DpmOutcomeReviewConflictError, match="IMMUTABLE"):
+        _raise_on_existing_review_conflict(
+            connection=immutable_connection,
+            review=review,
+        )
+    with pytest.raises(DpmOutcomeReviewConflictError, match="IDEMPOTENCY"):
+        _raise_on_idempotency_conflict(
+            connection=idempotency_connection,
+            review=review,
+        )
+
+    _raise_on_existing_review_conflict(connection=matching_connection, review=review)
+    _raise_on_idempotency_conflict(connection=matching_connection, review=review)
 
 
 def test_postgres_outcome_repository_rejects_immutable_and_idempotency_conflicts() -> None:


### PR DESCRIPTION
## Summary
- Extract PM quality score-run source-ref and replay hash-payload materialization helpers with direct helper tests.
- Extract outcome-review Postgres immutable/idempotency conflict and insert-parameter helpers with direct repository helper tests.
- Extract turnover-limit budget, proposed-turnover, ranking, and dropped-intent diagnostic helpers with direct engine helper tests.
- Refresh codebase review ledger through BACKEND-REVIEW-20260612-810 and quality reports.

## Validation
- python -m ruff check touched files per slice
- python -m ruff format --check touched files per slice
- python -m mypy --config-file mypy.ini touched src files per slice
- focused pytest per slice: PM quality (23 passed), outcome repository (21 passed), turnover/engine (17 passed)
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- git diff --check
- service leakage scan returned no matches
- make check: 2557 passed
- git fetch origin --prune
- git branch -r --no-merged origin/main: no output
- wiki drift check: DiffCount 0

## Wiki
- No wiki source change required; this is internal backend maintainability refactoring and repo-local quality evidence.