### PR TITLE
Refactor rebalance group constraint application

### DIFF
--- a/.github/workflows/feature-lane.yml
+++ b/.github/workflows/feature-lane.yml
@@ -51,6 +51,8 @@ jobs:
         run: make openapi-gate
       - name: API Vocabulary Gate
         run: make api-vocabulary-gate
+      - name: Service Boundary Gate
+        run: make service-boundary-gate
       - name: Architecture Gate
         run: make architecture-gate
         continue-on-error: true

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -51,6 +51,8 @@ jobs:
         run: make openapi-gate
       - name: API Vocabulary Gate
         run: make api-vocabulary-gate
+      - name: Service Boundary Gate
+        run: make service-boundary-gate
       - name: Migration Contract Smoke
         run: make migration-smoke
       - name: Architecture Gate

--- a/.github/workflows/quality-baseline.yml
+++ b/.github/workflows/quality-baseline.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           lint-imports --config .importlinter 2>&1 | tee output/quality-baseline/import-linter.txt
 
+      - name: Service Boundary Gate
+        continue-on-error: true
+        run: python scripts/service_boundary_gate.py 2>&1 | tee output/quality-baseline/service-boundary.txt
+
       - name: Complexity Baseline
         continue-on-error: true
         run: |

--- a/.github/workflows/quality-baseline.yml
+++ b/.github/workflows/quality-baseline.yml
@@ -42,30 +42,38 @@ jobs:
       - name: Ruff
         continue-on-error: true
         run: |
+          set -o pipefail
           mkdir -p output/quality-baseline
           python -m ruff check . 2>&1 | tee output/quality-baseline/ruff.txt
 
       - name: Mypy
         continue-on-error: true
         run: |
+          set -o pipefail
           python -m mypy --config-file mypy.ini src 2>&1 | tee output/quality-baseline/mypy.txt
 
       - name: Coverage
         continue-on-error: true
-        run: python -m pytest tests/unit --cov=src --cov-report=term-missing 2>&1 | tee output/quality-baseline/coverage.txt
+        run: |
+          set -o pipefail
+          python -m pytest tests/unit --cov=src --cov-report=term-missing 2>&1 | tee output/quality-baseline/coverage.txt
 
       - name: Architecture Import Rules
         continue-on-error: true
         run: |
+          set -o pipefail
           lint-imports --config .importlinter 2>&1 | tee output/quality-baseline/import-linter.txt
 
       - name: Service Boundary Gate
         continue-on-error: true
-        run: python scripts/service_boundary_gate.py 2>&1 | tee output/quality-baseline/service-boundary.txt
+        run: |
+          set -o pipefail
+          python scripts/service_boundary_gate.py 2>&1 | tee output/quality-baseline/service-boundary.txt
 
       - name: Complexity Baseline
         continue-on-error: true
         run: |
