### PR TITLE
Refactor manage source hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20148,3 +20148,28 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal proof-pack diagnostics
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-819: Target trace row projection helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/target_generation.py`,
+  `tests/unit/core/test_target_generation_helpers.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `build_target_trace` was the top current source-complexity hotspot after the
+  proof-pack diagnostics slice and mixed model-target row construction, capped/redistributed tag
+  derivation, non-model eligible position row construction, sell-to-zero/locked classification,
+  and final trace ordering in one mapper.
+- Action: extracted deterministic model-target, non-model target, and non-model tag helpers while
+  preserving trace ordering, target weights, final values, capped/redistributed tags, sell-to-zero
+  tags, and locked-position tags. Added direct helper tests for capped and redistributed target
+  rows plus non-model sell-to-zero and locked rows alongside existing public trace coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m mypy --config-file mypy.ini src/core/target_generation.py`,
+  `python -m pytest tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal target-generation mapper
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20094,3 +20094,30 @@ and improves internal transaction-cost source posture maintainability only.
   and service leakage scan (`rg -n "from src\\.api\\.routers|import src\\.api\\.routers|HTTPException|status\\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"` returned no matches).
 - Wiki decision: no wiki source change required; this is internal proof-pack section payload
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-817: Core sourcing source-product retry helper
+
+- Date: 2026-06-12
+- Scope: `src/infrastructure/core_sourcing/client.py`,
+  `tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_request_source_product` was the top current source-complexity hotspot and mixed
+  retry attempt counting, transient HTTP status retry behavior, transport exception retry
+  behavior, source-safe error mapping, response payload validation, and owned-client cleanup in
+  one resolver method.
+- Action: extracted `_source_product_payload_with_retries` as a deterministic helper while
+  preserving request dispatch, correlation headers, transient 502/503/504 retry semantics,
+  timeout/transport unavailable mapping, non-object payload rejection, and owned-client cleanup in
+  the resolver method. Added direct helper tests for transient retry success and exhausted
+  transient failure alongside the existing resolver helper coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `python -m ruff format --check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/core_sourcing/client.py`,
+  `python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal core-sourcing client
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20121,3 +20121,30 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal core-sourcing client
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-818: Proof-pack run diagnostics section helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/proof_packs/builder.py`,
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_run_diagnostics_section_payload` was the top current source-complexity hotspot after
+  the core-sourcing slice and mixed liquidity/cash projection, FX funding projection,
+  currency-overlay fallback evidence, reason-code selection, metrics, and dispatcher behavior in
+  one function.
+- Action: extracted deterministic liquidity/cash, FX funding, and currency-overlay diagnostics
+  section helpers while preserving section dispatcher semantics, ready/blocked/degraded states,
+  breach and missing-FX metrics, reason codes, and JSON payload shapes. Added direct helper tests
+  for blocked cash-ladder breaches and missing FX pairs alongside existing dispatcher/fallback
+  coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal proof-pack diagnostics
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:35:12+00:00`
+- Generated at: `2026-06-12T15:38:19+00:00`
 
-- Current ref: `959d574e`
+- Current ref: `eb4be547`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 2 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 3 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 4 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 5 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 6 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 7 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 8 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 9 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
-| 10 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 1 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 2 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 3 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 4 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 5 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 6 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 7 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 8 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
+| 9 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 10 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:38:19+00:00`
+- Generated at: `2026-06-12T15:40:59+00:00`
 
-- Current ref: `eb4be547`
+- Current ref: `4f6af6b8`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 2 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 3 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 4 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 5 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 6 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 7 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 8 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
-| 9 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
-| 10 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 1 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 2 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 3 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 4 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 5 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 6 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 7 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
+| 8 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 9 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 10 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:22:52+00:00`
+- Generated at: `2026-06-12T15:35:12+00:00`
 
-- Current ref: `1778f615`
+- Current ref: `959d574e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _request_source_product | src/infrastructure/core_sourcing/client.py | 8 | 44 |
-| 2 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
-| 3 | build_target_trace | src/core/target_generation.py | 8 | 42 |
-| 4 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 5 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 6 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 7 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 8 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 9 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 10 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
+| 1 | _run_diagnostics_section_payload | src/core/proof_packs/builder.py | 8 | 42 |
+| 2 | build_target_trace | src/core/target_generation.py | 8 | 42 |
+| 3 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
+| 4 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 5 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 6 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 7 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 8 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 9 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
+| 10 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:38:19+00:00`
+- Generated at: `2026-06-12T15:40:59+00:00`
 
