### PR TITLE
Refactor proof pack and campaign projection hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20001,3 +20001,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal mandate monitoring-exception
   repository maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-814: Proof-pack selected-alternative resolution helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `build_proof_pack_from_selected_alternative` was the top current source-complexity
+  hotspot and mixed selected-alternative lookup, missing-alternative error handling,
+  selection-record alternative-id validation, selection-record alternative-set validation, and
+  proof-pack construction delegation in one public builder.
+- Action: extracted deterministic selected-alternative resolution and selection-record validation
+  helpers while preserving public builder behavior, existing error codes, selected alternative set
+  identity checks, selected alternative identity checks, and downstream proof-pack construction
+  semantics. Added direct helper tests for successful resolution and both selection mismatch
+  failures alongside the existing public builder tests.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`,
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal proof-pack builder
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20032,3 +20032,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal proof-pack builder
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-815: Campaign approval-inbox governance projection helper
+
+- Date: 2026-06-12
+- Scope: `src/core/waves/campaign_approval_inbox.py`,
+  `tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `build_bulk_review_campaign_approval_inbox_item` was the top current
+  source-complexity hotspot after the proof-pack slice and mixed discovery/readiness derivation,
+  posture classification, governance field projection, governance count projection,
+  operating-boundary projection, content hashing, and final model validation in one builder.
+- Action: extracted a deterministic approval-inbox governance payload helper while preserving
+  approval metadata projection, missing-governance defaults, entitled actor counts, source-ref
+  counts, operating boundaries, content hashing, and public item/page behavior. Added direct helper
+  tests for populated governance and missing-governance payloads alongside existing inbox posture
+  tests.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_approval_inbox.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_approval_inbox.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_approval_inbox.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q`,
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal campaign approval-inbox
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20063,3 +20063,34 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal campaign approval-inbox
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-816: Proof-pack run-state section payload helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_run_state_section_payload` was the top current source-complexity hotspot after the
+  approval-inbox slice and mixed section dispatch with trade-intent empty-state handling,
+  trade-intent id/metric projection, after-state blocked status classification, after-state
+  summary projection, and blocked reason-code selection.
+- Action: extracted deterministic trade-intent and after-state section payload helpers while
+  preserving the public section dispatcher, ready/blocked state semantics, reason codes, intent id
+  ordering, trade counts, after-state summaries, and after-state position counts. Added direct
+  helper tests for ready and blocked trade-intent/after-state projections alongside existing
+  dispatcher coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`,
+  `python scripts/engineering_health_report.py`,
+  `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `git diff --check`,
+  and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
+- Wiki decision: no wiki source change required; this is internal proof-pack section payload
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:06:08+00:00`
+- Generated at: `2026-06-12T15:17:16+00:00`
 
-- Current ref: `24a6a6de`
+- Current ref: `cdd1c8ff`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_proof_pack_from_selected_alternative | src/core/proof_packs/builder.py | 8 | 49 |
-| 2 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 3 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 4 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 5 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 6 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 7 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 8 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 9 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 10 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 1 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
+| 2 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 3 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 4 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 5 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 6 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 7 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 8 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 9 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 10 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:17:16+00:00`
+- Generated at: `2026-06-12T15:20:04+00:00`
 
-- Current ref: `cdd1c8ff`
+- Current ref: `0c25ed9a`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_bulk_review_campaign_approval_inbox_item | src/core/waves/campaign_approval_inbox.py | 8 | 48 |
-| 2 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 3 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 4 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 5 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 6 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 7 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 8 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 9 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 10 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 1 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
+| 2 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 3 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 4 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 5 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 6 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 7 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 8 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 9 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 10 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:20:04+00:00`
+- Generated at: `2026-06-12T15:22:52+00:00`
 
-- Current ref: `0c25ed9a`
+- Current ref: `1778f615`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _run_state_section_payload | src/core/proof_packs/builder.py | 8 | 46 |
-| 2 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 3 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 4 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 5 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 6 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 7 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 8 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 9 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 10 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 1 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
+| 2 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 3 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 4 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 5 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 6 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 7 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 8 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 9 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 10 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:06:08+00:00`
+- Generated at: `2026-06-12T15:17:16+00:00`
 