+          set -o pipefail
           {
             radon cc src -s -a
             radon mi src -s
@@ -74,15 +82,20 @@ jobs:
 
       - name: Dead Code Baseline
         continue-on-error: true
-        run: vulture src tests --min-confidence 80 2>&1 | tee output/quality-baseline/vulture.txt
+        run: |
+          set -o pipefail
+          vulture src tests --min-confidence 80 2>&1 | tee output/quality-baseline/vulture.txt
 
       - name: Dependency Baseline
         continue-on-error: true
-        run: deptry . 2>&1 | tee output/quality-baseline/deptry.txt
+        run: |
+          set -o pipefail
+          deptry . 2>&1 | tee output/quality-baseline/deptry.txt
 
       - name: Security Baseline
         continue-on-error: true
         run: |
+          set -o pipefail
           {
             bandit -q -r src -c pyproject.toml
             pip-audit -r pyproject.toml
@@ -91,11 +104,14 @@ jobs:
 
       - name: Documentation Baseline
         continue-on-error: true
-        run: interrogate src 2>&1 | tee output/quality-baseline/interrogate.txt
+        run: |
+          set -o pipefail
+          interrogate src 2>&1 | tee output/quality-baseline/interrogate.txt
 
       - name: OpenAPI Spectral Baseline
         continue-on-error: true
         run: |
+          set -o pipefail
           python - <<'PY' > openapi.json
           import json
           from src.api.main import app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: architecture-gate complexity-gate dead-code-gate dependency-hygiene-gate install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate api-vocabulary-gate live-api-validate live-api-validate-core format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down
+.PHONY: architecture-gate complexity-gate dead-code-gate dependency-hygiene-gate install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate api-vocabulary-gate service-boundary-gate live-api-validate live-api-validate-core format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down
 
 COVERAGE_FAIL_UNDER ?= 99
 
@@ -14,9 +14,9 @@ install-ci:
 pre-commit:
 	pre-commit run --all-files
 
-check: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate mesh-contract-validate test
+check: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate service-boundary-gate mesh-contract-validate test
 
-ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate migration-smoke test-all security-audit
+ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate service-boundary-gate migration-smoke test-all security-audit
 
 test:
 	$(MAKE) test-unit
@@ -59,6 +59,7 @@ ci-local: lint check-deps
 	$(MAKE) no-alias-gate
 	$(MAKE) openapi-gate
 	$(MAKE) api-vocabulary-gate
+	$(MAKE) service-boundary-gate
 	$(MAKE) typecheck
 
 ci-local-docker:
@@ -83,6 +84,9 @@ no-alias-gate:
 
 api-vocabulary-gate:
 	python scripts/api_vocabulary_inventory.py --validate-only
+
+service-boundary-gate:
+	python scripts/service_boundary_gate.py
 
 live-api-validate:
 	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://127.0.0.1:8001}

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21327,8 +21327,9 @@ and improves internal transaction-cost source posture maintainability only.
   an ad hoc command instead of a repo-native active CI gate.
 - Action: added a service-boundary gate script backed by the same leakage patterns used by the
   engineering health report, wired it into `make check`, `make ci`, local CI parity, Feature Lane,
-  and PR Merge Gate, and captured the signal in Quality Baseline artifacts. Added direct tests for
-  blocked router/framework leakage and clean service modules.
+  and PR Merge Gate, and captured the signal in Quality Baseline artifacts. Added `pipefail` to
+  Quality Baseline report-only pipelines so warning signals remain visible when commands are piped
+  through `tee`. Added direct tests for blocked router/framework leakage and clean service modules.
 - Status: hardened.
 - Evidence:
   `python -m ruff check scripts/service_boundary_gate.py tests/unit/test_service_boundary_gate.py scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py`,

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21285,3 +21285,32 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal performance outcome source
   adapter maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-859: Rebalance group-constraint application helper
+
+- Date: 2026-06-13
+- Scope: `src/core/rebalance/targets.py`, `tests/unit/core/test_target_generation_helpers.py`,
+  `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and
+  `quality/complexity_report.md`.
+- Finding: `apply_group_constraints` became the next current source-complexity hotspot after the
+  performance attribution source snapshot slice and mixed deterministic constraint ordering,
+  constraint-key validation, member selection, tolerance checks, capping, redistribution, event
+  recording, and blocked status propagation in one orchestration loop.
+- Action: extracted single group-constraint application into a focused helper while preserving
+  deterministic constraint ordering, tolerance behavior, capped redistribution events, and
+  fail-closed blocked status when excess cannot be redistributed. Added direct helper coverage for
+  capped redistribution, within-limit no-op, and blocked no-recipient behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/targets.py tests/unit/core/test_target_generation_helpers.py`,
+  `python -m ruff format --check src/core/rebalance/targets.py tests/unit/core/test_target_generation_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/targets.py`,
+  `python -m pytest tests/unit/core/test_target_generation_helpers.py tests/unit/dpm/engine/coverage/test_engine_target_generation.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  service leakage scan,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal target-generation
+  maintainability refactoring and repo-local quality evidence.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21314,3 +21314,30 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal target-generation
   maintainability refactoring and repo-local quality evidence.
+
+## BACKEND-REVIEW-20260613-860: Service-boundary leakage gate enforcement
+
+- Date: 2026-06-13
+- Scope: `scripts/service_boundary_gate.py`, `Makefile`, `.github/workflows/feature-lane.yml`,
+  `.github/workflows/pr-merge-gate.yml`, `.github/workflows/quality-baseline.yml`,
+  `scripts/engineering_health_report.py`, `tests/unit/test_service_boundary_gate.py`,
+  `tests/unit/test_engineering_health_report.py`, and quality reports.
+- Finding: the enterprise backend refactoring workflow required service leakage scans to keep
+  router, FastAPI, and Starlette transport concerns out of service modules, but the check was still
+  an ad hoc command instead of a repo-native active CI gate.
+- Action: added a service-boundary gate script backed by the same leakage patterns used by the
+  engineering health report, wired it into `make check`, `make ci`, local CI parity, Feature Lane,
+  and PR Merge Gate, and captured the signal in Quality Baseline artifacts. Added direct tests for
+  blocked router/framework leakage and clean service modules.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check scripts/service_boundary_gate.py tests/unit/test_service_boundary_gate.py scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py`,
+  `python -m ruff format --check scripts/service_boundary_gate.py tests/unit/test_service_boundary_gate.py scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py`,
+  `python -m mypy --config-file mypy.ini scripts/service_boundary_gate.py scripts/engineering_health_report.py`,
+  `python -m pytest tests/unit/test_service_boundary_gate.py tests/unit/test_engineering_health_report.py -q`,
+  `python scripts/service_boundary_gate.py`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is repo-native CI gate hardening for existing
+  backend service-boundary governance.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T04:37:23+00:00`
+- Generated at: `2026-06-13T04:41:11+00:00`
 
-- Current ref: `b4ace7a0`
+- Current ref: `c19e1716`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T02:30:34+00:00`
+- Generated at: `2026-06-13T04:37:23+00:00`
 
-- Current ref: `a226f316`
+- Current ref: `b4ace7a0`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | apply_group_constraints | src/core/rebalance/targets.py | 7 | 66 |
-| 2 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
-| 3 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
-| 4 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
-| 5 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
-| 6 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
-| 7 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 8 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
-| 9 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
-| 10 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 1 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
+| 2 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
+| 3 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
+| 4 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
+| 5 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
+| 6 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 7 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
+| 8 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 9 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 10 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T04:41:11+00:00`
+- Generated at: `2026-06-13T04:41:46+00:00`
 
-- Current ref: `c19e1716`
+- Current ref: `fd496fc9`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T02:30:34+00:00`
+- Generated at: `2026-06-13T04:37:23+00:00`
 
-- Current ref: `a226f316`
+- Current ref: `b4ace7a0`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 
@@ -13,7 +13,7 @@
 | Unit tests | Active gate | `make check` runs `tests/unit`. |
 | OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |
 | API vocabulary | Active gate | `scripts/api_vocabulary_inventory.py --validate-only`. |
-| Service boundary leakage | Report plus focused scans | Current service boundary findings: 0. |
+| Service boundary | Active gate | `scripts/service_boundary_gate.py`. |
 | Router infrastructure imports | Baseline debt | Current router infra imports: 0. |
 | OpenAPI 4xx/5xx response markers | Baseline debt | Current missing markers: 0. |
 | Complexity | Report-only baseline | `quality/complexity_report.md`; add thresholds after baseline review. |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T04:37:23+00:00`
+- Generated at: `2026-06-13T04:41:11+00:00`
 
-- Current ref: `b4ace7a0`
+- Current ref: `c19e1716`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T04:41:11+00:00`
+- Generated at: `2026-06-13T04:41:46+00:00`
 
-- Current ref: `c19e1716`
+- Current ref: `fd496fc9`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T04:41:11+00:00`
+- Generated at: `2026-06-13T04:41:46+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `c19e1716`
+- Current ref: `fd496fc9`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T02:30:34+00:00`
+- Generated at: `2026-06-13T04:37:23+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `a226f316`
+- Current ref: `b4ace7a0`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 814 | 814 | +0 |
-| Total Python LOC | 169882 | 169993 | +111 |
-| Test functions | 2453 | 2453 | +0 |
+| Python files | 814 | 816 | +2 |
+| Total Python LOC | 169993 | 170162 | +169 |
+| Test functions | 2453 | 2458 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T04:37:23+00:00`
+- Generated at: `2026-06-13T04:41:11+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `b4ace7a0`
+- Current ref: `c19e1716`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -571,11 +571,7 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
         ["Unit tests", "Active gate", "`make check` runs `tests/unit`."],
         ["OpenAPI governance", "Active gate", "`scripts/openapi_quality_gate.py`."],
         ["API vocabulary", "Active gate", "`scripts/api_vocabulary_inventory.py --validate-only`."],
-        [
-            "Service boundary leakage",
-            "Report plus focused scans",
-            "Current service boundary findings: 0.",
-        ],
+        ["Service boundary", "Active gate", "`scripts/service_boundary_gate.py`."],
         [
             "Router infrastructure imports",
             "Baseline debt",

--- a/scripts/service_boundary_gate.py
+++ b/scripts/service_boundary_gate.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+
+SERVICE_DIR = Path("src/api/services")
+SERVICE_LEAKAGE_PATTERNS = (
+    "from src.api.routers",
+    "import src.api.routers",
+    "HTTPException",
+    "status.HTTP",
+    "from fastapi",
+    "import fastapi",
+    "from starlette",
+    "import starlette",
+)
+
+
+def _matching_lines(path: str, text: str, patterns: Iterable[str]) -> list[str]:
+    matches: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if any(pattern in line for pattern in patterns):
+            matches.append(f"{path}:{lineno}: {line.strip()}")
+    return matches
+
+
+def evaluate_service_boundary(service_dir: Path = SERVICE_DIR) -> list[str]:
+    violations: list[str] = []
+    for path in sorted(service_dir.rglob("*.py")):
+        violations.extend(
+            _matching_lines(path.as_posix(), path.read_text(), SERVICE_LEAKAGE_PATTERNS)
+        )
+    return violations
+
+
+def main() -> int:
+    violations = evaluate_service_boundary()
+    if violations:
+        print("Service boundary gate failed:")
+        print("\n".join(f"- {violation}" for violation in violations))
+        return 1
+    print("Service boundary gate passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/rebalance/targets.py
+++ b/src/core/rebalance/targets.py
@@ -152,56 +152,73 @@ def apply_group_constraints(
 
     buy_set = set(buy_list)
     shelf_attrs_by_id, known_attr_keys = _build_shelf_attr_indexes(shelf)
-    sorted_keys = sorted(options.group_constraints.keys())
-
-    for constraint_key in sorted_keys:
-        constraint = options.group_constraints[constraint_key]
-
-        constraint_parts = _constraint_key_parts(
-            constraint_key,
-            known_attr_keys=known_attr_keys,
-            diagnostics=diagnostics,
-        )
-        if constraint_parts is None:
-            continue
-
-        attr_key, attr_val = constraint_parts
-        group_members = _group_constraint_members(
-            eligible_targets=eligible_targets,
-            shelf_attrs_by_id=shelf_attrs_by_id,
-            attr_key=attr_key,
-            attr_val=attr_val,
-        )
-        if not group_members:
-            continue
-
-        current_w = sum((eligible_targets[i] for i in group_members), Decimal("0"))
-        if current_w <= constraint.max_weight + Decimal("0.0001"):
-            continue
-
-        current_w, excess = _cap_group_constraint_members(
-            eligible_targets=eligible_targets,
-            group_members=group_members,
-            max_weight=constraint.max_weight,
-        )
-        recipients = _redistribute_group_constraint_excess(
+    for constraint_key in sorted(options.group_constraints.keys()):
+        status = _apply_group_constraint(
+            constraint_key=constraint_key,
+            max_weight=options.group_constraints[constraint_key].max_weight,
             eligible_targets=eligible_targets,
             buy_set=buy_set,
-            group_members=group_members,
-            released_weight=excess,
-        )
-        status = _record_group_constraint_event(
+            shelf_attrs_by_id=shelf_attrs_by_id,
+            known_attr_keys=known_attr_keys,
             diagnostics=diagnostics,
-            constraint_key=constraint_key,
-            group_weight_before=current_w,
-            max_weight=constraint.max_weight,
-            released_weight=excess,
-            recipients=recipients,
         )
         if status == "BLOCKED":
             return "BLOCKED"
 
     return "READY"
+
+
+def _apply_group_constraint(
+    *,
+    constraint_key: str,
+    max_weight: Decimal,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+    shelf_attrs_by_id: dict[str, dict[str, str]],
+    known_attr_keys: set[str],
+    diagnostics: DiagnosticsData,
+) -> _GroupConstraintStatus:
+    constraint_parts = _constraint_key_parts(
+        constraint_key,
+        known_attr_keys=known_attr_keys,
+        diagnostics=diagnostics,
+    )
+    if constraint_parts is None:
+        return "READY"
+
+    attr_key, attr_val = constraint_parts
+    group_members = _group_constraint_members(
+        eligible_targets=eligible_targets,
+        shelf_attrs_by_id=shelf_attrs_by_id,
+        attr_key=attr_key,
+        attr_val=attr_val,
+    )
+    if not group_members:
+        return "READY"
+
+    current_w = sum((eligible_targets[i] for i in group_members), Decimal("0"))
+    if current_w <= max_weight + Decimal("0.0001"):
+        return "READY"
+
+    current_w, excess = _cap_group_constraint_members(
+        eligible_targets=eligible_targets,
+        group_members=group_members,
+        max_weight=max_weight,
+    )
+    recipients = _redistribute_group_constraint_excess(
+        eligible_targets=eligible_targets,
+        buy_set=buy_set,
+        group_members=group_members,
+        released_weight=excess,
+    )
+    return _record_group_constraint_event(
+        diagnostics=diagnostics,
+        constraint_key=constraint_key,
+        group_weight_before=current_w,
+        max_weight=max_weight,
+        released_weight=excess,
+        recipients=recipients,
+    )
 
 
 def generate_targets(

--- a/tests/unit/core/test_target_generation_helpers.py
+++ b/tests/unit/core/test_target_generation_helpers.py
@@ -8,6 +8,7 @@ from src.core.models import (
     ModelTarget,
     ShelfEntry,
 )
+from src.core.rebalance.targets import _apply_group_constraint
 from src.core.target_generation import (
     _apply_solver_values,
     _build_solver_problem,
@@ -201,6 +202,65 @@ def test_build_solver_problem_collects_cash_position_and_group_constraints() -> 
     assert problem_spec.weights.size == 1
     assert len(problem_spec.problem.constraints) == 5
     assert diagnostics.warnings == []
+
+
+def test_apply_group_constraint_caps_and_redistributes_matching_group() -> None:
+    diagnostics = DiagnosticsData(data_quality={}, suppressed_intents=[], warnings=[])
+    eligible_targets = {"TECH": Decimal("0.60"), "FI": Decimal("0.40")}
+
+    status = _apply_group_constraint(
+        constraint_key="sector:TECH",
+        max_weight=Decimal("0.20"),
+        eligible_targets=eligible_targets,
+        buy_set={"TECH", "FI"},
+        shelf_attrs_by_id={"TECH": {"sector": "TECH"}, "FI": {"sector": "FI"}},
+        known_attr_keys={"sector"},
+        diagnostics=diagnostics,
+    )
+
+    assert status == "READY"
+    assert eligible_targets["TECH"] == Decimal("0.20")
+    assert eligible_targets["FI"] == Decimal("0.80")
+    assert diagnostics.group_constraint_events[0].status == "CAPPED"
+
+
+def test_apply_group_constraint_skips_unknown_or_within_limit_group() -> None:
+    diagnostics = DiagnosticsData(data_quality={}, suppressed_intents=[], warnings=[])
+    eligible_targets = {"TECH": Decimal("0.20001"), "FI": Decimal("0.79999")}
+
+    status = _apply_group_constraint(
+        constraint_key="sector:TECH",
+        max_weight=Decimal("0.20"),
+        eligible_targets=eligible_targets,
+        buy_set={"TECH", "FI"},
+        shelf_attrs_by_id={"TECH": {"sector": "TECH"}, "FI": {"sector": "FI"}},
+        known_attr_keys={"sector"},
+        diagnostics=diagnostics,
+    )
+
+    assert status == "READY"
+    assert eligible_targets["TECH"] == Decimal("0.20001")
+    assert diagnostics.warnings == []
+    assert diagnostics.group_constraint_events == []
+
+
+def test_apply_group_constraint_blocks_when_no_redistribution_recipient() -> None:
+    diagnostics = DiagnosticsData(data_quality={}, suppressed_intents=[], warnings=[])
+    eligible_targets = {"TECH": Decimal("0.60"), "LOCKED": Decimal("0.40")}
+
+    status = _apply_group_constraint(
+        constraint_key="sector:TECH",
+        max_weight=Decimal("0.20"),
+        eligible_targets=eligible_targets,
+        buy_set={"TECH"},
+        shelf_attrs_by_id={"TECH": {"sector": "TECH"}, "LOCKED": {"sector": "FI"}},
+        known_attr_keys={"sector"},
+        diagnostics=diagnostics,
+    )
+
+    assert status == "BLOCKED"
+    assert "NO_ELIGIBLE_REDISTRIBUTION_DESTINATION" in diagnostics.warnings
+    assert diagnostics.group_constraint_events[0].status == "BLOCKED"
 
 
 def test_apply_solver_values_quantizes_and_fails_closed_without_values() -> None:

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -120,6 +120,7 @@ def test_quality_scorecard_separates_active_gates_from_planned_gates() -> None:
 
     assert "# lotus-manage Quality Scorecard" in scorecard
     assert "| OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |" in scorecard
+    assert "| Service boundary | Active gate | `scripts/service_boundary_gate.py`. |" in scorecard
     assert "| Complexity | Report-only baseline |" in scorecard
     assert (
         "| 4 - enterprise-readiness gates | Block release on full readiness posture." in scorecard

--- a/tests/unit/test_service_boundary_gate.py
+++ b/tests/unit/test_service_boundary_gate.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from scripts.service_boundary_gate import evaluate_service_boundary
+
+
+def test_service_boundary_gate_detects_router_and_http_framework_leakage(
+    tmp_path: Path,
+) -> None:
+    service_dir = tmp_path / "src" / "api" / "services"
+    service_dir.mkdir(parents=True)
+    (service_dir / "leaky_service.py").write_text(
+        "\n".join(
+            [
+                "from fastapi import HTTPException",
+                "from starlette.requests import Request",
+                "from src.api.routers.example import router",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = evaluate_service_boundary(service_dir)
+
+    assert violations == [
+        f"{(service_dir / 'leaky_service.py').as_posix()}:1: from fastapi import HTTPException",
+        f"{(service_dir / 'leaky_service.py').as_posix()}:2: from starlette.requests import Request",
+        f"{(service_dir / 'leaky_service.py').as_posix()}:3: from src.api.routers.example import router",
+    ]
+
+
+def test_service_boundary_gate_allows_transport_free_services(tmp_path: Path) -> None:
+    service_dir = tmp_path / "src" / "api" / "services"
+    service_dir.mkdir(parents=True)
+    (service_dir / "clean_service.py").write_text(
+        "\n".join(
+            [
+                "from src.core.models import Portfolio",
+                "",
+                "def load_portfolio() -> Portfolio | None:",
+                "    return None",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert evaluate_service_boundary(service_dir) == []


### PR DESCRIPTION
## Summary
- Extracts `_apply_group_constraint` from rebalance target generation so group cap, redistribution, and blocked-status handling are isolated and directly tested.
- Adds a repo-native `service-boundary-gate` and wires it into `make check`, `make ci`, Feature Lane, PR Merge Gate, and Quality Baseline reporting.
- Improves Quality Baseline warning visibility by adding `pipefail` to report-only pipelines that write artifacts through `tee`.
- Refreshes quality reports; `apply_group_constraints` drops out of the current top-ten source hotspot list and service boundary governance is now shown as an active gate.

## Validation
- `python -m pytest tests\unit\core\test_target_generation_helpers.py tests\unit\dpm\engine\coverage\test_engine_target_generation.py tests\unit\test_service_boundary_gate.py tests\unit\test_engineering_health_report.py -q` -> 46 passed
- `python -m ruff check scripts\service_boundary_gate.py tests\unit\test_service_boundary_gate.py scripts\engineering_health_report.py tests\unit\test_engineering_health_report.py`
- `python -m ruff format --check scripts\service_boundary_gate.py tests\unit\test_service_boundary_gate.py scripts\engineering_health_report.py tests\unit\test_engineering_health_report.py`
- `python -m mypy --config-file mypy.ini --explicit-package-bases scripts\service_boundary_gate.py scripts\engineering_health_report.py`
- `python scripts\service_boundary_gate.py` -> passed
- `python scripts\openapi_quality_gate.py` -> passed
- `python scripts\api_vocabulary_inventory.py --validate-only` -> passed
- `git diff --check` -> passed
- `make check` -> 2634 passed plus ruff, format, mypy, no-alias, OpenAPI, API vocabulary, service-boundary, and mesh contract gates

## Governance
- Stranded truth: `git fetch origin --prune` and `git branch -r --no-merged origin/main` returned no unmerged remote branches before PR creation.
- Open PR scan: `gh pr list --state open --limit 100 --json number,headRefName,title,state` returned `[]` before PR creation.
- Wiki drift: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`; no wiki publication required.
- Service/router boundary: remediated leakage scan is now enforced as `make service-boundary-gate` in local and GitHub CI.