### PR TITLE
Refactor tactical house view portfolio resolution

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21223,3 +21223,33 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal risk outcome source adapter
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-857: Tactical house-view portfolio resolution helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/routers/wave_portfolio_resolution.py`,
+  `tests/unit/api/test_wave_portfolio_resolution.py`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, and `quality/complexity_report.md`.
+- Finding: `_resolve_tactical_house_view_portfolios` became the next current source-complexity
+  hotspot after the rolling-risk source adapter slice and mixed tactical house-view source
+  precondition validation, eligible portfolio-type normalization, lotus-advise authority request
+  construction, downstream source call, and dependency failure mapping in one router helper.
+- Action: extracted tactical house-view source-evidence preconditions, eligible portfolio-type
+  normalization, and authority-request preparation into router-local helpers while preserving
+  lotus-advise source-owned cohort resolution, fail-closed unavailable/rejected/cohort-incomplete
+  behavior, and resolved portfolio lineage projection. Added direct helper coverage for
+  authority-request source context projection and missing source-evidence rejection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/wave_portfolio_resolution.py tests/unit/api/test_wave_portfolio_resolution.py`,
+  `python -m ruff format --check src/api/routers/wave_portfolio_resolution.py tests/unit/api/test_wave_portfolio_resolution.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/wave_portfolio_resolution.py`,
+  `python -m pytest tests/unit/api/test_wave_portfolio_resolution.py tests/unit/dpm/api/test_waves_api.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal wave portfolio-resolution
+  maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T02:05:16+00:00`
+- Generated at: `2026-06-13T02:18:16+00:00`
 
