### PR TITLE
Harden manage backend hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20929,3 +20929,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal PM operating-quality model
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-847: Persistence-profile guardrail error helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/persistence_profile.py`, `tests/unit/api/test_persistence_profile.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `validate_persistence_profile_guardrails` was the top current source-complexity hotspot
+  after the PM-quality policy validation slice and mixed production-profile branching, DPM
+  supportability-store checks, policy-pack catalog backend requirements, and explicit DSN
+  requirements in one API supportability guardrail.
+- Action: extracted explicit guardrail-error helpers for production persistence profile validation
+  and policy-pack catalog enforcement while preserving existing fail-fast error precedence and
+  runtime error strings. Added focused tests for policy-pack enablement flags plus the previously
+  uncovered DPM Postgres DSN and policy-pack Postgres DSN failure paths.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/persistence_profile.py tests/unit/api/test_persistence_profile.py`,
+  `python -m ruff format --check src/api/persistence_profile.py tests/unit/api/test_persistence_profile.py`,
+  `python -m mypy --config-file mypy.ini src/api/persistence_profile.py`,
+  `python -m pytest tests/unit/api/test_persistence_profile.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal production persistence-profile
+  guardrail maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20958,3 +20958,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal production persistence-profile
   guardrail maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-848: Rolling risk window selection helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/risk_sources.py`,
+  `tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_rolling_window_result` was the top current source-complexity hotspot after the
+  persistence-profile guardrail slice and mixed missing-window fallback, requested-window
+  matching, resolved-window normalization, and no-match fallback in one helper.
+- Action: extracted rolling-window match and fallback normalization helpers while preserving
+  existing source-owned payload behavior and source-id window labeling semantics. Added a focused
+  edge test proving a selected source window without declared `window_length` remains labeled as
+  `unknown`.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`,
+  `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal risk-source adapter
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20899,3 +20899,33 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal OpenAPI enrichment
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-846: PM quality policy validation guard helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/pm_quality/models.py`,
+  `tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `validate_policy` was the top current source-complexity hotspot after the OpenAPI
+  semantic example rules slice and mixed threshold ordering, enabled-policy evidence,
+  governance-approval requirements, duplicate-indicator rejection, and prohibited-use checks in
+  one model validator.
+- Action: extracted named PM-quality policy guard helpers for threshold ordering,
+  enabled-policy evidence, unique indicators, and permitted uses while preserving the public
+  Pydantic validation contract. Added focused model tests proving normalized prohibited-use
+  rejection and enabled-policy governance-approval fail-closed behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/pm_quality/models.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m ruff format --check src/core/pm_quality/models.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m mypy --config-file mypy.ini src/core/pm_quality/models.py`,
+  `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal PM operating-quality model
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:55:06+00:00`
+- Generated at: `2026-06-13T00:57:53+00:00`
 
-- Current ref: `1c52d1f4`
+- Current ref: `61127b34`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 2 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 3 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 4 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 5 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 6 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
-| 7 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
-| 8 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
-| 9 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
-| 10 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
+| 1 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 2 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 3 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 4 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 5 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 6 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 7 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
+| 8 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
+| 9 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
+| 10 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:57:53+00:00`
+- Generated at: `2026-06-13T01:00:56+00:00`
 
-- Current ref: `61127b34`
+- Current ref: `d6fe4656`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 2 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 3 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 4 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 5 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
-| 6 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
-| 7 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
-| 8 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
-| 9 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
-| 10 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
+| 1 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 2 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 3 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 4 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 5 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 6 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
+| 7 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
+| 8 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
+| 9 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
+| 10 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T00:43:03+00:00`
+- Generated at: `2026-06-13T00:55:06+00:00`
 
