### PR TITLE
Refactor manage backend hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20223,3 +20223,30 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal campaign candidate-selection
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-822: Construction method readiness dispatch helpers
+
+- Date: 2026-06-12
+- Scope: `src/api/services/construction_method_readiness.py`,
+  `tests/unit/dpm/construction/test_method_readiness.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `method_specific_reason_codes` and `method_specific_status` were adjacent current
+  source-complexity hotspots and encoded method dispatch, status fallback behavior, delegated
+  supportability checks, reason-code normalization, and currency-overlay missing-FX fallback in
+  branch-heavy public functions.
+- Action: extracted typed method readiness context objects, dispatch tables, and focused builder
+  helpers while preserving solver, liquidity, risk, cost, ESG, currency-overlay, and regime-stress
+  reason-code/status behavior. Added direct helper tests for currency-overlay missing-FX status
+  fallback and solver reason-code builder routing alongside existing public method-readiness
+  behavior coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_method_readiness.py tests/unit/dpm/construction/test_method_readiness.py`,
+  `python -m ruff format --check src/api/services/construction_method_readiness.py tests/unit/dpm/construction/test_method_readiness.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_method_readiness.py`,
+  `python -m pytest tests/unit/dpm/construction/test_method_readiness.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal construction method-readiness
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20197,3 +20197,29 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal workflow-board maintainability
   refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-821: Campaign candidate selection validation helpers
+
+- Date: 2026-06-12
+- Scope: `src/api/routers/wave_campaign_candidate_selection.py`,
+  `tests/unit/api/test_wave_campaign_candidate_selection.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `select_bulk_review_campaign_candidates` was the top current source-complexity hotspot
+  after the workflow-board slice and mixed candidate iteration, portfolio-type extraction and
+  normalization, ineligible-candidate counting, source-ref shape validation, missing-source-ref
+  validation, and selection result construction in one loop.
+- Action: extracted deterministic candidate portfolio-type and source-ref validation helpers while
+  preserving eligible-candidate ordering, excluded-count semantics, validation error codes, and
+  source-owned candidate evidence requirements. Added direct helper tests for non-string
+  portfolio types and non-sequence source refs alongside existing selection behavior tests.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/wave_campaign_candidate_selection.py tests/unit/api/test_wave_campaign_candidate_selection.py`,
+  `python -m ruff format --check src/api/routers/wave_campaign_candidate_selection.py tests/unit/api/test_wave_campaign_candidate_selection.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/wave_campaign_candidate_selection.py`,
+  `python -m pytest tests/unit/api/test_wave_campaign_candidate_selection.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal campaign candidate-selection
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20173,3 +20173,27 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal target-generation mapper
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260612-820: Campaign workflow-board action helpers
+
+- Date: 2026-06-12
+- Scope: `src/core/waves/campaign_workflow_board.py`,
+  `tests/unit/dpm/waves/test_campaign_discovery.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_classify_workflow_board_posture` was the top current source-complexity hotspot and
+  mixed closed-campaign detection, approval-inbox action precedence, entitlement/approval/expiry
+  action mapping, operating-queue ready mapping, and fallback attention mapping in one classifier.
+- Action: extracted deterministic approval-inbox and operating-queue workflow-action helpers while
+  preserving closed posture, approval-inbox precedence, board status, next-action values, and
+  reason-code propagation. Added direct helper tests for approval attention precedence and
+  operating-queue fallback alongside existing workflow-board page and assignment-plan coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_workflow_board.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_workflow_board.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_workflow_board.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal workflow-board maintainability
+  refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:52:32+00:00`
+- Generated at: `2026-06-12T15:55:22+00:00`
 
-- Current ref: `3d8199ec`
+- Current ref: `d2df18f8`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 2 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 3 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 4 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 5 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 6 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
-| 7 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
-| 8 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
-| 9 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
-| 10 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
+| 1 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 2 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 3 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 4 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 5 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
+| 6 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 7 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 8 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
+| 9 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
+| 10 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:40:59+00:00`
+- Generated at: `2026-06-12T15:52:32+00:00`
 
