### PR TITLE
Refactor execution acknowledgement source adapter

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21342,3 +21342,36 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is repo-native CI gate hardening for existing
   backend service-boundary governance.
+
+## BACKEND-REVIEW-20260613-861: Core execution acknowledgement source helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/core_sources.py`,
+  `tests/unit/core/test_core_realized_outcome_sources.py`, `src/core/waves/models.py`,
+  `tests/unit/dpm/waves/test_wave_domain.py`, and quality reports.
+- Finding: `realized_execution_acknowledgement_source_from_response` became the next current
+  source-complexity hotspot after the rebalance group-constraint slice and mixed Core metadata
+  extraction, fail-closed supportability posture parsing, deterministic source identity assembly,
+  source state/quality mapping, reason-code expansion, and snapshot construction in one adapter.
+  Focused tests also surfaced a deprecated Pydantic `Field(exclude_if=...)` warning in wave source
+  refs that did not change default serialization but weakened local signal quality.
+- Action: extracted execution-acknowledgement posture extraction, source-id assembly,
+  fail-closed state/quality mapping, and reason-code assembly into focused helpers while preserving
+  external OMS acknowledgement non-promotion semantics. Added direct helper coverage for
+  deterministic identity, reason-code expansion, empty selector defaults, and fail-closed mapping.
+  Removed the deprecated `exclude_if` field kwarg from `DpmWaveSourceRef` and added direct
+  serialization coverage for the existing null optional-field posture.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/core_sources.py tests/unit/core/test_core_realized_outcome_sources.py src/core/waves/models.py tests/unit/dpm/waves/test_wave_domain.py`,
+  `python -m ruff format --check src/core/outcomes/core_sources.py tests/unit/core/test_core_realized_outcome_sources.py src/core/waves/models.py tests/unit/dpm/waves/test_wave_domain.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/core_sources.py src/core/waves/models.py`,
+  `python -m pytest tests/unit/core/test_core_realized_outcome_sources.py tests/unit/dpm/waves/test_wave_domain.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/service_boundary_gate.py`,
+  `python scripts/engineering_health_report.py`,
+  `git diff --check`,
+  and `git restore quality/baseline_report.md`.
+- Wiki decision: no wiki source change required; this is internal source-adapter maintainability
+  and local warning-signal hardening.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21359,8 +21359,8 @@ and improves internal transaction-cost source posture maintainability only.
   fail-closed state/quality mapping, and reason-code assembly into focused helpers while preserving
   external OMS acknowledgement non-promotion semantics. Added direct helper coverage for
   deterministic identity, reason-code expansion, empty selector defaults, and fail-closed mapping.
-  Removed the deprecated `exclude_if` field kwarg from `DpmWaveSourceRef` and added direct
-  serialization coverage for the existing null optional-field posture.
+  Removed the deprecated `exclude_if` field kwarg from `DpmWaveSourceRef` and localized
+  optional-field omission to source-ref payload builders while preserving existing payload coverage.
 - Status: hardened.
 - Evidence:
   `python -m ruff check src/core/outcomes/core_sources.py tests/unit/core/test_core_realized_outcome_sources.py src/core/waves/models.py tests/unit/dpm/waves/test_wave_domain.py`,

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T04:41:46+00:00`
+- Generated at: `2026-06-13T05:00:35+00:00`
 
-- Current ref: `fd496fc9`
+- Current ref: `3f1a3509`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | realized_execution_acknowledgement_source_from_response | src/core/outcomes/core_sources.py | 7 | 62 |
-| 2 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
-| 3 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
-| 4 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
-| 5 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
-| 6 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 7 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
-| 8 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
-| 9 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
-| 10 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 1 | _source_refs | src/core/proof_packs/builder.py | 7 | 62 |
+| 2 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
+| 3 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
+| 4 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
+| 5 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 6 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
+| 7 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 8 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 9 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 10 | _run_policy_section_payload | src/core/proof_packs/builder.py | 7 | 49 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T05:00:35+00:00`
+- Generated at: `2026-06-13T05:03:46+00:00`
 
-- Current ref: `3f1a3509`
+- Current ref: `d7545641`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T04:41:46+00:00`
+- Generated at: `2026-06-13T05:00:35+00:00`
 
