### PR TITLE
Harden backend hotspot helper boundaries

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20580,3 +20580,33 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal PM-quality scoring
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-835: Transaction-cost observed estimate helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/construction_transaction_cost_supportability.py`,
+  `tests/unit/dpm/construction/test_transaction_cost_supportability.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `observed_transaction_cost_estimate` was the top current source-complexity hotspot and
+  mixed context readiness gating, transaction-cost curve lookup, security-trade filtering,
+  base-notional checks, matched-state tracking, per-intent observed cost calculation, and Money
+  construction in one construction supportability helper.
+- Action: extracted deterministic observed-cost term derivation and Money materialization helpers
+  while preserving READY-only application, base-notional-only behavior, curve key matching by
+  security and transaction side, no-match `None` posture, and quantized cost output. Added direct
+  helper tests for matched trade terms and no-match/matched Money creation alongside existing
+  enrichment and supportability coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_transaction_cost_supportability.py tests/unit/dpm/construction/test_transaction_cost_supportability.py`,
+  `python -m ruff format --check src/api/services/construction_transaction_cost_supportability.py tests/unit/dpm/construction/test_transaction_cost_supportability.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_transaction_cost_supportability.py`,
+  `python -m pytest tests/unit/dpm/construction/test_transaction_cost_supportability.py tests/unit/dpm/construction/test_enrichment.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal construction transaction-cost
+  supportability maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20640,3 +20640,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal expected outcome snapshot
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-837: PM quality lookback-window date helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/pm_quality/scoring.py`,
+  `tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_validate_lookback_window` was the top current source-complexity hotspot after the
+  outcome snapshot slice and combined optional policy handling, policy date parsing, required
+  dated-evidence detection, signal date parsing, and inclusive date-window checks in one validator.
+- Action: extracted deterministic lookback-window date parsing, signal business-date parsing, and
+  inclusive range helpers while preserving fail-closed validation error codes and stale-evidence
+  behavior. Added direct helper tests for parsed source dates and inclusive boundary handling
+  alongside existing PM-quality scoring guard coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m ruff format --check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m mypy --config-file mypy.ini src/core/pm_quality/scoring.py`,
+  `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal PM-quality lookback-window
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20610,3 +20610,33 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal construction transaction-cost
   supportability maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-836: Outcome construction-state precedence helper
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/snapshots.py`,
+  `tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_construction_state` was the top current source-complexity hotspot after the
+  transaction-cost supportability slice and encoded construction-set status, selected-method
+  status, source-supportability degradation, and precedence ordering through repeated branch
+  checks.
+- Action: extracted a deterministic construction outcome-state precedence helper while preserving
+  blocked-over-pending-review-over-degraded ordering, READY fallback, and source degradation
+  behavior. Added direct helper tests for mixed-state precedence and ready-only fallback alongside
+  existing expected snapshot assembly coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m ruff format --check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/snapshots.py`,
+  `python -m pytest tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal expected outcome snapshot
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T17:25:18+00:00`
+- Generated at: `2026-06-12T17:29:14+00:00`
 
-- Current ref: `64ce6b0e`
+- Current ref: `f4624a23`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 2 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 3 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 4 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 5 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 6 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 7 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 8 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 9 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 10 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 1 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 2 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 3 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 4 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 5 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 6 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 7 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 8 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 9 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 10 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T17:14:20+00:00`
+- Generated at: `2026-06-12T17:25:18+00:00`
 
-- Current ref: `61bfbc3d`
+- Current ref: `64ce6b0e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | observed_transaction_cost_estimate | src/api/services/construction_transaction_cost_supportability.py | 8 | 22 |
-| 2 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
-| 3 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 4 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 5 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 6 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 7 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 8 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 9 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 10 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 1 | _construction_state | src/core/outcomes/snapshots.py | 8 | 22 |
+| 2 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
+| 3 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 4 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 5 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 6 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 7 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 8 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 9 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 10 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T17:29:14+00:00`
+- Generated at: `2026-06-12T17:32:00+00:00`
 
