### PR TITLE
Refactor performance attribution source snapshot

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21253,3 +21253,35 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal wave portfolio-resolution
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-858: Performance attribution source snapshot helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/performance_sources.py`,
+  `tests/unit/core/test_performance_realized_outcome_sources.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `realized_attribution_source_from_attribution_response` became the next current
+  source-complexity hotspot after the tactical house-view portfolio-resolution slice and mixed
+  lotus-performance period navigation, source-owned attribution value selection, supportability
+  posture, READY value enforcement, benchmark context extraction, and realized source snapshot
+  assembly in one adapter function.
+- Action: extracted READY attribution value enforcement and `PERFORMANCE_ATTRIBUTION` snapshot
+  assembly into typed helpers while preserving source-owned attribution values, selector tokens,
+  benchmark reason codes, supportability posture, and no-local-attribution-math semantics. Added
+  direct helper coverage for non-READY missing-value tolerance, READY missing-value rejection, and
+  not-supported snapshot projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/performance_sources.py tests/unit/core/test_performance_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/performance_sources.py tests/unit/core/test_performance_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/performance_sources.py`,
+  `python -m pytest tests/unit/core/test_performance_realized_outcome_sources.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal performance outcome source
+  adapter maintainability refactoring and repo-local quality evidence.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T02:18:16+00:00`
+- Generated at: `2026-06-13T02:30:34+00:00`
 
-- Current ref: `e14b8b54`
+- Current ref: `a226f316`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | realized_attribution_source_from_attribution_response | src/core/outcomes/performance_sources.py | 7 | 66 |
-| 2 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
-| 3 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
-| 4 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
-| 5 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
-| 6 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
-| 7 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
-| 8 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 9 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
-| 10 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 1 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
+| 2 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
+| 3 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
+| 4 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
+| 5 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
+| 6 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
+| 7 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 8 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
+| 9 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 10 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T02:18:16+00:00`
+- Generated at: `2026-06-13T02:30:34+00:00`
 
-- Current ref: `e14b8b54`
+- Current ref: `a226f316`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T02:18:16+00:00`
+- Generated at: `2026-06-13T02:30:34+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `e14b8b54`
+- Current ref: `a226f316`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 813 | 814 | +1 |
-| Total Python LOC | 169739 | 169882 | +143 |
-| Test functions | 2451 | 2453 | +2 |
+| Python files | 814 | 814 | +0 |
+| Total Python LOC | 169882 | 169993 | +111 |
+| Test functions | 2453 | 2453 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/outcomes/performance_sources.py
+++ b/src/core/outcomes/performance_sources.py
@@ -29,6 +29,15 @@ AttributionOutcomeMeasure = Literal[
     "currency_selection",
     "currency_total_effect",
 ]
+_PerformanceSourceState = Literal["READY", "DEGRADED", "BLOCKED", "NOT_SUPPORTED"]
+_PerformanceSourceQuality = Literal[
+    "COMPLETE",
+    "STALE",
+    "UNAVAILABLE",
+    "PARTIAL",
+    "MISSING",
+    "NOT_SUPPORTED",
+]
 
 
 class PerformanceOutcomeSourceError(ValueError):
@@ -238,10 +247,12 @@ def realized_attribution_source_from_attribution_response(
         supportability_state=supportability_state,
         value=value,
     )
-    if source_state == "READY" and value is None:
-        raise PerformanceOutcomeSourceError(
-            f"lotus-performance attribution response is missing a numeric attribution {measure} for {period}"
-        )
+    _ensure_ready_attribution_value(
+        source_state=source_state,
+        value=value,
+        measure=measure,
+        period=period,
+    )
 
     input_mode = _read_text(response.get("input_mode")) or "unknown"
     model = _read_text(response.get("model")) or "unknown"
