### PR TITLE
Refactor manage backend hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20435,3 +20435,28 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal API-layer authorization
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-830: Mandate diff version-pair selection helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/mandate_diff.py`,
+  `tests/unit/dpm/mandates/test_mandate_diff.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `build_mandate_diff_for_versions` was the top current source-complexity hotspot after
+  the enterprise authorization slice and mixed version indexing, explicit version-pair validation,
+  missing-version errors, latest-two fallback selection, insufficient-version errors, and diff
+  construction in one service helper.
+- Action: extracted deterministic mandate diff version-index, requested-pair, latest-pair, and
+  pair-routing helpers while preserving explicit version selection, default latest-two ordering,
+  and existing `DPM_MANDATE_DIFF_*` error codes. Added direct helper tests for explicit/latest
+  selection and validation errors alongside existing public diff builder coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/mandate_diff.py tests/unit/dpm/mandates/test_mandate_diff.py`,
+  `python -m ruff format --check src/api/services/mandate_diff.py tests/unit/dpm/mandates/test_mandate_diff.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/mandate_diff.py`,
+  `python -m pytest tests/unit/dpm/mandates/test_mandate_diff.py`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal mandate diff service
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20460,3 +20460,34 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal mandate diff service
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-831: OpenAPI example enrichment traversal helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/openapi_enrichment.py`,
+  `tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_ensure_request_and_response_examples` was the top current source-complexity hotspot
+  after the mandate diff slice and duplicated schema-component fallback, path validation, metrics
+  special handling, HTTP-method filtering, operation validation, and operation example dispatch in
+  one OpenAPI enrichment coordinator.
+- Action: extracted deterministic example schema normalization, metrics path enrichment, and
+  non-metrics HTTP-operation traversal helpers while preserving metrics examples, malformed
+  fragment tolerance, and request/response example generation. Added direct helper tests for
+  non-metrics operation selection, invalid component-schema fallback, and metrics-only schema
+  enrichment alongside the existing full OpenAPI enrichment coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`,
+  `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal OpenAPI enrichment
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20408,3 +20408,30 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal rebalance intent dependency
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-829: Enterprise write authorization policy helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/enterprise_readiness.py`,
+  `tests/unit/api/test_enterprise_readiness_hardening.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `authorize_write_request` was the top current source-complexity hotspot and mixed write
+  method gating, environment enforcement, header normalization, required header validation,
+  service-identity validation, capability parsing, and capability denial in one API-layer security
+  helper.
+- Action: extracted deterministic write-authorization policy helpers for enforcement gating,
+  normalized headers, required-header detection, service identity, and capability parsing while
+  preserving existing deny reasons and authorization behavior. Added direct helper tests for
+  normalized required-header detection, service-identity detection, capability parsing, and
+  read-method bypass behavior alongside existing authorization and middleware coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`,
+  `python -m ruff format --check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`,
+  `python -m mypy --config-file mypy.ini src/api/enterprise_readiness.py`,
+  `python -m pytest tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`,
+  `python scripts/engineering_health_report.py`,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal API-layer authorization
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:50:28+00:00`
+- Generated at: `2026-06-12T16:53:04+00:00`
 
-- Current ref: `f3422309`
+- Current ref: `43236381`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
-| 2 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
-| 3 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
-| 4 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
-| 5 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
-| 6 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 7 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 8 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 9 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 10 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 1 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 2 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 3 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 4 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 5 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 6 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 7 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 8 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 9 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 10 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:53:04+00:00`
+- Generated at: `2026-06-12T16:57:19+00:00`
 
-- Current ref: `43236381`
+- Current ref: `bfe4cb53`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
-| 2 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
-| 3 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
-| 4 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
-| 5 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 6 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 7 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 8 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 9 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 10 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 1 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 2 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 3 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 4 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 5 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 6 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 7 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 8 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 9 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 10 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:40:14+00:00`
+- Generated at: `2026-06-12T16:50:28+00:00`
 