-- Current ref: `f4624a23`
+- Current ref: `5afc06c6`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _validate_lookback_window | src/core/pm_quality/scoring.py | 8 | 22 |
-| 2 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 3 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 4 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 5 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 6 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 7 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 8 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 9 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 10 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 1 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
+| 2 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 3 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 4 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 5 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 6 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 7 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 8 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 9 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 10 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T17:14:20+00:00`
+- Generated at: `2026-06-12T17:25:18+00:00`
 
-- Current ref: `61bfbc3d`
+- Current ref: `64ce6b0e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T17:29:14+00:00`
+- Generated at: `2026-06-12T17:32:00+00:00`
 
-- Current ref: `f4624a23`
+- Current ref: `5afc06c6`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T17:25:18+00:00`
+- Generated at: `2026-06-12T17:29:14+00:00`
 
-- Current ref: `64ce6b0e`
+- Current ref: `f4624a23`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T17:14:20+00:00`
+- Generated at: `2026-06-12T17:25:18+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `61bfbc3d`
+- Current ref: `64ce6b0e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168188 | 168340 | +152 |
-| Test functions | 2426 | 2430 | +4 |
+| Total Python LOC | 168340 | 168397 | +57 |
+| Test functions | 2430 | 2432 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T17:29:14+00:00`
+- Generated at: `2026-06-12T17:32:00+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f4624a23`
+- Current ref: `5afc06c6`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168340 | 168419 | +79 |
-| Test functions | 2430 | 2433 | +3 |
+| Total Python LOC | 168340 | 168477 | +137 |
+| Test functions | 2430 | 2434 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T17:25:18+00:00`
+- Generated at: `2026-06-12T17:29:14+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `64ce6b0e`
+- Current ref: `f4624a23`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168340 | 168397 | +57 |
-| Test functions | 2430 | 2432 | +2 |
+| Total Python LOC | 168340 | 168419 | +79 |
+| Test functions | 2430 | 2433 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/services/construction_transaction_cost_supportability.py
+++ b/src/api/services/construction_transaction_cost_supportability.py
@@ -72,19 +72,47 @@ def observed_transaction_cost_estimate(
     if context is None or context.supportability_status != ConstructionMethodStatus.READY:
         return None
     point_by_key = transaction_cost_curve_points_by_key(context=context)
-    total = Decimal("0")
-    currency = result.before.total_value.currency
-    matched = False
+    cost_terms = _observed_transaction_cost_terms(result=result, point_by_key=point_by_key)
+    return _observed_transaction_cost_money(
+        cost_terms=cost_terms,
+        currency=result.before.total_value.currency,
+    )
+
+
+def _observed_transaction_cost_terms(
+    *,
+    result: RebalanceResult,
+    point_by_key: dict[tuple[str, str], AuthoritativeTransactionCostPoint],
+) -> list[Decimal]:
+    cost_terms: list[Decimal] = []
     for intent in result.intents:
-        if not isinstance(intent, SecurityTradeIntent) or intent.notional_base is None:
-            continue
-        point = point_by_key.get((intent.instrument_id, intent.side))
-        if point is None:
-            continue
-        matched = True
-        total += abs(intent.notional_base.amount) * point.average_cost_bps / Decimal("10000")
-    if not matched:
+        term = _observed_transaction_cost_term(intent=intent, point_by_key=point_by_key)
+        if term is not None:
+            cost_terms.append(term)
+    return cost_terms
+
+
+def _observed_transaction_cost_term(
+    *,
+    intent: object,
+    point_by_key: dict[tuple[str, str], AuthoritativeTransactionCostPoint],
+) -> Decimal | None:
+    if not isinstance(intent, SecurityTradeIntent) or intent.notional_base is None:
         return None
+    point = point_by_key.get((intent.instrument_id, intent.side))
+    if point is None:
+        return None
+    return abs(intent.notional_base.amount) * point.average_cost_bps / Decimal("10000")
+
+
+def _observed_transaction_cost_money(
+    *,
+    cost_terms: list[Decimal],
+    currency: str,
+) -> Money | None:
+    if not cost_terms:
+        return None
+    total = sum(cost_terms, Decimal("0"))
     return Money(amount=total.quantize(_MONEY_QUANT), currency=currency)
 
 

--- a/src/core/outcomes/snapshots.py
+++ b/src/core/outcomes/snapshots.py
@@ -43,6 +43,11 @@ _PROOF_PACK_OUTCOME_STATES: dict[str, OutcomeDimensionState] = {
     "DEGRADED": "DEGRADED",
     "BLOCKED": "BLOCKED",
 }
+_CONSTRUCTION_OUTCOME_STATE_PRECEDENCE: tuple[OutcomeDimensionState, ...] = (
+    "BLOCKED",
+    "PENDING_REVIEW",
+    "DEGRADED",
+)
 
 
 def assemble_expected_outcome_snapshot(
@@ -538,24 +543,24 @@ def _construction_state(
     alternative_set: ConstructionAlternativeSet,
     selected_alternative: ConstructionAlternative,
 ) -> OutcomeDimensionState:
-    if (
-        str(alternative_set.status) == "BLOCKED"
-        or str(selected_alternative.method_status) == "BLOCKED"
-    ):
-        return "BLOCKED"
-    if (
-        str(alternative_set.status) == "PENDING_REVIEW"
-        or str(selected_alternative.method_status) == "PENDING_REVIEW"
-    ):
-        return "PENDING_REVIEW"
-    if (
-        str(alternative_set.status) == "DEGRADED"
-        or str(selected_alternative.method_status) == "DEGRADED"
-    ):
-        return "DEGRADED"
-    if alternative_set.source_supportability_state == "DEGRADED":
-        return "DEGRADED"
-    return "READY"
+    return (
+        _highest_construction_outcome_state(
+            str(alternative_set.status),
+            str(selected_alternative.method_status),
+            alternative_set.source_supportability_state,
+        )
+        or "READY"
+    )
+
+
+def _highest_construction_outcome_state(
+    *states: str | None,
+) -> OutcomeDimensionState | None:
+    observed_states = {state for state in states if state}
+    for outcome_state in _CONSTRUCTION_OUTCOME_STATE_PRECEDENCE:
+        if outcome_state in observed_states:
+            return outcome_state
+    return None
 
 
 def _proof_pack_state(status: str) -> OutcomeDimensionState:

--- a/src/core/pm_quality/scoring.py
+++ b/src/core/pm_quality/scoring.py
@@ -409,23 +409,46 @@ def _validate_lookback_window(
     policy: DpmPmOperatingQualityPolicy,
     signals: list[_PmQualitySignal],
 ) -> None:
-    if policy.lookback_window_policy is None:
+    window_dates = _lookback_window_dates(policy.lookback_window_policy)
+    if window_dates is None:
         return
-    try:
-        start_date = date.fromisoformat(policy.lookback_window_policy.start_date)
-        end_date = date.fromisoformat(policy.lookback_window_policy.end_date)
-    except ValueError as exc:
-        raise DpmPmQualityValidationError("PM_QUALITY_LOOKBACK_WINDOW_DATE_INVALID") from exc
+    start_date, end_date = window_dates
     dated_signals = [signal for signal in signals if signal.as_of_date is not None]
     if not dated_signals:
         raise DpmPmQualityValidationError("PM_QUALITY_LOOKBACK_WINDOW_EVIDENCE_DATE_REQUIRED")
     for signal in dated_signals:
-        try:
-            signal_date = date.fromisoformat(str(signal.as_of_date))
-        except ValueError as exc:
-            raise DpmPmQualityValidationError("PM_QUALITY_EVIDENCE_AS_OF_DATE_INVALID") from exc
-        if signal_date < start_date or signal_date > end_date:
+        signal_date = _signal_as_of_business_date(signal)
+        if not _date_in_inclusive_window(signal_date, start_date, end_date):
             raise DpmPmQualityValidationError("PM_QUALITY_EVIDENCE_OUTSIDE_LOOKBACK_WINDOW")
+
+
+def _lookback_window_dates(
+    lookback: DpmPmQualityLookbackWindowPolicy | None,
+) -> tuple[date, date] | None:
+    if lookback is None:
+        return None
+    try:
+        return (
+            date.fromisoformat(lookback.start_date),
+            date.fromisoformat(lookback.end_date),
+        )
+    except ValueError as exc:
+        raise DpmPmQualityValidationError("PM_QUALITY_LOOKBACK_WINDOW_DATE_INVALID") from exc
+
+
+def _signal_as_of_business_date(signal: _PmQualitySignal) -> date:
+    try:
+        return date.fromisoformat(str(signal.as_of_date))
+    except ValueError as exc:
+        raise DpmPmQualityValidationError("PM_QUALITY_EVIDENCE_AS_OF_DATE_INVALID") from exc
+
+
+def _date_in_inclusive_window(
+    observed_date: date,
+    start_date: date,
+    end_date: date,
+) -> bool:
+    return start_date <= observed_date <= end_date
 
 
 def _signal_as_of_date(source_refs: list[DpmOutcomeSourceRef]) -> str | None:

--- a/tests/unit/dpm/construction/test_transaction_cost_supportability.py
+++ b/tests/unit/dpm/construction/test_transaction_cost_supportability.py
@@ -1,6 +1,9 @@
 from decimal import Decimal
 
 from src.api.services.construction_transaction_cost_supportability import (
+    _observed_transaction_cost_money,
+    _observed_transaction_cost_term,
+    _observed_transaction_cost_terms,
     covered_transaction_cost_security_ids,
     observed_transaction_cost_estimate,
     transaction_cost_curve_points_by_key,
@@ -129,6 +132,32 @@ def test_transaction_cost_curve_points_by_key_indexes_security_and_transaction_t
 
     assert sorted(points_by_key) == [("EQ_A", "SELL"), ("EQ_B", "BUY")]
     assert points_by_key[("EQ_A", "SELL")].average_cost_bps == Decimal("10")
+
+
+def test_observed_transaction_cost_term_helpers_match_supported_trade_terms() -> None:
+    result = _trade_result()
+    context = _transaction_cost_context(security_ids=["EQ_A", "EQ_B"])
+    points_by_key = transaction_cost_curve_points_by_key(context=context)
+
+    assert _observed_transaction_cost_term(
+        intent=result.intents[0],
+        point_by_key=points_by_key,
+    ) == Decimal("0.5")
+    assert _observed_transaction_cost_terms(
+        result=result,
+        point_by_key=points_by_key,
+    ) == [Decimal("0.5"), Decimal("0.5")]
+
+
+def test_observed_transaction_cost_money_requires_matched_cost_terms() -> None:
+    assert _observed_transaction_cost_money(cost_terms=[], currency="USD") is None
+    money = _observed_transaction_cost_money(
+        cost_terms=[Decimal("0.12345"), Decimal("0.87655")],
+        currency="USD",
+    )
+
+    assert money is not None
+    assert money.amount == Decimal("1.0000")
 
 
 def test_transaction_cost_supportability_degrades_missing_traded_security_coverage() -> None:

--- a/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
+++ b/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
@@ -14,6 +14,7 @@ from src.core.models import Money
 from src.core.outcomes.snapshots import (
     DpmExpectedSnapshotAssemblyError,
     _find_wave_item,
+    _highest_construction_outcome_state,
     _proof_pack_state,
     _wave_item_lookup_required,
     assemble_expected_outcome_snapshot,
@@ -294,6 +295,22 @@ def test_expected_snapshot_calculation_trace_helper_records_source_posture() -> 
         "handoff_reason_code": "READY_FOR_OPERATIONS_REVIEW",
         "defaulted_expected_values": [],
     }
+
+
+@pytest.mark.parametrize(
+    ("states", "expected"),
+    [
+        (("READY", "DEGRADED"), "DEGRADED"),
+        (("DEGRADED", "PENDING_REVIEW"), "PENDING_REVIEW"),
+        (("PENDING_REVIEW", "BLOCKED"), "BLOCKED"),
+        (("READY", None), None),
+    ],
+)
+def test_highest_construction_outcome_state_applies_supportability_precedence(
+    states: tuple[str | None, ...],
+    expected: str | None,
+) -> None:
+    assert _highest_construction_outcome_state(*states) == expected
 
 
 def test_expected_snapshot_preserves_construction_proof_pack_wave_and_handoff_lineage() -> None:

--- a/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
+++ b/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
@@ -1,3 +1,4 @@
+from datetime import date
 from decimal import Decimal
 
 import pytest
@@ -903,6 +904,40 @@ def test_pm_quality_lookback_window_requires_dated_valid_evidence() -> None:
                 )
             ],
         )