-- Current ref: `4f6af6b8`
+- Current ref: `3d8199ec`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _classify_workflow_board_posture | src/core/waves/campaign_workflow_board.py | 8 | 42 |
-| 2 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
-| 3 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 4 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 5 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 6 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 7 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
-| 8 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
-| 9 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
-| 10 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
+| 1 | select_bulk_review_campaign_candidates | src/api/routers/wave_campaign_candidate_selection.py | 8 | 41 |
+| 2 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
+| 3 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 4 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 5 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 6 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
+| 7 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 8 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 9 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
+| 10 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T15:55:22+00:00`
+- Generated at: `2026-06-12T16:03:15+00:00`
 
-- Current ref: `d2df18f8`
+- Current ref: `0bd590cc`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | method_specific_reason_codes | src/api/services/construction_method_readiness.py | 8 | 41 |
-| 2 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 3 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 4 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 5 | method_specific_status | src/api/services/construction_method_readiness.py | 8 | 34 |
-| 6 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
-| 7 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
-| 8 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
-| 9 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
-| 10 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
+| 1 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
+| 2 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 3 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 4 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 5 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 6 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
+| 7 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
+| 8 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
+| 9 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
+| 10 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:55:22+00:00`
+- Generated at: `2026-06-12T16:03:15+00:00`
 
-- Current ref: `d2df18f8`
+- Current ref: `0bd590cc`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:52:32+00:00`
+- Generated at: `2026-06-12T15:55:22+00:00`
 
-- Current ref: `3d8199ec`
+- Current ref: `d2df18f8`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T15:40:59+00:00`
+- Generated at: `2026-06-12T15:52:32+00:00`
 
-- Current ref: `4f6af6b8`
+- Current ref: `3d8199ec`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:55:22+00:00`
+- Generated at: `2026-06-12T16:03:15+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `d2df18f8`
+- Current ref: `0bd590cc`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167164 | 167282 | +118 |
-| Test functions | 2402 | 2406 | +4 |
+| Total Python LOC | 167164 | 167421 | +257 |
+| Test functions | 2402 | 2408 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:52:32+00:00`
+- Generated at: `2026-06-12T15:55:22+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `3d8199ec`
+- Current ref: `d2df18f8`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167164 | 167239 | +75 |
-| Test functions | 2402 | 2404 | +2 |
+| Total Python LOC | 167164 | 167282 | +118 |
+| Test functions | 2402 | 2406 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T15:40:59+00:00`
+- Generated at: `2026-06-12T15:52:32+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `4f6af6b8`
+- Current ref: `3d8199ec`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 166935 | 167164 | +229 |
-| Test functions | 2396 | 2402 | +6 |
+| Total Python LOC | 167164 | 167239 | +75 |
+| Test functions | 2402 | 2404 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -39,12 +39,12 @@
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 5 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 6 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2427 |
+| 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
+| 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2168 |
 | 9 | src/core/dpm_source_context.py | 1886 |
-| 10 | src/infrastructure/core_sourcing/client.py | 1732 |
+| 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 
 ### current branch
 
@@ -57,7 +57,7 @@
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2168 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2228 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 

--- a/src/api/routers/wave_campaign_candidate_selection.py
+++ b/src/api/routers/wave_campaign_candidate_selection.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Iterable, Mapping, Sequence
-from typing import cast
 from dataclasses import dataclass
+from collections.abc import Collection, Iterable, Mapping, Sequence
 from typing import Generic, Protocol, TypeVar
+from typing import cast
 
 from src.api.routers.wave_portfolio_type_validation import normalize_required_portfolio_type
 from src.api.services import wave_service