-- Current ref: `fb64f3d0`
+- Current ref: `f3422309`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | authorize_write_request | src/api/enterprise_readiness.py | 8 | 25 |
-| 2 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
-| 3 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
-| 4 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
-| 5 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
-| 6 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
-| 7 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 8 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 9 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 10 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 1 | build_mandate_diff_for_versions | src/api/services/mandate_diff.py | 8 | 25 |
+| 2 | _ensure_request_and_response_examples | src/api/openapi_enrichment.py | 8 | 24 |
+| 3 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
+| 4 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 5 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 6 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 7 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 8 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 9 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 10 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:40:14+00:00`
+- Generated at: `2026-06-12T16:50:28+00:00`
 
-- Current ref: `fb64f3d0`
+- Current ref: `f3422309`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:50:28+00:00`
+- Generated at: `2026-06-12T16:53:04+00:00`
 
-- Current ref: `f3422309`
+- Current ref: `43236381`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:53:04+00:00`
+- Generated at: `2026-06-12T16:57:19+00:00`
 
-- Current ref: `43236381`
+- Current ref: `bfe4cb53`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:53:04+00:00`
+- Generated at: `2026-06-12T16:57:19+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `43236381`
+- Current ref: `bfe4cb53`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167997 | 168135 | +138 |
-| Test functions | 2419 | 2423 | +4 |
+| Total Python LOC | 167997 | 168188 | +191 |
+| Test functions | 2419 | 2426 | +7 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:50:28+00:00`
+- Generated at: `2026-06-12T16:53:04+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f3422309`
+- Current ref: `43236381`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167997 | 168052 | +55 |
-| Test functions | 2419 | 2421 | +2 |
+| Total Python LOC | 167997 | 168135 | +138 |
+| Test functions | 2419 | 2423 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:40:14+00:00`
+- Generated at: `2026-06-12T16:50:28+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `fb64f3d0`
+- Current ref: `f3422309`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167642 | 167997 | +355 |
-| Test functions | 2414 | 2419 | +5 |
+| Total Python LOC | 167997 | 168052 | +55 |
+| Test functions | 2419 | 2421 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/enterprise_readiness.py
+++ b/src/api/enterprise_readiness.py
@@ -104,28 +104,45 @@ def _required_capability(method: str, path: str) -> str | None:
 def authorize_write_request(
     method: str, path: str, headers: dict[str, str]
 ) -> tuple[bool, str | None]:
-    if method.upper() not in _WRITE_METHODS or not _env_enabled(
-        "ENTERPRISE_ENFORCE_AUTHZ", "false"
-    ):
+    if not _write_authorization_required(method):
         return True, None
 
-    normalized = {str(k).lower(): str(v) for k, v in headers.items()}
-    missing = sorted(header for header in _REQUIRED_HEADERS if not normalized.get(header))
+    normalized = _normalized_headers(headers)
+    missing = _missing_required_headers(normalized)
     if missing:
         return False, f"missing_headers:{','.join(missing)}"
 
-    if not (normalized.get("x-service-identity") or normalized.get("authorization")):
+    if not _has_service_identity(normalized):
         return False, "missing_service_identity"
 
     required_capability = _required_capability(method, path)
-    if required_capability:
-        capabilities = {
-            part.strip() for part in normalized.get("x-capabilities", "").split(",") if part.strip()
-        }
-        if required_capability not in capabilities:
-            return False, f"missing_capability:{required_capability}"
+    if required_capability and required_capability not in _provided_capabilities(normalized):
+        return False, f"missing_capability:{required_capability}"
 
     return True, None
+
+
+def _write_authorization_required(method: str) -> bool:
+    return method.upper() in _WRITE_METHODS and _env_enabled(
+        "ENTERPRISE_ENFORCE_AUTHZ",
+        "false",
+    )
+
+
+def _normalized_headers(headers: dict[str, str]) -> dict[str, str]:
+    return {str(key).lower(): str(value) for key, value in headers.items()}
+
+
+def _missing_required_headers(headers: dict[str, str]) -> list[str]:
+    return sorted(header for header in _REQUIRED_HEADERS if not headers.get(header))
+
+
+def _has_service_identity(headers: dict[str, str]) -> bool:
+    return bool(headers.get("x-service-identity") or headers.get("authorization"))
+
+
+def _provided_capabilities(headers: dict[str, str]) -> set[str]:
+    return {part.strip() for part in headers.get("x-capabilities", "").split(",") if part.strip()}
 
 
 def redact_sensitive(value: Any) -> Any:

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -472,29 +472,35 @@ def _is_error_status_code(status_code: str) -> bool:
 
 
 def _ensure_request_and_response_examples(schema: dict[str, Any]) -> None:
