### PR TITLE
Refactor manage source hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20277,3 +20277,29 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal Core source-context mapper
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-824: Campaign approval inbox posture helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/waves/campaign_approval_inbox.py`,
+  `tests/unit/dpm/waves/test_campaign_discovery.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_classify_approval_inbox_posture` was the top current source-complexity hotspot after
+  the Core tax-lot slice and mixed closed-campaign classification, entitlement attention,
+  expiry attention, governance evidence posture, reason-code filtering, and expiry fallback
+  reason construction in one classifier.
+- Action: extracted deterministic approval-inbox posture helpers for closed, entitlement, expiry,
+  and governance approval states while preserving precedence, bounded status values, reason-code
+  filtering, and expiry fallback semantics. Added direct helper tests for entitlement reason
+  filtering and expiry fallback reason construction alongside existing approval inbox page and
+  item coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_approval_inbox.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_approval_inbox.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_approval_inbox.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal campaign approval-inbox
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20303,3 +20303,29 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal campaign approval-inbox
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-825: Expected outcome wave-item resolution helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/snapshots.py`,
+  `tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_resolve_wave_item` was the top current source-complexity hotspot after the approval
+  inbox slice and mixed optional wave evidence validation, required item-id validation, wave item
+  lookup, portfolio/mandate/alternative/proof-pack linkage checks, and return selection in one
+  resolver.
+- Action: extracted deterministic wave-item lookup requirement validation, wave item lookup, and
+  wave item linkage validation helpers while preserving existing fail-closed error messages and
+  lineage checks. Added direct helper tests for lookup input validation and missing-item behavior
+  alongside existing expected-snapshot assembly and invalid-linkage coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m ruff format --check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/snapshots.py`,
+  `python -m pytest tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal expected-outcome snapshot
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20250,3 +20250,30 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal construction method-readiness
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-823: Core tax-lot snapshot mapping helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/dpm_source_context.py`,
+  `tests/unit/dpm/core/test_dpm_source_context.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `build_portfolio_snapshot_with_core_tax_lots` was the top current source-complexity
+  hotspot and mixed source supportability validation, portfolio identity validation, open-lot
+  filtering, unit-cost currency selection, tax-lot grouping, position reconstruction, and snapshot
+  rebuilding in one mapper.
+- Action: extracted deterministic helpers for Core open tax-lot grouping, Core tax-lot to engine
+  tax-lot conversion, and position-level tax-lot attachment while preserving READY-only
+  supportability, portfolio mismatch rejection, closed/depleted lot skipping, base-currency
+  fallback, local-currency unit cost, and portfolio snapshot reconstruction. Added direct helper
+  tests for base-currency fallback and grouped-lot position attachment alongside existing public
+  builder coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/dpm_source_context.py tests/unit/dpm/core/test_dpm_source_context.py`,
+  `python -m ruff format --check src/core/dpm_source_context.py tests/unit/dpm/core/test_dpm_source_context.py`,
+  `python -m mypy --config-file mypy.ini src/core/dpm_source_context.py`,
+  `python -m pytest tests/unit/dpm/core/test_dpm_source_context.py -q`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
+- Wiki decision: no wiki source change required; this is internal Core source-context mapper
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:14:07+00:00`
+- Generated at: `2026-06-12T16:17:03+00:00`
 
-- Current ref: `6f085243`
+- Current ref: `30d78bb5`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 2 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 3 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
-| 4 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
-| 5 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
-| 6 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
-| 7 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
-| 8 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
-| 9 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
-| 10 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 1 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 2 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 3 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 4 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
+| 5 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
+| 6 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
+| 7 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
+| 8 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 9 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 10 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:17:03+00:00`
+- Generated at: `2026-06-12T16:21:12+00:00`
 
-- Current ref: `30d78bb5`
+- Current ref: `2ab7e6e4`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 2 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
-| 3 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
-| 4 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
-| 5 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
-| 6 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
-| 7 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
-| 8 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
-| 9 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
-| 10 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 1 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 2 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 3 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
+| 4 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
+| 5 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
+| 6 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
+| 7 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 8 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 9 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 10 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:03:15+00:00`
+- Generated at: `2026-06-12T16:14:07+00:00`
 
