### PR TITLE
Refactor rolling risk outcome source helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21192,3 +21192,34 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal proof-pack source-analytics
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-856: Rolling-risk realized source identity helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/risk_sources.py`,
+  `tests/unit/core/test_risk_realized_outcome_sources.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `realized_rolling_risk_source_from_rolling_response` became the next current
+  source-complexity hotspot after the proof-pack source analytics slice and mixed
+  lotus-risk response navigation, supportability posture, source identity construction,
+  reason-code assembly, and realized source snapshot assembly in one adapter function.
+- Action: extracted rolling-risk source identity, metric value parsing, ready-value enforcement,
+  and reason-code assembly into pure helpers while preserving source-owned rolling metric values,
+  window selection, context posture, and `ROLLING_RISK_METRICS_REPORT` snapshot semantics. Added
+  direct helper coverage for decimal statistic parsing, missing-value tolerance outside READY
+  posture, READY missing-value rejection, beta percentile identity, and degraded risk-free context
+  reason-code projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`,
+  `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal risk outcome source adapter
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T01:50:20+00:00`
+- Generated at: `2026-06-13T02:05:16+00:00`
 
-- Current ref: `c8bc48e6`
+- Current ref: `ad7f2034`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | realized_rolling_risk_source_from_rolling_response | src/core/outcomes/risk_sources.py | 7 | 71 |
-| 2 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
-| 3 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
-| 4 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
-| 5 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
-| 6 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
-| 7 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
-| 8 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
-| 9 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
-| 10 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 1 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
+| 2 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
+| 3 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
+| 4 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
+| 5 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
+| 6 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
+| 7 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
+| 8 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
+| 9 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 10 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T01:50:20+00:00`
+- Generated at: `2026-06-13T02:05:16+00:00`
 
-- Current ref: `c8bc48e6`
+- Current ref: `ad7f2034`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T01:50:20+00:00`
+- Generated at: `2026-06-13T02:05:16+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `c8bc48e6`
+- Current ref: `ad7f2034`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 813 | 813 | +0 |
-| Total Python LOC | 169412 | 169611 | +199 |
-| Test functions | 2448 | 2451 | +3 |
+| Total Python LOC | 169611 | 169739 | +128 |
+| Test functions | 2451 | 2451 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -39,7 +39,7 @@
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
 | 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2492 |
