### PR TITLE
Refactor command center and OpenAPI hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20871,3 +20871,31 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal command-center supportability
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-845: OpenAPI semantic string example rules
+
+- Date: 2026-06-13
+- Scope: `src/api/openapi_enrichment.py`,
+  `tests/unit/api/test_openapi_enrichment_helpers.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_semantic_string_example_for_key` was the top current source-complexity hotspot after
+  the command-center supportability slice and encoded identifier, currency, timestamp, date,
+  status, and fallback string example semantics as a branch chain.
+- Action: introduced explicit ordered semantic string example rules and separated identifier
+  example generation from rule-based examples while preserving timestamp-before-date precedence
+  and generic string fallback behavior. Added direct tests for rule ordering, identifier examples,
+  rule examples, and no-match behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`,
+  `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal OpenAPI enrichment
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20842,3 +20842,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal enterprise runtime
   security/config maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-844: Command-center supportability source posture helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/mandate_command_center.py`,
+  `tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `command_center_supportability_state` was the top current source-complexity hotspot
+  after the enterprise runtime config slice and mixed empty-run handling, source-readiness
+  precedence, partial-completeness handling, and ready fallback in one helper.
+- Action: extracted named command-center source-readiness normalization, blocking, degradation,
+  and supportability-posture helpers while preserving blocked-before-degraded precedence, partial
+  reason selection, and ready fallback behavior. Added direct tests proving case normalization,
+  blocked/degraded detection, precedence, and ready-source no-op posture.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python -m ruff format --check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/mandate_command_center.py`,
+  `python -m pytest tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal command-center supportability
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:27:50+00:00`
+- Generated at: `2026-06-13T00:39:11+00:00`
 
-- Current ref: `29601cfd`
+- Current ref: `b0b8ccfc`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | command_center_supportability_state | src/api/services/mandate_command_center.py | 8 | 17 |
-| 2 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 3 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 4 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 5 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 6 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 7 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 8 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 9 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
-| 10 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 1 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
+| 2 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 3 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 4 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 5 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 6 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 7 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 8 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 9 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 10 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:39:11+00:00`
+- Generated at: `2026-06-13T00:43:03+00:00`
 
-- Current ref: `b0b8ccfc`
+- Current ref: `36b171a3`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _semantic_string_example_for_key | src/api/openapi_enrichment.py | 8 | 15 |
-| 2 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 3 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 4 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 5 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 6 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 7 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 8 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
-| 9 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
-| 10 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
+| 1 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
+| 2 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 3 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 4 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 5 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 6 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 7 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 8 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 9 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
+| 10 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:27:50+00:00`
+- Generated at: `2026-06-13T00:39:11+00:00`
 
-- Current ref: `29601cfd`
+- Current ref: `b0b8ccfc`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:39:11+00:00`
+- Generated at: `2026-06-13T00:43:03+00:00`
 
-- Current ref: `b0b8ccfc`
+- Current ref: `36b171a3`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:39:11+00:00`
+- Generated at: `2026-06-13T00:43:03+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `b0b8ccfc`
+- Current ref: `36b171a3`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168786 | 168841 | +55 |
-| Test functions | 2439 | 2440 | +1 |
+| Total Python LOC | 168786 | 168889 | +103 |
+| Test functions | 2439 | 2441 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:27:50+00:00`
+- Generated at: `2026-06-13T00:39:11+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `29601cfd`
+- Current ref: `b0b8ccfc`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168607 | 168786 | +179 |
-| Test functions | 2435 | 2439 | +4 |
+| Total Python LOC | 168786 | 168841 | +55 |
+| Test functions | 2439 | 2440 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -42,7 +42,7 @@
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
-| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2263 |
+| 8 | tests/unit/dpm/waves/test_campaign_discovery.py | 2310 |
 | 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/infrastructure/core_sourcing/client.py | 1752 |
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -57,6 +57,15 @@ class _SemanticDescriptionRule:
         return self.template.format(text=context.text)
 
 