-- Current ref: `ad7f2034`
+- Current ref: `e14b8b54`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _resolve_tactical_house_view_portfolios | src/api/routers/wave_portfolio_resolution.py | 7 | 66 |
-| 2 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
-| 3 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
-| 4 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
-| 5 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
-| 6 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
-| 7 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
-| 8 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
-| 9 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 10 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
+| 1 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
+| 2 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
+| 3 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
+| 4 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
+| 5 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
+| 6 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
+| 7 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
+| 8 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 9 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
+| 10 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T02:05:16+00:00`
+- Generated at: `2026-06-13T02:18:16+00:00`
 
-- Current ref: `ad7f2034`
+- Current ref: `e14b8b54`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T02:05:16+00:00`
+- Generated at: `2026-06-13T02:18:16+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `ad7f2034`
+- Current ref: `e14b8b54`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 813 | 813 | +0 |
-| Total Python LOC | 169611 | 169739 | +128 |
-| Test functions | 2451 | 2451 | +0 |
+| Python files | 813 | 814 | +1 |
+| Total Python LOC | 169739 | 169882 | +143 |
+| Test functions | 2451 | 2453 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/routers/wave_portfolio_resolution.py
+++ b/src/api/routers/wave_portfolio_resolution.py
@@ -18,6 +18,7 @@ from src.api.routers.wave_portfolio_type_validation import (
     normalize_required_portfolio_types,
 )
 from src.api.routers.wave_request_models import DpmWavePreviewRequest
+from src.api.routers.wave_request_models import DpmTacticalHouseViewInput
 from src.api.routers.wave_required_text_validation import normalize_required_text
 from src.api.routers.wave_risk_event_validation import (
     build_risk_event_candidate_payloads,
@@ -29,6 +30,7 @@ from src.api.routers.wave_source_dependency_http import (
     source_unavailable_http_exception,
 )
 from src.api.routers.wave_tactical_candidate_selection import (
+    TacticalHouseViewAuthorityRequest,
     build_tactical_house_view_authority_request,
     build_tactical_house_view_resolved_portfolios,
     tactical_house_view_cohort_failure,
@@ -97,41 +99,12 @@ def _resolve_tactical_house_view_portfolios(
     correlation_id: str,
     advise_authority_client: AdviseAuthorityClient | None,
 ) -> list[dict[str, object]]:
-    tactical_view = request.tactical_house_view
-    if tactical_view is None:
-        raise wave_service.DpmWaveValidationError(
-            "TACTICAL_HOUSE_VIEW_REQUIRED",
-            "TACTICAL_HOUSE_VIEW requires tactical_house_view source evidence.",
-        )
-    if not request.portfolios:
-        raise wave_service.DpmWaveValidationError(
-            "TACTICAL_HOUSE_VIEW_CANDIDATE_PORTFOLIOS_REQUIRED",
-            "TACTICAL_HOUSE_VIEW requires source-backed candidate portfolios.",
-        )
-    if not tactical_view.source_refs:
-        raise wave_service.DpmWaveValidationError(
-            "TACTICAL_HOUSE_VIEW_SOURCE_REFS_REQUIRED",
-            "TACTICAL_HOUSE_VIEW requires tactical house-view source_refs.",
-        )
     if advise_authority_client is None:
         raise source_unavailable_http_exception(
             code="DPM_TACTICAL_HOUSE_VIEW_COHORT_UNAVAILABLE",
             message="DPM_ADVISE_BASE_URL is not configured.",
         )
-    as_of_date = parse_wave_as_of_date(request.as_of_date)
-    eligible_portfolio_types = normalize_required_portfolio_types(
-        request.portfolio_types,
-        required_code="TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPES_REQUIRED",
-        required_message="TACTICAL_HOUSE_VIEW requires at least one eligible portfolio type.",
-    )
-
-    authority_request = build_tactical_house_view_authority_request(
-        tactical_view=tactical_view,
-        portfolios=request.portfolios,
-        eligible_portfolio_types=eligible_portfolio_types,
-        as_of_date=as_of_date,
-        min_exposure_weight=request.min_tactical_exposure_weight,
-    )
+    authority_request = _tactical_house_view_authority_request_for_wave(request)
 
     try:
         cohort = advise_authority_client.tactical_house_view_affected_cohort(
@@ -157,6 +130,65 @@ def _resolve_tactical_house_view_portfolios(
         )
 
     return build_tactical_house_view_resolved_portfolios(cohort)
+
+
+def _tactical_house_view_authority_request_for_wave(
+    request: DpmWavePreviewRequest,
+) -> TacticalHouseViewAuthorityRequest:
+    tactical_view = _required_tactical_house_view(request)
+    _require_tactical_house_view_candidate_portfolios(request)
+    _require_tactical_house_view_source_refs(tactical_view)
+    return build_tactical_house_view_authority_request(
+        tactical_view=tactical_view,
+        portfolios=request.portfolios,
+        eligible_portfolio_types=_tactical_house_view_portfolio_types(request),
+        as_of_date=parse_wave_as_of_date(request.as_of_date),
+        min_exposure_weight=request.min_tactical_exposure_weight,
+    )
+
+
+def _required_tactical_house_view(
+    request: DpmWavePreviewRequest,
+) -> DpmTacticalHouseViewInput:
+    tactical_view = request.tactical_house_view
+    if tactical_view is None:
+        raise wave_service.DpmWaveValidationError(
+            "TACTICAL_HOUSE_VIEW_REQUIRED",
+            "TACTICAL_HOUSE_VIEW requires tactical_house_view source evidence.",
+        )
+    return tactical_view
+
+
+def _require_tactical_house_view_candidate_portfolios(
+    request: DpmWavePreviewRequest,
+) -> None:
+    if request.portfolios:
+        return
+    raise wave_service.DpmWaveValidationError(
+        "TACTICAL_HOUSE_VIEW_CANDIDATE_PORTFOLIOS_REQUIRED",
+        "TACTICAL_HOUSE_VIEW requires source-backed candidate portfolios.",
+    )
+
+
+def _require_tactical_house_view_source_refs(
+    tactical_view: DpmTacticalHouseViewInput,
+) -> None:
+    if tactical_view.source_refs:
+        return
+    raise wave_service.DpmWaveValidationError(
+        "TACTICAL_HOUSE_VIEW_SOURCE_REFS_REQUIRED",
+        "TACTICAL_HOUSE_VIEW requires tactical house-view source_refs.",
+    )
+
+
+def _tactical_house_view_portfolio_types(
+    request: DpmWavePreviewRequest,
+) -> list[str]:
+    return normalize_required_portfolio_types(
+        request.portfolio_types,
+        required_code="TACTICAL_HOUSE_VIEW_PORTFOLIO_TYPES_REQUIRED",
+        required_message="TACTICAL_HOUSE_VIEW requires at least one eligible portfolio type.",
+    )
 
 
 def _resolve_risk_event_portfolios(

--- a/tests/unit/api/test_wave_portfolio_resolution.py
+++ b/tests/unit/api/test_wave_portfolio_resolution.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from src.api.routers.wave_portfolio_resolution import (
+    _require_tactical_house_view_candidate_portfolios,
+    _require_tactical_house_view_source_refs,
+    _required_tactical_house_view,
+    _tactical_house_view_authority_request_for_wave,
+)
+from src.api.routers.wave_request_models import DpmWavePreviewRequest
+from src.api.services import wave_service
+
+
+def _tactical_house_view_request(
+    **overrides: object,
+) -> DpmWavePreviewRequest:
+    payload: dict[str, object] = {
+        "trigger_type": "TACTICAL_HOUSE_VIEW",
+        "trigger_id": "wave-thv-20260519",
+        "rationale": "Review discretionary mandates affected by tactical house view.",
+        "as_of_date": "2026-05-19",
+        "actor_id": "pm_001",
+        "portfolio_types": [" discretionary ", "DPM"],
+        "min_tactical_exposure_weight": 0.05,
+        "tactical_house_view": {
+            "tactical_view_id": "THV_20260519",
+            "tactical_view_version": "v3",
+            "theme_id": "QUALITY_ROTATION",
+            "target_action": "INCREASE",
+            "rationale": "Increase quality equity exposure.",
+            "source_refs": [
+                {
+                    "source_system": "lotus-advise",
+                    "source_type": "TACTICAL_HOUSE_VIEW_DECISION",
+                    "source_id": "thv-quality-20260519",
+                    "source_version": "v3",
+                    "supportability_state": "READY",
+                    "content_hash": "sha256:tactical-view",
+                }
+            ],
+        },
+        "portfolios": [
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+                "portfolio_type": "DISCRETIONARY",
+                "discretionary_mandate": True,
+                "current_exposure_weight": 0.18,
+                "alignment_signal": "UNDERWEIGHT",
+                "source_refs": [
+                    {
+                        "source_system": "lotus-core",
+                        "source_type": "HoldingsAsOf",
+                        "source_id": "holdings-as-of-20260519",
+                        "source_version": "2026-05-19",
+                        "supportability_state": "READY",
+                        "content_hash": "sha256:holdings",
+                    }
+                ],
+            }
+        ],
+    }
+    payload.update(overrides)
+    return DpmWavePreviewRequest.model_validate(payload)
+
+
+def test_tactical_house_view_authority_request_for_wave_maps_source_context() -> None:
+    request = _tactical_house_view_request()
+
+    authority_request = _tactical_house_view_authority_request_for_wave(request)
+
+    assert authority_request.tactical_view["as_of_date"] == "2026-05-19"
+    assert authority_request.tactical_view["source_refs"] == [
+        {
+            "source_system": "lotus-advise",
+            "source_type": "TACTICAL_HOUSE_VIEW_DECISION",
+            "source_id": "thv-quality-20260519",
+            "source_version": "v3",
+            "supportability_state": "READY",
+            "content_hash": "sha256:tactical-view",
+        }
+    ]
+    assert authority_request.candidate_portfolios[0]["portfolio_id"] == ("PB_SG_GLOBAL_BAL_001")
+    assert authority_request.eligible_portfolio_types == ["DISCRETIONARY", "DPM"]
+    assert authority_request.min_exposure_weight == Decimal("0.05")
+
+
+def test_tactical_house_view_resolution_helpers_reject_missing_source_evidence() -> None:
+    request = _tactical_house_view_request(tactical_house_view=None)
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _required_tactical_house_view(request)
+    assert exc_info.value.code == "TACTICAL_HOUSE_VIEW_REQUIRED"
+
+    request = _tactical_house_view_request(portfolios=[])
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _require_tactical_house_view_candidate_portfolios(request)
+    assert exc_info.value.code == "TACTICAL_HOUSE_VIEW_CANDIDATE_PORTFOLIOS_REQUIRED"
+
+    request = _tactical_house_view_request(
+        tactical_house_view={
+            **_tactical_house_view_request().tactical_house_view.model_dump(mode="json"),
+            "source_refs": [],
+        }
+    )
+    tactical_view = _required_tactical_house_view(request)
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _require_tactical_house_view_source_refs(tactical_view)
+    assert exc_info.value.code == "TACTICAL_HOUSE_VIEW_SOURCE_REFS_REQUIRED"


### PR DESCRIPTION
## Summary
- Extract tactical house-view source-evidence preconditions and authority-request preparation into router-local helpers.
- Add direct helper coverage for source context projection and missing source-evidence rejection.
- Refresh quality reports; `_resolve_tactical_house_view_portfolios` drops out of the current top-ten source hotspot list.

## Evidence
- `python -m pytest tests\unit\api\test_wave_portfolio_resolution.py tests\unit\dpm\api\test_waves_api.py -q` -> 134 passed
- `python -m ruff check src\api\routers\wave_portfolio_resolution.py tests\unit\api\test_wave_portfolio_resolution.py` -> passed
- `python -m ruff format --check src\api\routers\wave_portfolio_resolution.py tests\unit\api\test_wave_portfolio_resolution.py` -> passed
- `python -m mypy --config-file mypy.ini src\api\routers\wave_portfolio_resolution.py` -> passed
- `python scripts\openapi_quality_gate.py` -> passed
- `python scripts\api_vocabulary_inventory.py --validate-only` -> passed
- service leakage scan -> no matches
- `git diff --check` -> passed
- `python scripts\engineering_health_report.py` -> refreshed reports
- `make check` -> 2629 passed

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no branches before PR.
- Open PR scan before PR: none.
- Wiki drift: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned DiffCount 0; no wiki publication required.
- Tiering: domain/shared backend service refactor; Feature Lane and PR Merge Gate are expected PR-blocking checks. Heavy platform end-to-end lanes are not required for this internal router-helper refactor.