+| 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2545 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2426 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -260,11 +260,7 @@ def realized_rolling_risk_source_from_rolling_response(
     metric_summary = _read_mapping(
         _read_mapping(selected_window.get("metric_summaries")).get(metric)
     )
-    value = (
-        _decimal_value(metric_summary.get(statistic))
-        if metric_summary.get(statistic) is not None
-        else None
-    )
+    value = _rolling_metric_value(metric_summary=metric_summary, statistic=statistic)
     supportability_state, supportability_reason = _supportability(metadata)
     context_reason = _rolling_context_reason(period_result=period_result, metric=metric)
     source_state, quality = _rolling_source_posture(
@@ -272,19 +268,26 @@ def realized_rolling_risk_source_from_rolling_response(
         value=value,
         context_reason=context_reason,
     )
-    if source_state == "READY" and value is None:
-        raise RiskOutcomeSourceError(
-            "lotus-risk rolling response is missing a numeric "
-            f"{metric} {statistic} value for {period} window {resolved_window_length}"
-        )
+    _ensure_ready_rolling_metric_value(
+        source_state=source_state,
+        value=value,
+        metric=metric,
+        statistic=statistic,
+        period=period,
+        resolved_window_length=resolved_window_length,
+    )
 
     input_mode = _read_text(response.get("input_mode")) or "unknown"
     return DpmRealizedSourceSnapshot(
         dimension="RISK_REDUCTION",
         source_system="lotus-risk",
         source_type="ROLLING_RISK_METRICS_REPORT",
-        source_id=(
-            f"{request_fingerprint}:{period}:rolling:{resolved_window_length}:{metric}:{statistic}"
+        source_id=_rolling_source_id(
+            request_fingerprint=request_fingerprint,
+            period=period,
+            resolved_window_length=resolved_window_length,
+            metric=metric,
+            statistic=statistic,
         ),
         value=value if source_state != "NOT_SUPPORTED" else None,
         unit="ratio",
@@ -293,17 +296,17 @@ def realized_rolling_risk_source_from_rolling_response(
         observed_at=_read_text(metric_summary.get("latest_observation_date")),
         as_of_date=_read_text(scope.get("as_of_date")),
         content_hash=request_fingerprint,
-        reason_codes=[
-            _primary_reason(source_state),
-            f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
-            f"RISK_REASON_{supportability_reason.upper()}",
-            f"RISK_PERIOD_{period}",
-            f"RISK_ROLLING_METRIC_{metric}",
-            f"RISK_ROLLING_STATISTIC_{statistic.upper()}",
-            f"RISK_ROLLING_WINDOW_{resolved_window_length}",
-            f"RISK_ROLLING_INPUT_MODE_{input_mode.upper()}",
-            context_reason,
-        ],
+        reason_codes=_rolling_reason_codes(
+            source_state=source_state,
+            supportability_state=supportability_state,
+            supportability_reason=supportability_reason,
+            period=period,
+            metric=metric,
+            statistic=statistic,
+            resolved_window_length=resolved_window_length,
+            input_mode=input_mode,
+            context_reason=context_reason,
+        ),
     )
 
 
@@ -591,6 +594,68 @@ def _rolling_window_result(
         ):
             return window_mapping, _resolved_window_length(resolved_window)
     return {}, _fallback_requested_window(window_length)
+
+
+def _rolling_source_id(
+    *,
+    request_fingerprint: str,
+    period: str,
+    resolved_window_length: int | str,
+    metric: RollingRiskOutcomeMetric,
+    statistic: RollingRiskOutcomeStatistic,
+) -> str:
+    return f"{request_fingerprint}:{period}:rolling:{resolved_window_length}:{metric}:{statistic}"
+
+
+def _rolling_metric_value(
+    *,
+    metric_summary: dict[str, Any],
+    statistic: RollingRiskOutcomeStatistic,
+) -> Decimal | None:
+    raw_value = metric_summary.get(statistic)
+    return _decimal_value(raw_value) if raw_value is not None else None
+
+
+def _ensure_ready_rolling_metric_value(
+    *,
+    source_state: _RiskSourceState,
+    value: Decimal | None,
+    metric: RollingRiskOutcomeMetric,
+    statistic: RollingRiskOutcomeStatistic,
+    period: str,
+    resolved_window_length: int | str,
+) -> None:
+    if source_state != "READY" or value is not None:
+        return
+    raise RiskOutcomeSourceError(
+        "lotus-risk rolling response is missing a numeric "
+        f"{metric} {statistic} value for {period} window {resolved_window_length}"
+    )
+
+
+def _rolling_reason_codes(
+    *,
+    source_state: _RiskSourceState,
+    supportability_state: str,
+    supportability_reason: str,
+    period: str,
+    metric: RollingRiskOutcomeMetric,
+    statistic: RollingRiskOutcomeStatistic,
+    resolved_window_length: int | str,
+    input_mode: str,
+    context_reason: str,
+) -> list[str]:
+    return [
+        _primary_reason(source_state),
+        f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
+        f"RISK_REASON_{supportability_reason.upper()}",
+        f"RISK_PERIOD_{period}",
+        f"RISK_ROLLING_METRIC_{metric}",
+        f"RISK_ROLLING_STATISTIC_{statistic.upper()}",
+        f"RISK_ROLLING_WINDOW_{resolved_window_length}",
+        f"RISK_ROLLING_INPUT_MODE_{input_mode.upper()}",
+        context_reason,
+    ]
 
 
 def _historical_attribution_source_id(

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -18,6 +18,7 @@ from src.core.outcomes.risk_sources import (
     _concentration_source_posture,
     _drawdown_measure_unavailable,
     _drawdown_source_posture,
+    _ensure_ready_rolling_metric_value,
     _historical_attribution_contributor,
     _historical_attribution_set,
     _historical_attribution_source_id,
@@ -30,6 +31,9 @@ from src.core.outcomes.risk_sources import (
     _risk_source_posture,
     _rolling_context_unavailable,
     _rolling_context_reason,
+    _rolling_metric_value,
+    _rolling_reason_codes,
+    _rolling_source_id,
     _rolling_source_posture,
     _rolling_window_result,
     _supportability_source_posture,
@@ -1436,6 +1440,65 @@ def test_concentration_drawdown_and_rolling_posture_edges_are_source_safe() -> N
 
 
 def test_rolling_and_historical_attribution_helper_edges_are_explicit() -> None:
+    assert _rolling_metric_value(
+        metric_summary={"latest": "0.42"},
+        statistic="latest",
+    ) == Decimal("0.42")
+    assert (
+        _rolling_metric_value(
+            metric_summary={},
+            statistic="p95",
+        )
+        is None
+    )
+    _ensure_ready_rolling_metric_value(
+        source_state="DEGRADED",
+        value=None,
+        metric="ROLLING_VOLATILITY",
+        statistic="latest",
+        period="YTD",
+        resolved_window_length=21,
+    )
+    with pytest.raises(RiskOutcomeSourceError, match="missing a numeric"):
+        _ensure_ready_rolling_metric_value(
+            source_state="READY",
+            value=None,
+            metric="ROLLING_VOLATILITY",
+            statistic="latest",
+            period="YTD",
+            resolved_window_length=21,
+        )
+    assert (
+        _rolling_source_id(
+            request_fingerprint="sha256:rolling-request",
+            period="YTD",
+            resolved_window_length=21,
+            metric="ROLLING_BETA",
+            statistic="p95",
+        )
+        == "sha256:rolling-request:YTD:rolling:21:ROLLING_BETA:p95"
+    )
+    assert _rolling_reason_codes(
+        source_state="DEGRADED",
+        supportability_state="stale",
+        supportability_reason="calculation_stale",
+        period="YTD",
+        metric="ROLLING_SHARPE",
+        statistic="latest",
+        resolved_window_length="unknown",
+        input_mode="stateless",
+        context_reason="RISK_ROLLING_RISK_FREE_UNAVAILABLE",
+    ) == [
+        "RISK_SOURCE_DEGRADED",
+        "RISK_SUPPORTABILITY_STALE",
+        "RISK_REASON_CALCULATION_STALE",
+        "RISK_PERIOD_YTD",
+        "RISK_ROLLING_METRIC_ROLLING_SHARPE",
+        "RISK_ROLLING_STATISTIC_LATEST",
+        "RISK_ROLLING_WINDOW_unknown",
+        "RISK_ROLLING_INPUT_MODE_STATELESS",
+        "RISK_ROLLING_RISK_FREE_UNAVAILABLE",
+    ]
     assert _rolling_window_result(period_result={}, window_length=None) == ({}, "unknown")
     assert _rolling_window_result(
         period_result={"window_results": [{"value": "latest"}]},


### PR DESCRIPTION
## Summary
- Extract rolling-risk realized source identity, metric value parsing, READY value enforcement, and reason-code assembly helpers.
- Add direct helper coverage for decimal statistic parsing, READY missing-value rejection, rolling source identity, and degraded risk-free context reason codes.
- Refresh quality reports; `realized_rolling_risk_source_from_rolling_response` drops out of the current top-ten source hotspot list.

## Evidence
- `python -m pytest tests\unit\core\test_risk_realized_outcome_sources.py -q` -> 53 passed
- `python -m ruff check src\core\outcomes\risk_sources.py tests\unit\core\test_risk_realized_outcome_sources.py` -> passed
- `python -m ruff format --check src\core\outcomes\risk_sources.py tests\unit\core\test_risk_realized_outcome_sources.py` -> passed
- `python -m mypy --config-file mypy.ini src\core\outcomes\risk_sources.py` -> passed
- `python scripts\openapi_quality_gate.py` -> passed
- `python scripts\api_vocabulary_inventory.py --validate-only` -> passed
- service leakage scan -> no matches
- `git diff --check` -> passed
- `python scripts\engineering_health_report.py` -> refreshed reports
- `make check` -> 2627 passed

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no branches before PR.
- Open PR scan before PR: none.
- Wiki drift: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned DiffCount 0; no wiki publication required.
- Tiering: shared/domain backend service refactor; Feature Lane and PR Merge Gate are expected PR-blocking checks. Heavy platform end-to-end lanes are not required for this internal source adapter refactor.