### PR TITLE
Refactor manage backend hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19936,3 +19936,37 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal mandate command-center
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-812: Tax-budget sell quantity lot-iteration helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_tax_budget_limited_sell_quantity` was the top current source-complexity hotspot after
+  the command-center slice and mixed tax-awareness gating, HIFO lot sourcing, remaining quantity
+  tracking, zero-lot skipping, lot allowance calculation, tax-budget mutation, allowed-quantity
+  accumulation, and early-stop conditions in one function.
+- Action: extracted deterministic tax-budget sale-allowance and lot-sequence helpers while
+  preserving HIFO lot order, missing-lot fallback behavior, zero-quantity lot skipping, realized
+  gain/loss accounting, budget exhaustion behavior, partial-allowance stop semantics, and public
+  intent-generation behavior. Added direct helper tests for depleted-sale/zero-lot skips and
+  partial budget-stop behavior. Refreshed current-state quality reports and preserved the stable
+  baseline artifact; the refreshed complexity report shows `_tax_budget_limited_sell_quantity`
+  dropped out of the top current source-complexity list without introducing a replacement hotspot
+  from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m ruff format --check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py tests/unit/dpm/engine/test_engine_tax_awareness.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py tests/unit/dpm/engine/test_engine_tax_awareness.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py -q` (47 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal tax-budget sell quantity
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19902,3 +19902,37 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal turnover-limit maintainability
   refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-811: Mandate command-center summary projection helpers
+
+- Date: 2026-06-12
+- Scope: `src/api/services/mandate_command_center.py`,
+  `tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `build_command_center_summary` was the top current source-complexity hotspot and mixed
+  health-distribution selection, partial-readiness reason collection, completeness classification,
+  supportability state/reason derivation, default field projection, attention bucket projection,
+  recommended-action projection, and final summary model construction in one service helper.
+- Action: extracted deterministic command-center read-model and field projection helpers while
+  preserving the public summary builder, supportability/completeness semantics, selected
+  health-state filtering, latest-run defaults, attention bucket ordering, recommended-action
+  ordering, and exported helper surface. Added direct helper tests for read-model derivation,
+  projection defaults, and non-exported private helper posture. Refreshed current-state quality
+  reports and preserved the stable baseline artifact; the refreshed complexity report shows
+  `build_command_center_summary` dropped out of the top current source-complexity list without
+  introducing a replacement hotspot from this slice.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python -m ruff format --check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/mandate_command_center.py`,
+  `python -m pytest tests/unit/dpm/mandates/test_mandate_command_center.py -q` (13 passed),
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal mandate command-center
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -19970,3 +19970,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal tax-budget sell quantity
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-813: Mandate monitoring-exception Postgres query helpers
+
+- Date: 2026-06-12
+- Scope: `src/infrastructure/mandates/postgres.py`,
+  `tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `list_monitoring_exceptions` was the top current source-complexity hotspot after the
+  tax-budget slice and mixed optional filter assembly, cursor predicate assembly, SQL rendering,
+  overfetch limit binding, Postgres execution, payload loading, page slicing, and next-cursor
+  selection in one repository method.
+- Action: extracted deterministic monitoring-exception list-query and page/cursor helpers while
+  preserving repository filter semantics, cursor predicate ordering, overfetch behavior, loaded
+  exception ordering, selected-run filtering before pagination, and public repository contract.
+  Added direct helper tests for combined filter/cursor query assembly and overfetch cursor
+  selection alongside the existing fake-Postgres repository behavior tests.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/mandates/postgres.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python -m ruff format --check src/infrastructure/mandates/postgres.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/mandates/postgres.py`,
+  `python -m pytest tests/unit/dpm/supportability/test_dpm_mandate_repository.py -q`,
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal mandate monitoring-exception
+  repository maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:02:06+00:00`
+- Generated at: `2026-06-12T15:06:08+00:00`
 
-- Current ref: `e1eab069`
+- Current ref: `24a6a6de`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 2 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 3 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 4 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 5 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 6 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 7 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 8 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 9 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 10 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 1 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 2 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 3 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 4 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 5 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 6 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 7 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 8 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 9 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 10 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T14:46:07+00:00`
+- Generated at: `2026-06-12T14:58:39+00:00`
 
-- Current ref: `14eee44f`
+- Current ref: `59e03473`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_command_center_summary | src/api/services/mandate_command_center.py | 8 | 58 |
-| 2 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 3 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 4 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 5 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 6 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 7 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 8 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 9 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 10 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 1 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
+| 2 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 3 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 4 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 5 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 6 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 7 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 8 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 9 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 10 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T14:58:39+00:00`
+- Generated at: `2026-06-12T15:02:06+00:00`
 
-- Current ref: `59e03473`
+- Current ref: `e1eab069`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _tax_budget_limited_sell_quantity | src/core/rebalance/intents.py | 8 | 52 |
-| 2 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
-| 3 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 4 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 5 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 6 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 7 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 8 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 9 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 10 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 1 | list_monitoring_exceptions | src/infrastructure/mandates/postgres.py | 8 | 52 |
+| 2 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
+| 3 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 4 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 5 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 6 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 7 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 8 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 9 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 10 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T14:58:39+00:00`
+- Generated at: `2026-06-12T15:02:06+00:00`
 
-- Current ref: `59e03473`
+- Current ref: `e1eab069`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:02:06+00:00`
+- Generated at: `2026-06-12T15:06:08+00:00`
 
-- Current ref: `e1eab069`
+- Current ref: `24a6a6de`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T14:46:07+00:00`
+- Generated at: `2026-06-12T14:58:39+00:00`
 
-- Current ref: `14eee44f`
+- Current ref: `59e03473`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T14:58:39+00:00`
+- Generated at: `2026-06-12T15:02:06+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `59e03473`
+- Current ref: `e1eab069`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166447 | 166543 | +96 |
-| Test functions | 2384 | 2386 | +2 |
+| Total Python LOC | 166447 | 166658 | +211 |
+| Test functions | 2384 | 2388 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T14:46:07+00:00`
+- Generated at: `2026-06-12T14:58:39+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `14eee44f`
+- Current ref: `59e03473`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166096 | 166447 | +351 |
-| Test functions | 2378 | 2384 | +6 |
+| Total Python LOC | 166447 | 166543 | +96 |
+| Test functions | 2384 | 2386 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:02:06+00:00`
+- Generated at: `2026-06-12T15:06:08+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `e1eab069`
+- Current ref: `24a6a6de`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166447 | 166658 | +211 |
-| Test functions | 2384 | 2388 | +4 |
+| Total Python LOC | 166447 | 166744 | +297 |
+| Test functions | 2384 | 2390 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/services/mandate_command_center.py
+++ b/src/api/services/mandate_command_center.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Literal
 
@@ -13,6 +14,15 @@ from src.core.mandates import (
     MandateRecommendedAction,
     MonitoringSeverity,
 )
+
+
+@dataclass(frozen=True)
+class _CommandCenterReadModel:
+    health_distribution: dict[str, int]
+    partial_reasons: list[str]
+    completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"]
+    supportability_state: Literal["READY", "PARTIAL", "EMPTY", "DEGRADED", "BLOCKED"]
+    supportability_reason: str
 
 
 def command_center_supportability_state(
@@ -131,6 +141,49 @@ def build_command_center_summary(
     limit: int,
     generated_at: datetime,
 ) -> DpmCommandCenterSummary:
+    read_model = _command_center_read_model(
+        health_state=health_state,
+        latest_run=latest_run,
+        portfolio_manager_id=portfolio_manager_id,
+        book_id=book_id,
+        active_exception_count=len(active_exceptions),
+        limit=limit,
+    )
+
+    return DpmCommandCenterSummary(
+        tenant_id=tenant_id,
+        portfolio_manager_id=portfolio_manager_id,
+        book_id=book_id,
+        as_of_date=_command_center_as_of_date(as_of_date=as_of_date, latest_run=latest_run),
+        selected_health_state=_selected_health_state(health_state),
+        evaluated_mandates=_evaluated_mandates(latest_run),
+        monitored_mandate_ids=_monitored_mandate_ids(latest_run),
+        health_distribution=read_model.health_distribution,
+        source_readiness_summary=_source_readiness_summary(latest_run),
+        active_exception_count=len(active_exceptions),
+        attention_buckets=attention_buckets(active_exceptions),
+        recommended_actions=recommended_actions(active_exceptions),
+        latest_monitoring_run=latest_run,
+        supportability=DpmCommandCenterSupportability(
+            state=read_model.supportability_state,
+            data_completeness_state=read_model.completeness,
+            reason=read_model.supportability_reason,
+            generated_at=generated_at,
+            source_run_id=latest_run.monitoring_run_id if latest_run else None,
+            partial_readiness_reasons=read_model.partial_reasons,
+        ),
+    )
+
+
+def _command_center_read_model(
+    *,
+    health_state: str | None,
+    latest_run: DpmMonitoringRun | None,
+    portfolio_manager_id: str | None,
+    book_id: str | None,
+    active_exception_count: int,
+    limit: int,
+) -> _CommandCenterReadModel:
     health_distribution = command_center_health_distribution(
         latest_run=latest_run,
         health_state=health_state,
@@ -139,7 +192,7 @@ def build_command_center_summary(
         latest_run=latest_run,
         portfolio_manager_id=portfolio_manager_id,
         book_id=book_id,
-        active_exception_count=len(active_exceptions),
+        active_exception_count=active_exception_count,
         limit=limit,
     )
     completeness = command_center_completeness(
@@ -151,32 +204,37 @@ def build_command_center_summary(
         completeness=completeness,
         partial_reasons=partial_reasons,
     )
-
-    return DpmCommandCenterSummary(
-        tenant_id=tenant_id,
-        portfolio_manager_id=portfolio_manager_id,
-        book_id=book_id,
-        as_of_date=as_of_date or (latest_run.as_of_date if latest_run else None),
-        selected_health_state=MandateHealthState(health_state)
-        if health_state is not None
-        else None,
-        evaluated_mandates=latest_run.total_mandates if latest_run else 0,
-        monitored_mandate_ids=list(latest_run.mandate_ids) if latest_run else [],
+    return _CommandCenterReadModel(
         health_distribution=health_distribution,
-        source_readiness_summary=dict(latest_run.source_readiness_summary) if latest_run else {},
-        active_exception_count=len(active_exceptions),
-        attention_buckets=attention_buckets(active_exceptions),
-        recommended_actions=recommended_actions(active_exceptions),
-        latest_monitoring_run=latest_run,
-        supportability=DpmCommandCenterSupportability(
-            state=supportability_state,
-            data_completeness_state=completeness,
-            reason=supportability_reason,
-            generated_at=generated_at,
-            source_run_id=latest_run.monitoring_run_id if latest_run else None,
-            partial_readiness_reasons=partial_reasons,
-        ),
+        partial_reasons=partial_reasons,
+        completeness=completeness,
+        supportability_state=supportability_state,
+        supportability_reason=supportability_reason,
     )
+
+
+def _command_center_as_of_date(
+    *,
+    as_of_date: date | None,
+    latest_run: DpmMonitoringRun | None,
+) -> date | None:
+    return as_of_date or (latest_run.as_of_date if latest_run else None)
+
+
+def _selected_health_state(health_state: str | None) -> MandateHealthState | None:
+    return MandateHealthState(health_state) if health_state is not None else None
+
+
+def _evaluated_mandates(latest_run: DpmMonitoringRun | None) -> int:
+    return latest_run.total_mandates if latest_run else 0
+
+
+def _monitored_mandate_ids(latest_run: DpmMonitoringRun | None) -> list[str]:
+    return list(latest_run.mandate_ids) if latest_run else []
+
+
+def _source_readiness_summary(latest_run: DpmMonitoringRun | None) -> dict[str, int]:
+    return dict(latest_run.source_readiness_summary) if latest_run else {}
 
 
 def attention_buckets(

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -243,6 +243,65 @@ def _apply_tax_budget_lot_allowance(
         tax_budget.total_realized_loss_base += abs(allowance.realized_base)
 
 
+def _tax_budget_sale_allowance(
+    *,
+    remaining_quantity: Decimal,
+    lot_quantity: Decimal,
+    lot_unit_cost: Decimal,
+    sell_price: Decimal,
+    base_rate: Decimal,
+    tax_budget: _TaxBudgetAccumulator,
+) -> _TaxBudgetLotAllowance | None:
+    if remaining_quantity <= Decimal("0"):
+        return None
+    if lot_quantity <= Decimal("0"):
+        return None
+    return _tax_budget_lot_allowance(
+        remaining_quantity=remaining_quantity,
+        lot_quantity=lot_quantity,
+        lot_unit_cost=lot_unit_cost,
+        sell_price=sell_price,
+        base_rate=base_rate,
+        tax_budget=tax_budget,
+    )
+
+
+def _tax_budget_limited_quantity_from_lots(
+    *,
+    sorted_lots: list[tuple[Any, Decimal]],
+    requested_qty: Decimal,
+    sell_price: Decimal,
+    base_rate: Decimal,
+    tax_budget: _TaxBudgetAccumulator,
+) -> Decimal:
+    remaining = requested_qty
+    allowed_qty = Decimal("0")
+    for lot, lot_unit_cost in sorted_lots:
+        allowance = _tax_budget_sale_allowance(
+            remaining_quantity=remaining,
+            lot_quantity=lot.quantity,
+            lot_unit_cost=lot_unit_cost,
+            sell_price=sell_price,
+            base_rate=base_rate,
+            tax_budget=tax_budget,
+        )
+        if allowance is None:
+            if remaining <= Decimal("0"):
+                break
+            continue
+        if allowance.allowed_quantity <= Decimal("0"):
+            break
+
+        _apply_tax_budget_lot_allowance(allowance=allowance, tax_budget=tax_budget)
+        allowed_qty += allowance.allowed_quantity
+        remaining -= allowance.allowed_quantity
+
+        if allowance.allowed_quantity < allowance.requested_quantity:
+            break
+
+    return allowed_qty
+
+
 def _tax_budget_limited_sell_quantity(
     *,
     options: EngineOptions,
@@ -267,34 +326,13 @@ def _tax_budget_limited_sell_quantity(
     if not sorted_lots:
         return requested_qty
 
-    remaining = requested_qty
-    allowed_qty = Decimal("0")
-    for lot, lot_unit_cost in sorted_lots:
-        if remaining <= Decimal("0"):
-            break
-        if lot.quantity <= Decimal("0"):
-            continue
-
-        allowance = _tax_budget_lot_allowance(
-            remaining_quantity=remaining,
-            lot_quantity=lot.quantity,
-            lot_unit_cost=lot_unit_cost,
-            sell_price=sell_price,
-            base_rate=base_rate,
-            tax_budget=tax_budget,
-        )
-        if allowance.allowed_quantity <= Decimal("0"):
-            break
-
-        _apply_tax_budget_lot_allowance(allowance=allowance, tax_budget=tax_budget)
-
-        allowed_qty += allowance.allowed_quantity
-        remaining -= allowance.allowed_quantity
-
-        if allowance.allowed_quantity < allowance.requested_quantity:
-            break
-
-    return allowed_qty
+    return _tax_budget_limited_quantity_from_lots(
+        sorted_lots=sorted_lots,
+        requested_qty=requested_qty,
+        sell_price=sell_price,
+        base_rate=base_rate,
+        tax_budget=tax_budget,
+    )
 
 
 def _intent_market_context(

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from contextlib import closing
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional
 
@@ -14,6 +15,12 @@ from src.core.mandates import (
 )
 from src.infrastructure.mandates.serialization import dump_model_json, load_model_json
 from src.infrastructure.postgres_migrations import apply_postgres_migrations
+
+
+@dataclass(frozen=True)
+class _MonitoringExceptionListQuery:
+    sql: str
+    args: tuple[Any, ...]
 
 
 class PostgresDpmMandateRepository:
@@ -345,48 +352,18 @@ class PostgresDpmMandateRepository:
         limit: int,
         cursor: Optional[str],
     ) -> tuple[list[DpmMonitoringException], Optional[str]]:
-        where_clauses: list[str] = []
-        args: list[Any] = []
-        if monitoring_run_id is not None:
-            where_clauses.append("monitoring_run_id = %s")
-            args.append(monitoring_run_id)
-        if mandate_id is not None:
-            where_clauses.append("mandate_id = %s")
-            args.append(mandate_id)
-        if portfolio_id is not None:
-            where_clauses.append("portfolio_id = %s")
-            args.append(portfolio_id)
-        if state is not None:
-            where_clauses.append("state = %s")
-            args.append(state)
-        if cursor is not None:
-            where_clauses.append(
-                """
-                (
-                    detected_at < (SELECT detected_at FROM dpm_monitoring_exceptions WHERE exception_id = %s)
-                    OR (
-                        detected_at = (SELECT detected_at FROM dpm_monitoring_exceptions WHERE exception_id = %s)
-                        AND exception_id < %s
-                    )
-                )
-                """
-            )
-            args.extend([cursor, cursor, cursor])
-        where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
-        query = f"""
-            SELECT payload_json, exception_id
-            FROM dpm_monitoring_exceptions
-            {where_sql}
-            ORDER BY detected_at DESC, exception_id DESC
-            LIMIT %s
-        """
-        args.append(limit + 1)
+        query = _monitoring_exception_list_query(
+            monitoring_run_id=monitoring_run_id,
+            mandate_id=mandate_id,
+            portfolio_id=portfolio_id,
+            state=state,
+            limit=limit,
+            cursor=cursor,
+        )
         with closing(self._connect()) as connection:
-            rows = connection.execute(query, tuple(args)).fetchall()
+            rows = connection.execute(query.sql, query.args).fetchall()
         exceptions = [load_model_json(DpmMonitoringException, _payload(row)) for row in rows]
-        page = exceptions[:limit]
-        next_cursor = page[-1].exception_id if len(exceptions) > limit else None
-        return page, next_cursor
+        return _monitoring_exception_page(exceptions, limit=limit)
 
     def resolve_monitoring_exception(
         self,
@@ -445,6 +422,63 @@ def _to_twin(row: Any) -> Optional[DpmMandateDigitalTwin]:
     if row is None:
         return None
     return load_model_json(DpmMandateDigitalTwin, _payload(row))
+
+
+def _monitoring_exception_list_query(
+    *,
+    monitoring_run_id: Optional[str],
+    mandate_id: Optional[str],
+    portfolio_id: Optional[str],
+    state: Optional[str],
+    limit: int,
+    cursor: Optional[str],
+) -> _MonitoringExceptionListQuery:
+    where_clauses: list[str] = []
+    args: list[Any] = []
+    for column, value in (
+        ("monitoring_run_id", monitoring_run_id),
+        ("mandate_id", mandate_id),
+        ("portfolio_id", portfolio_id),
+        ("state", state),
+    ):
+        if value is not None:
+            where_clauses.append(f"{column} = %s")
+            args.append(value)
+    if cursor is not None:
+        where_clauses.append(
+            """
+            (
+                detected_at < (SELECT detected_at FROM dpm_monitoring_exceptions WHERE exception_id = %s)
+                OR (
+                    detected_at = (SELECT detected_at FROM dpm_monitoring_exceptions WHERE exception_id = %s)
+                    AND exception_id < %s
+                )
+            )
+            """
+        )
+        args.extend([cursor, cursor, cursor])
+    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+    args.append(limit + 1)
+    return _MonitoringExceptionListQuery(
+        sql=f"""
+            SELECT payload_json, exception_id
+            FROM dpm_monitoring_exceptions
+            {where_sql}
+            ORDER BY detected_at DESC, exception_id DESC
+            LIMIT %s
+        """,
+        args=tuple(args),
+    )
+
+
+def _monitoring_exception_page(
+    exceptions: list[DpmMonitoringException],
+    *,
+    limit: int,
+) -> tuple[list[DpmMonitoringException], Optional[str]]:
+    page = exceptions[:limit]
+    next_cursor = page[-1].exception_id if len(exceptions) > limit else None
+    return page, next_cursor
 
 
 def _payload(row: Any) -> str | dict[str, Any]:

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -18,7 +18,9 @@ from src.core.rebalance.intents import (
     _target_weight_by_instrument,
     _tax_impact_from_budget,
     _tax_budget_lot_allowance,
+    _tax_budget_limited_quantity_from_lots,
     _tax_budget_limited_sell_quantity,
+    _tax_budget_sale_allowance,
     _trade_notional_threshold,
     generate_intents,
 )
@@ -463,6 +465,81 @@ def test_tax_budget_limited_sell_quantity_caps_realized_gain_to_budget() -> None
     assert allowed_quantity == Decimal("5")
     assert tax_budget.total_realized_gain_base == Decimal("50")
     assert tax_budget.total_realized_loss_base == Decimal("0")
+    assert tax_budget.tax_budget_used_base == Decimal("50")
+
+
+def test_tax_budget_sale_allowance_skips_depleted_sale_and_zero_lot_quantity() -> None:
+    tax_budget = _TaxBudgetAccumulator(
+        total_realized_gain_base=Decimal("0"),
+        total_realized_loss_base=Decimal("0"),
+        tax_budget_used_base=Decimal("0"),
+        tax_budget_limit_base=Decimal("50"),
+    )
+
+    assert (
+        _tax_budget_sale_allowance(
+            remaining_quantity=Decimal("0"),
+            lot_quantity=Decimal("10"),
+            lot_unit_cost=Decimal("90"),
+            sell_price=Decimal("100"),
+            base_rate=Decimal("1"),
+            tax_budget=tax_budget,
+        )
+        is None
+    )
+    assert (
+        _tax_budget_sale_allowance(
+            remaining_quantity=Decimal("10"),
+            lot_quantity=Decimal("0"),
+            lot_unit_cost=Decimal("90"),
+            sell_price=Decimal("100"),
+            base_rate=Decimal("1"),
+            tax_budget=tax_budget,
+        )
+        is None
+    )
+
+
+def test_tax_budget_limited_quantity_from_lots_skips_empty_lots_and_stops_on_partial() -> None:
+    empty_lot = TaxLot(
+        lot_id="LOT_EMPTY",
+        quantity=Decimal("0"),
+        unit_cost=Money(amount=Decimal("95"), currency="SGD"),
+        purchase_date="2024-01-01",
+    )
+    gain_lot = TaxLot(
+        lot_id="LOT_GAIN",
+        quantity=Decimal("10"),
+        unit_cost=Money(amount=Decimal("90"), currency="SGD"),
+        purchase_date="2024-02-01",
+    )
+    later_lot = TaxLot(
+        lot_id="LOT_LATER",
+        quantity=Decimal("10"),
+        unit_cost=Money(amount=Decimal("80"), currency="SGD"),
+        purchase_date="2024-03-01",
+    )
+    tax_budget = _TaxBudgetAccumulator(
+        total_realized_gain_base=Decimal("0"),
+        total_realized_loss_base=Decimal("0"),
+        tax_budget_used_base=Decimal("0"),
+        tax_budget_limit_base=Decimal("50"),
+    )
+
+    allowed_quantity = _tax_budget_limited_quantity_from_lots(
+        sorted_lots=[
+            (empty_lot, Decimal("95")),
+            (gain_lot, Decimal("90")),
+            (later_lot, Decimal("80")),
+        ],
+        requested_qty=Decimal("10"),
+        sell_price=Decimal("100"),
+        base_rate=Decimal("1"),
+        tax_budget=tax_budget,
+    )
+
+    assert allowed_quantity == Decimal("5")
+    assert tax_budget.total_realized_gain_base == Decimal("50")
     assert tax_budget.tax_budget_used_base == Decimal("50")
 
 

--- a/tests/unit/dpm/mandates/test_mandate_command_center.py
+++ b/tests/unit/dpm/mandates/test_mandate_command_center.py
@@ -12,6 +12,7 @@ from src.api.services.mandate_command_center import (
     run_matches_command_center_filters,
     severity_rank,
 )
+from src.api.services import mandate_command_center
 from src.core.mandates import (
     DpmMonitoringException,
     DpmMonitoringRun,
@@ -286,6 +287,45 @@ def test_build_command_center_summary_projects_empty_state_without_run() -> None
     assert summary.supportability.reason == "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
 
 
+def test_command_center_read_model_collects_projection_state_without_exporting_it() -> None:
+    read_model = mandate_command_center._command_center_read_model(
+        health_state="PENDING_REVIEW",
+        latest_run=_run(),
+        portfolio_manager_id=None,
+        book_id=None,
+        active_exception_count=50,
+        limit=50,
+    )
+
+    assert read_model.health_distribution == {"PENDING_REVIEW": 1}
+    assert read_model.partial_reasons == [
+        "PM_BOOK_DISCOVERY_NOT_YET_SOURCED",
+        "ATTENTION_QUEUE_LIMIT_REACHED",
+    ]
+    assert read_model.completeness == "PARTIAL"
+    assert read_model.supportability_state == "PARTIAL"
+    assert read_model.supportability_reason == "PM_BOOK_DISCOVERY_NOT_YET_SOURCED"
+    assert "_command_center_read_model" not in mandate_command_center.__all__
+
+
+def test_command_center_projection_helpers_preserve_empty_and_latest_run_defaults() -> None:
+    run = _run()
+
+    assert mandate_command_center._command_center_as_of_date(
+        as_of_date=date(2026, 5, 4),
+        latest_run=run,
+    ) == date(2026, 5, 4)
+    assert mandate_command_center._command_center_as_of_date(
+        as_of_date=None,
+        latest_run=run,
+    ) == date(2026, 5, 3)
+    assert mandate_command_center._selected_health_state("READY").value == "READY"
+    assert mandate_command_center._selected_health_state(None) is None
+    assert mandate_command_center._evaluated_mandates(None) == 0
+    assert mandate_command_center._monitored_mandate_ids(run) == ["MANDATE_1", "MANDATE_2"]
+    assert mandate_command_center._source_readiness_summary(None) == {}
+
+
 def test_command_center_health_distribution_filters_selected_state() -> None:
     assert command_center_health_distribution(
         latest_run=_run(),
@@ -324,8 +364,6 @@ def test_command_center_completeness_classifies_empty_partial_and_complete() -> 
 
 
 def test_mandate_command_center_exports_only_projection_helpers() -> None:
-    from src.api.services import mandate_command_center
-
     assert severity_rank("CRITICAL") == 3
     assert mandate_command_center.__all__ == [
         "attention_buckets",

--- a/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
@@ -244,6 +244,58 @@ def test_repository_filters_monitoring_exceptions_by_run_before_pagination() -> 
     assert cursor is None
 
 
+def test_postgres_monitoring_exception_query_combines_filters_and_cursor() -> None:
+    query = mandate_postgres._monitoring_exception_list_query(
+        monitoring_run_id="dmr_selected",
+        mandate_id="MANDATE_PB_SG_GLOBAL_BAL_001",
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        state="ACTIVE",
+        limit=25,
+        cursor="me_cursor",
+    )
+
+    assert "FROM dpm_monitoring_exceptions" in query.sql
+    assert "monitoring_run_id = %s" in query.sql
+    assert "mandate_id = %s" in query.sql
+    assert "portfolio_id = %s" in query.sql
+    assert "state = %s" in query.sql
+    assert "exception_id < %s" in query.sql
+    assert "ORDER BY detected_at DESC, exception_id DESC" in query.sql
+    assert query.args == (
+        "dmr_selected",
+        "MANDATE_PB_SG_GLOBAL_BAL_001",
+        "PB_SG_GLOBAL_BAL_001",
+        "ACTIVE",
+        "me_cursor",
+        "me_cursor",
+        "me_cursor",
+        26,
+    )
+
+
+def test_postgres_monitoring_exception_page_returns_overfetch_cursor() -> None:
+    twin = _twin()
+    snapshot = calculate_mandate_health(
+        DpmMandateHealthInput(
+            twin=twin,
+            current_weights={"EQ_US_AAPL": Decimal("0.60")},
+            target_weights={"EQ_US_AAPL": Decimal("0.60")},
+            cash_weight=Decimal("0.50"),
+        )
+    )
+    exception = monitoring_exceptions_from_health(snapshot, source_lineage=[])[0]
+    first = exception.model_copy(update={"exception_id": "me_first"})
+    second = exception.model_copy(update={"exception_id": "me_second"})
+
+    page, cursor = mandate_postgres._monitoring_exception_page(
+        [first, second],
+        limit=1,
+    )
+
+    assert page == [first]
+    assert cursor == "me_first"
+
+
 def test_repository_retention_keeps_active_exceptions_but_purges_old_resolved_records() -> None:
     repository = InMemoryDpmMandateRepository()
     old_twin = _twin(as_of=date(2024, 1, 1))


### PR DESCRIPTION
## Summary
- Extract mandate command-center summary projection helpers and add direct projection tests.
- Extract tax-budget sell quantity lot-iteration helpers and add direct helper tests for depleted/partial budget behavior.
- Extract Postgres mandate monitoring-exception query/page helpers and add direct query/page tests.
- Refresh codebase review ledger and current quality reports for the hardened slices.

## Validation
- `python -m ruff check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`
- `python -m ruff format --check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`
- `python -m mypy --config-file mypy.ini src/api/services/mandate_command_center.py`
- `python -m pytest tests/unit/dpm/mandates/test_mandate_command_center.py -q` (13 passed)
- `python -m ruff check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`
- `python -m ruff format --check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py tests/unit/dpm/engine/test_engine_tax_awareness.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`
- `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`
- `python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py tests/unit/dpm/engine/test_engine_tax_awareness.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py -q` (47 passed)
- `python -m ruff check src/infrastructure/mandates/postgres.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`
- `python -m ruff format --check src/infrastructure/mandates/postgres.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`
- `python -m mypy --config-file mypy.ini src/infrastructure/mandates/postgres.py`
- `python -m pytest tests/unit/dpm/supportability/test_dpm_mandate_repository.py -q` (15 passed)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan returned no matches: `rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"`
- `python scripts/engineering_health_report.py`
- `make check` (2563 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- `powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Wiki decision
No wiki source change required; this PR is internal backend maintainability refactoring with repo-local ledger/report evidence only.