@@ -250,6 +261,57 @@ def realized_attribution_source_from_attribution_response(
     benchmark_id = _read_text(benchmark.get("benchmark_id"))
     benchmark_source = _read_text(benchmark.get("return_source"))
 
+    return _attribution_source_snapshot(
+        metadata=metadata,
+        period=period,
+        measure=measure,
+        selector_token=selector_token,
+        value=value,
+        source_state=source_state,
+        quality=quality,
+        supportability_state=supportability_state,
+        supportability_reason=supportability_reason,
+        selector_reason=selector_reason,
+        input_mode=input_mode,
+        model=model,
+        linking=linking,
+        benchmark_id=benchmark_id,
+        benchmark_source=benchmark_source,
+    )
+
+
+def _ensure_ready_attribution_value(
+    *,
+    source_state: str,
+    value: Decimal | None,
+    measure: AttributionOutcomeMeasure,
+    period: str,
+) -> None:
+    if source_state != "READY" or value is not None:
+        return
+    raise PerformanceOutcomeSourceError(
+        f"lotus-performance attribution response is missing a numeric attribution {measure} for {period}"
+    )
+
+
+def _attribution_source_snapshot(
+    *,
+    metadata: dict[str, str | None],
+    period: str,
+    measure: AttributionOutcomeMeasure,
+    selector_token: str,
+    value: Decimal | None,
+    source_state: _PerformanceSourceState,
+    quality: _PerformanceSourceQuality,
+    supportability_state: str,
+    supportability_reason: str,
+    selector_reason: str,
+    input_mode: str,
+    model: str,
+    linking: str,
+    benchmark_id: str | None,
+    benchmark_source: str | None,
+) -> DpmRealizedSourceSnapshot:
     return DpmRealizedSourceSnapshot(
         dimension="PERFORMANCE",
         source_system="lotus-performance",

--- a/tests/unit/core/test_performance_realized_outcome_sources.py
+++ b/tests/unit/core/test_performance_realized_outcome_sources.py
@@ -290,6 +290,55 @@ def test_attribution_adapter_wraps_source_owned_active_return_reconciliation() -
 
 
 def test_attribution_source_helper_builds_source_id_and_reason_codes() -> None:
+    perf_sources._ensure_ready_attribution_value(
+        source_state="DEGRADED",
+        value=None,
+        measure="reconciliation_total_active_return",
+        period="YTD",
+    )
+    with pytest.raises(PerformanceOutcomeSourceError, match="numeric attribution"):
+        perf_sources._ensure_ready_attribution_value(
+            source_state="READY",
+            value=None,
+            measure="reconciliation_total_active_return",
+            period="YTD",
+        )
+
+    snapshot = perf_sources._attribution_source_snapshot(
+        metadata={
+            "calculation_id": "calc-001",
+            "calculation_hash": "sha256:attr",
+            "as_of_date": "2026-05-06",
+        },
+        period="YTD",
+        measure="currency_total_effect",
+        selector_token="currency:usd",
+        value=None,
+        source_state="NOT_SUPPORTED",
+        quality="NOT_SUPPORTED",
+        supportability_state="unsupported",
+        supportability_reason="methodology_not_supported",
+        selector_reason="PERFORMANCE_ATTRIBUTION_CURRENCY_USD",
+        input_mode="stateful",
+        model="brinson_fachler",
+        linking="carino",
+        benchmark_id="BMK_GLOBAL_60_40",
+        benchmark_source="calculated",
+    )
+
+    assert snapshot.source_id == "calc-001:YTD:attribution:currency_total_effect:currency:usd"
+    assert snapshot.value is None
+    assert snapshot.content_hash == "sha256:attr"
+    assert snapshot.reason_codes[:7] == [
+        "PERFORMANCE_SOURCE_NOT_SUPPORTED",
+        "PERFORMANCE_SUPPORTABILITY_UNSUPPORTED",
+        "PERFORMANCE_REASON_METHODOLOGY_NOT_SUPPORTED",
+        "PERFORMANCE_PERIOD_YTD",
+        "PERFORMANCE_MEASURE_FAMILY_ATTRIBUTION",
+        "PERFORMANCE_ATTRIBUTION_MEASURE_CURRENCY_TOTAL_EFFECT",
+        "PERFORMANCE_ATTRIBUTION_CURRENCY_USD",
+    ]
+
     assert (
         perf_sources._attribution_source_id(
             calculation_id="calc-001",


### PR DESCRIPTION
## Summary
- Extract READY attribution value enforcement and `PERFORMANCE_ATTRIBUTION` snapshot assembly helpers.
- Add direct helper coverage for non-READY missing-value tolerance, READY missing-value rejection, and not-supported snapshot projection.
- Refresh quality reports; `realized_attribution_source_from_attribution_response` drops out of the current top-ten source hotspot list.

## Evidence
- `python -m pytest tests\unit\core\test_performance_realized_outcome_sources.py -q` -> 29 passed
- `python -m ruff check src\core\outcomes\performance_sources.py tests\unit\core\test_performance_realized_outcome_sources.py` -> passed
- `python -m ruff format --check src\core\outcomes\performance_sources.py tests\unit\core\test_performance_realized_outcome_sources.py` -> passed
- `python -m mypy --config-file mypy.ini src\core\outcomes\performance_sources.py` -> passed
- `python scripts\openapi_quality_gate.py` -> passed
- `python scripts\api_vocabulary_inventory.py --validate-only` -> passed
- service leakage scan -> no matches
- `git diff --check` -> passed
- `python scripts\engineering_health_report.py` -> refreshed reports
- `make check` -> 2629 passed

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no branches before PR.
- Open PR scan before PR: none.
- Wiki drift: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned DiffCount 0; no wiki publication required.
- Tiering: domain/shared backend service refactor; Feature Lane and PR Merge Gate are expected PR-blocking checks. Heavy platform end-to-end lanes are not required for this internal source-adapter refactor.