### PR TITLE
Refactor manage backend hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20382,3 +20382,29 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal in-memory repository
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-828: Buy intent dependency selector helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/common/intent_dependencies.py`,
+  `tests/unit/core/test_intent_dependencies.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `link_buy_intent_dependencies` was the next current source-complexity hotspot and mixed
+  security-intent type/side selection, notional presence checks, FX dependency lookup,
+  same-currency sell dependency lookup, optional sell-link policy, and duplicate-safe append
+  behavior in one core helper.
+- Action: extracted typed BUY/SELL security-intent selectors and a deterministic buy dependency-id
+  builder while preserving in-place dependency mutation, FX-before-sell ordering, latest
+  same-currency sell selection, missing-notional exclusion, and duplicate-safe appends. Added
+  direct helper tests for selector filtering and dependency ordering alongside existing public
+  linking and common edge coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/common/intent_dependencies.py tests/unit/core/test_intent_dependencies.py`,
+  `python -m ruff format --check src/core/common/intent_dependencies.py tests/unit/core/test_intent_dependencies.py`,
+  `python -m mypy --config-file mypy.ini src/core/common/intent_dependencies.py`,
+  `python -m pytest tests/unit/core/test_intent_dependencies.py tests/unit/core/test_common_edge_coverage.py`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal rebalance intent dependency
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20329,3 +20329,29 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md quality/architecture_rules.md quality/api_governance_rules.md`.
 - Wiki decision: no wiki source change required; this is internal expected-outcome snapshot
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-826: Liquidity cashflow projection assessment helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/construction_liquidity_supportability.py`,
+  `tests/unit/dpm/construction/test_liquidity_supportability.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `cashflow_projection_status` and `cashflow_projection_reason_codes` were both current
+  source-complexity hotspots and duplicated cashflow projection usability, currency, total-value,
+  projected-weight, and policy-threshold branching.
+- Action: extracted a deterministic cashflow projection policy assessment with named blocking and
+  policy reason-code helpers while preserving source-owned projection posture, projected cashflow
+  weighting, degraded currency/total-value handling, and below-policy pending-review behavior.
+  Added direct helper tests for degraded source posture preservation and projected cash-pressure
+  policy review alongside existing public liquidity supportability coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_liquidity_supportability.py tests/unit/dpm/construction/test_liquidity_supportability.py`,
+  `python -m ruff format --check src/api/services/construction_liquidity_supportability.py tests/unit/dpm/construction/test_liquidity_supportability.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_liquidity_supportability.py`,
+  `python -m pytest tests/unit/dpm/construction/test_liquidity_supportability.py`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal construction liquidity
+  supportability maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20355,3 +20355,30 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal construction liquidity
   supportability maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-827: In-memory monitoring exception query helpers
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/mandates/in_memory.py`,
+  `tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `list_monitoring_exceptions` was the top current source-complexity hotspot after the
+  liquidity supportability slice and mixed filter selection, ordering, cursor lookup,
+  missing-cursor handling, page slicing, next-cursor derivation, and defensive copying in one
+  repository method.
+- Action: extracted deterministic in-memory monitoring-exception filter, match, cursor lookup, and
+  page helpers while preserving run/mandate/portfolio/state filter semantics, newest-first ordering,
+  missing-cursor empty page behavior, and defensive-copy repository returns. Added direct helper
+  tests for filter-before-sort and cursor pagination alongside existing repository and PostgreSQL
+  query-shape coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python -m ruff format --check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/mandates/in_memory.py`,
+  `python -m pytest tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal in-memory repository
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:21:12+00:00`
+- Generated at: `2026-06-12T16:34:32+00:00`
 
