### PR TITLE
Refactor manage PM quality and construction hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20491,3 +20491,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal OpenAPI enrichment
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-832: PM quality fairness analysis list helpers
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/pm_quality/in_memory.py`,
+  `tests/unit/dpm/pm_quality/test_pm_quality_repository.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `list_fairness_analyses` was the top current source-complexity hotspot and mixed
+  policy/version/date/state filtering, generated-time/id ordering, pagination, and defensive copy
+  behavior inline while neighboring PM-quality in-memory list methods already used direct pure
+  helper boundaries.
+- Action: extracted deterministic fairness-analysis filter, sort, and list-page helpers matching
+  the existing score-run, review-action, and summary-invocation repository pattern. Added direct
+  helper tests for optional filter matching, unrelated policy-version exclusion, ordering, and
+  pagination while preserving immutable in-memory repository behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/pm_quality/in_memory.py tests/unit/dpm/pm_quality/test_pm_quality_repository.py`,
+  `python -m ruff format --check src/infrastructure/pm_quality/in_memory.py tests/unit/dpm/pm_quality/test_pm_quality_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/pm_quality/in_memory.py`,
+  `python -m pytest tests/unit/dpm/pm_quality/test_pm_quality_repository.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal PM-quality repository
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20520,3 +20520,34 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal PM-quality repository
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-833: Construction proposed-change row helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/construction/alternative_engine.py`,
+  `tests/unit/dpm/construction/test_alternative_engine.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_proposed_changes` was the top current source-complexity hotspot after the
+  PM-quality repository slice and mixed security-trade filtering, base/notional fallback,
+  diagnostic row construction, optional quantity/value/rationale fields, constraint evidence, and
+  list assembly in one construction diagnostic helper.
+- Action: extracted deterministic security-trade notional fallback and row mapping helpers while
+  preserving public alternative diagnostic payloads, base-currency notional precedence, rationale
+  fields, absolute quantity/value formatting, and constraint-label evidence. Added direct helper
+  tests for notional fallback and row mapping alongside existing public alternative diagnostics
+  coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/construction/alternative_engine.py tests/unit/dpm/construction/test_alternative_engine.py`,
+  `python -m ruff format --check src/core/construction/alternative_engine.py tests/unit/dpm/construction/test_alternative_engine.py`,
+  `python -m mypy --config-file mypy.ini src/core/construction/alternative_engine.py`,
+  `python -m pytest tests/unit/dpm/construction/test_alternative_engine.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal construction diagnostic
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20551,3 +20551,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal construction diagnostic
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-834: PM quality worst-state policy maps
+
+- Date: 2026-06-13
+- Scope: `src/core/pm_quality/scoring.py`,
+  `tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_worst_state` was the top current source-complexity hotspot after the construction
+  diagnostic slice and encoded severity ranking, `NOT_SUPPORTED` normalization, known-state
+  returns, and unknown fallback through a local map plus branch chain.
+- Action: extracted explicit module-level PM-quality state ranking and normalization maps while
+  preserving state precedence, `NOT_SUPPORTED` fallback to `DEGRADED`, and unknown-state
+  conservative degradation. Added direct guard-edge assertions for mixed-state precedence and
+  unsupported/unknown fallback behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m ruff format --check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m mypy --config-file mypy.ini src/core/pm_quality/scoring.py`,
+  `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal PM-quality scoring
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T17:09:01+00:00`
+- Generated at: `2026-06-12T17:11:30+00:00`
 
-- Current ref: `62b61115`
+- Current ref: `330643ef`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
-| 2 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
-| 3 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 4 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 5 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 6 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 7 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 8 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 9 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 10 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 1 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 2 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 3 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 4 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 5 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 6 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 7 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 8 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 9 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 10 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T16:57:19+00:00`
+- Generated at: `2026-06-12T17:09:01+00:00`
 
-- Current ref: `bfe4cb53`
+- Current ref: `62b61115`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | list_fairness_analyses | src/infrastructure/pm_quality/in_memory.py | 8 | 24 |
-| 2 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
-| 3 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
-| 4 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 5 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 6 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 7 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 8 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 9 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 10 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 1 | _proposed_changes | src/core/construction/alternative_engine.py | 8 | 23 |
+| 2 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
+| 3 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 4 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 5 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 6 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 7 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 8 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 9 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 10 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T17:11:30+00:00`
+- Generated at: `2026-06-12T17:14:20+00:00`
 