-- Current ref: `0bd590cc`
+- Current ref: `6f085243`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_portfolio_snapshot_with_core_tax_lots | src/core/dpm_source_context.py | 8 | 36 |
-| 2 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
-| 3 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
-| 4 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
-| 5 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
-| 6 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
-| 7 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
-| 8 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
-| 9 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
-| 10 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 1 | _classify_approval_inbox_posture | src/core/waves/campaign_approval_inbox.py | 8 | 36 |
+| 2 | _resolve_wave_item | src/core/outcomes/snapshots.py | 8 | 35 |
+| 3 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
+| 4 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 5 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
+| 6 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
+| 7 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
+| 8 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
+| 9 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 10 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:03:15+00:00`
+- Generated at: `2026-06-12T16:14:07+00:00`
 
-- Current ref: `0bd590cc`
+- Current ref: `6f085243`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:17:03+00:00`
+- Generated at: `2026-06-12T16:21:12+00:00`
 
-- Current ref: `30d78bb5`
+- Current ref: `2ab7e6e4`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:14:07+00:00`
+- Generated at: `2026-06-12T16:17:03+00:00`
 
-- Current ref: `6f085243`
+- Current ref: `30d78bb5`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:17:03+00:00`
+- Generated at: `2026-06-12T16:21:12+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `30d78bb5`
+- Current ref: `2ab7e6e4`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167421 | 167579 | +158 |
-| Test functions | 2408 | 2412 | +4 |
+| Total Python LOC | 167421 | 167642 | +221 |
+| Test functions | 2408 | 2414 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:14:07+00:00`
+- Generated at: `2026-06-12T16:17:03+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `6f085243`
+- Current ref: `30d78bb5`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167421 | 167494 | +73 |
-| Test functions | 2408 | 2410 | +2 |
+| Total Python LOC | 167421 | 167579 | +158 |
+| Test functions | 2408 | 2412 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2228 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2263 |
 | 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:03:15+00:00`