-    schemas = schema.get("components", {}).get("schemas", {})
-    if not isinstance(schemas, dict):
-        schemas = {}
+    schemas = _schema_example_schemas(schema)
+    _ensure_metrics_paths_examples(schema)
 
-    paths = schema.get("paths", {})
-    for path, methods in paths.items():
-        if not isinstance(methods, dict):
-            continue
+    for path, method, operation in _schema_non_metrics_http_operations(schema):
+        _ensure_operation_examples(
+            method=method,
+            path=path,
+            operation=operation,
+            schemas=schemas,
+        )
+
+
+def _schema_example_schemas(schema: dict[str, Any]) -> dict[str, Any]:
+    return _schema_component_schemas(schema) or {}
+
+
+def _ensure_metrics_paths_examples(schema: dict[str, Any]) -> None:
+    for path, methods in _schema_path_methods(schema):
         if path == "/metrics":
             _ensure_metrics_path_examples(methods)
-            continue
-        for method, operation in methods.items():
-            if not _is_http_operation_method(method):
-                continue
-            if not isinstance(operation, dict):
-                continue
 
-            _ensure_operation_examples(
-                method=method,
-                path=path,
-                operation=operation,
-                schemas=schemas,
-            )
+
+def _schema_non_metrics_http_operations(
+    schema: dict[str, Any],
+) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    for path, methods in _schema_path_methods(schema):
+        if path == "/metrics":
+            continue
+        yield from _path_http_operations(path=path, methods=methods)
 
 
 def _ensure_operation_documentation(schema: dict[str, Any], service_name: str) -> None:

--- a/src/api/services/mandate_diff.py
+++ b/src/api/services/mandate_diff.py
@@ -90,24 +90,60 @@ def build_mandate_diff_for_versions(
     from_version: str | None,
     to_version: str | None,
 ) -> DpmMandateDiff:
-    by_version = {version.mandate_version: version for version in versions}
-    if from_version is not None or to_version is not None:
-        if from_version is None or to_version is None:
-            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
-        if from_version not in by_version or to_version not in by_version:
-            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_VERSION_NOT_FOUND")
-        previous = by_version[from_version]
-        current = by_version[to_version]
-    else:
-        if len(versions) < 2:
-            raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
-        current, previous = versions[0], versions[1]
-
+    previous, current = _mandate_diff_version_pair(
+        versions=versions,
+        from_version=from_version,
+        to_version=to_version,
+    )
     return build_mandate_diff(
         mandate_id=mandate_id,
         previous=previous,
         current=current,
     )