-- Current ref: `2ab7e6e4`
+- Current ref: `477c95ac`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | cashflow_projection_status | src/api/services/construction_liquidity_supportability.py | 8 | 33 |
-| 2 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
-| 3 | cashflow_projection_reason_codes | src/api/services/construction_liquidity_supportability.py | 8 | 27 |
-| 4 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
-| 5 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
-| 6 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
-| 7 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
-| 8 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
-| 9 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
-| 10 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 1 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
+| 2 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
+| 3 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
+| 4 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
+| 5 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 6 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 7 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 8 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 9 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 10 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:37:17+00:00`
+- Generated at: `2026-06-12T16:40:14+00:00`
 
-- Current ref: `7c1b447a`
+- Current ref: `fb64f3d0`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
-| 2 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
-| 3 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
-| 4 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
-| 5 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
-| 6 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
-| 7 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
-| 8 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 9 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 10 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 1 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
+| 2 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
+| 3 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 4 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 5 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 6 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 7 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 8 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 9 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 10 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:34:32+00:00`
+- Generated at: `2026-06-12T16:37:17+00:00`
 
-- Current ref: `477c95ac`
+- Current ref: `7c1b447a`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | list_monitoring_exceptions | src/infrastructure/mandates/in_memory.py | 8 | 32 |
-| 2 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
-| 3 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
-| 4 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
-| 5 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
-| 6 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
-| 7 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
-| 8 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
-| 9 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 10 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 1 | link_buy_intent_dependencies | src/core/common/intent_dependencies.py | 8 | 26 |
+| 2 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
+| 3 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
+| 4 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 5 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 6 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 7 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 8 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 9 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 10 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:21:12+00:00`
+- Generated at: `2026-06-12T16:34:32+00:00`
 
-- Current ref: `2ab7e6e4`
+- Current ref: `477c95ac`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:34:32+00:00`
+- Generated at: `2026-06-12T16:37:17+00:00`
 
