### PR TITLE
Harden manage backend source hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21016,3 +21016,31 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal mandate supportability repository
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-850: Rebalance final gate status resolution helper
+
+- Date: 2026-06-13
+- Scope: `src/core/rebalance/engine.py`,
+  `tests/unit/dpm/engine/test_engine_wrapper_helpers.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `run_simulation` was the top current source-complexity hotspot after the mandate
+  monitoring exception filter slice and carried the final target-generation versus execution
+  status reconciliation inline inside the broader rebalance orchestration.
+- Action: extracted a named final gate status resolver that preserves the existing rule where a
+  target-generation `PENDING_REVIEW` posture promotes an otherwise `READY` execution result, while
+  preserving execution `BLOCKED` dominance. Added direct helper tests for review promotion,
+  blocked preservation, and ready passthrough.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/engine.py tests/unit/dpm/engine/test_engine_wrapper_helpers.py tests/unit/dpm/engine/coverage/test_engine_status_blocking.py`,
+  `python -m ruff format --check src/core/rebalance/engine.py tests/unit/dpm/engine/test_engine_wrapper_helpers.py tests/unit/dpm/engine/coverage/test_engine_status_blocking.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/engine.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_wrapper_helpers.py tests/unit/dpm/engine/coverage/test_engine_status_blocking.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal rebalance orchestration
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -20987,3 +20987,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal risk-source adapter
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-849: Mandate monitoring exception filter predicate
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/mandates/in_memory.py`,
+  `tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `_monitoring_exception_matches` was the top current source-complexity hotspot after the
+  rolling risk window selection slice and repeated nullable equality logic for monitoring-run,
+  mandate, portfolio, and exception-state filters.
+- Action: extracted a generic nullable filter matcher and rewired the monitoring exception
+  predicate through that helper while preserving filtering, sorting, pagination, and repository
+  behavior. Added direct predicate coverage for wildcard filtering and mismatched monitoring-run
+  rejection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python -m ruff format --check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/mandates/in_memory.py`,
+  `python -m pytest tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal mandate supportability repository
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21044,3 +21044,31 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal rebalance orchestration
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-851: Historical risk attribution source identity helper
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/risk_sources.py`,
+  `tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `realized_historical_attribution_source_from_attribution_response` was the top current
+  source-complexity hotspot after the rebalance final gate status slice and assembled aggregate
+  versus contributor historical attribution source identity inline inside the source adapter.
+- Action: extracted a named historical attribution source-id helper while preserving source-owned
+  aggregate and contributor identity shape. Added direct helper coverage for both aggregate
+  attribution source IDs and contributor group source IDs.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`,
+  `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal risk-source adapter
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T01:15:01+00:00`
+- Generated at: `2026-06-13T01:18:08+00:00`
 
-- Current ref: `b3cb44ec`
+- Current ref: `088fbb1c`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 2 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
-| 3 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
-| 4 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
-| 5 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
-| 6 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
-| 7 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
-| 8 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
-| 9 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
-| 10 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
+| 1 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 2 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 3 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
+| 4 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
+| 5 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
+| 6 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
+| 7 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
+| 8 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
+| 9 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
+| 10 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T01:00:56+00:00`
+- Generated at: `2026-06-13T01:11:38+00:00`
 
-- Current ref: `d6fe4656`
+- Current ref: `5e52701a`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _monitoring_exception_matches | src/infrastructure/mandates/in_memory.py | 8 | 14 |
-| 2 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 3 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 4 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
-| 5 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
-| 6 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
-| 7 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
-| 8 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
-| 9 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
-| 10 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
+| 1 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
+| 2 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 3 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 4 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 5 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
+| 6 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
+| 7 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
+| 8 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
+| 9 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
+| 10 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T01:11:38+00:00`
+- Generated at: `2026-06-13T01:15:01+00:00`
 