-- Current ref: `36b171a3`
+- Current ref: `1c52d1f4`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | validate_policy | src/core/pm_quality/models.py | 8 | 15 |
-| 2 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
-| 3 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
-| 4 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 5 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 6 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 7 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
-| 8 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
-| 9 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
-| 10 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
+| 1 | validate_persistence_profile_guardrails | src/api/persistence_profile.py | 8 | 14 |
+| 2 | _rolling_window_result | src/core/outcomes/risk_sources.py | 8 | 14 |
+| 3 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
+| 4 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 5 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 6 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 7 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 8 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
+| 9 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
+| 10 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:55:06+00:00`
+- Generated at: `2026-06-13T00:57:53+00:00`
 
-- Current ref: `1c52d1f4`
+- Current ref: `61127b34`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:57:53+00:00`
+- Generated at: `2026-06-13T01:00:56+00:00`
 
-- Current ref: `61127b34`
+- Current ref: `d6fe4656`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T00:43:03+00:00`
+- Generated at: `2026-06-13T00:55:06+00:00`
 
-- Current ref: `36b171a3`
+- Current ref: `1c52d1f4`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:57:53+00:00`
+- Generated at: `2026-06-13T01:00:56+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `61127b34`
+- Current ref: `d6fe4656`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168889 | 168997 | +108 |
+| Total Python LOC | 168889 | 169020 | +131 |
 | Test functions | 2441 | 2444 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:55:06+00:00`