-- Current ref: `24a6a6de`
+- Current ref: `cdd1c8ff`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:20:04+00:00`
+- Generated at: `2026-06-12T15:22:52+00:00`
 
-- Current ref: `0c25ed9a`
+- Current ref: `1778f615`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:17:16+00:00`
+- Generated at: `2026-06-12T15:20:04+00:00`
 
-- Current ref: `cdd1c8ff`
+- Current ref: `0c25ed9a`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:06:08+00:00`
+- Generated at: `2026-06-12T15:17:16+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `24a6a6de`
+- Current ref: `cdd1c8ff`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166447 | 166744 | +297 |
-| Test functions | 2384 | 2390 | +6 |
+| Total Python LOC | 166744 | 166831 | +87 |
+| Test functions | 2390 | 2392 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -55,8 +55,8 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2327 |
+| 6 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2387 |
+| 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2137 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:17:16+00:00`
+- Generated at: `2026-06-12T15:20:04+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `cdd1c8ff`
+- Current ref: `0c25ed9a`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166744 | 166831 | +87 |
-| Test functions | 2390 | 2392 | +2 |
+| Total Python LOC | 166744 | 166882 | +138 |
+| Test functions | 2390 | 2394 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 6 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2387 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2137 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2168 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:20:04+00:00`
+- Generated at: `2026-06-12T15:22:52+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `0c25ed9a`
+- Current ref: `1778f615`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166744 | 166882 | +138 |
-| Test functions | 2390 | 2394 | +4 |
+| Total Python LOC | 166744 | 166935 | +191 |
+| Test functions | 2390 | 2396 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -55,7 +55,7 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2387 |
+| 6 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2427 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2168 |
 | 9 | src/core/dpm_source_context.py | 1886 |

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -184,21 +184,11 @@ def build_proof_pack_from_selected_alternative(
     workflow_decisions: list[DpmRunWorkflowDecisionRecord] | None = None,
     direct_regime_stress_context: AuthoritativeRegimeStressContext | None = None,
 ) -> DpmPreTradeProofPack:
