### PR TITLE
Harden backend hotspot supportability helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20698,3 +20698,33 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal construction supportability
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-839: Workflow gate route precedence table
+
+- Date: 2026-06-13
+- Scope: `src/core/common/workflow_gates.py`,
+  `tests/unit/dpm/engine/test_engine_workflow_gates.py`,
+  `tests/unit/core/test_common_edge_coverage.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_select_gate_route` was the top current source-complexity hotspot after the
+  construction supportability selector slice and encoded workflow gate precedence through a branch
+  stack that made blocked, compliance, risk, approval, and execution routing order harder to audit.
+- Action: introduced an explicit workflow gate route context and precedence table while preserving
+  the existing decision order and default execution route. Expanded direct route tests to cover
+  blocked, compliance, risk, already-approved execution, mandate-approval, and clean execution
+  decisions alongside the existing end-to-end gate evaluation coverage.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/common/workflow_gates.py tests/unit/dpm/engine/test_engine_workflow_gates.py`,
+  `python -m ruff format --check src/core/common/workflow_gates.py tests/unit/dpm/engine/test_engine_workflow_gates.py`,
+  `python -m mypy --config-file mypy.ini src/core/common/workflow_gates.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_workflow_gates.py tests/unit/core/test_common_edge_coverage.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal workflow gate maintainability
+  refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20728,3 +20728,31 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal workflow gate maintainability
   refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-840: Drawdown source posture helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/risk_sources.py`,
+  `tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_drawdown_source_posture` was the top current source-complexity hotspot after the
+  workflow gate slice and repeated supportability-state handling already available elsewhere in
+  the risk-source adapter module.
+- Action: reused the shared supportability posture and degraded-value quality helpers, extracted
+  the drawdown-specific unavailable-measure predicate, and added direct tests for relative versus
+  absolute drawdown availability behavior while preserving existing risk-source adapter semantics.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`,
+  `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal risk-source adapter
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20669,3 +20669,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal PM-quality lookback-window
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-838: Construction method enrichment selector map
+
+- Date: 2026-06-13
+- Scope: `src/api/services/construction_supportability_application.py`,
+  `tests/unit/dpm/construction/test_supportability_application.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `method_enrichment_statuses` was the top current source-complexity hotspot after the
+  PM-quality lookback slice and encoded method-to-enrichment-status routing through repeated branch
+  checks, with only partial direct coverage over the supported construction methods.
+- Action: replaced the branch chain with an explicit construction-method enrichment selector map
+  while preserving solver-diagnostic status handling and empty posture for methods without an
+  enrichment overlay. Expanded direct tests to cover every mapped method and the solver-specific
+  diagnostic projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_supportability_application.py tests/unit/dpm/construction/test_supportability_application.py`,
+  `python -m ruff format --check src/api/services/construction_supportability_application.py tests/unit/dpm/construction/test_supportability_application.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_supportability_application.py`,
+  `python -m pytest tests/unit/dpm/construction/test_supportability_application.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal construction supportability
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-12T17:32:00+00:00`
+- Generated at: `2026-06-13T00:01:13+00:00`
 
-- Current ref: `5afc06c6`
+- Current ref: `4e731b72`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | method_enrichment_statuses | src/api/services/construction_supportability_application.py | 8 | 21 |
-| 2 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 3 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 4 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 5 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 6 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 7 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 8 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 9 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 10 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 1 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
+| 2 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 3 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 4 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 5 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 6 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 7 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 8 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 9 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 10 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:03:54+00:00`
+- Generated at: `2026-06-13T00:06:22+00:00`
 
-- Current ref: `22b56d4e`
+- Current ref: `2bd9ae72`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 2 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 3 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 4 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 5 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 6 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 7 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 8 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 9 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 10 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 1 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 2 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 3 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 4 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 5 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 6 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 7 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 8 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 9 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 10 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:01:13+00:00`
+- Generated at: `2026-06-13T00:03:54+00:00`
 
-- Current ref: `4e731b72`
+- Current ref: `22b56d4e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _select_gate_route | src/core/common/workflow_gates.py | 8 | 21 |
-| 2 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
-| 3 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 4 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 5 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 6 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 7 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 8 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 9 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 10 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 1 | _drawdown_source_posture | src/core/outcomes/risk_sources.py | 8 | 20 |
+| 2 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
+| 3 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 4 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 5 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 6 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 7 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 8 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 9 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 10 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-12T17:32:00+00:00`
+- Generated at: `2026-06-13T00:01:13+00:00`
 
-- Current ref: `5afc06c6`
+- Current ref: `4e731b72`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:01:13+00:00`
+- Generated at: `2026-06-13T00:03:54+00:00`
 
