### PR TITLE
Refactor manage hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20756,3 +20756,31 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal risk-source adapter
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-841: Security intent constraint predicates
+
+- Date: 2026-06-13
+- Scope: `src/core/rebalance/intents.py`,
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_security_intent_constraints` was the top current source-complexity hotspot after the
+  drawdown source posture slice and mixed min-notional, sell safety, and tax-budget constraint
+  label decisions in one helper.
+- Action: extracted named sell-side available-holding and tax-budget constraint predicates while
+  preserving min-notional, available-holding, and tax-budget label ordering. Added direct tests
+  proving the predicates are sell-side only and respect disabled tax awareness.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m ruff format --check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal rebalance intent safety
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20813,3 +20813,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal campaign operating queue
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-843: Enterprise runtime config issue helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/enterprise_readiness.py`,
+  `tests/unit/api/test_enterprise_readiness_hardening.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `validate_enterprise_runtime_config` was the top current source-complexity hotspot after
+  the campaign operating queue slice and mixed policy-version validation, secret-rotation bounds,
+  authz key-material requirements, and fail-fast enforcement in one helper.
+- Action: extracted named runtime-config issue helpers for policy version, secret rotation, and
+  authz key material, then made the public validator assemble those bounded issues before applying
+  enforcement. Added direct tests for both failing and passing helper states while preserving the
+  existing runtime enforcement behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py tests/unit/api/test_enterprise_readiness.py`,
+  `python -m ruff format --check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py tests/unit/api/test_enterprise_readiness.py`,
+  `python -m mypy --config-file mypy.ini src/api/enterprise_readiness.py`,
+  `python -m pytest tests/unit/api/test_enterprise_readiness_hardening.py tests/unit/api/test_enterprise_readiness.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal enterprise runtime
+  security/config maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20784,3 +20784,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal rebalance intent safety
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-842: Campaign operating queue posture helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/waves/campaign_operating_queue.py`,
+  `tests/unit/dpm/waves/test_campaign_discovery.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_classify_queue_posture` was the top current source-complexity hotspot after the
+  security intent constraint slice and mixed terminal campaign-definition handling, preview
+  readiness, discovery expiry reason enrichment, and fallback review-required semantics in one
+  helper.
+- Action: extracted explicit closed-posture and attention-reason helpers, centralized discovery
+  expiry reason-code mapping, and preserved ready-to-launch precedence and bounded queue status
+  results. Added direct tests for closed-state precedence and expiry reason de-duplication through
+  real campaign definition/readiness/discovery models.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_operating_queue.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_operating_queue.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_operating_queue.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal campaign operating queue
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:18:05+00:00`
+- Generated at: `2026-06-13T00:23:52+00:00`
 
-- Current ref: `0d12a9dd`
+- Current ref: `61b57d25`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 2 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 3 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 4 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 5 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 6 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 7 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 8 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 9 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 10 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 1 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 2 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 3 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 4 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 5 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 6 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 7 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 8 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 9 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 10 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:23:52+00:00`
+- Generated at: `2026-06-13T00:27:50+00:00`
 
-- Current ref: `61b57d25`
+- Current ref: `29601cfd`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 2 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 3 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 4 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 5 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 6 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 7 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 8 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 9 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 10 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 1 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 2 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 3 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 4 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 5 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 6 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 7 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 8 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 9 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 10 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:06:22+00:00`
+- Generated at: `2026-06-13T00:18:05+00:00`
 
-- Current ref: `2bd9ae72`
+- Current ref: `0d12a9dd`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _security_intent_constraints | src/core/rebalance/intents.py | 8 | 20 |
-| 2 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
-| 3 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
-| 4 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 5 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 6 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 7 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 8 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 9 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 10 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 1 | _classify_queue_posture | src/core/waves/campaign_operating_queue.py | 8 | 19 |
+| 2 | validate_enterprise_runtime_config | src/api/enterprise_readiness.py | 8 | 18 |
+| 3 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
+| 4 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 5 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 6 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 7 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 8 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 9 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 10 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:23:52+00:00`
+- Generated at: `2026-06-13T00:27:50+00:00`
 