+
+
+def test_pm_quality_lookback_window_helpers_parse_source_dates_and_boundaries() -> None:
+    lookback = DpmPmQualityLookbackWindowPolicy(
+        window_id="pmq_30d_20260512",
+        start_date="2026-04-13",
+        end_date="2026-05-12",
+        timezone="UTC",
+        source_refs=[_source_ref()],
+    )
+    signal = scoring._PmQualitySignal(
+        indicator="OUTCOME_DISCIPLINE",
+        score=Decimal("92"),
+        state="READY",
+        reason_codes=["PM_OUTCOME_DISCIPLINE_SOURCE_SIGNAL"],
+        source_refs=[_source_ref()],
+        as_of_date="2026-05-12",
+    )
+
+    assert scoring._lookback_window_dates(lookback) == (
+        date(2026, 4, 13),
+        date(2026, 5, 12),
+    )
+    assert scoring._signal_as_of_business_date(signal) == date(2026, 5, 12)
+    assert scoring._date_in_inclusive_window(
+        date(2026, 4, 13),
+        date(2026, 4, 13),
+        date(2026, 5, 12),
+    )
+    assert not scoring._date_in_inclusive_window(
+        date(2026, 5, 13),
+        date(2026, 4, 13),
+        date(2026, 5, 12),
+    )
 
 
 def test_pm_quality_scoring_guard_edges_are_source_safe() -> None:


### PR DESCRIPTION
## Summary
- Extract transaction-cost observed estimate helpers and add direct cost-term/Money tests.
- Extract expected outcome construction-state precedence helper and add direct precedence tests.
- Extract PM-quality lookback-window date helpers and add direct date/boundary tests.
- Refresh review ledger and quality reports through BACKEND-REVIEW-20260613-837.

## Validation
- python -m ruff check <touched files>
- python -m ruff format --check <touched files>
- python -m mypy --config-file mypy.ini <touched src files>
- Focused pytest for changed behavior:
  - tests/unit/dpm/construction/test_transaction_cost_supportability.py tests/unit/dpm/construction/test_enrichment.py
  - tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
  - tests/unit/dpm/pm_quality/test_pm_operating_quality.py
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- git diff --check
- service leakage scan: no matches
- python scripts/engineering_health_report.py
- make check: 2610 passed
- git fetch origin --prune
- git branch -r --no-merged origin/main: only this feature branch
- wiki drift check: DiffCount 0

## Wiki
No wiki source change required. These are internal backend helper refactors, direct tests, ledger, and repo-local quality evidence only.