-    selected = next(
-        (
-            alternative
-            for alternative in alternative_set.alternatives
-            if alternative.alternative_id == selected_alternative_id
-        ),
-        None,
+    selected = _selected_alternative_for_proof_pack(
+        alternative_set=alternative_set,
+        selected_alternative_id=selected_alternative_id,
+        selection=selection,
     )
-    if selected is None:
-        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_NOT_FOUND")
-    if selection is not None and selection.alternative_id != selected_alternative_id:
-        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_SELECTION_MISMATCH")
-    if selection is not None and selection.alternative_set_id != alternative_set.alternative_set_id:
-        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_SET_MISMATCH")
-
     return _build_proof_pack(
         source_type="SELECTED_ALTERNATIVE",
         run=run,
@@ -216,6 +206,43 @@ def build_proof_pack_from_selected_alternative(
         workflow_decisions=workflow_decisions or [],
         direct_regime_stress_context=direct_regime_stress_context,
     )
+
+
+def _selected_alternative_for_proof_pack(
+    *,
+    alternative_set: ConstructionAlternativeSet,
+    selected_alternative_id: str,
+    selection: ConstructionAlternativeSelection | None,
+) -> ConstructionAlternative:
+    selected = next(
+        (
+            alternative
+            for alternative in alternative_set.alternatives
+            if alternative.alternative_id == selected_alternative_id
+        ),
+        None,
+    )
+    if selected is None:
+        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_NOT_FOUND")
+    if selection is not None:
+        _validate_selected_alternative_selection(
+            alternative_set_id=alternative_set.alternative_set_id,
+            selected_alternative_id=selected_alternative_id,
+            selection=selection,
+        )
+    return selected
+
+
+def _validate_selected_alternative_selection(
+    *,
+    alternative_set_id: str,
+    selected_alternative_id: str,
+    selection: ConstructionAlternativeSelection,
+) -> None:
+    if selection.alternative_id != selected_alternative_id:
+        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_SELECTION_MISMATCH")
+    if selection.alternative_set_id != alternative_set_id:
+        raise ProofPackSourceValidationError("DPM_SELECTED_ALTERNATIVE_SET_MISMATCH")
 
 
 def _build_proof_pack(

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -596,30 +596,43 @@ def _run_state_section_payload(
             [],
         )
     if section_type == "trade_intents":
-        if not result.intents:
-            return (
-                "BLOCKED",
-                "No trade intents are available for pre-trade proof.",
-                {"intent_ids": []},
-                {"trade_count": 0},
-                ["DPM_TRADE_INTENTS_MISSING"],
-            )
-        return (
-            "READY",
-            "Trade intents captured from source run.",
-            {"intent_ids": [intent.intent_id for intent in result.intents]},
-            {"trade_count": len(result.intents)},
-            [],
-        )
+        return _trade_intents_section_payload(result)
     if section_type == "after_state":
-        return (
-            "READY" if result.status != "BLOCKED" else "BLOCKED",
-            "After-state simulation summary captured from source run.",
-            {"after_summary": result.after_simulated.model_dump(mode="json")},
-            {"position_count": len(result.after_simulated.positions)},
-            [] if result.status != "BLOCKED" else ["DPM_AFTER_STATE_BLOCKED"],
-        )
+        return _after_state_section_payload(result)
     return None
+
+
+def _trade_intents_section_payload(
+    result: RebalanceResult,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    if not result.intents:
+        return (
+            "BLOCKED",
+            "No trade intents are available for pre-trade proof.",
+            {"intent_ids": []},
+            {"trade_count": 0},
+            ["DPM_TRADE_INTENTS_MISSING"],
+        )
+    return (
+        "READY",
+        "Trade intents captured from source run.",
+        {"intent_ids": [intent.intent_id for intent in result.intents]},
+        {"trade_count": len(result.intents)},
+        [],
+    )
+
+
+def _after_state_section_payload(
+    result: RebalanceResult,
+) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
+    blocked = result.status == "BLOCKED"
+    return (
+        "BLOCKED" if blocked else "READY",
+        "After-state simulation summary captured from source run.",
+        {"after_summary": result.after_simulated.model_dump(mode="json")},
+        {"position_count": len(result.after_simulated.positions)},
+        ["DPM_AFTER_STATE_BLOCKED"] if blocked else [],
+    )
 
 
 def _run_diagnostics_section_payload(

--- a/src/core/waves/campaign_approval_inbox.py
+++ b/src/core/waves/campaign_approval_inbox.py
@@ -11,7 +11,10 @@ from src.core.waves.campaign_definition_readiness import (
     DpmBulkReviewCampaignDefinitionPreviewReadiness,
     build_bulk_review_campaign_definition_preview_readiness,
 )
-from src.core.waves.campaign_definitions import DpmBulkReviewCampaignDefinition
+from src.core.waves.campaign_definitions import (
+    DpmBulkReviewCampaignDefinition,
+    DpmBulkReviewCampaignDefinitionGovernance,
+)
 from src.core.waves.campaign_discovery import (
     DpmBulkReviewCampaignDiscoveryItem,
     build_bulk_review_campaign_discovery_item,
@@ -127,7 +130,6 @@ def build_bulk_review_campaign_approval_inbox_item(
         discovery=discovery,
         readiness=readiness,
     )
-    governance = definition.governance
     payload: dict[str, object] = {
         "product_name": "BulkReviewCampaignApprovalInboxItem",
         "product_version": "v1",
@@ -140,18 +142,36 @@ def build_bulk_review_campaign_approval_inbox_item(
         "inbox_reason_codes": reason_codes,
         "discovery": discovery.model_dump(mode="json"),
         "preview_readiness": readiness.model_dump(mode="json"),
-        "approval_ref": governance.approval_ref if governance else None,
-        "approved_by": governance.approved_by if governance else None,
-        "approved_at": governance.approved_at if governance else None,
-        "expires_on": governance.expires_on if governance else None,
-        "access_purpose": governance.access_purpose if governance else None,
-        "entitled_actor_count": len(governance.entitled_actor_ids) if governance else 0,
-        "approval_source_ref_count": len(governance.source_refs) if governance else 0,
+        **_approval_inbox_governance_payload(definition.governance),
         "operating_boundaries": list(CAMPAIGN_APPROVAL_INBOX_OPERATING_BOUNDARIES),
         "content_hash": "",
     }
     payload["content_hash"] = _hash_payload(payload)
     return DpmBulkReviewCampaignApprovalInboxItem.model_validate(payload)
+
+
+def _approval_inbox_governance_payload(
+    governance: DpmBulkReviewCampaignDefinitionGovernance | None,
+) -> dict[str, object]:
+    if governance is None:
+        return {
+            "approval_ref": None,
+            "approved_by": None,
+            "approved_at": None,
+            "expires_on": None,
+            "access_purpose": None,
+            "entitled_actor_count": 0,
+            "approval_source_ref_count": 0,
+        }
+    return {
+        "approval_ref": governance.approval_ref,
+        "approved_by": governance.approved_by,
+        "approved_at": governance.approved_at,
+        "expires_on": governance.expires_on,
+        "access_purpose": governance.access_purpose,
+        "entitled_actor_count": len(governance.entitled_actor_ids),
+        "approval_source_ref_count": len(governance.source_refs),
+    }
 
 
 def build_bulk_review_campaign_approval_inbox_page(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -1502,6 +1502,66 @@ def test_selected_alternative_proof_pack_captures_method_trace_and_selection_eve
     ]
 
 
+def test_selected_alternative_for_proof_pack_resolves_selected_alternative() -> None:
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+    alternative_set = build_alternative_set(
+        alternative_set_id="cas_proof_pack_1",
+        portfolio_id="pf_proof_pack_1",
+        as_of="2026-05-03",
+        alternatives=[alternative],
+    )
+    selection = ConstructionAlternativeSelection(
+        selection_id="sel_proof_pack_1",
+        alternative_set_id=alternative_set.alternative_set_id,
+        alternative_id=alternative.alternative_id,
+        actor_id="pm_001",
+        reason_code="MODEL_DRIFT_REVIEW",
+    )
+
+    selected = builder_module._selected_alternative_for_proof_pack(
+        alternative_set=alternative_set,
+        selected_alternative_id=alternative.alternative_id,
+        selection=selection,
+    )
+
+    assert selected == alternative
+
+
+def test_validate_selected_alternative_selection_rejects_mismatched_ids() -> None:
+    with pytest.raises(
+        ProofPackSourceValidationError,
+        match="DPM_SELECTED_ALTERNATIVE_SELECTION_MISMATCH",
+    ):
+        builder_module._validate_selected_alternative_selection(
+            alternative_set_id="cas_proof_pack_1",
+            selected_alternative_id="ca_selected",
+            selection=ConstructionAlternativeSelection(
+                selection_id="sel_proof_pack_1",
+                alternative_set_id="cas_proof_pack_1",
+                alternative_id="ca_different",
+                actor_id="pm_001",
+                reason_code="MODEL_DRIFT_REVIEW",
+            ),
+        )
+
+    with pytest.raises(
+        ProofPackSourceValidationError,
+        match="DPM_SELECTED_ALTERNATIVE_SET_MISMATCH",
+    ):
+        builder_module._validate_selected_alternative_selection(
+            alternative_set_id="cas_proof_pack_1",
+            selected_alternative_id="ca_selected",
+            selection=ConstructionAlternativeSelection(
+                selection_id="sel_proof_pack_2",
+                alternative_set_id="cas_different",
+                alternative_id="ca_selected",
+                actor_id="pm_001",
+                reason_code="MODEL_DRIFT_REVIEW",
+            ),
+        )
+
+
 def test_selected_alternative_proof_pack_attaches_source_owned_risk_and_performance() -> None:
     result = _ready_rebalance_result()
     authority_context = ConstructionAuthorityContext(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -340,6 +340,46 @@ def test_run_state_section_payload_blocks_missing_trade_intents() -> None:
     assert reason_codes == ["DPM_TRADE_INTENTS_MISSING"]
 
 
+def test_trade_intents_section_payload_projects_ready_and_blocked_states() -> None:
+    ready = _ready_rebalance_result()
+    blocked = ready.model_copy(update={"intents": []})
+
+    ready_state, _summary, ready_facts, ready_metrics, ready_reasons = (
+        builder_module._trade_intents_section_payload(ready)
+    )
+    blocked_state, _summary, blocked_facts, blocked_metrics, blocked_reasons = (
+        builder_module._trade_intents_section_payload(blocked)
+    )
+
+    assert ready_state == "READY"
+    assert ready_facts["intent_ids"] == [intent.intent_id for intent in ready.intents]
+    assert ready_metrics == {"trade_count": len(ready.intents)}
+    assert ready_reasons == []
+    assert blocked_state == "BLOCKED"
+    assert blocked_facts == {"intent_ids": []}
+    assert blocked_metrics == {"trade_count": 0}
+    assert blocked_reasons == ["DPM_TRADE_INTENTS_MISSING"]
+
+
+def test_after_state_section_payload_marks_blocked_runs() -> None:
+    ready = _ready_rebalance_result()
+    blocked = ready.model_copy(update={"status": "BLOCKED"})
+
+    ready_state, _summary, _facts, ready_metrics, ready_reasons = (
+        builder_module._after_state_section_payload(ready)
+    )
+    blocked_state, _summary, _facts, blocked_metrics, blocked_reasons = (
+        builder_module._after_state_section_payload(blocked)
+    )
+
+    assert ready_state == "READY"
+    assert ready_metrics == {"position_count": len(ready.after_simulated.positions)}
+    assert ready_reasons == []
+    assert blocked_state == "BLOCKED"
+    assert blocked_metrics == {"position_count": len(blocked.after_simulated.positions)}
+    assert blocked_reasons == ["DPM_AFTER_STATE_BLOCKED"]
+
+
 def test_run_state_section_payload_ignores_unrelated_sections() -> None:
     assert (
         builder_module._run_state_section_payload(

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timezone
 import pytest
 from pydantic import BaseModel, ValidationError
 
+import src.core.waves.campaign_approval_inbox as approval_inbox_module
 from src.core.waves import DpmWaveSourceRef
 from src.core.common.canonical import hash_canonical_payload, strip_keys
 from src.core.waves.campaign_definitions import (
@@ -385,6 +386,36 @@ def test_campaign_approval_inbox_classifies_governance_attention() -> None:
     assert expired.inbox_status == "EXPIRY_ATTENTION"
     assert unauthorized.inbox_status == "ENTITLEMENT_ATTENTION"
     assert "NO_APPROVAL_STATE_MUTATION" in unauthorized.operating_boundaries
+
+
+def test_campaign_approval_inbox_governance_payload_projects_counts() -> None:
+    governance = _definition(entitled_actor_ids=["pm_001", "ops"]).governance
+
+    payload = approval_inbox_module._approval_inbox_governance_payload(governance)
+
+    assert payload == {
+        "approval_ref": "BRC-APPROVAL-2026-05",
+        "approved_by": "cio_ops_committee",
+        "approved_at": "2026-05-14T08:30:00+08:00",
+        "expires_on": "2026-06-30",
+        "access_purpose": "DPM_BULK_REVIEW_CAMPAIGN",
+        "entitled_actor_count": 2,
+        "approval_source_ref_count": 1,
+    }
+
+
+def test_campaign_approval_inbox_governance_payload_handles_missing_governance() -> None:
+    payload = approval_inbox_module._approval_inbox_governance_payload(None)
+
+    assert payload == {
+        "approval_ref": None,
+        "approved_by": None,
+        "approved_at": None,
+        "expires_on": None,
+        "access_purpose": None,
+        "entitled_actor_count": 0,
+        "approval_source_ref_count": 0,
+    }
 
 
 def test_campaign_approval_inbox_page_filters_closed_and_status() -> None:


### PR DESCRIPTION
## Summary
- Extract proof-pack selected-alternative resolution and selection-record validation helpers with direct helper tests.
- Extract campaign approval-inbox governance payload projection with direct missing/populated governance tests.
- Extract proof-pack run-state trade-intent and after-state payload helpers with direct ready/blocked tests.
- Refresh codebase review ledger and current quality reports for the hardened slices.

## Validation
- `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` (81 passed)
- `python -m ruff check src/core/waves/campaign_approval_inbox.py tests/unit/dpm/waves/test_campaign_discovery.py`
- `python -m ruff format --check src/core/waves/campaign_approval_inbox.py tests/unit/dpm/waves/test_campaign_discovery.py`
- `python -m mypy --config-file mypy.ini src/core/waves/campaign_approval_inbox.py`
- `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q` (76 passed)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan returned no matches: `rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"`
- `python scripts/engineering_health_report.py`
- `make check` (2569 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (no output)
- `powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Wiki decision
No wiki source change required; this PR is internal backend maintainability refactoring with repo-local ledger/report evidence only.