-- Current ref: `61b57d25`
+- Current ref: `29601cfd`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:18:05+00:00`
+- Generated at: `2026-06-13T00:23:52+00:00`
 
-- Current ref: `0d12a9dd`
+- Current ref: `61b57d25`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:06:22+00:00`
+- Generated at: `2026-06-13T00:18:05+00:00`
 
-- Current ref: `2bd9ae72`
+- Current ref: `0d12a9dd`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:18:05+00:00`
+- Generated at: `2026-06-13T00:23:52+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `0d12a9dd`
+- Current ref: `61b57d25`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168607 | 168668 | +61 |
-| Test functions | 2435 | 2436 | +1 |
+| Total Python LOC | 168607 | 168747 | +140 |
+| Test functions | 2435 | 2438 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2263 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2310 |
 | 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:06:22+00:00`
+- Generated at: `2026-06-13T00:18:05+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `2bd9ae72`
+- Current ref: `0d12a9dd`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168477 | 168607 | +130 |
-| Test functions | 2434 | 2435 | +1 |
+| Total Python LOC | 168607 | 168668 | +61 |
+| Test functions | 2435 | 2436 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:23:52+00:00`
+- Generated at: `2026-06-13T00:27:50+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `61b57d25`
+- Current ref: `29601cfd`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168607 | 168747 | +140 |
-| Test functions | 2435 | 2438 | +3 |
+| Total Python LOC | 168607 | 168786 | +179 |
+| Test functions | 2435 | 2439 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/enterprise_readiness.py
+++ b/src/api/enterprise_readiness.py
@@ -50,23 +50,40 @@ def enterprise_policy_version() -> str:
 
 
 def validate_enterprise_runtime_config() -> list[str]:
-    issues: list[str] = []
-    if not enterprise_policy_version().strip():
-        issues.append("missing_policy_version")
-
-    rotation_days = _env_int("ENTERPRISE_SECRET_ROTATION_DAYS", 90)
-    if rotation_days <= 0 or rotation_days > 90:
-        issues.append("secret_rotation_days_out_of_range")
-
-    if (
-        _env_enabled("ENTERPRISE_ENFORCE_AUTHZ", "false")
-        and not os.getenv("ENTERPRISE_PRIMARY_KEY_ID", "").strip()
-    ):
-        issues.append("missing_primary_key_id")
-
+    issues = _enterprise_runtime_config_issues()
     if issues and _env_enabled("ENTERPRISE_ENFORCE_RUNTIME_CONFIG", "false"):
         raise RuntimeError(f"enterprise_runtime_config_invalid:{','.join(issues)}")
     return issues
+
+
+def _enterprise_runtime_config_issues() -> list[str]:
+    issue_candidates = (
+        _policy_version_issue(),
+        _secret_rotation_issue(),
+        _authz_key_material_issue(),
+    )
+    return [issue for issue in issue_candidates if issue is not None]
+
+
+def _policy_version_issue() -> str | None:
+    if enterprise_policy_version().strip():
+        return None
+    return "missing_policy_version"
+
+
+def _secret_rotation_issue() -> str | None:
+    rotation_days = _env_int("ENTERPRISE_SECRET_ROTATION_DAYS", 90)
+    if 0 < rotation_days <= 90:
+        return None
+    return "secret_rotation_days_out_of_range"
+
+
+def _authz_key_material_issue() -> str | None:
+    if not _env_enabled("ENTERPRISE_ENFORCE_AUTHZ", "false"):
+        return None
+    if os.getenv("ENTERPRISE_PRIMARY_KEY_ID", "").strip():
+        return None
+    return "missing_primary_key_id"
 
 
 def load_feature_flags() -> dict[str, dict[str, dict[str, bool]]]:

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -118,16 +118,44 @@ def _security_intent_constraints(
     tax_awareness_enabled: bool,
 ) -> list[str]:
     applied_constraints = ["MIN_NOTIONAL"] if threshold else []
-    if side == "SELL" and quantity < requested_quantity:
+    if _available_holding_constraint_applies(
+        side=side,
+        quantity=quantity,
+        requested_quantity=requested_quantity,
+    ):
         applied_constraints.append("AVAILABLE_HOLDING")