-- Current ref: `477c95ac`
+- Current ref: `7c1b447a`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:37:17+00:00`
+- Generated at: `2026-06-12T16:40:14+00:00`
 
-- Current ref: `7c1b447a`
+- Current ref: `fb64f3d0`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:21:12+00:00`
+- Generated at: `2026-06-12T16:34:32+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `2ab7e6e4`
+- Current ref: `477c95ac`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167421 | 167642 | +221 |
-| Test functions | 2408 | 2414 | +6 |
+| Total Python LOC | 167642 | 167794 | +152 |
+| Test functions | 2414 | 2416 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -42,8 +42,8 @@
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2228 |
-| 9 | src/core/dpm_source_context.py | 1886 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2263 |
+| 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 
 ### current branch

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:37:17+00:00`
+- Generated at: `2026-06-12T16:40:14+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `7c1b447a`
+- Current ref: `fb64f3d0`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167642 | 167920 | +278 |
-| Test functions | 2414 | 2417 | +3 |
+| Total Python LOC | 167642 | 167997 | +355 |
+| Test functions | 2414 | 2419 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:34:32+00:00`
+- Generated at: `2026-06-12T16:37:17+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `477c95ac`
+- Current ref: `7c1b447a`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167642 | 167794 | +152 |
-| Test functions | 2414 | 2416 | +2 |
+| Total Python LOC | 167642 | 167920 | +278 |
+| Test functions | 2414 | 2417 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/services/construction_liquidity_supportability.py
+++ b/src/api/services/construction_liquidity_supportability.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from decimal import Decimal
 
 from src.core.construction.models import (
@@ -38,33 +39,15 @@ def cashflow_projection_status(
     context: AuthoritativeLiquidityContext,
     cash_weight: Decimal | None,
 ) -> ConstructionMethodStatus | None:
-    if context.cashflow_projection is None:
+    assessment = _cashflow_projection_policy_assessment(
+        result=result,
+        context=context,
+        cash_weight=cash_weight,
+        derive_cash_weight=False,
+    )
+    if assessment is None:
         return None
-    cashflow_status = context.cashflow_projection.data_quality_status
-    if not context.cashflow_projection.include_projected:
-        cashflow_status = lowest_construction_status(
-            [cashflow_status, ConstructionMethodStatus.DEGRADED]
-        )
-    if (
-        context.cashflow_projection.total_net_cashflow.currency
-        != result.after_simulated.total_value.currency
-    ):
-        cashflow_status = lowest_construction_status(
-            [cashflow_status, ConstructionMethodStatus.DEGRADED]
-        )
-    elif result.after_simulated.total_value.amount <= Decimal("0"):
-        cashflow_status = lowest_construction_status(
-            [cashflow_status, ConstructionMethodStatus.DEGRADED]
-        )
-    elif cash_weight is not None:
-        projected_cash_weight = projected_cashflow_weight(result=result, context=context)
-        if projected_cash_weight is None:
-            return cashflow_status
-        if cash_weight + projected_cash_weight < context.minimum_cash_weight:
-            cashflow_status = lowest_construction_status(
-                [cashflow_status, ConstructionMethodStatus.PENDING_REVIEW]
-            )
-    return cashflow_status
+    return assessment.status
 
 
 def liquidity_reason_codes(
@@ -95,25 +78,136 @@ def cashflow_projection_reason_codes(
     projection = context.cashflow_projection
     if projection is None:
         return []
+    assessment = _cashflow_projection_policy_assessment(
+        result=result,
+        context=context,
+        cash_weight=None,
+        derive_cash_weight=True,
+    )
+    assert assessment is not None
     reason_codes = ["CASHFLOW_PROJECTION_CONTEXT_PRESENT", *projection.reason_codes]
     reason_codes.extend(_cashflow_projection_usability_reason_codes(projection))
-    if _cashflow_projection_currency_mismatch(result=result, projection=projection):
-        reason_codes.append("CASHFLOW_PROJECTION_CURRENCY_MISMATCH")
+    blocking_reason = _cashflow_projection_blocking_reason_code(assessment)
+    if blocking_reason is not None:
+        reason_codes.append(blocking_reason)
         return reason_codes
-    if _post_trade_total_value_unavailable(result=result):
-        reason_codes.append("CASHFLOW_PROJECTION_TOTAL_VALUE_UNAVAILABLE")
-        return reason_codes
-    cash_weight = post_trade_cash_weight(result=result)
-    if cash_weight is None:
-        return reason_codes
-    projected_cash_weight = projected_cashflow_weight(result=result, context=context)
-    if projected_cash_weight is None:
-        return reason_codes
-    if cash_weight + projected_cash_weight < context.minimum_cash_weight:
-        reason_codes.append("CASHFLOW_PROJECTION_ADJUSTED_CASH_BELOW_POLICY")
-    elif _cashflow_projection_is_usable(projection):
-        reason_codes.append("CASHFLOW_PROJECTION_READY")
+    policy_reason = _cashflow_projection_policy_reason_code(
+        assessment=assessment,
+        projection=projection,
+    )
+    if policy_reason is not None:
+        reason_codes.append(policy_reason)
     return reason_codes
+
+
+@dataclass(frozen=True)
+class _CashflowProjectionPolicyAssessment:
+    status: ConstructionMethodStatus
+    currency_mismatch: bool
+    post_trade_total_value_unavailable: bool
+    projected_cash_weight: Decimal | None
+    adjusted_cash_below_policy: bool
+
+
+def _cashflow_projection_policy_assessment(
+    *,
+    result: RebalanceResult,
+    context: AuthoritativeLiquidityContext,
+    cash_weight: Decimal | None,
+    derive_cash_weight: bool,
+) -> _CashflowProjectionPolicyAssessment | None:
+    projection = context.cashflow_projection
+    if projection is None:
+        return None
+    currency_mismatch = _cashflow_projection_currency_mismatch(
+        result=result,
+        projection=projection,
+    )
+    total_value_unavailable = (
+        False if currency_mismatch else _post_trade_total_value_unavailable(result=result)
+    )
+    effective_cash_weight = (
+        post_trade_cash_weight(result=result)
+        if derive_cash_weight and cash_weight is None
+        else cash_weight
+    )
+    projected_weight = _policy_projected_cashflow_weight(
+        result=result,
+        context=context,
+        cash_weight=effective_cash_weight,
+        currency_mismatch=currency_mismatch,
+        total_value_unavailable=total_value_unavailable,
+    )
+    below_policy = (
+        effective_cash_weight is not None
+        and projected_weight is not None
+        and effective_cash_weight + projected_weight < context.minimum_cash_weight
+    )
+    status = _cashflow_projection_assessed_status(
+        projection=projection,
+        currency_mismatch=currency_mismatch,
+        total_value_unavailable=total_value_unavailable,
+        below_policy=below_policy,
+    )
+    return _CashflowProjectionPolicyAssessment(
+        status=status,
+        currency_mismatch=currency_mismatch,
+        post_trade_total_value_unavailable=total_value_unavailable,
+        projected_cash_weight=projected_weight,
+        adjusted_cash_below_policy=below_policy,
+    )
+
+
+def _cashflow_projection_blocking_reason_code(
+    assessment: _CashflowProjectionPolicyAssessment,
+) -> str | None:
+    if assessment.currency_mismatch:
+        return "CASHFLOW_PROJECTION_CURRENCY_MISMATCH"
+    if assessment.post_trade_total_value_unavailable:
+        return "CASHFLOW_PROJECTION_TOTAL_VALUE_UNAVAILABLE"
+    return None
+
+
+def _cashflow_projection_policy_reason_code(
+    *,
+    assessment: _CashflowProjectionPolicyAssessment,
+    projection: AuthoritativeLiquidityCashflowProjection,
+) -> str | None:
+    if assessment.projected_cash_weight is None:
+        return None
+    if assessment.adjusted_cash_below_policy:
+        return "CASHFLOW_PROJECTION_ADJUSTED_CASH_BELOW_POLICY"
+    if _cashflow_projection_is_usable(projection):
+        return "CASHFLOW_PROJECTION_READY"
+    return None
+
+
+def _cashflow_projection_assessed_status(
+    *,
+    projection: AuthoritativeLiquidityCashflowProjection,
+    currency_mismatch: bool,
+    total_value_unavailable: bool,
+    below_policy: bool,
+) -> ConstructionMethodStatus:
+    status = projection.data_quality_status
+    if not projection.include_projected or currency_mismatch or total_value_unavailable:
+        status = lowest_construction_status([status, ConstructionMethodStatus.DEGRADED])
+    if below_policy:
+        status = lowest_construction_status([status, ConstructionMethodStatus.PENDING_REVIEW])
+    return status
+
+
+def _policy_projected_cashflow_weight(
+    *,
+    result: RebalanceResult,
+    context: AuthoritativeLiquidityContext,
+    cash_weight: Decimal | None,
+    currency_mismatch: bool,
+    total_value_unavailable: bool,
+) -> Decimal | None:
+    if cash_weight is None or currency_mismatch or total_value_unavailable:
+        return None
+    return projected_cashflow_weight(result=result, context=context)
 
 
 def _cashflow_projection_usability_reason_codes(

--- a/src/core/common/intent_dependencies.py
+++ b/src/core/common/intent_dependencies.py
@@ -18,32 +18,63 @@ def link_buy_intent_dependencies(
         sell_intent_id_by_currency(intents) if include_same_currency_sell_dependency else {}
     )
 
-    for intent in intents:
-        if intent.intent_type != "SECURITY_TRADE" or intent.side != "BUY":
-            continue
-
-        if intent.notional is None:
-            continue
-        currency = intent.notional.currency
-        fx_dependency = fx_dependencies.get(currency)
-        append_intent_dependency_once(intent, fx_dependency)
-
-        if not include_same_currency_sell_dependency:
-            continue
-
-        append_intent_dependency_once(intent, sell_dependencies.get(currency))
+    for intent in buy_security_intents_with_notional(intents):
+        for dependency_id in buy_intent_dependency_ids(
+            intent,
+            fx_dependencies=fx_dependencies,
+            sell_dependencies=sell_dependencies,
+            include_same_currency_sell_dependency=include_same_currency_sell_dependency,
+        ):
+            append_intent_dependency_once(intent, dependency_id)
 
 
 def sell_intent_id_by_currency(intents: Sequence[RebalanceIntent]) -> dict[str, str]:
     """Return the latest sell intent id by notional currency."""
-    dependencies: dict[str, str] = {}
-    for intent in intents:
-        if intent.intent_type != "SECURITY_TRADE" or intent.side != "SELL":
-            continue
-        if intent.notional is None:
-            continue
-        dependencies[intent.notional.currency] = intent.intent_id
-    return dependencies
+    return {
+        intent.notional.currency: intent.intent_id
+        for intent in sell_security_intents_with_notional(intents)
+        if intent.notional is not None
+    }
+
+
+def buy_security_intents_with_notional(
+    intents: Sequence[RebalanceIntent],
+) -> list[SecurityTradeIntent]:
+    return [
+        intent
+        for intent in intents
+        if isinstance(intent, SecurityTradeIntent)
+        and intent.side == "BUY"
+        and intent.notional is not None
+    ]
+
+
+def sell_security_intents_with_notional(
+    intents: Sequence[RebalanceIntent],
+) -> list[SecurityTradeIntent]:
+    return [
+        intent
+        for intent in intents
+        if isinstance(intent, SecurityTradeIntent)
+        and intent.side == "SELL"
+        and intent.notional is not None
+    ]
+
+
+def buy_intent_dependency_ids(
+    intent: SecurityTradeIntent,
+    *,
+    fx_dependencies: Mapping[str, str],
+    sell_dependencies: Mapping[str, str],
+    include_same_currency_sell_dependency: bool,
+) -> list[str | None]:
+    if intent.notional is None:
+        return []
+    currency = intent.notional.currency
+    dependency_ids = [fx_dependencies.get(currency)]
+    if include_same_currency_sell_dependency:
+        dependency_ids.append(sell_dependencies.get(currency))
+    return dependency_ids
 
 
 def append_intent_dependency_once(

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -134,26 +134,18 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
         cursor: Optional[str],
     ) -> tuple[list[DpmMonitoringException], Optional[str]]:
         with self._lock:
-            rows = list(self._exceptions.values())
-            if monitoring_run_id is not None:
-                rows = [row for row in rows if row.monitoring_run_id == monitoring_run_id]
-            if mandate_id is not None:
-                rows = [row for row in rows if row.mandate_id == mandate_id]
-            if portfolio_id is not None:
-                rows = [row for row in rows if row.portfolio_id == portfolio_id]
-            if state is not None:
-                rows = [row for row in rows if row.state == state]
-            rows = sorted(rows, key=lambda row: (row.detected_at, row.exception_id), reverse=True)
-            if cursor is not None:
-                cursor_index = next(
-                    (index for index, row in enumerate(rows) if row.exception_id == cursor),
-                    None,
-                )
-                if cursor_index is None:
-                    return [], None
-                rows = rows[cursor_index + 1 :]
-            page = rows[:limit]
-            next_cursor = page[-1].exception_id if len(rows) > limit else None
+            rows = _filtered_monitoring_exceptions(
+                list(self._exceptions.values()),
+                monitoring_run_id=monitoring_run_id,
+                mandate_id=mandate_id,
+                portfolio_id=portfolio_id,
+                state=state,
+            )
+            page, next_cursor = _monitoring_exception_page(
+                rows,
+                limit=limit,
+                cursor=cursor,
+            )
             return [deepcopy(row) for row in page], next_cursor
 
     def resolve_monitoring_exception(
@@ -212,3 +204,71 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
 
 def _latest_twin(rows: list[DpmMandateDigitalTwin]) -> DpmMandateDigitalTwin:
     return max(rows, key=lambda row: (row.as_of_date, row.mandate_version))
+
+
+def _filtered_monitoring_exceptions(
+    rows: list[DpmMonitoringException],
+    *,
+    monitoring_run_id: Optional[str],
+    mandate_id: Optional[str],
+    portfolio_id: Optional[str],
+    state: Optional[str],
+) -> list[DpmMonitoringException]:
+    filtered = [
+        row
+        for row in rows
+        if _monitoring_exception_matches(
+            row,
+            monitoring_run_id=monitoring_run_id,
+            mandate_id=mandate_id,
+            portfolio_id=portfolio_id,
+            state=state,
+        )
+    ]
+    return sorted(
+        filtered,
+        key=lambda row: (row.detected_at, row.exception_id),
+        reverse=True,
+    )
+
+
+def _monitoring_exception_matches(
+    row: DpmMonitoringException,
+    *,
+    monitoring_run_id: Optional[str],
+    mandate_id: Optional[str],
+    portfolio_id: Optional[str],
+    state: Optional[str],
+) -> bool:
+    return (
+        (monitoring_run_id is None or row.monitoring_run_id == monitoring_run_id)
+        and (mandate_id is None or row.mandate_id == mandate_id)
+        and (portfolio_id is None or row.portfolio_id == portfolio_id)
+        and (state is None or row.state == state)
+    )
+
+
+def _monitoring_exception_page(
+    rows: list[DpmMonitoringException],
+    *,
+    limit: int,
+    cursor: Optional[str],
+) -> tuple[list[DpmMonitoringException], Optional[str]]:
+    if cursor is not None:
+        cursor_index = _monitoring_exception_cursor_index(rows, cursor)
+        if cursor_index is None:
+            return [], None
+        rows = rows[cursor_index + 1 :]
+    page = rows[:limit]
+    next_cursor = page[-1].exception_id if len(rows) > limit else None
+    return page, next_cursor
+
+
+def _monitoring_exception_cursor_index(
+    rows: list[DpmMonitoringException],
+    cursor: str,
+) -> Optional[int]:
+    return next(
+        (index for index, row in enumerate(rows) if row.exception_id == cursor),
+        None,
+    )

--- a/tests/unit/core/test_intent_dependencies.py
+++ b/tests/unit/core/test_intent_dependencies.py
@@ -2,10 +2,13 @@ from decimal import Decimal
 
 from src.core.common.intent_dependencies import (
     append_intent_dependency_once,
+    buy_intent_dependency_ids,
+    buy_security_intents_with_notional,
     link_buy_intent_dependencies,
     sell_intent_id_by_currency,
+    sell_security_intents_with_notional,
 )
-from src.core.models import Money, SecurityTradeIntent
+from src.core.models import FxSpotIntent, Money, SecurityTradeIntent
 
 
 def _security_intent(
@@ -23,6 +26,17 @@ def _security_intent(
     )
 
 
+def _fx_intent() -> FxSpotIntent:
+    return FxSpotIntent(
+        intent_id="fx_usd_sgd",
+        pair="USD/SGD",
+        buy_currency="USD",
+        buy_amount=Decimal("10"),
+        sell_currency="SGD",
+        sell_amount_estimated=Decimal("13"),
+    )
+
+
 def test_sell_intent_id_by_currency_indexes_latest_sell_with_notional() -> None:
     assert sell_intent_id_by_currency(
         [
@@ -36,6 +50,38 @@ def test_sell_intent_id_by_currency_indexes_latest_sell_with_notional() -> None:
         "USD": "sell_usd_2",
         "SGD": "sell_sgd",
     }
+
+
+def test_security_intent_selectors_require_side_and_notional() -> None:
+    buy = _security_intent(intent_id="buy_usd", side="BUY", currency="USD")
+    sell = _security_intent(intent_id="sell_usd", side="SELL", currency="USD")
+    buy_missing_notional = _security_intent(
+        intent_id="buy_missing_notional",
+        side="BUY",
+        currency=None,
+    )
+
+    intents = [sell, buy_missing_notional, _fx_intent(), buy]
+
+    assert buy_security_intents_with_notional(intents) == [buy]
+    assert sell_security_intents_with_notional(intents) == [sell]
+
+
+def test_buy_intent_dependency_ids_preserves_fx_then_optional_sell_order() -> None:
+    buy = _security_intent(intent_id="buy_usd", side="BUY", currency="USD")
+
+    assert buy_intent_dependency_ids(
+        buy,
+        fx_dependencies={"USD": "fx_usd"},
+        sell_dependencies={"USD": "sell_usd"},
+        include_same_currency_sell_dependency=True,
+    ) == ["fx_usd", "sell_usd"]
+    assert buy_intent_dependency_ids(
+        buy,
+        fx_dependencies={"USD": "fx_usd"},
+        sell_dependencies={"USD": "sell_usd"},
+        include_same_currency_sell_dependency=False,
+    ) == ["fx_usd"]
 
 
 def test_append_intent_dependency_once_preserves_existing_order() -> None:

--- a/tests/unit/dpm/construction/test_liquidity_supportability.py
+++ b/tests/unit/dpm/construction/test_liquidity_supportability.py
@@ -1,10 +1,12 @@
 from decimal import Decimal
 
 from src.api.services.construction_liquidity_supportability import (
+    _cashflow_projection_policy_assessment,
     _cashflow_projection_currency_mismatch,
     _cashflow_projection_is_usable,
     _cashflow_projection_usability_reason_codes,
     _post_trade_total_value_unavailable,
+    cashflow_projection_reason_codes,
     cashflow_projection_status,
     derive_liquidity_context,
     liquidity_reason_codes,
@@ -131,6 +133,62 @@ def test_projected_cashflow_weight_absent_for_missing_projection() -> None:
             context=derive_liquidity_context(result=result),
         )
         is None
+    )
+
+
+def test_cashflow_projection_policy_assessment_preserves_source_posture() -> None:
+    result = _trade_result()
+    source_context = source_liquidity_context(
+        cashflow_projection=cashflow_projection_response(),
+        income_needs=None,
+        reserve_requirement=None,
+        planned_withdrawals=None,
+    )
+
+    assert source_context is not None
+    assessment = _cashflow_projection_policy_assessment(
+        result=result,
+        context=source_context,
+        cash_weight=post_trade_cash_weight(result=result),
+        derive_cash_weight=False,
+    )
+
+    assert assessment is not None
+    assert assessment.status == ConstructionMethodStatus.DEGRADED
+    assert not assessment.currency_mismatch
+    assert not assessment.post_trade_total_value_unavailable
+    assert assessment.projected_cash_weight == Decimal("1.2505")
+    assert not assessment.adjusted_cash_below_policy
+
+
+def test_cashflow_projection_policy_assessment_flags_projected_policy_pressure() -> None:
+    result = _trade_result()
+    source_context = source_liquidity_context(
+        cashflow_projection=cashflow_projection_response().model_copy(
+            update={
+                "data_quality_status": "READY",
+                "total_net_cashflow": Decimal("-10"),
+            }
+        ),
+        income_needs=None,
+        reserve_requirement=None,
+        planned_withdrawals=None,
+    )
+
+    assert source_context is not None
+    assessment = _cashflow_projection_policy_assessment(
+        result=result,
+        context=source_context,
+        cash_weight=post_trade_cash_weight(result=result),
+        derive_cash_weight=False,
+    )
+
+    assert assessment is not None
+    assert assessment.status == ConstructionMethodStatus.PENDING_REVIEW
+    assert assessment.projected_cash_weight == Decimal("-0.01")
+    assert assessment.adjusted_cash_below_policy
+    assert "CASHFLOW_PROJECTION_ADJUSTED_CASH_BELOW_POLICY" in (
+        cashflow_projection_reason_codes(result=result, context=source_context)
     )
 
 

--- a/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
@@ -17,6 +17,7 @@ from src.core.mandates import (
     monitoring_exceptions_from_health,
 )
 from src.infrastructure.mandates import InMemoryDpmMandateRepository
+import src.infrastructure.mandates.in_memory as mandate_in_memory
 import src.infrastructure.mandates.postgres as mandate_postgres
 from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository
 from src.infrastructure.mandates.serialization import dump_model_json, load_model_json
@@ -242,6 +243,71 @@ def test_repository_filters_monitoring_exceptions_by_run_before_pagination() -> 
 
     assert [row.exception_id for row in rows] == ["me_selected_run"]
     assert cursor is None
+
+
+def test_in_memory_monitoring_exception_helpers_filter_sort_and_page() -> None:
+    twin = _twin()
+    snapshot = calculate_mandate_health(
+        DpmMandateHealthInput(
+            twin=twin,
+            current_weights={"EQ_US_AAPL": Decimal("0.60")},
+            target_weights={"EQ_US_AAPL": Decimal("0.60")},
+            cash_weight=Decimal("0.50"),
+        )
+    )
+    exception = monitoring_exceptions_from_health(snapshot, source_lineage=[])[0]
+    selected_old = exception.model_copy(
+        update={
+            "exception_id": "me_selected_old",
+            "monitoring_run_id": "dmr_selected",
+            "detected_at": datetime(2026, 5, 3, 8, 0, tzinfo=timezone.utc),
+        }
+    )
+    selected_new = exception.model_copy(
+        update={
+            "exception_id": "me_selected_new",
+            "monitoring_run_id": "dmr_selected",
+            "detected_at": datetime(2026, 5, 3, 9, 0, tzinfo=timezone.utc),
+        }
+    )
+    unrelated = exception.model_copy(
+        update={
+            "exception_id": "me_unrelated",
+            "monitoring_run_id": "dmr_unrelated",
+            "detected_at": datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc),
+        }
+    )
+
+    filtered = mandate_in_memory._filtered_monitoring_exceptions(
+        [selected_old, unrelated, selected_new],
+        monitoring_run_id="dmr_selected",
+        mandate_id=twin.mandate_id,
+        portfolio_id=twin.portfolio_id,
+        state="ACTIVE",
+    )
+    page, next_cursor = mandate_in_memory._monitoring_exception_page(
+        filtered,
+        limit=1,
+        cursor=None,
+    )
+    cursor_page, cursor_page_next = mandate_in_memory._monitoring_exception_page(
+        filtered,
+        limit=1,
+        cursor=next_cursor,
+    )
+    missing_page, missing_cursor = mandate_in_memory._monitoring_exception_page(
+        filtered,
+        limit=1,
+        cursor="UNKNOWN_CURSOR",
+    )
+
+    assert [row.exception_id for row in filtered] == ["me_selected_new", "me_selected_old"]
+    assert [row.exception_id for row in page] == ["me_selected_new"]
+    assert next_cursor == "me_selected_new"
+    assert [row.exception_id for row in cursor_page] == ["me_selected_old"]
+    assert cursor_page_next is None
+    assert missing_page == []
+    assert missing_cursor is None
 
 
 def test_postgres_monitoring_exception_query_combines_filters_and_cursor() -> None:


### PR DESCRIPTION
## Summary
- Extracted a shared liquidity cashflow projection policy assessment and direct helper coverage.
- Extracted in-memory monitoring exception filtering and cursor paging helpers with direct repository-helper tests.
- Extracted buy/sell security-intent selectors and buy dependency-id assembly for rebalance intent dependency linking.
- Updated `docs/architecture/CODEBASE-REVIEW-LEDGER.md` through `BACKEND-REVIEW-20260613-828` plus quality reports.

## Quality outcome
- `cashflow_projection_status`, `cashflow_projection_reason_codes`, `list_monitoring_exceptions`, and `link_buy_intent_dependencies` dropped out of the top current source hotspot table in `quality/complexity_report.md`.
- Service boundary findings remain 0.
- Router infrastructure imports remain 0.
- No README/wiki/operator truth changed; wiki check returned DiffCount 0.

## Evidence
- `python -m ruff check src/api/services/construction_liquidity_supportability.py tests/unit/dpm/construction/test_liquidity_supportability.py`
- `python -m ruff format --check src/api/services/construction_liquidity_supportability.py tests/unit/dpm/construction/test_liquidity_supportability.py`
- `python -m mypy --config-file mypy.ini src/api/services/construction_liquidity_supportability.py`
- `python -m pytest tests/unit/dpm/construction/test_liquidity_supportability.py`: 8 passed
- `python -m ruff check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`
- `python -m ruff format --check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`
- `python -m mypy --config-file mypy.ini src/infrastructure/mandates/in_memory.py`
- `python -m pytest tests/unit/dpm/supportability/test_dpm_mandate_repository.py`: 16 passed
- `python -m ruff check src/core/common/intent_dependencies.py tests/unit/core/test_intent_dependencies.py`
- `python -m ruff format --check src/core/common/intent_dependencies.py tests/unit/core/test_intent_dependencies.py`
- `python -m mypy --config-file mypy.ini src/core/common/intent_dependencies.py`
- `python -m pytest tests/unit/core/test_intent_dependencies.py tests/unit/core/test_common_edge_coverage.py`: 17 passed
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- Service leakage scan: no matches
- `make check`: 2592 passed
- `git fetch origin --prune; git branch -r --no-merged origin/main`: only this active feature branch
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage`: DiffCount 0

## Tiering
- Feature Lane and PR Merge Gate should cover lint, type, unit, governance, coverage, and Docker build for this backend refactor.
- No platform end-to-end or canonical Workbench proof is required; this PR only refactors internal backend helpers and tests without API contract or operator-doc changes.

## Stranded truth
- No durable governance branches were stranded before PR creation. The only unmerged remote branch is this active PR branch.