+- Generated at: `2026-06-12T16:14:07+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `0bd590cc`
+- Current ref: `6f085243`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167164 | 167421 | +257 |
-| Test functions | 2402 | 2408 | +6 |
+| Total Python LOC | 167421 | 167494 | +73 |
+| Test functions | 2408 | 2410 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -42,7 +42,7 @@
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2168 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2228 |
 | 9 | src/core/dpm_source_context.py | 1886 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 
@@ -58,7 +58,7 @@
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2228 |
-| 9 | src/core/dpm_source_context.py | 1886 |
+| 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 
 ## Largest Functions

--- a/src/core/dpm_source_context.py
+++ b/src/core/dpm_source_context.py
@@ -13,6 +13,7 @@ from src.core.models import (
     ModelPortfolio,
     ModelTarget,
     PortfolioSnapshot,
+    Position,
     Price,
     ShelfEntry,
     SimulationScenario,
@@ -1759,32 +1760,63 @@ def build_portfolio_snapshot_with_core_tax_lots(
     if response.portfolio_id != portfolio_snapshot.portfolio_id:
         raise DpmCoreContextIncompleteError("DPM_CORE_TAX_LOT_PORTFOLIO_MISMATCH")
 
+    lots_by_instrument = _open_core_tax_lots_by_instrument(
+        response=response,
+        base_currency=portfolio_snapshot.base_currency,
+    )
+    positions = [
+        _portfolio_position_with_tax_lots(
+            position=position,
+            lots_by_instrument=lots_by_instrument,
+        )
+        for position in portfolio_snapshot.positions
+    ]
+    return PortfolioSnapshot.model_validate(
+        {**portfolio_snapshot.model_dump(mode="python"), "positions": positions}
+    )
+
+
+def _open_core_tax_lots_by_instrument(
+    *,
+    response: DpmCorePortfolioTaxLotWindowResponse,
+    base_currency: str,
+) -> dict[str, list[TaxLot]]:
     lots_by_instrument: dict[str, list[TaxLot]] = {}
     for lot in response.lots:
         if lot.tax_lot_status != "OPEN" or lot.open_quantity <= Decimal("0"):
             continue
-        unit_cost_amount = lot.cost_basis_base / lot.open_quantity
-        unit_cost_currency = portfolio_snapshot.base_currency
-        if lot.local_currency:
-            unit_cost_amount = lot.cost_basis_local / lot.open_quantity
-            unit_cost_currency = lot.local_currency
         lots_by_instrument.setdefault(lot.instrument_id, []).append(
-            TaxLot(
-                lot_id=lot.lot_id,
-                quantity=lot.open_quantity,
-                unit_cost=Money(amount=unit_cost_amount, currency=unit_cost_currency),
-                purchase_date=lot.acquisition_date.isoformat(),
-            )
+            _core_tax_lot_to_engine_lot(lot=lot, base_currency=base_currency)
         )
+    return lots_by_instrument
 
-    positions = []
-    for position in portfolio_snapshot.positions:
-        position_payload = position.model_dump(mode="python")
-        position_payload["lots"] = lots_by_instrument.get(position.instrument_id, [])
-        positions.append(type(position).model_validate(position_payload))
-    return PortfolioSnapshot.model_validate(
-        {**portfolio_snapshot.model_dump(mode="python"), "positions": positions}
+
+def _core_tax_lot_to_engine_lot(
+    *,
+    lot: DpmCorePortfolioTaxLotRecord,
+    base_currency: str,
+) -> TaxLot:
+    unit_cost_amount = lot.cost_basis_base / lot.open_quantity
+    unit_cost_currency = base_currency
+    if lot.local_currency:
+        unit_cost_amount = lot.cost_basis_local / lot.open_quantity
+        unit_cost_currency = lot.local_currency
+    return TaxLot(
+        lot_id=lot.lot_id,
+        quantity=lot.open_quantity,
+        unit_cost=Money(amount=unit_cost_amount, currency=unit_cost_currency),
+        purchase_date=lot.acquisition_date.isoformat(),
     )
+
+
+def _portfolio_position_with_tax_lots(
+    *,
+    position: Position,
+    lots_by_instrument: dict[str, list[TaxLot]],
+) -> Position:
+    position_payload = position.model_dump(mode="python")
+    position_payload["lots"] = lots_by_instrument.get(position.instrument_id, [])
+    return type(position).model_validate(position_payload)
 
 
 def build_market_data_snapshot_from_core_coverage(

--- a/src/core/outcomes/snapshots.py
+++ b/src/core/outcomes/snapshots.py
@@ -220,18 +220,55 @@ def _resolve_wave_item(
     selection: ConstructionAlternativeSelection,
     proof_pack: DpmPreTradeProofPack,
 ) -> DpmRebalanceWaveItem | None:
+    if not _wave_item_lookup_required(wave=wave, wave_item_id=wave_item_id):
+        return None
+    assert wave is not None
+    assert wave_item_id is not None
+    wave_item = _find_wave_item(wave=wave, wave_item_id=wave_item_id)
+    _validate_wave_item_linkage(
+        wave_item=wave_item,
+        alternative_set=alternative_set,
+        selection=selection,
+        proof_pack=proof_pack,
+    )
+    return wave_item
+
+
+def _wave_item_lookup_required(
+    *,
+    wave: DpmRebalanceWave | None,
+    wave_item_id: str | None,
+) -> bool:
     if not wave and wave_item_id:
         msg = "wave_item_id cannot be supplied without wave"
         raise DpmExpectedSnapshotAssemblyError(msg)
     if not wave:
-        return None
+        return False
     if not wave_item_id:
         msg = "wave_item_id is required when wave evidence is supplied"
         raise DpmExpectedSnapshotAssemblyError(msg)
-    wave_item = next((item for item in wave.items if item.wave_item_id == wave_item_id), None)
-    if wave_item is None:
-        msg = "wave_item_id does not exist in wave"
-        raise DpmExpectedSnapshotAssemblyError(msg)
+    return True
+
+
+def _find_wave_item(
+    *,
+    wave: DpmRebalanceWave,
+    wave_item_id: str,
+) -> DpmRebalanceWaveItem:
+    for item in wave.items:
+        if item.wave_item_id == wave_item_id:
+            return item
+    msg = "wave_item_id does not exist in wave"
+    raise DpmExpectedSnapshotAssemblyError(msg)
+
+
+def _validate_wave_item_linkage(
+    *,
+    wave_item: DpmRebalanceWaveItem,
+    alternative_set: ConstructionAlternativeSet,
+    selection: ConstructionAlternativeSelection,
+    proof_pack: DpmPreTradeProofPack,
+) -> None:
     _require_equal("wave_item.portfolio_id", wave_item.portfolio_id, alternative_set.portfolio_id)
     if proof_pack.mandate_id and wave_item.mandate_id:
         _require_equal("wave_item.mandate_id", wave_item.mandate_id, proof_pack.mandate_id)
@@ -246,7 +283,6 @@ def _resolve_wave_item(
         selection.alternative_id,
     )
     _require_equal("wave_item.proof_pack_id", wave_item.proof_pack_id, proof_pack.proof_pack_id)
-    return wave_item
 
 
 def _resolve_handoff(

--- a/src/core/waves/campaign_approval_inbox.py
+++ b/src/core/waves/campaign_approval_inbox.py
@@ -223,31 +223,81 @@ def _classify_approval_inbox_posture(
     discovery: DpmBulkReviewCampaignDiscoveryItem,
     readiness: DpmBulkReviewCampaignDefinitionPreviewReadiness,
 ) -> tuple[CampaignApprovalInboxStatus, list[str]]:
-    if definition.status in {"RETIRED", "SUPERSEDED"}:
-        return "CLOSED", [f"CAMPAIGN_DEFINITION_{definition.status}"]
-    if readiness.actor_entitlement_state in {"ACTOR_REQUIRED", "UNAUTHORIZED"}:
-        return "ENTITLEMENT_ATTENTION", [
-            reason
-            for reason in readiness.reason_codes
-            if reason
-            in {
-                "BULK_REVIEW_CAMPAIGN_ACTOR_REQUIRED_FOR_ENTITLEMENT",
-                "BULK_REVIEW_CAMPAIGN_ACTOR_NOT_ENTITLED",
-            }
-        ]
-    if discovery.expiry_state in {"EXPIRED", "INVALID"} or readiness.expiry_state in {
+    for posture in (
+        _closed_approval_inbox_posture(definition),
+        _entitlement_attention_posture(readiness),
+        _expiry_attention_posture(discovery=discovery, readiness=readiness),
+    ):
+        if posture is not None:
+            return posture
+    return _governance_approval_posture(discovery)
+
+
+def _closed_approval_inbox_posture(
+    definition: DpmBulkReviewCampaignDefinition,
+) -> tuple[CampaignApprovalInboxStatus, list[str]] | None:
+    if definition.status not in {"RETIRED", "SUPERSEDED"}:
+        return None
+    return "CLOSED", [f"CAMPAIGN_DEFINITION_{definition.status}"]
+
+
+def _entitlement_attention_posture(
+    readiness: DpmBulkReviewCampaignDefinitionPreviewReadiness,
+) -> tuple[CampaignApprovalInboxStatus, list[str]] | None:
+    if readiness.actor_entitlement_state not in {"ACTOR_REQUIRED", "UNAUTHORIZED"}:
+        return None
+    return "ENTITLEMENT_ATTENTION", _entitlement_attention_reason_codes(readiness)
+
+
+def _entitlement_attention_reason_codes(
+    readiness: DpmBulkReviewCampaignDefinitionPreviewReadiness,
+) -> list[str]:
+    return [
+        reason
+        for reason in readiness.reason_codes
+        if reason
+        in {
+            "BULK_REVIEW_CAMPAIGN_ACTOR_REQUIRED_FOR_ENTITLEMENT",
+            "BULK_REVIEW_CAMPAIGN_ACTOR_NOT_ENTITLED",
+        }
+    ]
+
+
+def _expiry_attention_posture(
+    *,
+    discovery: DpmBulkReviewCampaignDiscoveryItem,
+    readiness: DpmBulkReviewCampaignDefinitionPreviewReadiness,
+) -> tuple[CampaignApprovalInboxStatus, list[str]] | None:
+    if discovery.expiry_state not in {"EXPIRED", "INVALID"} and readiness.expiry_state not in {
         "EXPIRED",
         "INVALID",
     }:
-        return "EXPIRY_ATTENTION", [
-            reason
-            for reason in readiness.reason_codes
-            if reason
-            in {
-                "BULK_REVIEW_CAMPAIGN_EXPIRED",
-                "BULK_REVIEW_CAMPAIGN_EXPIRY_DATE_INVALID",
-            }
-        ] or [f"CAMPAIGN_DEFINITION_EXPIRY_{discovery.expiry_state}"]
+        return None
+    return "EXPIRY_ATTENTION", _expiry_attention_reason_codes(
+        discovery=discovery,
+        readiness=readiness,
+    )
+
+
+def _expiry_attention_reason_codes(
+    *,
+    discovery: DpmBulkReviewCampaignDiscoveryItem,
+    readiness: DpmBulkReviewCampaignDefinitionPreviewReadiness,
+) -> list[str]:
+    return [
+        reason
+        for reason in readiness.reason_codes
+        if reason
+        in {
+            "BULK_REVIEW_CAMPAIGN_EXPIRED",
+            "BULK_REVIEW_CAMPAIGN_EXPIRY_DATE_INVALID",
+        }
+    ] or [f"CAMPAIGN_DEFINITION_EXPIRY_{discovery.expiry_state}"]
+
+
+def _governance_approval_posture(
+    discovery: DpmBulkReviewCampaignDiscoveryItem,
+) -> tuple[CampaignApprovalInboxStatus, list[str]]:
     if discovery.governance_status == "INCOMPLETE":
         return "APPROVAL_INCOMPLETE", ["BULK_REVIEW_CAMPAIGN_APPROVAL_EVIDENCE_INCOMPLETE"]
     if discovery.governance_status == "NOT_SUPPLIED":

--- a/tests/unit/dpm/core/test_dpm_source_context.py
+++ b/tests/unit/dpm/core/test_dpm_source_context.py
@@ -11,6 +11,8 @@ from src.core.dpm_source_context import (
     DpmCorePortfolioTaxLotWindowResponse,
     _core_coverage_fx_rates,
     _core_coverage_prices,
+    _core_tax_lot_to_engine_lot,
+    _portfolio_position_with_tax_lots,
     build_batch_rebalance_request_from_core_context,
     build_core_resolver_payload,
     build_market_data_snapshot_from_core_coverage,
@@ -593,6 +595,45 @@ def test_core_tax_lots_skip_closed_or_depleted_lots_without_blocking_snapshot():
     )
 
     assert enriched.positions[0].lots == []
+
+
+def test_core_tax_lot_helper_uses_base_currency_when_local_currency_missing():
+    lot_payload = _core_tax_lot_payload()
+    lot_payload["lots"][0]["local_currency"] = None
+    lot_payload["lots"][0]["cost_basis_base"] = "7800.0000000000"
+    lot_payload["lots"][0]["cost_basis_local"] = "0.0000000000"
+    response = DpmCorePortfolioTaxLotWindowResponse.model_validate(lot_payload)
+
+    tax_lot = _core_tax_lot_to_engine_lot(
+        lot=response.lots[0],
+        base_currency="SGD",
+    )
+
+    assert tax_lot.lot_id == "LOT-AAPL-001"
+    assert tax_lot.unit_cost.amount == Decimal("130.0000000000")
+    assert tax_lot.unit_cost.currency == "SGD"
+
+
+def test_portfolio_position_tax_lot_helper_attaches_grouped_lots_by_instrument():
+    portfolio = PortfolioSnapshot.model_validate(
+        {
+            **_core_context().portfolio_snapshot.model_dump(mode="python"),
+            "positions": [{"instrument_id": "EQ_US_AAPL", "quantity": "60.0000000000"}],
+        }
+    )
+    response = DpmCorePortfolioTaxLotWindowResponse.model_validate(_core_tax_lot_payload())
+    tax_lot = _core_tax_lot_to_engine_lot(
+        lot=response.lots[0],
+        base_currency=portfolio.base_currency,
+    )
+
+    position = _portfolio_position_with_tax_lots(
+        position=portfolio.positions[0],
+        lots_by_instrument={"EQ_US_AAPL": [tax_lot]},
+    )
+
+    assert [lot.lot_id for lot in position.lots] == ["LOT-AAPL-001"]
+    assert position.lots[0].quantity == Decimal("60.0000000000")
 
 
 def test_core_tax_lots_reject_partial_or_wrong_portfolio_context():

--- a/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
+++ b/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
@@ -13,7 +13,9 @@ from src.core.construction.vocabulary import ConstructionMethod, ConstructionMet
 from src.core.models import Money
 from src.core.outcomes.snapshots import (
     DpmExpectedSnapshotAssemblyError,
+    _find_wave_item,
     _proof_pack_state,
+    _wave_item_lookup_required,
     assemble_expected_outcome_snapshot,
     build_expected_snapshot_calculation_trace,
     build_expected_snapshot_identity,
@@ -441,6 +443,31 @@ def test_expected_snapshot_requires_complete_wave_item_context() -> None:
             proof_pack=_proof_pack(),
             wave=_wave(),
         )
+
+
+def test_wave_item_lookup_required_helper_validates_lookup_inputs() -> None:
+    assert _wave_item_lookup_required(wave=None, wave_item_id=None) is False
+    assert _wave_item_lookup_required(wave=_wave(), wave_item_id="dwi_outcome_001") is True
+
+    with pytest.raises(
+        DpmExpectedSnapshotAssemblyError,
+        match="wave_item_id cannot be supplied without wave",
+    ):
+        _wave_item_lookup_required(wave=None, wave_item_id="dwi_outcome_001")
+
+    with pytest.raises(
+        DpmExpectedSnapshotAssemblyError,
+        match="wave_item_id is required when wave evidence is supplied",
+    ):
+        _wave_item_lookup_required(wave=_wave(), wave_item_id=None)
+
+
+def test_find_wave_item_helper_returns_matching_wave_item_or_fails_closed() -> None:
+    wave = _wave()
+
+    assert _find_wave_item(wave=wave, wave_item_id="dwi_outcome_001") == wave.items[0]
+    with pytest.raises(DpmExpectedSnapshotAssemblyError, match="wave_item_id does not exist"):
+        _find_wave_item(wave=wave, wave_item_id="dwi_missing")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -22,6 +22,9 @@ from src.core.waves.campaign_discovery import (
 from src.core.waves.campaign_definition_workflow_overview import (
     build_bulk_review_campaign_definition_workflow_overview,
 )
+from src.core.waves.campaign_definition_readiness import (
+    build_bulk_review_campaign_definition_preview_readiness,
+)
 from src.core.waves.campaign_operating_queue import (
     DpmBulkReviewCampaignOperatingQueuePage,
     build_bulk_review_campaign_operating_queue_item,
@@ -417,6 +420,38 @@ def test_campaign_approval_inbox_governance_payload_handles_missing_governance()
         "entitled_actor_count": 0,
         "approval_source_ref_count": 0,
     }
+
+
+def test_campaign_approval_inbox_entitlement_helper_filters_attention_reasons() -> None:
+    readiness = build_bulk_review_campaign_definition_preview_readiness(
+        definition=_definition(entitled_actor_ids=["ops"]),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+    )
+
+    assert approval_inbox_module._entitlement_attention_posture(readiness) == (
+        "ENTITLEMENT_ATTENTION",
+        ["BULK_REVIEW_CAMPAIGN_ACTOR_NOT_ENTITLED"],
+    )
+
+
+def test_campaign_approval_inbox_expiry_helper_falls_back_to_discovery_state() -> None:
+    definition = _definition(expires_on="invalid-date")
+    discovery = build_bulk_review_campaign_discovery_item(
+        definition=definition,
+        active_on=date(2026, 5, 16),
+    )
+    readiness = build_bulk_review_campaign_definition_preview_readiness(
+        definition=definition,
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+    )
+    readiness = readiness.model_copy(update={"reason_codes": []})
+
+    assert approval_inbox_module._expiry_attention_posture(
+        discovery=discovery,
+        readiness=readiness,
+    ) == ("EXPIRY_ATTENTION", ["CAMPAIGN_DEFINITION_EXPIRY_INVALID"])
 
 
 def test_campaign_approval_inbox_page_filters_closed_and_status() -> None:


### PR DESCRIPTION
## Summary
- extracted Core tax-lot snapshot mapping helpers for open-lot grouping, engine lot conversion, and position attachment
- extracted campaign approval inbox posture helpers for closed, entitlement, expiry, and governance approval routing
- extracted expected outcome wave-item resolution helpers for lookup validation, lookup, and linkage checks
- refreshed codebase review ledger and quality reports through BACKEND-REVIEW-20260613-825

## Validation
- python -m ruff check touched files for each slice
- python -m ruff format --check touched files for each slice
- python -m mypy --config-file mypy.ini touched src files for each slice
- focused pytest for changed behavior: DPM source context, campaign discovery, expected snapshot assembly
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- git diff --check
- service leakage scan found no matches
- python scripts/engineering_health_report.py after each slice; baseline/rule artifacts restored
- make check: 2587 passed
- git fetch origin --prune
- git branch -r --no-merged origin/main: only origin/feat/manage-hotspot-hardening-20260613-19
- wiki drift check: DiffCount 0

## Wiki
No wiki source change required; this PR only changes internal refactor helpers, tests, ledger evidence, and repo-local quality evidence.