+@dataclass(frozen=True)
+class _SemanticStringExampleRule:
+    keyword_terms: tuple[str, ...]
+    example: str
+
+    def matches(self, key: str) -> bool:
+        return any(term in key for term in self.keyword_terms)
+
+
 _SEMANTIC_DESCRIPTION_RULES = (
     _SemanticDescriptionRule(
         ("date",),
@@ -70,6 +79,13 @@ _SEMANTIC_DESCRIPTION_RULES = (
     _SemanticDescriptionRule(("quantity",), (), "Quantity value for {text}."),
     _SemanticDescriptionRule(("rate", "price"), (), "Rate/price value for {text}."),
     _SemanticDescriptionRule(("status",), (), "Current status for {text}."),
+)
+
+_SEMANTIC_STRING_EXAMPLE_RULES = (
+    _SemanticStringExampleRule(("currency",), "USD"),
+    _SemanticStringExampleRule(("time", "timestamp"), "2026-03-02T10:30:00Z"),
+    _SemanticStringExampleRule(("date",), "2026-03-02"),
+    _SemanticStringExampleRule(("status",), "READY"),
 )
 
 
@@ -94,20 +110,32 @@ def _number_example_for_key(key: str) -> float:
 
 
 def _semantic_string_example_for_key(key: str, schema_type: Any) -> str | None:
-    if key.endswith("_id"):
-        entity = key[: -len("_id")]
-        return f"{entity.upper()}_001"
-    if "currency" in key:
-        return "USD"
-    if "time" in key or "timestamp" in key:
-        return "2026-03-02T10:30:00Z"
-    if "date" in key:
-        return "2026-03-02"
-    if "status" in key:
-        return "READY"
+    identifier_example = _semantic_identifier_example(key)
+    if identifier_example is not None:
+        return identifier_example
+
+    rule_example = _semantic_string_rule_example(key)
+    if rule_example is not None:
+        return rule_example
+
     if schema_type == "string":
         return f"sample_{key}"
     return None
+
+
+def _semantic_identifier_example(key: str) -> str | None:
+    if not key.endswith("_id"):
+        return None
+    entity = key[: -len("_id")]
+    return f"{entity.upper()}_001"
+
+
+def _semantic_string_rule_example(key: str) -> str | None:
+    matching_rule = next(
+        (rule for rule in _SEMANTIC_STRING_EXAMPLE_RULES if rule.matches(key)),
+        None,
+    )
+    return matching_rule.example if matching_rule is not None else None
 
 
 def _enum_example(prop_schema: dict[str, Any]) -> tuple[bool, Any]:

--- a/src/api/services/mandate_command_center.py
+++ b/src/api/services/mandate_command_center.py
@@ -15,13 +15,18 @@ from src.core.mandates import (
     MonitoringSeverity,
 )
 
+CommandCenterSupportabilityState = Literal["READY", "PARTIAL", "EMPTY", "DEGRADED", "BLOCKED"]
+CommandCenterSupportabilityPosture = tuple[CommandCenterSupportabilityState, str]
+_BLOCKING_SOURCE_READINESS_STATES = {"INCOMPLETE", "UNAVAILABLE", "BLOCKED"}
+_DEGRADED_SOURCE_READINESS_STATES = {"DEGRADED", "STALE"}
+
 
 @dataclass(frozen=True)
 class _CommandCenterReadModel:
     health_distribution: dict[str, int]
     partial_reasons: list[str]
     completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"]
-    supportability_state: Literal["READY", "PARTIAL", "EMPTY", "DEGRADED", "BLOCKED"]
+    supportability_state: CommandCenterSupportabilityState
     supportability_reason: str
 
 
@@ -30,18 +35,42 @@ def command_center_supportability_state(
     latest_run: DpmMonitoringRun | None,
     completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"],
     partial_reasons: list[str],
-) -> tuple[Literal["READY", "PARTIAL", "EMPTY", "DEGRADED", "BLOCKED"], str]:
+) -> CommandCenterSupportabilityPosture:
     if latest_run is None or completeness == "EMPTY":
         return "EMPTY", "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
 
-    source_states = {state.upper() for state in latest_run.source_readiness_summary}
-    if source_states.intersection({"INCOMPLETE", "UNAVAILABLE", "BLOCKED"}):
-        return "BLOCKED", "COMMAND_CENTER_SOURCE_READINESS_BLOCKED"
-    if source_states.intersection({"DEGRADED", "STALE"}):
-        return "DEGRADED", "COMMAND_CENTER_SOURCE_READINESS_DEGRADED"
+    source_posture = _source_readiness_supportability_posture(
+        source_readiness_summary=latest_run.source_readiness_summary
+    )
+    if source_posture is not None:
+        return source_posture
     if completeness == "PARTIAL" or partial_reasons:
         return "PARTIAL", partial_reasons[0] if partial_reasons else "COMMAND_CENTER_PARTIAL"
     return "READY", "COMMAND_CENTER_READY"
+
+
+def _source_readiness_supportability_posture(
+    *,
+    source_readiness_summary: dict[str, int],
+) -> CommandCenterSupportabilityPosture | None:
+    source_states = _normalized_source_readiness_states(source_readiness_summary)
+    if _source_readiness_blocks_command_center(source_states):
+        return "BLOCKED", "COMMAND_CENTER_SOURCE_READINESS_BLOCKED"
+    if _source_readiness_degrades_command_center(source_states):
+        return "DEGRADED", "COMMAND_CENTER_SOURCE_READINESS_DEGRADED"
+    return None
+
+
+def _normalized_source_readiness_states(source_readiness_summary: dict[str, int]) -> set[str]:
+    return {state.upper() for state in source_readiness_summary}
+
+
+def _source_readiness_blocks_command_center(source_states: set[str]) -> bool:
+    return bool(source_states.intersection(_BLOCKING_SOURCE_READINESS_STATES))
+
+
+def _source_readiness_degrades_command_center(source_states: set[str]) -> bool:
+    return bool(source_states.intersection(_DEGRADED_SOURCE_READINESS_STATES))
 
 
 def run_matches_command_center_filters(

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -30,8 +30,11 @@ from src.api.openapi_enrichment import (
     _schema_path_methods,
     _schema_type_example,
     _SEMANTIC_DESCRIPTION_RULES,
+    _SEMANTIC_STRING_EXAMPLE_RULES,
     _semantic_description_for_context,
+    _semantic_identifier_example,
     _semantic_string_example_for_key,
+    _semantic_string_rule_example,
     enrich_openapi_schema,
 )
 
@@ -126,6 +129,23 @@ def test_openapi_enrichment_semantic_string_examples_follow_domain_semantics() -
     assert _semantic_string_example_for_key("workflow_status", "string") == "READY"
     assert _semantic_string_example_for_key("display_name", "string") == "sample_display_name"
     assert _semantic_string_example_for_key("unknown", None) is None
+
+
+def test_openapi_enrichment_semantic_string_rules_preserve_precedence() -> None:
+    rule_examples = [rule.example for rule in _SEMANTIC_STRING_EXAMPLE_RULES]
+
+    assert rule_examples == [
+        "USD",
+        "2026-03-02T10:30:00Z",
+        "2026-03-02",
+        "READY",
+    ]
+    assert _semantic_identifier_example("custom_id") == "CUSTOM_001"
+    assert _semantic_identifier_example("status") is None
+    assert _semantic_string_rule_example("updated_timestamp") == "2026-03-02T10:30:00Z"
+    assert _semantic_string_rule_example("as_of_date") == "2026-03-02"
+    assert _semantic_string_rule_example("workflow_status") == "READY"
+    assert _semantic_string_rule_example("display_name") is None
 
 
 def test_openapi_enrichment_infer_example_helpers_separate_schema_concerns() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_command_center.py
+++ b/tests/unit/dpm/mandates/test_mandate_command_center.py
@@ -1,6 +1,10 @@
 from datetime import date, datetime, timezone
 
 from src.api.services.mandate_command_center import (
+    _normalized_source_readiness_states,
+    _source_readiness_blocks_command_center,
+    _source_readiness_degrades_command_center,
+    _source_readiness_supportability_posture,
     attention_buckets,
     build_command_center_summary,
     command_center_completeness,
@@ -94,6 +98,28 @@ def test_command_center_supportability_state_maps_empty_and_source_postures() ->
         completeness="COMPLETE",
         partial_reasons=[],
     ) == ("READY", "COMMAND_CENTER_READY")
+
+
+def test_command_center_source_readiness_helpers_preserve_precedence() -> None:
+    source_states = _normalized_source_readiness_states(
+        {
+            "ready": 2,
+            "blocked": 1,
+            "stale": 1,
+        }
+    )
+
+    assert source_states == {"READY", "BLOCKED", "STALE"}
+    assert _source_readiness_blocks_command_center(source_states)
+    assert _source_readiness_degrades_command_center(source_states)
+    assert _source_readiness_supportability_posture(
+        source_readiness_summary={"STALE": 1, "BLOCKED": 1}
+    ) == ("BLOCKED", "COMMAND_CENTER_SOURCE_READINESS_BLOCKED")
+    assert _source_readiness_supportability_posture(source_readiness_summary={"STALE": 1}) == (
+        "DEGRADED",
+        "COMMAND_CENTER_SOURCE_READINESS_DEGRADED",
+    )
+    assert _source_readiness_supportability_posture(source_readiness_summary={"READY": 2}) is None
 
 
 def test_run_matches_command_center_filters_uses_bounded_filter_values() -> None:


### PR DESCRIPTION
## Summary
- refactor command-center supportability source-readiness classification into named posture helpers
- refactor OpenAPI semantic string example inference into explicit ordered rules
- refresh codebase review ledger through BACKEND-REVIEW-20260613-845 and quality reports

## Evidence
- python -m ruff check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py
- python -m ruff format --check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py
- python -m mypy --config-file mypy.ini src/api/services/mandate_command_center.py
- python -m pytest tests/unit/dpm/mandates/test_mandate_command_center.py
- python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py
- python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py
- python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py
- python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- python scripts/engineering_health_report.py
- git diff --check
- service leakage scan: no matches
- make check: 2617 passed
- git fetch origin --prune
- git branch -r --no-merged origin/main: only origin/feat/manage-hotspot-hardening-20260613-26
- wiki drift check: DiffCount 0

## Quality Movement
- `command_center_supportability_state` dropped out of the current source hotspot list
- `_semantic_string_example_for_key` dropped out of the current source hotspot list

## Wiki
No wiki source change required. This is internal backend maintainability refactoring plus tests, ledger, and repo-local quality evidence only.