@@ -43,36 +43,45 @@ def select_bulk_review_campaign_candidates(
     included_candidates: list[T] = []
     excluded_count = 0
     for candidate in candidates:
-        portfolio_type_value = _candidate_attribute(candidate, "portfolio_type")
-        if portfolio_type_value is not None and not isinstance(portfolio_type_value, str):
-            raise wave_service.DpmWaveValidationError(
-                "BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_INVALID",
-                "BULK_REVIEW_CAMPAIGN candidate portfolio_type must be a string.",
-            )
-        portfolio_type = normalize_required_portfolio_type(
-            portfolio_type_value,
-            required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_REQUIRED",
-            required_message=(
-                "BULK_REVIEW_CAMPAIGN candidate portfolios require source-owned portfolio_type."
-            ),
-        )
+        portfolio_type = _candidate_portfolio_type(candidate)
         if portfolio_type not in eligible_portfolio_types:
             excluded_count += 1
             continue
-        source_refs = _candidate_attribute(candidate, "source_refs")
-        if source_refs is not None and not isinstance(source_refs, Sequence):
-            raise wave_service.DpmWaveValidationError(
-                "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_INVALID",
-                "BULK_REVIEW_CAMPAIGN candidate source_refs must be a sequence.",
-            )
-        if not source_refs:
-            raise wave_service.DpmWaveValidationError(
-                "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_REQUIRED",
-                "BULK_REVIEW_CAMPAIGN candidate portfolios require source_refs.",
-            )
+        _candidate_source_refs(candidate)
         included_candidates.append(candidate)
 
     return BulkReviewCampaignCandidateSelection(
         included_candidates=included_candidates,
         excluded_count=excluded_count,
     )
+
+
+def _candidate_portfolio_type(candidate: object) -> str:
+    portfolio_type_value = _candidate_attribute(candidate, "portfolio_type")
+    if portfolio_type_value is not None and not isinstance(portfolio_type_value, str):
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_INVALID",
+            "BULK_REVIEW_CAMPAIGN candidate portfolio_type must be a string.",
+        )
+    return normalize_required_portfolio_type(
+        portfolio_type_value,
+        required_code="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_REQUIRED",
+        required_message=(
+            "BULK_REVIEW_CAMPAIGN candidate portfolios require source-owned portfolio_type."
+        ),
+    )
+
+
+def _candidate_source_refs(candidate: object) -> Sequence[object]:
+    source_refs = _candidate_attribute(candidate, "source_refs")
+    if source_refs is not None and not isinstance(source_refs, Sequence):
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_INVALID",
+            "BULK_REVIEW_CAMPAIGN candidate source_refs must be a sequence.",
+        )
+    if not source_refs:
+        raise wave_service.DpmWaveValidationError(
+            "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_REQUIRED",
+            "BULK_REVIEW_CAMPAIGN candidate portfolios require source_refs.",
+        )
+    return source_refs