-    if (
+    if _tax_budget_constraint_applies(
+        side=side,
+        quantity=quantity,
+        sell_quantity_before_tax=sell_quantity_before_tax,
+        tax_awareness_enabled=tax_awareness_enabled,
+    ):
+        applied_constraints.append("TAX_BUDGET")
+    return applied_constraints
+
+
+def _available_holding_constraint_applies(
+    *,
+    side: Literal["BUY", "SELL"],
+    quantity: Decimal,
+    requested_quantity: Decimal,
+) -> bool:
+    return side == "SELL" and quantity < requested_quantity
+
+
+def _tax_budget_constraint_applies(
+    *,
+    side: Literal["BUY", "SELL"],
+    quantity: Decimal,
+    sell_quantity_before_tax: Decimal | None,
+    tax_awareness_enabled: bool,
+) -> bool:
+    return (
         side == "SELL"
         and tax_awareness_enabled
         and sell_quantity_before_tax is not None
         and quantity < sell_quantity_before_tax
-    ):
-        applied_constraints.append("TAX_BUDGET")
-    return applied_constraints
+    )
 
 
 def _suppress_dust_trade(

--- a/src/core/waves/campaign_operating_queue.py
+++ b/src/core/waves/campaign_operating_queue.py
@@ -27,6 +27,13 @@ from src.core.waves.campaign_operating_boundaries import (
 )
 from src.core.waves.campaign_page_validation import validate_count_map, validate_page_count
 
+CampaignOperatingQueueStatus = Literal["READY_TO_LAUNCH", "ATTENTION_REQUIRED", "CLOSED"]
+CampaignOperatingQueuePosture = tuple[CampaignOperatingQueueStatus, list[str]]
+CAMPAIGN_DISCOVERY_EXPIRY_REASON_CODES = {
+    "EXPIRED": "CAMPAIGN_DEFINITION_EXPIRED",
+    "INVALID": "CAMPAIGN_DEFINITION_EXPIRY_INVALID",
+}
+
 
 class DpmBulkReviewCampaignOperatingQueueItem(BaseModel):
     """Operator queue row for one persisted bulk-review campaign definition."""
@@ -200,20 +207,45 @@ def _classify_queue_posture(
     definition: DpmBulkReviewCampaignDefinition,
     readiness: DpmBulkReviewCampaignDefinitionPreviewReadiness,
     discovery: DpmBulkReviewCampaignDiscoveryItem,
-) -> tuple[Literal["READY_TO_LAUNCH", "ATTENTION_REQUIRED", "CLOSED"], list[str]]:
-    if definition.status in {"RETIRED", "SUPERSEDED"}:
-        return "CLOSED", [f"CAMPAIGN_DEFINITION_{definition.status}"]
+) -> CampaignOperatingQueuePosture:
+    closed_posture = _closed_queue_posture(definition=definition)
+    if closed_posture is not None:
+        return closed_posture
     if readiness.preview_create_allowed:
         return "READY_TO_LAUNCH", ["CAMPAIGN_DEFINITION_READY_TO_LAUNCH"]
 
+    return "ATTENTION_REQUIRED", _attention_queue_reason_codes(
+        readiness=readiness,
+        discovery=discovery,
+    )
+
+
+def _closed_queue_posture(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+) -> CampaignOperatingQueuePosture | None:
+    if definition.status not in {"RETIRED", "SUPERSEDED"}:
+        return None
+    return "CLOSED", [f"CAMPAIGN_DEFINITION_{definition.status}"]
+
+
+def _attention_queue_reason_codes(
+    *,
+    readiness: DpmBulkReviewCampaignDefinitionPreviewReadiness,
+    discovery: DpmBulkReviewCampaignDiscoveryItem,
+) -> list[str]:
     reasons = list(readiness.reason_codes)
-    if discovery.expiry_state == "EXPIRED" and "CAMPAIGN_DEFINITION_EXPIRED" not in reasons:
-        reasons.append("CAMPAIGN_DEFINITION_EXPIRED")
-    if discovery.expiry_state == "INVALID" and "CAMPAIGN_DEFINITION_EXPIRY_INVALID" not in reasons:
-        reasons.append("CAMPAIGN_DEFINITION_EXPIRY_INVALID")
+    expiry_reason = CAMPAIGN_DISCOVERY_EXPIRY_REASON_CODES.get(discovery.expiry_state)
+    if expiry_reason is not None:
+        _append_reason_once(reasons=reasons, reason_code=expiry_reason)
     if not reasons:
         reasons.append("CAMPAIGN_DEFINITION_REVIEW_REQUIRED")