+
+
+def _mandate_diff_version_pair(
+    *,
+    versions: list[DpmMandateDigitalTwin],
+    from_version: str | None,
+    to_version: str | None,
+) -> tuple[DpmMandateDigitalTwin, DpmMandateDigitalTwin]:
+    if from_version is not None or to_version is not None:
+        return _requested_mandate_diff_version_pair(
+            versions=versions,
+            from_version=from_version,
+            to_version=to_version,
+        )
+    return _latest_mandate_diff_version_pair(versions)
+
+
+def _requested_mandate_diff_version_pair(
+    *,
+    versions: list[DpmMandateDigitalTwin],
+    from_version: str | None,
+    to_version: str | None,
+) -> tuple[DpmMandateDigitalTwin, DpmMandateDigitalTwin]:
+    if from_version is None or to_version is None:
+        raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
+    by_version = _mandate_version_index(versions)
+    try:
+        return by_version[from_version], by_version[to_version]
+    except KeyError as exc:
+        raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_VERSION_NOT_FOUND") from exc
+
+
+def _latest_mandate_diff_version_pair(
+    versions: list[DpmMandateDigitalTwin],
+) -> tuple[DpmMandateDigitalTwin, DpmMandateDigitalTwin]:
+    if len(versions) < 2:
+        raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
+    return versions[1], versions[0]
+
+
+def _mandate_version_index(
+    versions: list[DpmMandateDigitalTwin],
+) -> dict[str, DpmMandateDigitalTwin]:
+    return {version.mandate_version: version for version in versions}
 
 
 def iter_changed_fields(

--- a/tests/unit/api/test_enterprise_readiness_hardening.py
+++ b/tests/unit/api/test_enterprise_readiness_hardening.py
@@ -3,6 +3,11 @@ from fastapi.testclient import TestClient
 import pytest
 
 from src.api.enterprise_readiness import (
+    _has_service_identity,
+    _missing_required_headers,
+    _normalized_headers,
+    _provided_capabilities,
+    _write_authorization_required,
     authorize_write_request,
     build_enterprise_audit_middleware,
     is_feature_enabled,
@@ -48,6 +53,39 @@ def test_capability_rule_ignores_non_matching_method(monkeypatch) -> None:
     }
 
     assert authorize_write_request("POST", "/write", headers) == (True, None)
+
+
+def test_write_authorization_policy_helpers_normalize_required_headers(monkeypatch) -> None:
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_AUTHZ", "true")
+    headers = _normalized_headers(
+        {
+            "X-Actor-Id": "actor",
+            "X-Tenant-Id": "tenant",
+            "X-Capabilities": " rebalance.read, rebalance.write ,, ",
+            "Authorization": "Bearer service-token",
+        }
+    )
+
+    assert _write_authorization_required("POST")
+    assert not _write_authorization_required("GET")
+    assert _missing_required_headers(headers) == ["x-correlation-id", "x-role"]
+    assert _has_service_identity(headers)
+    assert _provided_capabilities(headers) == {"rebalance.read", "rebalance.write"}
+
+
+def test_write_authorization_policy_helpers_detect_missing_service_identity() -> None:
+    headers = _normalized_headers(
+        {
+            "X-Actor-Id": "actor",
+            "X-Tenant-Id": "tenant",
+            "X-Role": "operator",
+            "X-Correlation-Id": "corr",
+        }
+    )
+
+    assert _missing_required_headers(headers) == []
+    assert not _has_service_identity(headers)
+    assert _provided_capabilities(headers) == set()
 
 
 def test_enterprise_runtime_enforcement_reports_missing_identity(monkeypatch) -> None:

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -8,6 +8,7 @@ from src.api.openapi_enrichment import (
     _ensure_operation_default_docs,
     _ensure_operation_default_error_response,
     _ensure_operation_examples,
+    _ensure_metrics_paths_examples,
     _ensure_property_documentation,
     _infer_description,
     _infer_example,
@@ -18,12 +19,14 @@ from src.api.openapi_enrichment import (
     _operation_has_error_response,
     _operation_tag_for_path,
     _path_http_operations,
+    _schema_example_schemas,
     _ref_example_from_schema,
     _schema_component_schemas,
     _schema_declared_example,
     _schema_documentable_properties,
     _schema_format_example,
     _schema_http_operations,
+    _schema_non_metrics_http_operations,
     _schema_path_methods,
     _schema_type_example,
     _SEMANTIC_DESCRIPTION_RULES,
@@ -447,6 +450,33 @@ def test_openapi_enrichment_path_http_operations_filters_methods() -> None:
     ]
 
 
+def test_openapi_enrichment_example_operation_iterator_excludes_metrics() -> None:
+    metrics_operation = {"responses": {"200": {"description": "metrics"}}}
+    post_operation = {"responses": {"200": {"description": "ok"}}}
+    schema = {
+        "paths": {
+            "/metrics": {"get": metrics_operation},
+            "/api/v1/custom": {"post": post_operation, "trace": {"responses": {}}},
+            "/bad-operation": {"post": []},
+        }
+    }
+
+    assert list(_schema_non_metrics_http_operations(schema)) == [
+        ("/api/v1/custom", "post", post_operation)
+    ]
+    assert list(_schema_non_metrics_http_operations({"paths": []})) == []
+
+
+def test_openapi_enrichment_example_schema_helper_defaults_invalid_components() -> None:
+    component_schemas = {"Payload": {"type": "object"}}
+
+    assert _schema_example_schemas({"components": {"schemas": component_schemas}}) == (
+        component_schemas
+    )
+    assert _schema_example_schemas({"components": {"schemas": []}}) == {}
+    assert _schema_example_schemas({"components": []}) == {}
+
+
 def test_openapi_enrichment_schema_documentable_properties_filters_fragments() -> None:
     good_property = {"type": "string"}
     schema = {
@@ -522,6 +552,23 @@ def test_openapi_enrichment_metrics_helper_adds_prometheus_and_error_examples() 
         responses["503"]["content"]["application/json"]["examples"]["default"]["value"]["status"]
         == 503
     )
+
+
+def test_openapi_enrichment_metrics_schema_helper_targets_metrics_only() -> None:
+    schema = {
+        "paths": {
+            "/metrics": {"get": {"responses": {"200": {"description": "metrics"}}}},
+            "/api/v1/custom": {"get": {"responses": {"200": {"description": "ok"}}}},
+        }
+    }
+
+    _ensure_metrics_paths_examples(schema)
+
+    assert (
+        "text/plain; version=0.0.4"
+        in schema["paths"]["/metrics"]["get"]["responses"]["200"]["content"]
+    )
+    assert "content" not in schema["paths"]["/api/v1/custom"]["get"]["responses"]["200"]
 
 
 def test_openapi_enrichment_adds_operation_docs_errors_and_prometheus_examples() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_diff.py
+++ b/tests/unit/dpm/mandates/test_mandate_diff.py
@@ -6,6 +6,9 @@ from src.api.services.mandate_errors import DpmMandateDiffUnavailableError
 from src.api.services.mandate_diff import (
     DpmMandateDiff,
     DpmMandateFieldChange,
+    _latest_mandate_diff_version_pair,
+    _mandate_version_index,
+    _requested_mandate_diff_version_pair,
     build_mandate_diff,
     build_mandate_diff_for_versions,
     diff_payloads,
@@ -133,6 +136,50 @@ def test_build_mandate_diff_for_versions_defaults_to_latest_two_versions() -> No
 
     assert diff.from_version == "2"
     assert diff.to_version == "3"
+
+
+def test_mandate_diff_version_helpers_select_explicit_and_latest_pairs() -> None:
+    versions = [
+        _twin(version="3", turnover_budget=Decimal("0.15")),
+        _twin(version="2", turnover_budget=Decimal("0.10")),
+        _twin(version="1", turnover_budget=Decimal("0.08")),
+    ]
+
+    by_version = _mandate_version_index(versions)
+    requested_previous, requested_current = _requested_mandate_diff_version_pair(
+        versions=versions,
+        from_version="1",
+        to_version="3",
+    )
+    latest_previous, latest_current = _latest_mandate_diff_version_pair(versions)
+
+    assert set(by_version) == {"1", "2", "3"}
+    assert requested_previous.mandate_version == "1"
+    assert requested_current.mandate_version == "3"
+    assert latest_previous.mandate_version == "2"
+    assert latest_current.mandate_version == "3"
+
+
+def test_mandate_diff_version_helpers_preserve_validation_errors() -> None:
+    versions = [_twin(version="3")]
+
+    try:
+        _requested_mandate_diff_version_pair(
+            versions=versions,
+            from_version="2",
+            to_version=None,
+        )
+    except DpmMandateDiffUnavailableError as exc:
+        assert exc.args == ("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS",)
+    else:
+        raise AssertionError("Expected requested mandate diff version-pair validation error.")
+
+    try:
+        _latest_mandate_diff_version_pair(versions)
+    except DpmMandateDiffUnavailableError as exc:
+        assert exc.args == ("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS",)
+    else:
+        raise AssertionError("Expected latest mandate diff version-pair validation error.")
 
 
 def test_build_mandate_diff_for_versions_requires_complete_version_pair() -> None:


### PR DESCRIPTION
## Summary
- extracted enterprise write-authorization policy helpers with direct API-layer hardening tests
- extracted mandate diff version-pair selection helpers with direct service tests
- extracted OpenAPI example enrichment traversal helpers with direct helper tests and refreshed quality evidence

## Evidence
- `python -m ruff check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`
- `python -m ruff format --check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`
- `python -m mypy --config-file mypy.ini src/api/enterprise_readiness.py`
- `python -m pytest tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`
- `python -m ruff check src/api/services/mandate_diff.py tests/unit/dpm/mandates/test_mandate_diff.py`
- `python -m ruff format --check src/api/services/mandate_diff.py tests/unit/dpm/mandates/test_mandate_diff.py`
- `python -m mypy --config-file mypy.ini src/api/services/mandate_diff.py`
- `python -m pytest tests/unit/dpm/mandates/test_mandate_diff.py`
- `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`
- `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py`
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan: no matches
- `make check` (2599 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (only this feature branch)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Wiki
- No wiki source change required; this PR only changes internal backend/API maintainability helpers, tests, and repo-local quality evidence.