-- Current ref: `eb4be547`
+- Current ref: `4f6af6b8`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:22:52+00:00`
+- Generated at: `2026-06-12T15:35:12+00:00`
 
-- Current ref: `1778f615`
+- Current ref: `959d574e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:35:12+00:00`
+- Generated at: `2026-06-12T15:38:19+00:00`
 
-- Current ref: `959d574e`
+- Current ref: `eb4be547`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:35:12+00:00`
+- Generated at: `2026-06-12T15:38:19+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `959d574e`
+- Current ref: `eb4be547`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166935 | 167002 | +67 |
-| Test functions | 2396 | 2398 | +2 |
+| Total Python LOC | 166935 | 167079 | +144 |
+| Test functions | 2396 | 2400 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -54,8 +54,8 @@
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2427 |
+| 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
+| 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2168 |
 | 9 | src/core/dpm_source_context.py | 1886 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:22:52+00:00`
+- Generated at: `2026-06-12T15:35:12+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `1778f615`
+- Current ref: `959d574e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166744 | 166935 | +191 |
-| Test functions | 2390 | 2396 | +6 |
+| Total Python LOC | 166935 | 167002 | +67 |
+| Test functions | 2396 | 2398 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -40,9 +40,9 @@
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 7 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2327 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2137 |
+| 6 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2427 |
+| 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2168 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1732 |
 
@@ -59,7 +59,7 @@
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2168 |
 | 9 | src/core/dpm_source_context.py | 1886 |
-| 10 | src/infrastructure/core_sourcing/client.py | 1732 |
+| 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:38:19+00:00`
+- Generated at: `2026-06-12T15:40:59+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `eb4be547`
+- Current ref: `4f6af6b8`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166935 | 167079 | +144 |
-| Test functions | 2396 | 2400 | +4 |
+| Total Python LOC | 166935 | 167164 | +229 |
+| Test functions | 2396 | 2402 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -641,42 +641,54 @@ def _run_diagnostics_section_payload(
     result: RebalanceResult,
 ) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]] | None:
     if section_type == "liquidity_and_cash":
-        breaches = result.diagnostics.cash_ladder_breaches
-        return (
-            "BLOCKED" if breaches else "READY",
-            "Liquidity and cash posture captured from run diagnostics.",
-            {
-                "cash_ladder": [
-                    item.model_dump(mode="json") for item in result.diagnostics.cash_ladder
-                ],
-                "cash_ladder_breaches": [item.model_dump(mode="json") for item in breaches],
-            },
-            {"breach_count": len(breaches)},
-            ["DPM_CASH_LADDER_BREACH"] if breaches else [],
-        )
+        return _liquidity_and_cash_section_payload(result)
     if section_type == "fx_funding_plan":
-        missing_pairs = result.diagnostics.missing_fx_pairs
-        return (
-            "BLOCKED" if missing_pairs else "READY",
-            "FX funding posture captured from run diagnostics.",
-            {
-                "funding_plan": [
-                    item.model_dump(mode="json") for item in result.diagnostics.funding_plan
-                ],
-                "missing_fx_pairs": missing_pairs,
-            },
-            {"missing_fx_pair_count": len(missing_pairs)},
-            ["DPM_REQUIRED_FX_PAIR_MISSING"] if missing_pairs else [],
-        )
+        return _fx_funding_plan_section_payload(result)
     if section_type == "currency_overlay_evidence":
-        return (
-            "DEGRADED",
-            "Currency-overlay authority context is not attached.",
-            {},
-            {},
-            ["DPM_CURRENCY_OVERLAY_CONTEXT_MISSING"],
-        )
+        return _currency_overlay_evidence_section_payload()
     return None