-    return "ATTENTION_REQUIRED", reasons
+    return reasons
+
+
+def _append_reason_once(*, reasons: list[str], reason_code: str) -> None:
+    if reason_code not in reasons:
+        reasons.append(reason_code)
 
 
 def _hash_payload(payload: dict[str, object]) -> str:

--- a/tests/unit/api/test_enterprise_readiness_hardening.py
+++ b/tests/unit/api/test_enterprise_readiness_hardening.py
@@ -3,10 +3,13 @@ from fastapi.testclient import TestClient
 import pytest
 
 from src.api.enterprise_readiness import (
+    _authz_key_material_issue,
     _has_service_identity,
     _missing_required_headers,
     _normalized_headers,
+    _policy_version_issue,
     _provided_capabilities,
+    _secret_rotation_issue,
     _write_authorization_required,
     authorize_write_request,
     build_enterprise_audit_middleware,
@@ -39,6 +42,25 @@ def test_enterprise_runtime_config_reports_missing_policy_version(monkeypatch) -
     monkeypatch.setenv("ENTERPRISE_POLICY_VERSION", " ")
 
     assert validate_enterprise_runtime_config() == ["missing_policy_version"]
+
+
+def test_enterprise_runtime_config_issue_helpers_are_bounded(monkeypatch) -> None:
+    monkeypatch.setenv("ENTERPRISE_POLICY_VERSION", " ")
+    monkeypatch.setenv("ENTERPRISE_SECRET_ROTATION_DAYS", "0")
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_AUTHZ", "true")
+    monkeypatch.setenv("ENTERPRISE_PRIMARY_KEY_ID", "")
+
+    assert _policy_version_issue() == "missing_policy_version"
+    assert _secret_rotation_issue() == "secret_rotation_days_out_of_range"
+    assert _authz_key_material_issue() == "missing_primary_key_id"
+
+    monkeypatch.setenv("ENTERPRISE_POLICY_VERSION", "1.2.3")
+    monkeypatch.setenv("ENTERPRISE_SECRET_ROTATION_DAYS", "90")
+    monkeypatch.setenv("ENTERPRISE_PRIMARY_KEY_ID", "kid-active")
+
+    assert _policy_version_issue() is None
+    assert _secret_rotation_issue() is None
+    assert _authz_key_material_issue() is None
 
 
 def test_capability_rule_ignores_non_matching_method(monkeypatch) -> None:

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -5,6 +5,7 @@ from src.core.rebalance.intents import (
     _TaxBudgetAccumulator,
     _TaxBudgetLotAllowance,
     _apply_tax_budget_lot_allowance,
+    _available_holding_constraint_applies,
     _clamped_sell_quantity,
     _current_instrument_value_and_unit_value,
     _hifo_sorted_lots,
@@ -21,6 +22,7 @@ from src.core.rebalance.intents import (
     _tax_budget_limited_quantity_from_lots,
     _tax_budget_limited_sell_quantity,
     _tax_budget_sale_allowance,
+    _tax_budget_constraint_applies,
     _trade_notional_threshold,
     generate_intents,
 )
@@ -250,6 +252,37 @@ def test_security_intent_constraints_include_sell_safety_and_tax_budget_labels()
         sell_quantity_before_tax=Decimal("8"),
         tax_awareness_enabled=True,
     ) == ["MIN_NOTIONAL", "AVAILABLE_HOLDING", "TAX_BUDGET"]
+
+
+def test_security_intent_constraint_predicates_are_sell_side_only() -> None:
+    assert _available_holding_constraint_applies(
+        side="SELL",
+        quantity=Decimal("5"),
+        requested_quantity=Decimal("10"),
+    )
+    assert not _available_holding_constraint_applies(
+        side="BUY",
+        quantity=Decimal("5"),
+        requested_quantity=Decimal("10"),
+    )
+    assert _tax_budget_constraint_applies(
+        side="SELL",
+        quantity=Decimal("5"),
+        sell_quantity_before_tax=Decimal("8"),
+        tax_awareness_enabled=True,
+    )
+    assert not _tax_budget_constraint_applies(
+        side="SELL",
+        quantity=Decimal("5"),
+        sell_quantity_before_tax=Decimal("8"),
+        tax_awareness_enabled=False,
+    )
+    assert not _tax_budget_constraint_applies(
+        side="BUY",
+        quantity=Decimal("5"),
+        sell_quantity_before_tax=Decimal("8"),
+        tax_awareness_enabled=True,
+    )
 
 
 def test_suppress_dust_trade_records_below_min_notional_intent() -> None:

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -27,6 +27,9 @@ from src.core.waves.campaign_definition_readiness import (
 )
 from src.core.waves.campaign_operating_queue import (
     DpmBulkReviewCampaignOperatingQueuePage,
+    _attention_queue_reason_codes,
+    _classify_queue_posture,
+    _closed_queue_posture,
     build_bulk_review_campaign_operating_queue_item,
     build_bulk_review_campaign_operating_queue_page,
 )
@@ -325,6 +328,50 @@ def test_campaign_operating_queue_classifies_ready_and_attention_rows() -> None:
     assert attention_item.queue_status == "ATTENTION_REQUIRED"
     assert "BULK_REVIEW_CAMPAIGN_EXPIRED" in attention_item.queue_reason_codes
     assert "NO_OMS_EXECUTION_CLAIM" in attention_item.operating_boundaries
+
+
+def test_campaign_operating_queue_posture_helpers_preserve_precedence() -> None:
+    retired_definition = _definition().model_copy(update={"status": "RETIRED"})
+    retired_discovery = build_bulk_review_campaign_discovery_item(
+        definition=retired_definition,
+        active_on=date(2026, 5, 16),
+    )
+    retired_readiness = build_bulk_review_campaign_definition_preview_readiness(
+        definition=retired_definition,
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+    )
+
+    assert _closed_queue_posture(definition=retired_definition) == (
+        "CLOSED",
+        ["CAMPAIGN_DEFINITION_RETIRED"],
+    )
+    assert _classify_queue_posture(
+        definition=retired_definition,
+        readiness=retired_readiness,
+        discovery=retired_discovery,
+    ) == ("CLOSED", ["CAMPAIGN_DEFINITION_RETIRED"])
+
+
+def test_campaign_operating_queue_attention_reasons_are_deduplicated() -> None:
+    expired_definition = _definition(expires_on="2026-05-01")
+    expired_discovery = build_bulk_review_campaign_discovery_item(
+        definition=expired_definition,
+        active_on=date(2026, 5, 16),
+    )
+    expired_readiness = build_bulk_review_campaign_definition_preview_readiness(
+        definition=expired_definition,
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+    )
+
+    reasons = _attention_queue_reason_codes(
+        readiness=expired_readiness,
+        discovery=expired_discovery,
+    )
+
+    assert reasons.count("CAMPAIGN_DEFINITION_EXPIRED") == 1
+    assert "BULK_REVIEW_CAMPAIGN_EXPIRED" in reasons
 
 
 def test_campaign_operating_queue_page_filters_expired_rows_and_counts_statuses() -> None:


### PR DESCRIPTION
## Summary
- refactor rebalance security intent constraint labelling into named sell-side predicates
- refactor campaign operating queue posture classification into closed-state and attention-reason helpers
- refactor enterprise runtime config validation into bounded issue helpers
- refresh codebase review ledger and quality reports through BACKEND-REVIEW-20260613-843

## Evidence
- python -m ruff check <touched files>
- python -m ruff format --check <touched files>
- python -m mypy --config-file mypy.ini <touched src files>
- python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py
- python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py
- python -m pytest tests/unit/api/test_enterprise_readiness_hardening.py tests/unit/api/test_enterprise_readiness.py
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- python scripts/engineering_health_report.py
- git diff --check
- service leakage scan: no matches
- make check: 2615 passed
- git fetch origin --prune
- git branch -r --no-merged origin/main: only origin/feat/manage-hotspot-hardening-20260613-25
- wiki drift check: DiffCount 0

## Wiki
No wiki source change required. The branch changes internal backend maintainability, tests, review ledger, and repo-local quality evidence only.