-- Current ref: `fd496fc9`
+- Current ref: `3f1a3509`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T05:00:35+00:00`
+- Generated at: `2026-06-13T05:03:46+00:00`
 
-- Current ref: `3f1a3509`
+- Current ref: `d7545641`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T05:00:35+00:00`
+- Generated at: `2026-06-13T05:03:46+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `3f1a3509`
+- Current ref: `d7545641`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T04:41:46+00:00`
+- Generated at: `2026-06-13T05:00:35+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `fd496fc9`
+- Current ref: `3f1a3509`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 814 | 816 | +2 |
-| Total Python LOC | 169993 | 170162 | +169 |
-| Test functions | 2453 | 2458 | +5 |
+| Python files | 816 | 816 | +0 |
+| Total Python LOC | 170162 | 170286 | +124 |
+| Test functions | 2458 | 2461 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/routers/wave_source_refs.py
+++ b/src/api/routers/wave_source_refs.py
@@ -10,7 +10,7 @@ from src.core.waves import DpmWaveSourceRef
 def source_refs_payload(refs: Iterable[DpmWaveSourceRef]) -> list[dict[str, object]]:
     def _ref_payload(ref: DpmWaveSourceRef | Mapping[str, object]) -> dict[str, object]:
         if hasattr(ref, "model_dump"):
-            payload = ref.model_dump(mode="json")
+            payload = ref.model_dump(mode="json", exclude_none=True)
             if isinstance(payload, dict):
                 return cast(dict[str, object], payload)
         if isinstance(ref, Mapping):

--- a/src/api/services/wave_core_portfolio_universe_resolution.py
+++ b/src/api/services/wave_core_portfolio_universe_resolution.py
@@ -55,7 +55,7 @@ def _portfolio_universe_candidate_ref(
         source_version=str(candidate.binding_version),
         supportability_state="READY",
         selection_basis=selection_basis,
-    ).model_dump(mode="json")
+    ).model_dump(mode="json", exclude_none=True)
 
 
 def _portfolio_universe_candidate_page_ref(
@@ -68,7 +68,7 @@ def _portfolio_universe_candidate_page_ref(
         source_version=page.product_version,
         supportability_state=page.supportability.state,
         content_hash=page.source_batch_fingerprint,
-    ).model_dump(mode="json")
+    ).model_dump(mode="json", exclude_none=True)
 
 
 def resolve_core_dpm_portfolio_universe_candidates(

--- a/src/core/outcomes/core_sources.py
+++ b/src/core/outcomes/core_sources.py
@@ -38,6 +38,16 @@ class _CoreSourceMetadata(TypedDict):
     content_hash: str | None
 
 
+class _ExecutionAcknowledgementPosture(TypedDict):
+    acknowledgement_count: int
+    supportability_state: str
+    supportability_reason: str
+    execution_intent_id: str
+    order_reference_ids: list[str]
+    missing_data_families: list[str]
+    blocked_capabilities: list[str]
+
+
 def realized_cash_source_from_cash_balances_response(
     response: dict[str, Any],
     *,
@@ -365,61 +375,109 @@ def realized_execution_acknowledgement_source_from_response(
 
     metadata = _core_metadata(response)
     portfolio_id = _read_required_text(response.get("portfolio_id"), "portfolio_id")
+    posture = _execution_acknowledgement_posture(response, metadata=metadata)
+    source_state, quality = _execution_acknowledgement_state_quality(
+        posture["supportability_state"]
+    )
+    return DpmRealizedSourceSnapshot(
+        dimension="EXECUTION_QUALITY",
+        source_system="lotus-core",
+        source_type="EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT",
+        source_id=_execution_acknowledgement_source_id(
+            metadata=metadata,
+            portfolio_id=portfolio_id,
+            posture=posture,
+        ),
+        value=Decimal(posture["acknowledgement_count"]),
+        unit="acknowledgements",
+        source_state=source_state,
+        quality=quality,
+        observed_at=metadata["observed_at"],
+        as_of_date=metadata["as_of_date"],
+        content_hash=metadata["content_hash"],
+        reason_codes=_execution_acknowledgement_reason_codes(
+            metadata=metadata,
+            posture=posture,
+        ),
+    )
+
+
+def _execution_acknowledgement_posture(
+    response: dict[str, Any],
+    *,
+    metadata: _CoreSourceMetadata,
+) -> _ExecutionAcknowledgementPosture:
     supportability = _read_mapping(response.get("supportability"))
-    acknowledgement_count = _read_int(
-        supportability.get("acknowledgement_count"),
-        "supportability.acknowledgement_count",
+    return {
+        "acknowledgement_count": _read_int(
+            supportability.get("acknowledgement_count"),
+            "supportability.acknowledgement_count",
+        ),
+        "supportability_state": (
+            _read_text(supportability.get("state")) or metadata["data_quality_status"]
+        ).upper(),
+        "supportability_reason": (
+            _read_text(supportability.get("reason")) or "EXTERNAL_OMS_ACKNOWLEDGEMENT_UNAVAILABLE"
+        ),
+        "execution_intent_id": _read_text(response.get("execution_intent_id")) or "none",
+        "order_reference_ids": _read_text_list(response.get("order_reference_ids")),
+        "missing_data_families": _read_text_list(supportability.get("missing_data_families")),
+        "blocked_capabilities": _read_text_list(supportability.get("blocked_capabilities")),
+    }
+
+
+def _execution_acknowledgement_source_id(
+    *,
+    metadata: _CoreSourceMetadata,
+    portfolio_id: str,
+    posture: _ExecutionAcknowledgementPosture,
+) -> str:
+    order_basis = (
+        ",".join(posture["order_reference_ids"]) if posture["order_reference_ids"] else "none"
     )
-    supportability_state = (
-        _read_text(supportability.get("state")) or metadata["data_quality_status"]
-    ).upper()
-    supportability_reason = (
-        _read_text(supportability.get("reason")) or "EXTERNAL_OMS_ACKNOWLEDGEMENT_UNAVAILABLE"
-    )
-    execution_intent_id = _read_text(response.get("execution_intent_id")) or "none"
-    order_reference_ids = _read_text_list(response.get("order_reference_ids"))
-    order_basis = ",".join(order_reference_ids) if order_reference_ids else "none"
-    source_id = _source_id(
+    return _source_id(
         product_name=metadata["product_name"],
         product_version=metadata["product_version"],
         portfolio_id=portfolio_id,
         as_of_date=metadata["as_of_date"],
         basis=(
             "external_order_execution_acknowledgement:"
-            f"execution_intent={execution_intent_id}:orders={order_basis}"
+            f"execution_intent={posture['execution_intent_id']}:orders={order_basis}"
         ),
         fingerprint=metadata["content_hash"],
     )
-    return DpmRealizedSourceSnapshot(
-        dimension="EXECUTION_QUALITY",
-        source_system="lotus-core",
-        source_type="EXTERNAL_ORDER_EXECUTION_ACKNOWLEDGEMENT",
-        source_id=source_id,
-        value=Decimal(acknowledgement_count),
-        unit="acknowledgements",
-        source_state="BLOCKED" if supportability_state == "UNAVAILABLE" else "DEGRADED",
-        quality="MISSING" if supportability_state == "UNAVAILABLE" else "UNAVAILABLE",
-        observed_at=metadata["observed_at"],
-        as_of_date=metadata["as_of_date"],
-        content_hash=metadata["content_hash"],
-        reason_codes=[
-            "CORE_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
-            f"CORE_PRODUCT_{metadata['product_name'].upper()}",
-            f"CORE_PRODUCT_VERSION_{metadata['product_version'].upper()}",
-            f"EXECUTION_ACKNOWLEDGEMENT_SUPPORTABILITY_{supportability_state}",
-            supportability_reason,
-            f"EXECUTION_ACKNOWLEDGEMENT_COUNT_{acknowledgement_count}",
-            *_prefixed_reason_codes(
-                "EXECUTION_ACKNOWLEDGEMENT_MISSING_DATA",
-                _read_text_list(supportability.get("missing_data_families")),
-            ),
-            *_prefixed_reason_codes(
-                "EXECUTION_ACKNOWLEDGEMENT_BLOCKED_CAPABILITY",
-                _read_text_list(supportability.get("blocked_capabilities")),
-            ),
-            f"CORE_DATA_QUALITY_{metadata['data_quality_status'].upper()}",
-        ],
-    )
+
+
+def _execution_acknowledgement_state_quality(
+    supportability_state: str,
+) -> tuple[Literal["BLOCKED", "DEGRADED"], Literal["MISSING", "UNAVAILABLE"]]:
+    if supportability_state == "UNAVAILABLE":
+        return "BLOCKED", "MISSING"
+    return "DEGRADED", "UNAVAILABLE"
+
+
+def _execution_acknowledgement_reason_codes(
+    *,
+    metadata: _CoreSourceMetadata,
+    posture: _ExecutionAcknowledgementPosture,
+) -> list[str]:
+    return [
+        "CORE_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
+        f"CORE_PRODUCT_{metadata['product_name'].upper()}",
+        f"CORE_PRODUCT_VERSION_{metadata['product_version'].upper()}",
+        f"EXECUTION_ACKNOWLEDGEMENT_SUPPORTABILITY_{posture['supportability_state']}",
+        posture["supportability_reason"],
+        f"EXECUTION_ACKNOWLEDGEMENT_COUNT_{posture['acknowledgement_count']}",
+        *_prefixed_reason_codes(
+            "EXECUTION_ACKNOWLEDGEMENT_MISSING_DATA",
+            posture["missing_data_families"],
+        ),
+        *_prefixed_reason_codes(
+            "EXECUTION_ACKNOWLEDGEMENT_BLOCKED_CAPABILITY",
+            posture["blocked_capabilities"],
+        ),
+        f"CORE_DATA_QUALITY_{metadata['data_quality_status'].upper()}",
+    ]
 
 
 def unavailable_core_cash_source(

--- a/src/core/waves/models.py
+++ b/src/core/waves/models.py
@@ -90,7 +90,6 @@ class DpmWaveSourceRef(BaseModel):
                 "source_table": "portfolio_mandate_bindings",
             }
         ],
-        exclude_if=lambda value: value is None,
     )
 
 

--- a/tests/unit/core/test_core_realized_outcome_sources.py
+++ b/tests/unit/core/test_core_realized_outcome_sources.py
@@ -15,8 +15,13 @@ from src.core.outcomes import (
 from src.core.outcomes.core_sources import (
     _cash_movement_bucket_matches,
     _cash_movement_buckets,
+    _core_metadata,
     _currency_total_matches,
     _currency_total_rows,
+    _execution_acknowledgement_posture,
+    _execution_acknowledgement_reason_codes,
+    _execution_acknowledgement_source_id,
+    _execution_acknowledgement_state_quality,
     _normalized_currency_filter,
     _raise_on_invalid_currency_total_selection,
     _transaction_cashflow_value,
@@ -749,6 +754,68 @@ def test_external_order_execution_acknowledgement_blocks_rfc42_execution_dimensi
     )
     assert snapshot.source_hashes[source.source_id] == (
         "sha256:external-order-execution-acknowledgement"
+    )
+
+
+def test_execution_acknowledgement_helpers_build_deterministic_identity_and_reasons() -> None:
+    response = _external_order_execution_acknowledgement_response()
+    metadata = _core_metadata(response)
+
+    posture = _execution_acknowledgement_posture(response, metadata=metadata)
+    source_id = _execution_acknowledgement_source_id(
+        metadata=metadata,
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        posture=posture,
+    )
+    reason_codes = _execution_acknowledgement_reason_codes(
+        metadata=metadata,
+        posture=posture,
+    )
+
+    assert source_id == (
+        "ExternalOrderExecutionAcknowledgement:v1:PB_SG_GLOBAL_BAL_001:2026-05-06:"
+        "external_order_execution_acknowledgement:execution_intent=intent_rebalance_001:"
+        "orders=ORD-001,ORD-002:sha256:external-order-execution-acknowledgement"
+    )
+    assert reason_codes[:6] == [
+        "CORE_EXECUTION_ACKNOWLEDGEMENT_FAIL_CLOSED",
+        "CORE_PRODUCT_EXTERNALORDEREXECUTIONACKNOWLEDGEMENT",
+        "CORE_PRODUCT_VERSION_V1",
+        "EXECUTION_ACKNOWLEDGEMENT_SUPPORTABILITY_UNAVAILABLE",
+        "EXTERNAL_OMS_SOURCE_NOT_INGESTED",
+        "EXECUTION_ACKNOWLEDGEMENT_COUNT_0",
+    ]
+    assert (
+        "EXECUTION_ACKNOWLEDGEMENT_MISSING_DATA_EXTERNAL_OMS_ORDER_EXECUTION_ACKNOWLEDGEMENT"
+        in reason_codes
+    )
+    assert "EXECUTION_ACKNOWLEDGEMENT_BLOCKED_CAPABILITY_OMS_ACKNOWLEDGEMENT" in reason_codes
+
+
+def test_execution_acknowledgement_helpers_default_empty_selector_identity() -> None:
+    response = _external_order_execution_acknowledgement_response()
+    response["execution_intent_id"] = ""
+    response["order_reference_ids"] = []
+    metadata = _core_metadata(response)
+
+    posture = _execution_acknowledgement_posture(response, metadata=metadata)
+
+    assert _execution_acknowledgement_source_id(
+        metadata=metadata,
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        posture=posture,
+    ) == (
+        "ExternalOrderExecutionAcknowledgement:v1:PB_SG_GLOBAL_BAL_001:2026-05-06:"
+        "external_order_execution_acknowledgement:execution_intent=none:orders=none:"
+        "sha256:external-order-execution-acknowledgement"
+    )
+
+
+def test_execution_acknowledgement_state_quality_preserves_fail_closed_mapping() -> None:
+    assert _execution_acknowledgement_state_quality("UNAVAILABLE") == ("BLOCKED", "MISSING")
+    assert _execution_acknowledgement_state_quality("DEGRADED") == (
+        "DEGRADED",
+        "UNAVAILABLE",
     )
 
 


### PR DESCRIPTION
## Summary
- Extracted execution acknowledgement posture, source-id, fail-closed state/quality, and reason-code helpers from the core realized outcome source adapter.
- Removed deprecated `exclude_if` usage from `DpmWaveSourceRef` while preserving source-ref payload omission behavior in router/service payload builders.
- Added focused direct helper tests and refreshed the codebase review ledger plus quality reports.

## Validation
- `make check` (ruff, format check, monetary float guard, no-alias contract guard, mypy, OpenAPI quality gate, API vocabulary inventory, service boundary gate, domain-data-product contracts, trust telemetry contracts, observability contracts, 2637 unit tests)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- `git diff --check`
- service leakage scan: no matches
- wiki drift check: `DiffCount 0`
- pre-PR hygiene: no open PRs and no remote branches unmerged into `origin/main` before this branch was pushed

## Wiki
- No wiki source change required; this is internal source-adapter maintainability and CI/warning-signal hardening.