-- Current ref: `5e52701a`
+- Current ref: `b3cb44ec`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | run_simulation | src/core/rebalance/engine.py | 7 | 144 |
-| 2 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
-| 3 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
-| 4 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
-| 5 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
-| 6 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
-| 7 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
-| 8 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
-| 9 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
-| 10 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
+| 1 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 7 | 88 |
+| 2 | generate_targets_solver | src/core/target_generation.py | 7 | 85 |
+| 3 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 7 | 77 |
+| 4 | generate_proof_pack | src/api/routers/proof_pack_generate_routes.py | 7 | 76 |
+| 5 | _regime_stress_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 73 |
+| 6 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
+| 7 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
+| 8 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
+| 9 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
+| 10 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T01:15:01+00:00`
+- Generated at: `2026-06-13T01:18:08+00:00`
 
-- Current ref: `b3cb44ec`
+- Current ref: `088fbb1c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T01:11:38+00:00`
+- Generated at: `2026-06-13T01:15:01+00:00`
 
-- Current ref: `5e52701a`
+- Current ref: `b3cb44ec`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T01:00:56+00:00`
+- Generated at: `2026-06-13T01:11:38+00:00`
 
-- Current ref: `d6fe4656`
+- Current ref: `5e52701a`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T01:11:38+00:00`
+- Generated at: `2026-06-13T01:15:01+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `5e52701a`
+- Current ref: `b3cb44ec`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 169020 | 169038 | +18 |
-| Test functions | 2444 | 2444 | +0 |
+| Total Python LOC | 169020 | 169073 | +53 |
+| Test functions | 2444 | 2445 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T01:15:01+00:00`
+- Generated at: `2026-06-13T01:18:08+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `b3cb44ec`
+- Current ref: `088fbb1c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 169020 | 169073 | +53 |
+| Total Python LOC | 169020 | 169119 | +99 |
 | Test functions | 2444 | 2445 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T01:00:56+00:00`