+
+
+def _liquidity_and_cash_section_payload(result: RebalanceResult) -> _SectionPayload:
+    breaches = result.diagnostics.cash_ladder_breaches
+    return (
+        "BLOCKED" if breaches else "READY",
+        "Liquidity and cash posture captured from run diagnostics.",
+        {
+            "cash_ladder": [
+                item.model_dump(mode="json") for item in result.diagnostics.cash_ladder
+            ],
+            "cash_ladder_breaches": [item.model_dump(mode="json") for item in breaches],
+        },
+        {"breach_count": len(breaches)},
+        ["DPM_CASH_LADDER_BREACH"] if breaches else [],
+    )
+
+
+def _fx_funding_plan_section_payload(result: RebalanceResult) -> _SectionPayload:
+    missing_pairs = result.diagnostics.missing_fx_pairs
+    return (
+        "BLOCKED" if missing_pairs else "READY",
+        "FX funding posture captured from run diagnostics.",
+        {
+            "funding_plan": [
+                item.model_dump(mode="json") for item in result.diagnostics.funding_plan
+            ],
+            "missing_fx_pairs": missing_pairs,
+        },
+        {"missing_fx_pair_count": len(missing_pairs)},
+        ["DPM_REQUIRED_FX_PAIR_MISSING"] if missing_pairs else [],
+    )
+
+
+def _currency_overlay_evidence_section_payload() -> _SectionPayload:
+    return (
+        "DEGRADED",
+        "Currency-overlay authority context is not attached.",
+        {},
+        {},
+        ["DPM_CURRENCY_OVERLAY_CONTEXT_MISSING"],
+    )
 
 
 def _run_policy_section_payload(

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -359,37 +359,74 @@ def build_target_trace(
     buy_set = set(buy_list)
     model_target_ids = {t.instrument_id for t in model.targets}
     for t in model.targets:
-        final_w = eligible_targets.get(t.instrument_id, Decimal("0.0"))
-        tags = ["CAPPED_BY_MAX_WEIGHT"] if t.weight > final_w else []
-
-        if final_w > t.weight:
-            tags.append("REDISTRIBUTED_RECIPIENT")
         trace.append(
-            TargetInstrument(
-                instrument_id=t.instrument_id,
-                model_weight=t.weight,
-                final_weight=final_w,
-                final_value=Money(amount=total_val * final_w, currency=base_ccy),
-                tags=tags,
+            _model_target_trace_row(
+                target=t,
+                final_weight=eligible_targets.get(t.instrument_id, Decimal("0.0")),
+                total_val=total_val,
+                base_ccy=base_ccy,
             )
         )
 
     for i_id, final_w in eligible_targets.items():
         if i_id not in model_target_ids:
-            tag = (
-                "IMPLICIT_SELL_TO_ZERO" if (i_id in buy_set or final_w == 0) else "LOCKED_POSITION"
-            )
             trace.append(
-                TargetInstrument(
+                _non_model_target_trace_row(
                     instrument_id=i_id,
-                    model_weight=Decimal("0.0"),
                     final_weight=final_w,
-                    final_value=Money(amount=total_val * final_w, currency=base_ccy),
-                    tags=[tag],
+                    buy_set=buy_set,
+                    total_val=total_val,
+                    base_ccy=base_ccy,
                 )
             )
 
     return trace
+
+
+def _model_target_trace_row(
+    *,
+    target: Any,
+    final_weight: Decimal,
+    total_val: Decimal,
+    base_ccy: str,
+) -> TargetInstrument:
+    tags = ["CAPPED_BY_MAX_WEIGHT"] if target.weight > final_weight else []
+    if final_weight > target.weight:
+        tags.append("REDISTRIBUTED_RECIPIENT")
+    return TargetInstrument(
+        instrument_id=target.instrument_id,
+        model_weight=target.weight,
+        final_weight=final_weight,
+        final_value=Money(amount=total_val * final_weight, currency=base_ccy),
+        tags=tags,
+    )
+
+
+def _non_model_target_trace_row(
+    *,
+    instrument_id: str,
+    final_weight: Decimal,
+    buy_set: set[str],
+    total_val: Decimal,
+    base_ccy: str,
+) -> TargetInstrument:
+    return TargetInstrument(
+        instrument_id=instrument_id,
+        model_weight=Decimal("0.0"),
+        final_weight=final_weight,
+        final_value=Money(amount=total_val * final_weight, currency=base_ccy),
+        tags=[_non_model_target_trace_tag(instrument_id, final_weight, buy_set)],
+    )
+
+
+def _non_model_target_trace_tag(
+    instrument_id: str,
+    final_weight: Decimal,
+    buy_set: set[str],
+) -> str:
+    if instrument_id in buy_set or final_weight == 0:
+        return "IMPLICIT_SELL_TO_ZERO"
+    return "LOCKED_POSITION"
 
 
 def generate_targets_solver(

--- a/src/infrastructure/core_sourcing/client.py
+++ b/src/infrastructure/core_sourcing/client.py
@@ -95,6 +95,43 @@ def _source_product_request(
     return cast(httpx.Response, client.get(url, params=selector, headers=headers))
 
 
+def _source_product_payload_with_retries(
+    client: Any,
+    *,
+    attempts: int,
+    method: _SourceProductMethod,
+    url: str,
+    selector: dict[str, Any],
+    headers: dict[str, str],
+    unavailable_code: str,
+    incomplete_code: str,
+) -> dict[str, Any]:
+    last_error: Exception | None = None
+    for attempt in range(attempts):
+        try:
+            response = _source_product_request(
+                client,
+                method=method,
+                url=url,
+                selector=selector,
+                headers=headers,
+            )
+        except (httpx.TimeoutException, httpx.TransportError) as exc:
+            last_error = exc
+            if attempt + 1 >= attempts:
+                raise DpmCoreResolverUnavailableError(unavailable_code) from exc
+            continue
+        if response.status_code in _TRANSIENT_SOURCE_STATUS_CODES and attempt + 1 < attempts:
+            continue
+        _raise_for_source_product_status(
+            response,
+            unavailable_code=unavailable_code,
+            incomplete_code=incomplete_code,
+        )
+        return _source_product_response_payload(response, incomplete_code=incomplete_code)
+    raise DpmCoreResolverUnavailableError(unavailable_code) from last_error
+
+
 @dataclass(frozen=True)
 class _CoreSnapshotMappedRow:
     position: Position | None = None
@@ -433,33 +470,16 @@ class DpmCoreResolverClient:
         headers = _source_product_headers(correlation_id)
         client = self._client or httpx.Client(timeout=self._config.timeout_seconds)
         try:
-            last_error: Exception | None = None
-            for attempt in range(attempts):
-                try:
-                    response = _source_product_request(
-                        client,
-                        method=method,
-                        url=url,
-                        selector=selector,
-                        headers=headers,
-                    )
-                except (httpx.TimeoutException, httpx.TransportError) as exc:
-                    last_error = exc
-                    if attempt + 1 >= attempts:
-                        raise DpmCoreResolverUnavailableError(unavailable_code) from exc
-                    continue
-                if (
-                    response.status_code in _TRANSIENT_SOURCE_STATUS_CODES
-                    and attempt + 1 < attempts
-                ):
-                    continue
-                _raise_for_source_product_status(
-                    response,
-                    unavailable_code=unavailable_code,
-                    incomplete_code=incomplete_code,
-                )
-                return _source_product_response_payload(response, incomplete_code=incomplete_code)
-            raise DpmCoreResolverUnavailableError(unavailable_code) from last_error
+            return _source_product_payload_with_retries(
+                client,
+                attempts=attempts,
+                method=method,
+                url=url,
+                selector=selector,
+                headers=headers,
+                unavailable_code=unavailable_code,
+                incomplete_code=incomplete_code,
+            )
         finally:
             if self._owns_client:
                 client.close()

--- a/tests/unit/core/test_target_generation_helpers.py
+++ b/tests/unit/core/test_target_generation_helpers.py
@@ -13,6 +13,9 @@ from src.core.target_generation import (
     _build_solver_attempts,
     _collect_infeasibility_hints,
     _infeasibility_capacity_hints,
+    _model_target_trace_row,
+    _non_model_target_trace_row,
+    _non_model_target_trace_tag,
     _solver_model_weight_array,
     _solver_group_members,
     _solver_invested_bounds,
@@ -134,6 +137,51 @@ def test_apply_solver_values_quantizes_and_fails_closed_without_values() -> None
         diagnostics=diagnostics,
     )
     assert diagnostics.warnings == ["SOLVER_ERROR"]
+
+
+def test_model_target_trace_row_marks_capped_and_redistributed_targets() -> None:
+    capped = _model_target_trace_row(
+        target=ModelTarget(instrument_id="EQ_CAPPED", weight=Decimal("0.30")),
+        final_weight=Decimal("0.20"),
+        total_val=Decimal("1000"),
+        base_ccy="USD",
+    )
+    redistributed = _model_target_trace_row(
+        target=ModelTarget(instrument_id="EQ_REDISTRIBUTED", weight=Decimal("0.20")),
+        final_weight=Decimal("0.30"),
+        total_val=Decimal("1000"),
+        base_ccy="USD",
+    )
+
+    assert capped.final_value.amount == Decimal("200")
+    assert capped.tags == ["CAPPED_BY_MAX_WEIGHT"]
+    assert redistributed.final_value.amount == Decimal("300")
+    assert redistributed.tags == ["REDISTRIBUTED_RECIPIENT"]
+
+
+def test_non_model_target_trace_row_classifies_sell_to_zero_and_locked_positions() -> None:
+    sell_to_zero = _non_model_target_trace_row(
+        instrument_id="EQ_SELL",
+        final_weight=Decimal("0"),
+        buy_set=set(),
+        total_val=Decimal("1000"),
+        base_ccy="USD",
+    )
+    locked = _non_model_target_trace_row(
+        instrument_id="EQ_LOCKED",
+        final_weight=Decimal("0.15"),
+        buy_set=set(),
+        total_val=Decimal("1000"),
+        base_ccy="USD",
+    )
+
+    assert sell_to_zero.tags == ["IMPLICIT_SELL_TO_ZERO"]
+    assert sell_to_zero.final_value.amount == Decimal("0")
+    assert locked.tags == ["LOCKED_POSITION"]
+    assert locked.final_value.amount == Decimal("150.00")
+    assert _non_model_target_trace_tag("EQ_BUY", Decimal("0.10"), {"EQ_BUY"}) == (
+        "IMPLICIT_SELL_TO_ZERO"
+    )
 
 
 def test_collect_infeasibility_hints_reports_capacity_and_group_lock() -> None:

--- a/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
+++ b/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
@@ -13,6 +13,7 @@ from src.infrastructure.core_sourcing.client import (
     _portfolio_snapshot_from_core_snapshot,
     _portfolio_positions_and_cash_from_core_rows,
     _required_currency_pairs,
+    _source_product_payload_with_retries,
 )
 
 
@@ -133,6 +134,52 @@ def test_core_resolver_shared_post_helper_retries_transport_then_succeeds() -> N
     )
 
     assert response == {"ok": True}
+    assert calls["count"] == 2
+
+
+def test_source_product_retry_helper_maps_transient_status_then_payload() -> None:
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return httpx.Response(503, json={"detail": "retry"})
+        return httpx.Response(200, json={"source": "ready"})
+
+    payload = _source_product_payload_with_retries(
+        httpx.Client(transport=httpx.MockTransport(handler)),
+        attempts=2,
+        method="get",
+        url="https://core.example.test/integration/source",
+        selector={"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+        headers={"X-Correlation-Id": "corr-source"},
+        unavailable_code="UNAVAILABLE",
+        incomplete_code="INCOMPLETE",
+    )
+
+    assert payload == {"source": "ready"}
+    assert calls["count"] == 2
+
+
+def test_source_product_retry_helper_exhausts_transient_status_safely() -> None:
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(503, json={"detail": "still unavailable"})
+
+    with pytest.raises(DpmCoreResolverUnavailableError, match="UNAVAILABLE"):
+        _source_product_payload_with_retries(
+            httpx.Client(transport=httpx.MockTransport(handler)),
+            attempts=2,
+            method="post",
+            url="https://core.example.test/integration/source",
+            selector={"portfolio_id": "PB_SG_GLOBAL_BAL_001"},
+            headers={},
+            unavailable_code="UNAVAILABLE",
+            incomplete_code="INCOMPLETE",
+        )
+
     assert calls["count"] == 2
 
 

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -19,8 +19,10 @@ from src.core.construction import (
     build_rebalance_result_alternative,
 )
 from src.core.models import (
+    CashLadderBreach,
     EngineOptions,
     ExcludedInstrument,
+    FundingPlanEntry,
     GateDecision,
     GateDecisionSummary,
     GateReason,
@@ -414,6 +416,69 @@ def test_run_diagnostics_section_payload_returns_currency_overlay_fallback() -> 
     assert facts == {}
     assert metrics == {}
     assert reason_codes == ["DPM_CURRENCY_OVERLAY_CONTEXT_MISSING"]
+
+
+def test_liquidity_and_cash_section_payload_marks_cash_breaches() -> None:
+    result = _ready_rebalance_result()
+    result = result.model_copy(
+        update={
+            "diagnostics": result.diagnostics.model_copy(
+                update={
+                    "cash_ladder_breaches": [
+                        CashLadderBreach(
+                            date_offset=2,
+                            currency="USD",
+                            projected_balance=Decimal("-25"),
+                            allowed_floor=Decimal("0"),
+                            reason_code="OVERDRAFT_ON_T_PLUS_2",
+                        )
+                    ]
+                }
+            )
+        }
+    )
+
+    state, _summary, facts, metrics, reason_codes = (
+        builder_module._liquidity_and_cash_section_payload(result)
+    )
+
+    assert state == "BLOCKED"
+    assert facts["cash_ladder_breaches"][0]["reason_code"] == "OVERDRAFT_ON_T_PLUS_2"
+    assert metrics == {"breach_count": 1}
+    assert reason_codes == ["DPM_CASH_LADDER_BREACH"]
+
+
+def test_fx_funding_plan_section_payload_marks_missing_pairs() -> None:
+    result = _ready_rebalance_result()
+    result = result.model_copy(
+        update={
+            "diagnostics": result.diagnostics.model_copy(
+                update={
+                    "missing_fx_pairs": ["USD/SGD"],
+                    "funding_plan": [
+                        FundingPlanEntry(
+                            target_currency="SGD",
+                            required=Decimal("100"),
+                            available_before_fx=Decimal("25"),
+                            fx_needed=Decimal("75"),
+                            fx_pair=None,
+                            funding_currency=None,
+                        )
+                    ],
+                }
+            )
+        }
+    )
+
+    state, _summary, facts, metrics, reason_codes = builder_module._fx_funding_plan_section_payload(
+        result
+    )
+
+    assert state == "BLOCKED"
+    assert facts["missing_fx_pairs"] == ["USD/SGD"]
+    assert facts["funding_plan"][0]["target_currency"] == "SGD"
+    assert metrics == {"missing_fx_pair_count": 1}
+    assert reason_codes == ["DPM_REQUIRED_FX_PAIR_MISSING"]
 
 
 def test_run_policy_section_payload_returns_direct_run_drift_fallback() -> None:


### PR DESCRIPTION
Summary:
- Extract core-sourcing source-product retry orchestration into a direct helper with focused retry/error tests.
- Extract proof-pack run diagnostics section helpers for liquidity, FX funding, and currency-overlay fallback evidence.
- Extract target-generation trace row helpers for model and non-model target projections.
- Refresh review ledger and quality reports; source hotspot list now starts at workflow-board posture after these slices.

Evidence:
- python -m ruff check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
- python -m ruff format --check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
- python -m mypy --config-file mypy.ini src/infrastructure/core_sourcing/client.py
- python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py -q: 24 passed
- python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py
- python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py
- python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py
- python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q: 83 passed
- python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py
- python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py
- python -m mypy --config-file mypy.ini src/core/target_generation.py
- python -m pytest tests/unit/core/test_target_generation_helpers.py tests/unit/core/test_target_generation_solver_fallbacks.py -q: 26 passed
- python scripts/openapi_quality_gate.py: passed
- python scripts/api_vocabulary_inventory.py --validate-only: passed, no drift
- git diff --check: passed
- Service leakage scan returned no matches
- python scripts/engineering_health_report.py: refreshed quality evidence
- make check: 2575 passed
- git fetch origin --prune: passed
- git branch -r --no-merged origin/main: only origin/feat/manage-hotspot-hardening-20260612-17
- powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage: DiffCount 0

Behavior changes: none intended.
Wiki/source docs: no wiki source change required; this is internal maintainability hardening with repo-local ledger and quality evidence.