-- Current ref: `4e731b72`
+- Current ref: `22b56d4e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:03:54+00:00`
+- Generated at: `2026-06-13T00:06:22+00:00`
 
-- Current ref: `22b56d4e`
+- Current ref: `2bd9ae72`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:01:13+00:00`
+- Generated at: `2026-06-13T00:03:54+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `4e731b72`
+- Current ref: `22b56d4e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168477 | 168513 | +36 |
+| Total Python LOC | 168477 | 168600 | +123 |
 | Test functions | 2434 | 2435 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:03:54+00:00`
+- Generated at: `2026-06-13T00:06:22+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `22b56d4e`
+- Current ref: `2bd9ae72`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168477 | 168600 | +123 |
+| Total Python LOC | 168477 | 168607 | +130 |
 | Test functions | 2434 | 2435 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-12T17:32:00+00:00`
+- Generated at: `2026-06-13T00:01:13+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `5afc06c6`
+- Current ref: `4e731b72`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168340 | 168477 | +137 |
-| Test functions | 2430 | 2434 | +4 |
+| Total Python LOC | 168477 | 168513 | +36 |
+| Test functions | 2434 | 2435 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/services/construction_supportability_application.py
+++ b/src/api/services/construction_supportability_application.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 from src.api.request_models import RebalanceRequest
 from src.api.services.construction_esg_supportability import with_esg_restriction_constraints
 from src.api.services.construction_method_readiness import (
@@ -22,6 +24,23 @@ from src.core.construction.models import (
 from src.core.construction.status import lowest_construction_status
 from src.core.construction.vocabulary import ConstructionMethod, ConstructionMethodStatus
 from src.core.models import RebalanceResult
+
+_EnrichmentStatusSelector = Callable[
+    [ConstructionEnrichmentSummary],
+    ConstructionMethodStatus,
+]
+
+_METHOD_ENRICHMENT_STATUS_SELECTORS: dict[
+    ConstructionMethod,
+    _EnrichmentStatusSelector,
+] = {
+    ConstructionMethod.TAX_AWARE: lambda enrichment: enrichment.tax_status,
+    ConstructionMethod.MIN_TURNOVER: lambda enrichment: enrichment.turnover_status,
+    ConstructionMethod.COST_AWARE: lambda enrichment: enrichment.cost_status,
+    ConstructionMethod.LIQUIDITY_AWARE: lambda enrichment: enrichment.liquidity_status,
+    ConstructionMethod.CURRENCY_OVERLAY: lambda enrichment: enrichment.fx_status,
+    ConstructionMethod.RISK_AWARE: lambda enrichment: enrichment.risk_status,
+}
 
 
 def apply_construction_supportability(
@@ -170,20 +189,11 @@ def method_enrichment_statuses(
     result: RebalanceResult,
     enrichment: ConstructionEnrichmentSummary,
 ) -> list[ConstructionMethodStatus]:
-    if method == ConstructionMethod.TAX_AWARE:
-        return [enrichment.tax_status]
-    if method == ConstructionMethod.MIN_TURNOVER:
-        return [enrichment.turnover_status]
-    if method == ConstructionMethod.COST_AWARE:
-        return [enrichment.cost_status]
+    selector = _METHOD_ENRICHMENT_STATUS_SELECTORS.get(method)
+    if selector is not None:
+        return [selector(enrichment)]
     if method == ConstructionMethod.SOLVER_CONSTRAINED:
         return [solver_method_status(result=result)]
-    if method == ConstructionMethod.LIQUIDITY_AWARE:
-        return [enrichment.liquidity_status]
-    if method == ConstructionMethod.CURRENCY_OVERLAY:
-        return [enrichment.fx_status]
-    if method == ConstructionMethod.RISK_AWARE:
-        return [enrichment.risk_status]
     return []
 
 

--- a/src/core/common/workflow_gates.py
+++ b/src/core/common/workflow_gates.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
-from typing import Literal
+from dataclasses import dataclass
+from typing import Callable, Literal
 
 from src.core.models import (
     DiagnosticsData,
@@ -29,6 +30,63 @@ _NextStep = Literal[
     "EXECUTE",
     "NONE",
 ]
+
+_SimulationStatus = Literal["READY", "BLOCKED", "PENDING_REVIEW"]
+
+
+@dataclass(frozen=True)
+class _GateRouteContext:
+    status: _SimulationStatus
+    hard_fail_count: int
+    soft_fail_count: int
+    new_high: int
+    new_medium: int
+    options: EngineOptions
+    requires_mandate_approval: bool
+
+
+_GateRoutePredicate = Callable[[_GateRouteContext], bool]
+
+
+@dataclass(frozen=True)
+class _GateRouteDecision:
+    gate: _GateName
+    next_step: _NextStep
+    applies: _GateRoutePredicate
+
+
+_GATE_ROUTE_PRECEDENCE: tuple[_GateRouteDecision, ...] = (
+    _GateRouteDecision(
+        gate="BLOCKED",
+        next_step="FIX_INPUT",
+        applies=lambda context: context.status == "BLOCKED" or context.hard_fail_count > 0,
+    ),
+    _GateRouteDecision(
+        gate="COMPLIANCE_REVIEW_REQUIRED",
+        next_step="COMPLIANCE_REVIEW",
+        applies=lambda context: context.new_high > 0,
+    ),
+    _GateRouteDecision(
+        gate="RISK_REVIEW_REQUIRED",
+        next_step="RISK_REVIEW",
+        applies=lambda context: context.soft_fail_count > 0 or context.new_medium > 0,
+    ),
+    _GateRouteDecision(
+        gate="EXECUTION_READY",
+        next_step="EXECUTE",
+        applies=lambda context: context.options.mandate_approval_already_obtained,
+    ),
+    _GateRouteDecision(
+        gate="MANDATE_APPROVAL_REQUIRED",
+        next_step="REQUEST_MANDATE_APPROVAL",
+        applies=lambda context: context.requires_mandate_approval,
+    ),
+    _GateRouteDecision(
+        gate="EXECUTION_READY",
+        next_step="EXECUTE",
+        applies=lambda context: True,
+    ),
+)
 
 
 def _dq_reasons(diagnostics: DiagnosticsData | None) -> list[GateReason]:
@@ -125,7 +183,7 @@ def _suitability_reasons(
 
 def evaluate_gate_decision(
     *,
-    status: Literal["READY", "BLOCKED", "PENDING_REVIEW"],
+    status: _SimulationStatus,
     rule_results: Iterable[RuleResult],
     suitability: SuitabilityResult | None,
     diagnostics: DiagnosticsData | None,
@@ -167,7 +225,7 @@ def evaluate_gate_decision(
 
 def _select_gate_route(
     *,
-    status: Literal["READY", "BLOCKED", "PENDING_REVIEW"],
+    status: _SimulationStatus,
     hard_fail_count: int,
     soft_fail_count: int,
     new_high: int,
@@ -175,17 +233,19 @@ def _select_gate_route(
     options: EngineOptions,
     requires_mandate_approval: bool,
 ) -> tuple[_GateName, _NextStep]:
-    if status == "BLOCKED" or hard_fail_count > 0:
-        return "BLOCKED", "FIX_INPUT"
-    if new_high > 0:
-        return "COMPLIANCE_REVIEW_REQUIRED", "COMPLIANCE_REVIEW"
-    if soft_fail_count > 0 or new_medium > 0:
-        return "RISK_REVIEW_REQUIRED", "RISK_REVIEW"
-    if options.mandate_approval_already_obtained:
-        return "EXECUTION_READY", "EXECUTE"
-    if requires_mandate_approval:
-        return "MANDATE_APPROVAL_REQUIRED", "REQUEST_MANDATE_APPROVAL"
-    return "EXECUTION_READY", "EXECUTE"
+    context = _GateRouteContext(
+        status=status,
+        hard_fail_count=hard_fail_count,
+        soft_fail_count=soft_fail_count,
+        new_high=new_high,
+        new_medium=new_medium,
+        options=options,
+        requires_mandate_approval=requires_mandate_approval,
+    )
+    for route in _GATE_ROUTE_PRECEDENCE:
+        if route.applies(context):
+            return route.gate, route.next_step
+    raise AssertionError("workflow gate route precedence did not define a default route")
 
 
 def _sorted_gate_reasons(reasons: list[GateReason]) -> list[GateReason]:

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -708,21 +708,19 @@ def _drawdown_source_posture(
     supportability_state: str,
     value: Decimal | None,
     measure_reason: str,
-) -> tuple[
-    Literal["READY", "DEGRADED", "BLOCKED", "NOT_SUPPORTED"],
-    Literal["COMPLETE", "STALE", "UNAVAILABLE", "PARTIAL", "MISSING", "NOT_SUPPORTED"],
-]:
-    if supportability_state == "unsupported":
-        return "NOT_SUPPORTED", "NOT_SUPPORTED"
-    if supportability_state == "permission_blocked":
-        return "BLOCKED", "MISSING"
-    if supportability_state == "stale":
-        return "DEGRADED", "STALE"
-    if value is None and measure_reason != "RISK_DRAWDOWN_ABSOLUTE":
+) -> _RiskSourcePosture:
+    supportability_posture = _supportability_source_posture(supportability_state)
+    if supportability_posture is not None:
+        return supportability_posture
+    if _drawdown_measure_unavailable(value=value, measure_reason=measure_reason):
         return "DEGRADED", "UNAVAILABLE"
     if supportability_state != "ready":
-        return "DEGRADED", "PARTIAL" if value is not None else "UNAVAILABLE"
+        return "DEGRADED", _quality_for_degraded_value(value)
     return "READY", "COMPLETE"
+
+
+def _drawdown_measure_unavailable(*, value: Decimal | None, measure_reason: str) -> bool:
+    return value is None and measure_reason != "RISK_DRAWDOWN_ABSOLUTE"
 
 
 def _rolling_source_posture(

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -16,6 +16,7 @@ from src.core.outcomes.risk_sources import (
     _concentration_reason_codes,
     _concentration_source_snapshot,
     _concentration_source_posture,
+    _drawdown_measure_unavailable,
     _drawdown_source_posture,
     _historical_attribution_contributor,
     _historical_attribution_set,
@@ -1401,6 +1402,14 @@ def test_concentration_drawdown_and_rolling_posture_edges_are_source_safe() -> N
         value=None,
         measure_reason="RISK_DRAWDOWN_RELATIVE",
     ) == ("DEGRADED", "UNAVAILABLE")
+    assert _drawdown_measure_unavailable(
+        value=None,
+        measure_reason="RISK_DRAWDOWN_RELATIVE",
+    )
+    assert not _drawdown_measure_unavailable(
+        value=None,
+        measure_reason="RISK_DRAWDOWN_ABSOLUTE",
+    )
     assert _rolling_source_posture(
         supportability_state="unsupported",
         value=None,

--- a/tests/unit/dpm/construction/test_supportability_application.py
+++ b/tests/unit/dpm/construction/test_supportability_application.py
@@ -451,21 +451,47 @@ def test_method_enrichment_statuses_project_method_specific_enrichment() -> None
         liquidity_context=_liquidity_context(),
     )
 
+    expected_statuses = {
+        ConstructionMethod.TAX_AWARE: enrichment.tax_status,
+        ConstructionMethod.MIN_TURNOVER: enrichment.turnover_status,
+        ConstructionMethod.COST_AWARE: enrichment.cost_status,
+        ConstructionMethod.LIQUIDITY_AWARE: enrichment.liquidity_status,
+        ConstructionMethod.CURRENCY_OVERLAY: enrichment.fx_status,
+        ConstructionMethod.RISK_AWARE: enrichment.risk_status,
+    }
+
+    for method, expected_status in expected_statuses.items():
+        assert method_enrichment_statuses(
+            method=method,
+            result=result,
+            enrichment=enrichment,
+        ) == [expected_status]
+
+
+def test_method_enrichment_statuses_project_solver_diagnostics() -> None:
+    result = _trade_result().model_copy(
+        update={
+            "diagnostics": _trade_result().diagnostics.model_copy(
+                update={"warnings": ["SOLVER_FALLBACK_USED"]}
+            )
+        }
+    )
+    enrichment = summarize_enrichment_posture(
+        result=result,
+        tax_required=False,
+        risk_required=False,
+        risk_context=None,
+        performance_context=None,
+        performance_required=False,
+        transaction_cost_context=None,
+        liquidity_context=None,
+    )
+
     assert method_enrichment_statuses(
-        method=ConstructionMethod.TAX_AWARE,
+        method=ConstructionMethod.SOLVER_CONSTRAINED,
         result=result,
         enrichment=enrichment,
-    ) == [enrichment.tax_status]
-    assert method_enrichment_statuses(
-        method=ConstructionMethod.LIQUIDITY_AWARE,
-        result=result,
-        enrichment=enrichment,
-    ) == [enrichment.liquidity_status]
-    assert method_enrichment_statuses(
-        method=ConstructionMethod.RISK_AWARE,
-        result=result,
-        enrichment=enrichment,
-    ) == [enrichment.risk_status]
+    ) == [ConstructionMethodStatus.DEGRADED]
 
 
 def test_method_enrichment_statuses_empty_for_method_without_overlay() -> None:

--- a/tests/unit/dpm/engine/test_engine_workflow_gates.py
+++ b/tests/unit/dpm/engine/test_engine_workflow_gates.py
@@ -184,11 +184,38 @@ def test_select_gate_route_preserves_decision_precedence() -> None:
     assert _select_gate_route(
         status="READY",
         hard_fail_count=0,
+        soft_fail_count=1,
+        new_high=0,
+        new_medium=1,
+        options=EngineOptions(),
+        requires_mandate_approval=True,
+    ) == ("RISK_REVIEW_REQUIRED", "RISK_REVIEW")
+    assert _select_gate_route(
+        status="READY",
+        hard_fail_count=0,
         soft_fail_count=0,
         new_high=0,
         new_medium=0,
         options=EngineOptions(mandate_approval_already_obtained=True),
         requires_mandate_approval=True,
+    ) == ("EXECUTION_READY", "EXECUTE")
+    assert _select_gate_route(
+        status="READY",
+        hard_fail_count=0,
+        soft_fail_count=0,
+        new_high=0,
+        new_medium=0,
+        options=EngineOptions(),
+        requires_mandate_approval=True,
+    ) == ("MANDATE_APPROVAL_REQUIRED", "REQUEST_MANDATE_APPROVAL")
+    assert _select_gate_route(
+        status="READY",
+        hard_fail_count=0,
+        soft_fail_count=0,
+        new_high=0,
+        new_medium=0,
+        options=EngineOptions(),
+        requires_mandate_approval=False,
     ) == ("EXECUTION_READY", "EXECUTE")
 
 


### PR DESCRIPTION
## Summary
- Replace construction method enrichment branch routing with an explicit selector map and direct tests for all mapped methods plus solver diagnostics.
- Replace workflow gate route branch stack with an explicit precedence table and direct tests for all route outcomes.
- Reuse shared risk-source posture helpers for drawdown source posture and add direct drawdown availability tests.
- Refresh codebase review ledger and quality reports through BACKEND-REVIEW-20260613-840.

## Validation
- Focused checks per slice:
  - python -m pytest tests/unit/dpm/construction/test_supportability_application.py
  - python -m pytest tests/unit/dpm/engine/test_engine_workflow_gates.py tests/unit/core/test_common_edge_coverage.py
  - python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py
  - python -m ruff check <touched files>
  - python -m ruff format --check <touched files>
  - python -m mypy --config-file mypy.ini <touched src files>
  - python scripts/openapi_quality_gate.py
  - python scripts/api_vocabulary_inventory.py --validate-only
  - git diff --check
  - service leakage scan: no matches
  - python scripts/engineering_health_report.py
- Full local gate:
  - make check: 2611 passed
- Pre-PR hygiene:
  - git fetch origin --prune
  - git branch -r --no-merged origin/main: only this feature branch
  - wiki drift check: DiffCount 0
  - gh pr list --state open: []

## Wiki
No wiki source change required. This PR changes internal backend helper structure, direct tests, repo-local ledger, and quality evidence only.