+- Generated at: `2026-06-13T00:57:53+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `1c52d1f4`
+- Current ref: `61127b34`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168889 | 168948 | +59 |
-| Test functions | 2441 | 2441 | +0 |
+| Total Python LOC | 168889 | 168997 | +108 |
+| Test functions | 2441 | 2444 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T00:43:03+00:00`
+- Generated at: `2026-06-13T00:55:06+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `36b171a3`
+- Current ref: `1c52d1f4`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168786 | 168889 | +103 |
-| Test functions | 2439 | 2441 | +2 |
+| Total Python LOC | 168889 | 168948 | +59 |
+| Test functions | 2441 | 2441 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/persistence_profile.py
+++ b/src/api/persistence_profile.py
@@ -28,17 +28,27 @@ def policy_pack_catalog_required_in_profile() -> bool:
 def validate_persistence_profile_guardrails() -> None:
     if app_persistence_profile_name() != _PRODUCTION_PROFILE:
         return
+    guardrail_error = _persistence_profile_guardrail_error()
+    if guardrail_error is not None:
+        raise RuntimeError(guardrail_error)
+
+
+def _persistence_profile_guardrail_error() -> str | None:
     if supportability_store_backend_name() != "POSTGRES":
-        raise RuntimeError("PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES")
+        return "PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES"
     if not supportability_postgres_dsn():
-        raise RuntimeError("PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES_DSN")
-    if (
-        policy_pack_catalog_required_in_profile()
-        and policy_pack_catalog_backend_name() != "POSTGRES"
-    ):
-        raise RuntimeError("PERSISTENCE_PROFILE_REQUIRES_POLICY_PACK_POSTGRES")
-    if policy_pack_catalog_required_in_profile() and not _explicit_policy_pack_postgres_dsn():
-        raise RuntimeError("PERSISTENCE_PROFILE_REQUIRES_POLICY_PACK_POSTGRES_DSN")
+        return "PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES_DSN"
+    return _policy_pack_catalog_guardrail_error(required=policy_pack_catalog_required_in_profile())
+
+
+def _policy_pack_catalog_guardrail_error(*, required: bool) -> str | None:
+    if not required:
+        return None
+    if policy_pack_catalog_backend_name() != "POSTGRES":
+        return "PERSISTENCE_PROFILE_REQUIRES_POLICY_PACK_POSTGRES"
+    if not _explicit_policy_pack_postgres_dsn():
+        return "PERSISTENCE_PROFILE_REQUIRES_POLICY_PACK_POSTGRES_DSN"
+    return None
 
 
 def _env_flag(name: str, default: bool) -> bool:

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -584,13 +584,32 @@ def _rolling_window_result(
 ) -> tuple[dict[str, Any], int | str]:
     window_results = period_result.get("window_results")
     if not isinstance(window_results, list):
-        return {}, window_length or "unknown"
+        return {}, _fallback_requested_window(window_length)
     for window_result in window_results:
         window_mapping = _read_mapping(window_result)
         resolved_window = window_mapping.get("window_length")
-        if window_length is None or resolved_window == window_length:
-            return window_mapping, resolved_window if resolved_window is not None else "unknown"
-    return {}, window_length or "unknown"
+        if _rolling_window_matches_request(
+            resolved_window=resolved_window,
+            requested_window=window_length,
+        ):
+            return window_mapping, _resolved_window_length(resolved_window)
+    return {}, _fallback_requested_window(window_length)
+
+
+def _rolling_window_matches_request(
+    *,
+    resolved_window: object,
+    requested_window: int | None,
+) -> bool:
+    return requested_window is None or resolved_window == requested_window
+
+
+def _fallback_requested_window(window_length: int | None) -> int | str:
+    return window_length or "unknown"
+
+
+def _resolved_window_length(window_length: Any) -> int | str:
+    return window_length if window_length is not None else "unknown"
 
 
 def _rolling_context_reason(

--- a/src/core/pm_quality/models.py
+++ b/src/core/pm_quality/models.py
@@ -67,6 +67,46 @@ PmQualitySummaryInvocationState = Literal[
     "FAILED",
 ]
 
+_PM_QUALITY_FORBIDDEN_POLICY_USES = {
+    "compensation",
+    "hr",
+    "conduct_enforcement",
+    "autonomous_decisioning",
+}
+
+
+def _ensure_policy_threshold_order(
+    *,
+    ready_threshold: Decimal,
+    watch_threshold: Decimal,
+) -> None:
+    if ready_threshold < watch_threshold:
+        raise ValueError("ready_threshold must be greater than or equal to watch_threshold")
+
+
+def _ensure_enabled_policy_has_required_evidence(
+    *,
+    enabled: bool,
+    weights: list["DpmPmQualityWeight"],
+    governance_approval: "DpmPmQualityGovernanceApproval | None",
+) -> None:
+    if enabled and not weights:
+        raise ValueError("enabled PM quality policies require at least one configured weight")
+    if enabled and governance_approval is None:
+        raise ValueError("PM_QUALITY_GOVERNANCE_APPROVAL_REQUIRED")
+
+
+def _ensure_policy_indicators_are_unique(weights: list["DpmPmQualityWeight"]) -> None:
+    indicators = [weight.indicator for weight in weights]
+    if len(set(indicators)) != len(indicators):
+        raise ValueError("PM quality policy indicators must be unique")
+
+
+def _ensure_policy_uses_are_permitted(allowed_uses: list[str]) -> None:
+    normalized_uses = {use.strip().lower() for use in allowed_uses}
+    if normalized_uses & _PM_QUALITY_FORBIDDEN_POLICY_USES:
+        raise ValueError("PM quality policy contains a prohibited use")
+
 
 class DpmPmQualityWeight(BaseModel):
     """One configured scoring dimension for PM operating quality."""
@@ -246,19 +286,17 @@ class DpmPmOperatingQualityPolicy(BaseModel):
 
     @model_validator(mode="after")
     def validate_policy(self) -> "DpmPmOperatingQualityPolicy":
-        if self.ready_threshold < self.watch_threshold:
-            raise ValueError("ready_threshold must be greater than or equal to watch_threshold")
-        if self.enabled and not self.weights:
-            raise ValueError("enabled PM quality policies require at least one configured weight")
-        if self.enabled and self.governance_approval is None:
-            raise ValueError("PM_QUALITY_GOVERNANCE_APPROVAL_REQUIRED")
-        indicators = [weight.indicator for weight in self.weights]
-        if len(set(indicators)) != len(indicators):
-            raise ValueError("PM quality policy indicators must be unique")
-        forbidden = {"compensation", "hr", "conduct_enforcement", "autonomous_decisioning"}
-        normalized_uses = {use.strip().lower() for use in self.allowed_uses}
-        if normalized_uses & forbidden:
-            raise ValueError("PM quality policy contains a prohibited use")
+        _ensure_policy_threshold_order(
+            ready_threshold=self.ready_threshold,
+            watch_threshold=self.watch_threshold,
+        )
+        _ensure_enabled_policy_has_required_evidence(
+            enabled=self.enabled,
+            weights=self.weights,
+            governance_approval=self.governance_approval,
+        )
+        _ensure_policy_indicators_are_unique(self.weights)
+        _ensure_policy_uses_are_permitted(self.allowed_uses)
         return self
 
 

--- a/tests/unit/api/test_persistence_profile.py
+++ b/tests/unit/api/test_persistence_profile.py
@@ -17,6 +17,17 @@ def test_policy_pack_catalog_required_in_profile() -> None:
     assert profile.policy_pack_catalog_required_in_profile() is False
 
 
+def test_policy_pack_catalog_required_when_runtime_or_admin_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DPM_POLICY_PACKS_ENABLED", "true")
+    assert profile.policy_pack_catalog_required_in_profile() is True
+
+    monkeypatch.setenv("DPM_POLICY_PACKS_ENABLED", "false")
+    monkeypatch.setenv("DPM_POLICY_PACK_ADMIN_APIS_ENABLED", "on")
+    assert profile.policy_pack_catalog_required_in_profile() is True
+
+
 def test_validate_persistence_profile_noop_for_local(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -34,6 +45,17 @@ def test_validate_persistence_profile_requires_dpm_postgres(
         profile.validate_persistence_profile_guardrails()
 
 
+def test_validate_persistence_profile_requires_dpm_postgres_dsn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_PERSISTENCE_PROFILE", "PRODUCTION")
+    monkeypatch.setattr(profile, "supportability_store_backend_name", lambda: "POSTGRES")
+    monkeypatch.setattr(profile, "supportability_postgres_dsn", lambda: "")
+
+    with pytest.raises(RuntimeError, match="PERSISTENCE_PROFILE_REQUIRES_DPM_POSTGRES_DSN"):
+        profile.validate_persistence_profile_guardrails()
+
+
 def test_validate_persistence_profile_requires_policy_pack_postgres_when_enabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -44,6 +66,23 @@ def test_validate_persistence_profile_requires_policy_pack_postgres_when_enabled
     monkeypatch.setattr(profile, "policy_pack_catalog_backend_name", lambda: "ENV_JSON")
 
     with pytest.raises(RuntimeError, match="PERSISTENCE_PROFILE_REQUIRES_POLICY_PACK_POSTGRES"):
+        profile.validate_persistence_profile_guardrails()
+
+
+def test_validate_persistence_profile_requires_policy_pack_postgres_dsn_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("APP_PERSISTENCE_PROFILE", "PRODUCTION")
+    monkeypatch.setenv("DPM_POLICY_PACKS_ENABLED", "true")
+    monkeypatch.delenv("DPM_POLICY_PACK_POSTGRES_DSN", raising=False)
+    monkeypatch.setattr(profile, "supportability_store_backend_name", lambda: "POSTGRES")
+    monkeypatch.setattr(profile, "supportability_postgres_dsn", lambda: "postgresql://dpm")
+    monkeypatch.setattr(profile, "policy_pack_catalog_backend_name", lambda: "POSTGRES")
+
+    with pytest.raises(
+        RuntimeError,
+        match="PERSISTENCE_PROFILE_REQUIRES_POLICY_PACK_POSTGRES_DSN",
+    ):
         profile.validate_persistence_profile_guardrails()
 
 

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -1437,6 +1437,10 @@ def test_concentration_drawdown_and_rolling_posture_edges_are_source_safe() -> N
 def test_rolling_and_historical_attribution_helper_edges_are_explicit() -> None:
     assert _rolling_window_result(period_result={}, window_length=None) == ({}, "unknown")
     assert _rolling_window_result(
+        period_result={"window_results": [{"value": "latest"}]},
+        window_length=None,
+    ) == ({"value": "latest"}, "unknown")
+    assert _rolling_window_result(
         period_result={"window_results": [{"window_length": 63, "value": "old"}]},
         window_length=126,
     ) == ({}, 126)

--- a/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
+++ b/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
@@ -745,6 +745,17 @@ def test_pm_operating_quality_policy_rejects_prohibited_uses_and_date_mismatch()
             governance_approval=_governance_approval(),
             allowed_uses=["portfolio_management_review", "compensation"],
         )
+    with pytest.raises(ValueError, match="prohibited use"):
+        DpmPmOperatingQualityPolicy(
+            policy_id="pmq_bad_normalized_use",
+            policy_version="2026.05",
+            enabled=True,
+            as_of_date="2026-05-12",
+            access_purpose="SUPERVISORY_CONTROL_REVIEW",
+            weights=[DpmPmQualityWeight(indicator="OUTCOME_DISCIPLINE", weight=Decimal("100"))],
+            governance_approval=_governance_approval(),
+            allowed_uses=["portfolio_management_review", " HR "],
+        )
 
 
 def test_pm_quality_scope_policy_models_reject_unproven_or_invalid_scope() -> None:
@@ -819,6 +830,16 @@ def test_pm_quality_policy_model_rejects_threshold_weight_and_indicator_edges() 
             access_purpose="SUPERVISORY_CONTROL_REVIEW",
             weights=[],
             governance_approval=_governance_approval(),
+        )
+    with pytest.raises(ValueError, match="PM_QUALITY_GOVERNANCE_APPROVAL_REQUIRED"):
+        DpmPmOperatingQualityPolicy(
+            policy_id="pmq_missing_governance",
+            policy_version="2026.05",
+            enabled=True,
+            as_of_date="2026-05-12",
+            access_purpose="SUPERVISORY_CONTROL_REVIEW",
+            weights=[DpmPmQualityWeight(indicator="OUTCOME_DISCIPLINE", weight=Decimal("100"))],
+            governance_approval=None,
         )
     with pytest.raises(ValueError, match="indicators must be unique"):
         DpmPmOperatingQualityPolicy(


### PR DESCRIPTION
## Summary
- extracted PM operating-quality policy validation guard helpers and added fail-closed model edge coverage
- extracted production persistence-profile guardrail error helpers and added missing DSN/enablement coverage
- extracted rolling risk window selection helpers and added source-owned unknown-window edge coverage
- refreshed codebase review ledger through BACKEND-REVIEW-20260613-848 and quality reports

## Evidence
- `python -m ruff check src/core/pm_quality/models.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`
- `python -m ruff format --check src/core/pm_quality/models.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`
- `python -m mypy --config-file mypy.ini src/core/pm_quality/models.py`
- `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py` -> 24 passed
- `python -m ruff check src/api/persistence_profile.py tests/unit/api/test_persistence_profile.py`
- `python -m ruff format --check src/api/persistence_profile.py tests/unit/api/test_persistence_profile.py`
- `python -m mypy --config-file mypy.ini src/api/persistence_profile.py`
- `python -m pytest tests/unit/api/test_persistence_profile.py` -> 10 passed
- `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`
- `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`
- `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`
- `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py` -> 53 passed
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/engineering_health_report.py` plus `git restore quality/baseline_report.md`
- `git diff --check`
- service leakage scan: no matches
- `make check` -> 2607 passed, 13 skipped
- `git fetch origin --prune; git branch -r --no-merged origin/main` -> no unmerged remote branches
- wiki drift check -> DiffCount 0
- open PR check before branch push -> none
- server-side origin heads before branch push -> only main

## Governance
- Domain API / backend maintainability slice.
- No README/wiki/operator truth changed; ledger records no-wiki-change decisions for all three slices.
- Complexity report now removes `validate_policy`, `validate_persistence_profile_guardrails`, and `_rolling_window_result` from the current source hotspot table.