--- a/src/api/services/construction_method_readiness.py
+++ b/src/api/services/construction_method_readiness.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+
 from src.api.request_models import RebalanceRequest
 from src.api.services.construction_esg_supportability import (
     esg_restriction_reason_codes,
@@ -22,6 +25,25 @@ from src.core.construction.vocabulary import ConstructionMethod, ConstructionMet
 from src.core.models import RebalanceResult
 
 
+@dataclass(frozen=True)
+class _MethodStatusContext:
+    request: RebalanceRequest
+    result: RebalanceResult
+    enrichment: ConstructionEnrichmentSummary
+    authority_context: ConstructionAuthorityContext
+
+
+@dataclass(frozen=True)
+class _MethodReasonCodeContext:
+    request: RebalanceRequest
+    result: RebalanceResult
+    authority_context: ConstructionAuthorityContext
+
+
+_MethodStatusBuilder = Callable[[_MethodStatusContext], ConstructionMethodStatus]
+_MethodReasonCodeBuilder = Callable[[_MethodReasonCodeContext], list[str]]
+
+
 def method_specific_status(
     *,
     request: RebalanceRequest,
@@ -30,32 +52,17 @@ def method_specific_status(
     enrichment: ConstructionEnrichmentSummary,
     authority_context: ConstructionAuthorityContext,
 ) -> ConstructionMethodStatus:
-    if method == ConstructionMethod.ESG_AWARE:
-        return esg_restriction_status(
+    builder = _status_builder_for_method(method=method, result=result)
+    if builder is None:
+        return ConstructionMethodStatus.READY
+    return builder(
+        _MethodStatusContext(
             request=request,
             result=result,
+            enrichment=enrichment,
             authority_context=authority_context,
         )
-    if method == ConstructionMethod.REGIME_STRESS_AWARE:
-        return regime_stress_status(authority_context.regime_stress_context)
-    if method == ConstructionMethod.CURRENCY_OVERLAY and not result.diagnostics.missing_fx_pairs:
-        return currency_overlay_status(
-            request=request,
-            context=authority_context.currency_overlay_context,
-        )
-    if method == ConstructionMethod.RISK_AWARE:
-        return enrichment.risk_status
-    if method == ConstructionMethod.COST_AWARE:
-        return transaction_cost_status(
-            result=result,
-            context=authority_context.transaction_cost_context,
-        )
-    if method == ConstructionMethod.LIQUIDITY_AWARE:
-        return liquidity_status(
-            result=result,
-            context=authority_context.liquidity_context,
-        )
-    return ConstructionMethodStatus.READY
+    )
 
 
 def method_specific_reason_codes(
@@ -65,40 +72,113 @@ def method_specific_reason_codes(
     result: RebalanceResult,
     authority_context: ConstructionAuthorityContext,
 ) -> list[str]:
-    if method == ConstructionMethod.SOLVER_CONSTRAINED:
-        return _sorted_unique_reason_codes(solver_reason_codes(result=result))
-    if method == ConstructionMethod.LIQUIDITY_AWARE:
-        return _sorted_unique_reason_codes(
-            _liquidity_aware_reason_codes(result=result, authority_context=authority_context)
-        )
-    if method == ConstructionMethod.RISK_AWARE:
-        return _sorted_unique_reason_codes(_risk_aware_reason_codes(authority_context))
-    if method == ConstructionMethod.COST_AWARE:
-        return _sorted_unique_reason_codes(
-            transaction_cost_reason_codes(
-                result=result,
-                context=authority_context.transaction_cost_context,
-            )
-        )
-    if method == ConstructionMethod.ESG_AWARE:
-        return _sorted_unique_reason_codes(
-            esg_restriction_reason_codes(
+    builder = _reason_code_builder_for_method(method)
+    if builder is None:
+        return []
+    return _sorted_unique_reason_codes(
+        builder(
+            _MethodReasonCodeContext(
                 request=request,
                 result=result,
                 authority_context=authority_context,
             )
         )
-    if method == ConstructionMethod.CURRENCY_OVERLAY:
-        return _sorted_unique_reason_codes(
-            currency_overlay_reason_codes(
-                request=request,
-                result=result,
-                authority_context=authority_context,
-            )
-        )
-    if method == ConstructionMethod.REGIME_STRESS_AWARE:
-        return _sorted_unique_reason_codes(_regime_stress_reason_codes(authority_context))
-    return []
+    )
+
+
+def _status_builder_for_method(
+    *,
+    method: ConstructionMethod,
+    result: RebalanceResult,
+) -> _MethodStatusBuilder | None:
+    if method == ConstructionMethod.CURRENCY_OVERLAY and result.diagnostics.missing_fx_pairs:
+        return None
+    return _METHOD_STATUS_BUILDERS.get(method)
+
+
+def _reason_code_builder_for_method(
+    method: ConstructionMethod,
+) -> _MethodReasonCodeBuilder | None:
+    return _METHOD_REASON_CODE_BUILDERS.get(method)
+
+
+def _esg_aware_status(context: _MethodStatusContext) -> ConstructionMethodStatus:
+    return esg_restriction_status(
+        request=context.request,
+        result=context.result,
+        authority_context=context.authority_context,
+    )
+
+
+def _regime_stress_status(context: _MethodStatusContext) -> ConstructionMethodStatus:
+    return regime_stress_status(context.authority_context.regime_stress_context)
+
+
+def _currency_overlay_method_status(context: _MethodStatusContext) -> ConstructionMethodStatus:
+    return currency_overlay_status(
+        request=context.request,
+        context=context.authority_context.currency_overlay_context,
+    )
+
+
+def _risk_aware_status(context: _MethodStatusContext) -> ConstructionMethodStatus:
+    return context.enrichment.risk_status
+
+
+def _cost_aware_status(context: _MethodStatusContext) -> ConstructionMethodStatus:
+    return transaction_cost_status(
+        result=context.result,
+        context=context.authority_context.transaction_cost_context,
+    )
+
+
+def _liquidity_aware_status(context: _MethodStatusContext) -> ConstructionMethodStatus:
+    return liquidity_status(
+        result=context.result,
+        context=context.authority_context.liquidity_context,
+    )
+
+
+def _solver_method_reason_codes(context: _MethodReasonCodeContext) -> list[str]:
+    return solver_reason_codes(result=context.result)
+
+
+def _liquidity_method_reason_codes(context: _MethodReasonCodeContext) -> list[str]:
+    return _liquidity_aware_reason_codes(
+        result=context.result,
+        authority_context=context.authority_context,
+    )
+
+
+def _risk_method_reason_codes(context: _MethodReasonCodeContext) -> list[str]:
+    return _risk_aware_reason_codes(context.authority_context)
+
+
+def _cost_method_reason_codes(context: _MethodReasonCodeContext) -> list[str]:
+    return transaction_cost_reason_codes(
+        result=context.result,
+        context=context.authority_context.transaction_cost_context,
+    )
+
+
+def _esg_method_reason_codes(context: _MethodReasonCodeContext) -> list[str]:
+    return esg_restriction_reason_codes(
+        request=context.request,
+        result=context.result,
+        authority_context=context.authority_context,
+    )
+
+
+def _currency_overlay_method_reason_codes(context: _MethodReasonCodeContext) -> list[str]:
+    return currency_overlay_reason_codes(
+        request=context.request,
+        result=context.result,
+        authority_context=context.authority_context,
+    )
+
+
+def _regime_stress_method_reason_codes(context: _MethodReasonCodeContext) -> list[str]:
+    return _regime_stress_reason_codes(context.authority_context)
 
 
 def _liquidity_aware_reason_codes(
@@ -164,6 +244,26 @@ def currency_overlay_reason_codes(
     else:
         reason_codes.extend(authority_context.currency_overlay_context.reason_codes)
     return reason_codes
+
+
+_METHOD_STATUS_BUILDERS: dict[ConstructionMethod, _MethodStatusBuilder] = {
+    ConstructionMethod.ESG_AWARE: _esg_aware_status,
+    ConstructionMethod.REGIME_STRESS_AWARE: _regime_stress_status,
+    ConstructionMethod.CURRENCY_OVERLAY: _currency_overlay_method_status,
+    ConstructionMethod.RISK_AWARE: _risk_aware_status,
+    ConstructionMethod.COST_AWARE: _cost_aware_status,
+    ConstructionMethod.LIQUIDITY_AWARE: _liquidity_aware_status,
+}
+
+_METHOD_REASON_CODE_BUILDERS: dict[ConstructionMethod, _MethodReasonCodeBuilder] = {
+    ConstructionMethod.SOLVER_CONSTRAINED: _solver_method_reason_codes,
+    ConstructionMethod.LIQUIDITY_AWARE: _liquidity_method_reason_codes,
+    ConstructionMethod.RISK_AWARE: _risk_method_reason_codes,
+    ConstructionMethod.COST_AWARE: _cost_method_reason_codes,
+    ConstructionMethod.ESG_AWARE: _esg_method_reason_codes,
+    ConstructionMethod.CURRENCY_OVERLAY: _currency_overlay_method_reason_codes,
+    ConstructionMethod.REGIME_STRESS_AWARE: _regime_stress_method_reason_codes,
+}
 
 
 __all__ = [

--- a/src/core/waves/campaign_workflow_board.py
+++ b/src/core/waves/campaign_workflow_board.py
@@ -218,6 +218,15 @@ def _classify_workflow_board_posture(
 ) -> tuple[CampaignWorkflowBoardStatus, CampaignWorkflowNextAction, list[str]]:
     if operating_queue.queue_status == "CLOSED" or approval_inbox.inbox_status == "CLOSED":
         return "CLOSED", "NO_ACTION_CLOSED", ["CAMPAIGN_DEFINITION_CLOSED"]
+    approval_action = _approval_inbox_workflow_action(approval_inbox)
+    if approval_action is not None:
+        return approval_action
+    return _operating_queue_workflow_action(operating_queue)
+
+
+def _approval_inbox_workflow_action(
+    approval_inbox: DpmBulkReviewCampaignApprovalInboxItem,
+) -> tuple[CampaignWorkflowBoardStatus, CampaignWorkflowNextAction, list[str]] | None:
     if approval_inbox.inbox_status == "ENTITLEMENT_ATTENTION":
         return (
             "ATTENTION_FOR_ACTOR",
@@ -242,6 +251,12 @@ def _classify_workflow_board_posture(
             "REFRESH_EXPIRY_OR_AS_OF_DATE",
             approval_inbox.inbox_reason_codes,
         )
+    return None
+
+
+def _operating_queue_workflow_action(
+    operating_queue: DpmBulkReviewCampaignOperatingQueueItem,
+) -> tuple[CampaignWorkflowBoardStatus, CampaignWorkflowNextAction, list[str]]:
     if operating_queue.queue_status == "READY_TO_LAUNCH":
         return (
             "READY_FOR_ACTOR",

--- a/tests/unit/api/test_wave_campaign_candidate_selection.py
+++ b/tests/unit/api/test_wave_campaign_candidate_selection.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 import pytest
 
 from src.api.routers.wave_campaign_candidate_selection import (
+    _candidate_portfolio_type,
+    _candidate_source_refs,
     select_bulk_review_campaign_candidates,
 )
 from src.api.services import wave_service
@@ -90,4 +92,36 @@ def test_select_bulk_review_campaign_candidates_requires_source_refs() -> None:
     assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_REQUIRED"
     assert (
         exc_info.value.message == "BULK_REVIEW_CAMPAIGN candidate portfolios require source_refs."
+    )
+
+
+def test_candidate_portfolio_type_helper_rejects_non_string_values() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _candidate_portfolio_type(
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "portfolio_type": 123,
+                "source_refs": [{"source_id": "candidate-source"}],
+            }
+        )
+
+    assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPE_INVALID"
+    assert (
+        exc_info.value.message == "BULK_REVIEW_CAMPAIGN candidate portfolio_type must be a string."
+    )
+
+
+def test_candidate_source_refs_helper_rejects_non_sequence_values() -> None:
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _candidate_source_refs(
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "portfolio_type": "DISCRETIONARY",
+                "source_refs": object(),
+            }
+        )
+
+    assert exc_info.value.code == "BULK_REVIEW_CAMPAIGN_SOURCE_REFS_INVALID"
+    assert (
+        exc_info.value.message == "BULK_REVIEW_CAMPAIGN candidate source_refs must be a sequence."
     )

--- a/tests/unit/dpm/construction/test_method_readiness.py
+++ b/tests/unit/dpm/construction/test_method_readiness.py
@@ -2,6 +2,9 @@ from decimal import Decimal
 
 from src.api.request_models import RebalanceRequest
 from src.api.services.construction_method_readiness import (
+    _MethodReasonCodeContext,
+    _reason_code_builder_for_method,
+    _status_builder_for_method,
     currency_overlay_reason_codes,
     method_specific_reason_codes,
     method_specific_status,
@@ -108,6 +111,42 @@ def test_currency_overlay_reason_codes_preserve_missing_policy_context() -> None
         "CURRENCY_OVERLAY_NO_NON_BASE_EXPOSURE",
         "CURRENCY_OVERLAY_POLICY_CONTEXT_MISSING",
     ]
+
+
+def test_method_status_builder_preserves_currency_overlay_missing_fx_fallback() -> None:
+    result = _trade_result().model_copy(deep=True)
+    result.diagnostics.missing_fx_pairs.append("USD/EUR")
+
+    assert (
+        _status_builder_for_method(method=ConstructionMethod.CURRENCY_OVERLAY, result=result)
+        is None
+    )
+    assert (
+        method_specific_status(
+            request=_request(),
+            method=ConstructionMethod.CURRENCY_OVERLAY,
+            result=result,
+            enrichment=_enrichment(),
+            authority_context=ConstructionAuthorityContext(),
+        )
+        == ConstructionMethodStatus.READY
+    )
+
+
+def test_reason_code_builder_routes_solver_reason_codes() -> None:
+    result = _trade_result().model_copy(deep=True)
+    result.diagnostics.warnings.extend(["SOLVER_NON_OPTIMAL_USER_LIMIT", "TURNOVER_WARNING"])
+
+    builder = _reason_code_builder_for_method(ConstructionMethod.SOLVER_CONSTRAINED)
+
+    assert builder is not None
+    assert builder(
+        _MethodReasonCodeContext(
+            request=_request(),
+            result=result,
+            authority_context=ConstructionAuthorityContext(),
+        )
+    ) == ["SOLVER_NON_OPTIMAL_USER_LIMIT"]
 
 
 def test_risk_method_status_uses_enrichment_and_records_missing_authority() -> None:

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 import src.core.waves.campaign_approval_inbox as approval_inbox_module
+import src.core.waves.campaign_workflow_board as workflow_board_module
 from src.core.waves import DpmWaveSourceRef
 from src.core.common.canonical import hash_canonical_payload, strip_keys
 from src.core.waves.campaign_definitions import (
@@ -481,6 +482,65 @@ def test_campaign_workflow_board_derives_actor_next_actions() -> None:
     assert unauthorized.board_status == "ATTENTION_FOR_ACTOR"
     assert unauthorized.next_action == "REVIEW_ACTOR_ENTITLEMENT"
     assert unauthorized.assigned_actor_ids == ["ops"]
+
+
+def test_campaign_workflow_board_action_helpers_prioritize_approval_attention() -> None:
+    operating_queue = build_bulk_review_campaign_operating_queue_item(
+        definition=_definition(),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+    approval_inbox = build_bulk_review_campaign_approval_inbox_item(
+        definition=_definition(approval_ref=None, approved_by=None, approved_at=None),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+
+    assert workflow_board_module._approval_inbox_workflow_action(approval_inbox) == (
+        "ATTENTION_FOR_ACTOR",
+        "RECORD_APPROVAL_DECISION",
+        ["BULK_REVIEW_CAMPAIGN_APPROVAL_EVIDENCE_NOT_SUPPLIED"],
+    )
+    assert workflow_board_module._classify_workflow_board_posture(
+        operating_queue=operating_queue,
+        approval_inbox=approval_inbox,
+    ) == (
+        "ATTENTION_FOR_ACTOR",
+        "RECORD_APPROVAL_DECISION",
+        ["BULK_REVIEW_CAMPAIGN_APPROVAL_EVIDENCE_NOT_SUPPLIED"],
+    )
+
+
+def test_campaign_workflow_board_action_helpers_fall_back_to_operating_queue() -> None:
+    operating_queue = build_bulk_review_campaign_operating_queue_item(
+        definition=_definition(),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+    approval_inbox = build_bulk_review_campaign_approval_inbox_item(
+        definition=_definition(),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+
+    assert workflow_board_module._approval_inbox_workflow_action(approval_inbox) is None
+    assert workflow_board_module._operating_queue_workflow_action(operating_queue) == (
+        "READY_FOR_ACTOR",
+        "LAUNCH_CAMPAIGN",
+        operating_queue.queue_reason_codes,
+    )
+    assert workflow_board_module._classify_workflow_board_posture(
+        operating_queue=operating_queue,
+        approval_inbox=approval_inbox,
+    ) == (
+        "READY_FOR_ACTOR",
+        "LAUNCH_CAMPAIGN",
+        operating_queue.queue_reason_codes,
+    )
 
 
 def test_campaign_workflow_board_page_filters_next_action_and_counts() -> None:


### PR DESCRIPTION
## Summary
- extracted workflow-board action helpers for campaign discovery posture classification
- extracted candidate portfolio-type/source-ref validation helpers for bulk campaign selection
- extracted construction method readiness dispatch helpers for status and reason-code routing
- refreshed codebase review ledger and quality reports through BACKEND-REVIEW-20260612-822

## Validation
- python -m ruff check touched files for each slice
- python -m ruff format --check touched files for each slice
- python -m mypy --config-file mypy.ini touched src files for each slice
- focused pytest for changed behavior: campaign discovery, campaign candidate selection, construction method readiness
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- git diff --check
- service leakage scan found no matches
- python scripts/engineering_health_report.py after each slice; baseline/rule artifacts restored
- make check: 2581 passed
- git fetch origin --prune
- git branch -r --no-merged origin/main: only origin/feat/manage-hotspot-hardening-20260612-18
- wiki drift check: DiffCount 0

## Wiki
No wiki source change required; this PR only changes internal refactor helpers, tests, ledger evidence, and repo-local quality evidence.