-- Current ref: `330643ef`
+- Current ref: `61bfbc3d`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _worst_state | src/core/pm_quality/scoring.py | 8 | 23 |
-| 2 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 3 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 4 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 5 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 6 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 7 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 8 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 9 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 10 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 1 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
+| 2 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 3 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 4 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 5 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 6 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 7 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 8 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 9 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 10 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T17:09:01+00:00`
+- Generated at: `2026-06-12T17:11:30+00:00`
 
-- Current ref: `62b61115`
+- Current ref: `330643ef`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T16:57:19+00:00`
+- Generated at: `2026-06-12T17:09:01+00:00`
 
-- Current ref: `bfe4cb53`
+- Current ref: `62b61115`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T17:11:30+00:00`
+- Generated at: `2026-06-12T17:14:20+00:00`
 
-- Current ref: `330643ef`
+- Current ref: `61bfbc3d`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T17:11:30+00:00`
+- Generated at: `2026-06-12T17:14:20+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `330643ef`
+- Current ref: `61bfbc3d`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168188 | 168337 | +149 |
+| Total Python LOC | 168188 | 168340 | +152 |
 | Test functions | 2426 | 2430 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T16:57:19+00:00`
+- Generated at: `2026-06-12T17:09:01+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `bfe4cb53`
+- Current ref: `62b61115`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 167997 | 168188 | +191 |
-| Test functions | 2419 | 2426 | +7 |
+| Total Python LOC | 168188 | 168298 | +110 |
+| Test functions | 2426 | 2428 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T17:09:01+00:00`
+- Generated at: `2026-06-12T17:11:30+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `62b61115`
+- Current ref: `330643ef`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168188 | 168298 | +110 |
-| Test functions | 2426 | 2428 | +2 |
+| Total Python LOC | 168188 | 168337 | +149 |
+| Test functions | 2426 | 2430 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/construction/alternative_engine.py
+++ b/src/core/construction/alternative_engine.py
@@ -17,7 +17,7 @@ from src.core.construction.vocabulary import (
     ConstructionSourceFamily,
     ConstructionTraceTerm,
 )
-from src.core.models import RebalanceResult, SecurityTradeIntent
+from src.core.models import Money, RebalanceResult, SecurityTradeIntent
 
 _RATIO_QUANT = Decimal("0.0001")
 
@@ -250,25 +250,32 @@ def _diagnostic_summary(result: RebalanceResult) -> dict[str, object]:
 
 
 def _proposed_changes(result: RebalanceResult) -> list[dict[str, object]]:
-    changes: list[dict[str, object]] = []
-    for intent in result.intents:
-        if not isinstance(intent, SecurityTradeIntent):
-            continue
-        notional = intent.notional_base or intent.notional
-        row: dict[str, object] = {
-            "intent_id": intent.intent_id,
-            "security_id": intent.instrument_id,
-            "action": intent.side.upper(),
-        }
-        if intent.quantity is not None:
-            row["quantity"] = str(abs(intent.quantity))
-        if notional is not None:
-            row["estimated_value"] = str(abs(notional.amount))
-            row["currency"] = notional.currency
-        if intent.rationale is not None:
-            row["reason"] = intent.rationale.message
-            row["reason_code"] = intent.rationale.code
-        if intent.constraints_applied:
-            row["constraints_applied"] = list(intent.constraints_applied)
-        changes.append(row)
-    return changes
+    return [
+        _security_trade_change_row(intent)
+        for intent in result.intents
+        if isinstance(intent, SecurityTradeIntent)
+    ]
+
+
+def _security_trade_change_notional(intent: SecurityTradeIntent) -> Money | None:
+    return intent.notional_base or intent.notional
+
+
+def _security_trade_change_row(intent: SecurityTradeIntent) -> dict[str, object]:
+    notional = _security_trade_change_notional(intent)
+    row: dict[str, object] = {
+        "intent_id": intent.intent_id,
+        "security_id": intent.instrument_id,
+        "action": intent.side.upper(),
+    }
+    if intent.quantity is not None:
+        row["quantity"] = str(abs(intent.quantity))
+    if notional is not None:
+        row["estimated_value"] = str(abs(notional.amount))
+        row["currency"] = notional.currency
+    if intent.rationale is not None:
+        row["reason"] = intent.rationale.message
+        row["reason_code"] = intent.rationale.code
+    if intent.constraints_applied:
+        row["constraints_applied"] = list(intent.constraints_applied)
+    return row

--- a/src/core/pm_quality/scoring.py
+++ b/src/core/pm_quality/scoring.py
@@ -77,6 +77,26 @@ class _FairnessPosture:
     reason_codes: list[str]
 
 
+_PM_QUALITY_STATE_RANK: dict[str, int] = {
+    "BLOCKED": 6,
+    "BREACHED": 5,
+    "DEGRADED": 4,
+    "PENDING_REVIEW": 3,
+    "READY": 2,
+    "DISABLED": 1,
+}
+
+_NORMALIZED_WORST_STATE: dict[str, PmQualityState] = {
+    "BLOCKED": "BLOCKED",
+    "BREACHED": "BREACHED",
+    "DEGRADED": "DEGRADED",
+    "NOT_SUPPORTED": "DEGRADED",
+    "PENDING_REVIEW": "PENDING_REVIEW",
+    "READY": "READY",
+    "DISABLED": "DISABLED",
+}
+
+
 def build_pm_operating_quality_score_run(
     *,
     pm_id: str,
@@ -902,28 +922,8 @@ def _state_score(state: str) -> Decimal:
 
 
 def _worst_state(states: list[str]) -> PmQualityState:
-    rank = {
-        "BLOCKED": 6,
-        "BREACHED": 5,
-        "DEGRADED": 4,
-        "PENDING_REVIEW": 3,
-        "READY": 2,
-        "DISABLED": 1,
-    }
-    worst = max(states, key=lambda state: rank.get(state, 0))
-    if worst == "BLOCKED":
-        return "BLOCKED"
-    if worst == "BREACHED":
-        return "BREACHED"
-    if worst == "DEGRADED" or worst == "NOT_SUPPORTED":
-        return "DEGRADED"
-    if worst == "PENDING_REVIEW":
-        return "PENDING_REVIEW"
-    if worst == "READY":
-        return "READY"
-    if worst == "DISABLED":
-        return "DISABLED"
-    return "DEGRADED"
+    worst = max(states, key=lambda state: _PM_QUALITY_STATE_RANK.get(state, 0))
+    return _NORMALIZED_WORST_STATE.get(worst, "DEGRADED")
 
 
 def _mean(values: list[Decimal]) -> Decimal:

--- a/src/infrastructure/pm_quality/in_memory.py
+++ b/src/infrastructure/pm_quality/in_memory.py
@@ -37,6 +37,14 @@ class _ScoreRunFilters:
 
 
 @dataclass(frozen=True)
+class _FairnessAnalysisFilters:
+    policy_id: str | None
+    policy_version: str | None
+    as_of_date: str | None
+    state: str | None
+
+
+@dataclass(frozen=True)
 class _ReviewActionFilters:
     target_type: str | None
     target_id: str | None
@@ -183,19 +191,18 @@ class InMemoryDpmPmQualityFairnessAnalysisRepository(DpmPmQualityFairnessAnalysi
         offset: int = 0,
     ) -> list[DpmPmQualityFairnessAnalysis]:
         with self._lock:
-            analyses = [
-                analysis
-                for analysis in self._analyses.values()
-                if (policy_id is None or analysis.policy_id == policy_id)
-                and (policy_version is None or analysis.policy_version == policy_version)
-                and (as_of_date is None or analysis.as_of_date == as_of_date)
-                and (state is None or analysis.state == state)
-            ]
-            analyses.sort(
-                key=lambda analysis: (analysis.generated_at, analysis.fairness_analysis_id),
-                reverse=True,
+            page = _list_fairness_analyses(
+                analyses=list(self._analyses.values()),
+                filters=_FairnessAnalysisFilters(
+                    policy_id=policy_id,
+                    policy_version=policy_version,
+                    as_of_date=as_of_date,
+                    state=state,
+                ),
+                limit=limit,
+                offset=offset,
             )
-            return deepcopy(analyses[offset : offset + limit])
+            return deepcopy(page)
 
 
 class InMemoryDpmPmQualityReviewActionRepository(DpmPmQualityReviewActionRepository):
@@ -334,6 +341,43 @@ def _list_score_runs(
         score_run for score_run in score_runs if _score_run_matches_filters(score_run, filters)
     ]
     return _sort_score_runs(filtered)[offset : offset + limit]
+
+
+def _fairness_analysis_matches_filters(
+    analysis: DpmPmQualityFairnessAnalysis,
+    filters: _FairnessAnalysisFilters,
+) -> bool:
+    return all(
+        (
+            _optional_value_matches(analysis.policy_id, filters.policy_id),
+            _optional_value_matches(analysis.policy_version, filters.policy_version),
+            _optional_value_matches(analysis.as_of_date, filters.as_of_date),
+            _optional_value_matches(analysis.state, filters.state),
+        )
+    )
+
+
+def _sort_fairness_analyses(
+    analyses: list[DpmPmQualityFairnessAnalysis],
+) -> list[DpmPmQualityFairnessAnalysis]:
+    return sorted(
+        analyses,
+        key=lambda analysis: (analysis.generated_at, analysis.fairness_analysis_id),
+        reverse=True,
+    )
+
+
+def _list_fairness_analyses(
+    *,
+    analyses: list[DpmPmQualityFairnessAnalysis],
+    filters: _FairnessAnalysisFilters,
+    limit: int,
+    offset: int,
+) -> list[DpmPmQualityFairnessAnalysis]:
+    filtered = [
+        analysis for analysis in analyses if _fairness_analysis_matches_filters(analysis, filters)
+    ]
+    return _sort_fairness_analyses(filtered)[offset : offset + limit]
 
 
 def _review_action_matches_filters(

--- a/tests/unit/dpm/construction/test_alternative_engine.py
+++ b/tests/unit/dpm/construction/test_alternative_engine.py
@@ -8,6 +8,10 @@ from src.core.construction import (
     build_do_nothing_baseline,
     build_rebalance_result_alternative,
 )
+from src.core.construction.alternative_engine import (
+    _security_trade_change_notional,
+    _security_trade_change_row,
+)
 from src.core.models import EngineOptions, RebalanceResult
 from src.core.rebalance.engine import run_simulation
 from tests.shared.factories import (
@@ -127,6 +131,34 @@ def test_rebalance_result_proposed_changes_preserve_constraint_labels() -> None:
 
     proposed_changes = alternative.diagnostics["proposed_changes"]
     assert proposed_changes[0]["constraints_applied"] == ["MIN_LOT_SIZE"]
+
+
+def test_security_trade_change_notional_prefers_base_notional() -> None:
+    intent = _ready_rebalance_result().intents[0]
+    assert _security_trade_change_notional(intent) == intent.notional_base
+
+    without_base = intent.model_copy(update={"notional_base": None})
+    assert _security_trade_change_notional(without_base) == intent.notional
+
+
+def test_security_trade_change_row_maps_optional_trade_evidence() -> None:
+    intent = (
+        _ready_rebalance_result()
+        .intents[0]
+        .model_copy(update={"constraints_applied": ["MIN_LOT_SIZE"]})
+    )
+
+    assert _security_trade_change_row(intent) == {
+        "intent_id": "oi_1",
+        "security_id": "EQ_A",
+        "action": "SELL",
+        "quantity": "5",
+        "estimated_value": "500.0",
+        "currency": "USD",
+        "reason": "Align",
+        "reason_code": "DRIFT_REBALANCE",
+        "constraints_applied": ["MIN_LOT_SIZE"],
+    }
 
 
 def test_alternative_set_rolls_up_conservative_status() -> None:

--- a/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
+++ b/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
@@ -957,6 +957,9 @@ def test_pm_quality_scoring_guard_edges_are_source_safe() -> None:
     assert scoring._worst_state(["BREACHED"]) == "BREACHED"
     assert scoring._worst_state(["DEGRADED"]) == "DEGRADED"
     assert scoring._worst_state(["PENDING_REVIEW"]) == "PENDING_REVIEW"
+    assert scoring._worst_state(["READY", "PENDING_REVIEW", "DISABLED"]) == "PENDING_REVIEW"
+    assert scoring._worst_state(["READY", "NOT_SUPPORTED"]) == "READY"
+    assert scoring._worst_state(["NOT_SUPPORTED"]) == "DEGRADED"
     assert scoring._worst_state(["UNKNOWN"]) == "DEGRADED"
     assert scoring._mean([]) == Decimal("0")
 

--- a/tests/unit/dpm/pm_quality/test_pm_quality_repository.py
+++ b/tests/unit/dpm/pm_quality/test_pm_quality_repository.py
@@ -32,14 +32,18 @@ from src.infrastructure.pm_quality import (
     InMemoryDpmPmQualitySummaryInvocationRepository,
 )
 from src.infrastructure.pm_quality.in_memory import (
+    _FairnessAnalysisFilters,
     _ReviewActionFilters,
     _ScoreRunFilters,
     _SummaryInvocationFilters,
+    _fairness_analysis_matches_filters,
+    _list_fairness_analyses,
     _list_review_actions,
     _list_score_runs,
     _list_summary_invocations,
     _review_action_matches_filters,
     _score_run_matches_filters,
+    _sort_fairness_analyses,
     _sort_review_actions,
     _sort_score_runs,
     _sort_summary_invocations,
@@ -694,6 +698,68 @@ def test_in_memory_pm_quality_repository_lists_fairness_analyses() -> None:
     assert repository.list_fairness_analyses(as_of_date="missing") == []
     assert repository.list_fairness_analyses(state=analysis.state) == [analysis]
     assert repository.list_fairness_analyses(limit=1, offset=1) == []
+
+
+def test_fairness_analysis_filter_helper_matches_all_optional_fields() -> None:
+    analysis = _fairness_analysis()
+
+    assert _fairness_analysis_matches_filters(
+        analysis,
+        _FairnessAnalysisFilters(
+            policy_id=analysis.policy_id,
+            policy_version=analysis.policy_version,
+            as_of_date=analysis.as_of_date,
+            state=analysis.state,
+        ),
+    )
+    assert not _fairness_analysis_matches_filters(
+        analysis,
+        _FairnessAnalysisFilters(
+            policy_id=None,
+            policy_version="missing",
+            as_of_date=None,
+            state=None,
+        ),
+    )
+
+
+def test_fairness_analysis_list_helper_filters_sorts_and_pages() -> None:
+    older = _fairness_analysis()
+    newer = older.model_copy(
+        update={
+            "fairness_analysis_id": "pmq_fairness_newer",
+            "generated_at": older.generated_at + timedelta(minutes=1),
+            "content_hash": "sha256:fairness-newer",
+        }
+    )
+    unrelated = older.model_copy(
+        update={
+            "fairness_analysis_id": "pmq_fairness_unrelated",
+            "policy_version": "2026.04",
+            "generated_at": older.generated_at + timedelta(minutes=2),
+            "content_hash": "sha256:fairness-unrelated",
+        }
+    )
+    filters = _FairnessAnalysisFilters(
+        policy_id=older.policy_id,
+        policy_version=older.policy_version,
+        as_of_date=older.as_of_date,
+        state=older.state,
+    )
+
+    assert _sort_fairness_analyses([older, newer]) == [newer, older]
+    assert _list_fairness_analyses(
+        analyses=[older, newer, unrelated],
+        filters=filters,
+        limit=1,
+        offset=0,
+    ) == [newer]
+    assert _list_fairness_analyses(
+        analyses=[older, newer, unrelated],
+        filters=filters,
+        limit=1,
+        offset=1,
+    ) == [older]
 
 
 def test_postgres_pm_quality_fairness_analysis_repository_round_trips_analyses(


### PR DESCRIPTION
## Summary
- extracted PM quality fairness-analysis filter/sort/page helpers with direct repository tests
- extracted construction proposed-change notional and row mapping helpers with direct diagnostic tests
- extracted PM quality worst-state ranking/normalization policy maps with direct precedence tests
- refreshed codebase review ledger and quality reports

## Evidence
- `python -m ruff check src/infrastructure/pm_quality/in_memory.py tests/unit/dpm/pm_quality/test_pm_quality_repository.py`
- `python -m ruff format --check src/infrastructure/pm_quality/in_memory.py tests/unit/dpm/pm_quality/test_pm_quality_repository.py`
- `python -m mypy --config-file mypy.ini src/infrastructure/pm_quality/in_memory.py`
- `python -m pytest tests/unit/dpm/pm_quality/test_pm_quality_repository.py` (29 passed)
- `python -m ruff check src/core/construction/alternative_engine.py tests/unit/dpm/construction/test_alternative_engine.py`
- `python -m ruff format --check src/core/construction/alternative_engine.py tests/unit/dpm/construction/test_alternative_engine.py`
- `python -m mypy --config-file mypy.ini src/core/construction/alternative_engine.py`
- `python -m pytest tests/unit/dpm/construction/test_alternative_engine.py` (6 passed)
- `python -m ruff check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`
- `python -m ruff format --check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`
- `python -m mypy --config-file mypy.ini src/core/pm_quality/scoring.py`
- `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py` (23 passed)
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `git diff --check`
- service leakage scan: no matches
- `make check` (2603 passed)
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (only this feature branch)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Wiki
- No wiki source change required; this PR only changes internal backend maintainability helpers, tests, and repo-local quality evidence.