+- Generated at: `2026-06-13T01:11:38+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `d6fe4656`
+- Current ref: `5e52701a`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 168889 | 169020 | +131 |
-| Test functions | 2441 | 2444 | +3 |
+| Total Python LOC | 169020 | 169038 | +18 |
+| Test functions | 2444 | 2444 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -355,23 +355,20 @@ def realized_historical_attribution_source_from_attribution_response(
         )
 
     input_mode = _read_text(response.get("input_mode")) or "unknown"
-    source_id_parts = [
-        request_fingerprint,
-        period,
-        "historical-attribution",
-        attribution_type,
-        metric,
-        grouping_dimension,
-        measure,
-    ]
-    if contributor_group_key is not None:
-        source_id_parts.append(contributor_group_key)
 
     return DpmRealizedSourceSnapshot(
         dimension="RISK_REDUCTION",
         source_system="lotus-risk",
         source_type="HISTORICAL_RISK_ATTRIBUTION",
-        source_id=":".join(source_id_parts),
+        source_id=_historical_attribution_source_id(
+            request_fingerprint=request_fingerprint,
+            period=period,
+            attribution_type=attribution_type,
+            metric=metric,
+            grouping_dimension=grouping_dimension,
+            measure=measure,
+            contributor_group_key=contributor_group_key,
+        ),
         value=value if source_state != "NOT_SUPPORTED" else None,
         unit="ratio",
         source_state=source_state,
@@ -594,6 +591,30 @@ def _rolling_window_result(
         ):
             return window_mapping, _resolved_window_length(resolved_window)
     return {}, _fallback_requested_window(window_length)
+
+
+def _historical_attribution_source_id(
+    *,
+    request_fingerprint: str,
+    period: str,
+    attribution_type: str,
+    metric: str,
+    grouping_dimension: str,
+    measure: HistoricalAttributionOutcomeMeasure,
+    contributor_group_key: str | None,
+) -> str:
+    source_id_parts = [
+        request_fingerprint,
+        period,
+        "historical-attribution",
+        attribution_type,
+        metric,
+        grouping_dimension,
+        measure,
+    ]
+    if contributor_group_key is not None:
+        source_id_parts.append(contributor_group_key)
+    return ":".join(source_id_parts)
 
 
 def _rolling_window_matches_request(

--- a/src/core/rebalance/engine.py
+++ b/src/core/rebalance/engine.py
@@ -331,6 +331,16 @@ def _check_blocking_dq(dq_log: dict[str, list[str]], options: EngineOptions) -> 
     return check_blocking_dq_impl(dq_log, options)
 
 
+def _resolve_final_gate_status(
+    *,
+    target_status: str,
+    execution_status: Literal["READY", "BLOCKED", "PENDING_REVIEW"],
+) -> Literal["READY", "BLOCKED", "PENDING_REVIEW"]:
+    if target_status == "PENDING_REVIEW" and execution_status == "READY":
+        return "PENDING_REVIEW"
+    return execution_status
+
+
 def run_simulation(
     portfolio: PortfolioSnapshot,
     market_data: MarketDataSnapshot,
@@ -426,9 +436,10 @@ def run_simulation(
         portfolio, market_data, shelf, security_intents, options, tv, diag_data
     )
 
-    if s3_stat == "PENDING_REVIEW" and f_stat == "READY":
-        f_stat = "PENDING_REVIEW"
-    gate_status: Literal["READY", "BLOCKED", "PENDING_REVIEW"] = f_stat
+    gate_status = _resolve_final_gate_status(
+        target_status=s3_stat,
+        execution_status=f_stat,
+    )
     gate_decision = None
     if options.enable_workflow_gates:
         gate_decision = evaluate_gate_decision(

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -241,11 +241,15 @@ def _monitoring_exception_matches(
     state: Optional[str],
 ) -> bool:
     return (
-        (monitoring_run_id is None or row.monitoring_run_id == monitoring_run_id)
-        and (mandate_id is None or row.mandate_id == mandate_id)
-        and (portfolio_id is None or row.portfolio_id == portfolio_id)
-        and (state is None or row.state == state)
+        _matches_optional_filter(row.monitoring_run_id, monitoring_run_id)
+        and _matches_optional_filter(row.mandate_id, mandate_id)
+        and _matches_optional_filter(row.portfolio_id, portfolio_id)
+        and _matches_optional_filter(row.state, state)
     )
+
+
+def _matches_optional_filter(value: object, expected: object | None) -> bool:
+    return expected is None or value == expected
 
 
 def _monitoring_exception_page(

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -20,6 +20,7 @@ from src.core.outcomes.risk_sources import (
     _drawdown_source_posture,
     _historical_attribution_contributor,
     _historical_attribution_set,
+    _historical_attribution_source_id,
     _historical_attribution_source_posture,
     _historical_attribution_value,
     _metric_unit,
@@ -1462,6 +1463,30 @@ def test_rolling_and_historical_attribution_helper_edges_are_explicit() -> None:
     )
     assert (
         _historical_attribution_contributor(attribution_set={}, contributor_group_key="TECH") == {}
+    )
+    assert (
+        _historical_attribution_source_id(
+            request_fingerprint="sha256:hist-attr",
+            period="YTD",
+            attribution_type="ACTIVE_RISK",
+            metric="TRACKING_ERROR",
+            grouping_dimension="SECTOR",
+            measure="total_value",
+            contributor_group_key=None,
+        )
+        == "sha256:hist-attr:YTD:historical-attribution:ACTIVE_RISK:TRACKING_ERROR:SECTOR:total_value"
+    )
+    assert _historical_attribution_source_id(
+        request_fingerprint="sha256:hist-attr",
+        period="YTD",
+        attribution_type="ACTIVE_RISK",
+        metric="TRACKING_ERROR",
+        grouping_dimension="SECTOR",
+        measure="contributor_percent_contribution",
+        contributor_group_key="TECH",
+    ) == (
+        "sha256:hist-attr:YTD:historical-attribution:ACTIVE_RISK:"
+        "TRACKING_ERROR:SECTOR:contributor_percent_contribution:TECH"
     )
     assert _historical_attribution_value(
         attribution_set={"total_value": "0.15"},

--- a/tests/unit/dpm/engine/test_engine_wrapper_helpers.py
+++ b/tests/unit/dpm/engine/test_engine_wrapper_helpers.py
@@ -99,6 +99,30 @@ def test_compare_target_methods_if_requested_records_divergence_warnings(monkeyp
     ]
 
 
+def test_resolve_final_gate_status_preserves_target_review_requirement():
+    assert (
+        dpm_engine._resolve_final_gate_status(
+            target_status="PENDING_REVIEW",
+            execution_status="READY",
+        )
+        == "PENDING_REVIEW"
+    )
+    assert (
+        dpm_engine._resolve_final_gate_status(
+            target_status="PENDING_REVIEW",
+            execution_status="BLOCKED",
+        )
+        == "BLOCKED"
+    )
+    assert (
+        dpm_engine._resolve_final_gate_status(
+            target_status="READY",
+            execution_status="READY",
+        )
+        == "READY"
+    )
+
+
 def test_build_settlement_ladder_wrapper_delegates(monkeypatch):
     monkeypatch.setattr(
         dpm_engine,

--- a/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
@@ -301,6 +301,20 @@ def test_in_memory_monitoring_exception_helpers_filter_sort_and_page() -> None:
         cursor="UNKNOWN_CURSOR",
     )
 
+    assert mandate_in_memory._monitoring_exception_matches(
+        selected_new,
+        monitoring_run_id=None,
+        mandate_id=twin.mandate_id,
+        portfolio_id=twin.portfolio_id,
+        state="ACTIVE",
+    )
+    assert not mandate_in_memory._monitoring_exception_matches(
+        selected_new,
+        monitoring_run_id="dmr_unrelated",
+        mandate_id=twin.mandate_id,
+        portfolio_id=twin.portfolio_id,
+        state="ACTIVE",
+    )
     assert [row.exception_id for row in filtered] == ["me_selected_new", "me_selected_old"]
     assert [row.exception_id for row in page] == ["me_selected_new"]
     assert next_cursor == "me_selected_new"


### PR DESCRIPTION
## Summary
- extracted nullable monitoring-exception filter matching for the in-memory mandate repository
- extracted final rebalance gate-status resolution from `run_simulation`
- extracted historical risk-attribution source identity assembly
- refreshed codebase review ledger through BACKEND-REVIEW-20260613-851 and quality reports

## Evidence
- `python -m ruff check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`
- `python -m ruff format --check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`
- `python -m mypy --config-file mypy.ini src/infrastructure/mandates/in_memory.py`
- `python -m pytest tests/unit/dpm/supportability/test_dpm_mandate_repository.py` -> 16 passed
- `python -m ruff check src/core/rebalance/engine.py tests/unit/dpm/engine/test_engine_wrapper_helpers.py tests/unit/dpm/engine/coverage/test_engine_status_blocking.py`
- `python -m ruff format --check src/core/rebalance/engine.py tests/unit/dpm/engine/test_engine_wrapper_helpers.py tests/unit/dpm/engine/coverage/test_engine_status_blocking.py`
- `python -m mypy --config-file mypy.ini src/core/rebalance/engine.py`
- `python -m pytest tests/unit/dpm/engine/test_engine_wrapper_helpers.py tests/unit/dpm/engine/coverage/test_engine_status_blocking.py` -> 9 passed
- `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`
- `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`
- `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`
- `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py` -> 53 passed
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/engineering_health_report.py` plus `git restore quality/baseline_report.md`
- `git diff --check`
- service leakage scan: no matches
- `make check` -> 2621 passed
- `git fetch origin --prune; git branch -r --no-merged origin/main` -> no unmerged remote branches
- wiki drift check -> DiffCount 0
- open PR check before branch push -> none
- server-side origin heads before branch push -> only main

## Governance
- Domain API / backend maintainability slice.
- No README/wiki/operator truth changed; ledger records no-wiki-change decisions for all three slices.
- Complexity report now removes `_monitoring_exception_matches`, `run_simulation`, and `realized_historical_attribution_source_from_attribution_response` from the current source hotspot table.