### PR TITLE
Enforce remediated quality gates

### DIFF
--- a/.github/workflows/feature-lane.yml
+++ b/.github/workflows/feature-lane.yml
@@ -55,16 +55,12 @@ jobs:
         run: make service-boundary-gate
       - name: Architecture Gate
         run: make architecture-gate
-        continue-on-error: true
       - name: Complexity Gate
         run: make complexity-gate
-        continue-on-error: true
       - name: Dependency Hygiene Gate
         run: make dependency-hygiene-gate
-        continue-on-error: true
       - name: Dead Code Gate
         run: make dead-code-gate
-        continue-on-error: true
       - name: Security Audit
         run: make security-audit
 

--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -55,16 +55,12 @@ jobs:
         run: make migration-smoke
       - name: Architecture Gate
         run: make architecture-gate
-        continue-on-error: true
       - name: Complexity Gate
         run: make complexity-gate
-        continue-on-error: true
       - name: Dependency Hygiene Gate
         run: make dependency-hygiene-gate
-        continue-on-error: true
       - name: Dead Code Gate
         run: make dead-code-gate
-        continue-on-error: true
       - name: Security Audit
         run: make security-audit
 

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -57,16 +57,12 @@ jobs:
         run: make migration-smoke
       - name: Architecture Gate
         run: make architecture-gate
-        continue-on-error: true
       - name: Complexity Gate
         run: make complexity-gate
-        continue-on-error: true
       - name: Dependency Hygiene Gate
         run: make dependency-hygiene-gate
-        continue-on-error: true
       - name: Dead Code Gate
         run: make dead-code-gate
-        continue-on-error: true
       - name: Security Audit
         run: make security-audit
 

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21375,3 +21375,30 @@ and improves internal transaction-cost source posture maintainability only.
   and `git restore quality/baseline_report.md`.
 - Wiki decision: no wiki source change required; this is internal source-adapter maintainability
   and local warning-signal hardening.
+
+## BACKEND-REVIEW-20260613-862: Enforced quality gate promotion
+
+- Date: 2026-06-13
+- Scope: `.github/workflows/feature-lane.yml`, `.github/workflows/pr-merge-gate.yml`,
+  `.github/workflows/main-releasability.yml`, `quality/ci_quality_gates.md`,
+  `scripts/engineering_health_report.py`, `tests/unit/test_ci_workflow_gate_enforcement.py`,
+  and `tests/unit/test_engineering_health_report.py`.
+- Finding: architecture, complexity, dependency-hygiene, and dead-code gates were clean under
+  their current repo-native thresholds, but Feature Lane, PR Merge Gate, and Main Releasability
+  still treated them as advisory `continue-on-error` steps. That left remediated quality checks
+  weaker than the refactoring program's active enforcement posture.
+- Action: promoted the four remediated quality gates to enforced CI steps across Feature Lane, PR
+  Merge Gate, and Main Releasability, updated CI quality documentation and generated scorecard
+  language to distinguish active gates from the separate report-only Quality Baseline workflow,
+  and added a unit guard that rejects reintroducing `continue-on-error` for those gates.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py tests/unit/test_ci_workflow_gate_enforcement.py`,
+  `python -m ruff format --check scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py tests/unit/test_ci_workflow_gate_enforcement.py`,
+  `python -m pytest tests/unit/test_engineering_health_report.py tests/unit/test_ci_workflow_gate_enforcement.py -q`,
+  `make architecture-gate`,
+  `make complexity-gate`,
+  `make dependency-hygiene-gate`,
+  and `make dead-code-gate`.
+- Wiki decision: no wiki source change required; this is repo-local CI enforcement and quality
+  scorecard truth.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-04T13:53:42+00:00`
+- Generated at: `2026-06-13T05:17:02+00:00`
 
-- Baseline commit: `e197d2cc`
+- Baseline commit: `22e1497d`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -10,9 +10,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 796 |
-| Total Python LOC | 153392 |
-| Test functions | 2078 |
+| Python files | 817 |
+| Total Python LOC | 170325 |
+| Test functions | 2462 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 
@@ -37,8 +37,8 @@
 | Service boundary leakage | service leakage scan plus this report | 2 - active/new-regression |
 | Router infrastructure imports | reported as known baseline debt | 1 - baseline |
 | Complexity/maintainability | `quality/complexity_report.md` | 1 - baseline |
-| Dead code | vulture baseline capture via `quality-baseline.yml` | 1 - report-only baseline |
-| Dependency hygiene | `deptry` + `pip check` via `quality-baseline.yml` and `make security-audit` | 2 - active/new-regression |
+| Dead code | `make dead-code-gate` plus vulture baseline capture via `quality-baseline.yml` | 2 - active/new-regression |
+| Dependency hygiene | `make dependency-hygiene-gate`, `pip check`, and `make security-audit` | 2 - active/new-regression |
 | Security | `bandit` + `pip-audit` via `quality-baseline.yml` and `make security-audit` | 2 - active/new-regression |
 | Documentation gaps | current docs tests plus planned docs scorecard | planned |
 | Observability gaps | `scripts/validate_observability_contracts.py`; richer runtime gap report planned | 2 - active/new-regression |

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -26,8 +26,7 @@ The following commands are active repository gates:
   - `make architecture-gate` (`python -m importlinter.cli import-linter lint --config .importlinter`)
   - `make complexity-gate` (`python -m radon cc src -s -n C`, `python -m radon mi src -s`)
   - `make dependency-hygiene-gate` (`python -m deptry src tests`)
-  - `make dead-code-gate` (`python -m vulture src tests --min-confidence 80`)  
-    (currently report-only until noise budget is reduced)
+  - `make dead-code-gate` (`python -m vulture src tests --min-confidence 80`)
   - `python -m pytest tests/unit`
 
 - `make ci`
@@ -47,7 +46,7 @@ The following commands are active repository gates:
 - Workflow file: `.github/workflows/feature-lane.yml`
 - Required lanes:
   - `ruff` + `mypy` + `no-alias` + `openapi` + `api-vocabulary` + `security-audit`
-  - `importlinter` + `radon` + `deptry` + `vulture` (non-blocking report-only)
+  - `architecture-gate` + `complexity-gate` + `dependency-hygiene-gate` + `dead-code-gate`
   - unit tests
 
 ### PR Merge Gate
@@ -55,7 +54,7 @@ The following commands are active repository gates:
 - Workflow file: `.github/workflows/pr-merge-gate.yml`
 - Required lanes:
   - same static/type/openapi/vocabulary/security gates as Feature Lane
-  - `architecture-gate` + `complexity-gate` + `dependency-hygiene-gate` + `dead-code-gate` (non-blocking report-only)
+  - `architecture-gate` + `complexity-gate` + `dependency-hygiene-gate` + `dead-code-gate`
   - migration smoke
   - matrix unit/integration/e2e tests with coverage upload
   - combined coverage floor (`99`)

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T05:03:46+00:00`
+- Generated at: `2026-06-13T05:17:02+00:00`
 
-- Current ref: `d7545641`
+- Current ref: `22e1497d`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T05:03:46+00:00`
+- Generated at: `2026-06-13T05:17:02+00:00`
 
-- Current ref: `d7545641`
+- Current ref: `22e1497d`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 
@@ -17,8 +17,8 @@
 | Router infrastructure imports | Baseline debt | Current router infra imports: 0. |
 | OpenAPI 4xx/5xx response markers | Baseline debt | Current missing markers: 0. |
 | Complexity | Report-only baseline | `quality/complexity_report.md`; add thresholds after baseline review. |
-| Dead code | Report-only baseline | `quality-baseline.yml` captures `vulture` output; add thresholds after baseline review. |
-| Dependency architecture | Report-only baseline | `quality-baseline.yml` captures `importlinter` and `deptry`; add thresholds after baseline review. |
+| Dead code | Active gate | `make dead-code-gate` runs vulture over `src` and `tests`; baseline workflow still captures expanded output. |
+| Dependency architecture | Active gate | `make architecture-gate` and `make dependency-hygiene-gate` run import-linter and deptry. |
 | Security depth | Partially active | `make security-audit` is active; `bandit` and `pip-audit` are report-only in `quality-baseline.yml`. |
 | Documentation coverage | Partially active | Docs current-state tests exist; add docs-gap scoring later. |
 | Observability | Partially active | Observability contract validator exists; add runtime posture scoring later. |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T05:03:46+00:00`
+- Generated at: `2026-06-13T05:17:02+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `d7545641`
+- Current ref: `22e1497d`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 816 | 816 | +0 |
-| Total Python LOC | 170162 | 170286 | +124 |
-| Test functions | 2458 | 2461 | +3 |
+| Python files | 816 | 817 | +1 |
+| Total Python LOC | 170286 | 170325 | +39 |
+| Test functions | 2461 | 2462 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -536,12 +536,12 @@ def build_baseline_report(context: HealthReportContext) -> str:
                 ],
                 [
                     "Dead code",
-                    "vulture baseline capture via `quality-baseline.yml`",
-                    "1 - report-only baseline",
+                    "`make dead-code-gate` plus vulture baseline capture via `quality-baseline.yml`",
+                    "2 - active/new-regression",
                 ],
                 [
                     "Dependency hygiene",
-                    "`deptry` + `pip check` via `quality-baseline.yml` and `make security-audit`",
+                    "`make dependency-hygiene-gate`, `pip check`, and `make security-audit`",
                     "2 - active/new-regression",
                 ],
                 [
@@ -589,13 +589,13 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
         ],
         [
             "Dead code",
-            "Report-only baseline",
-            "`quality-baseline.yml` captures `vulture` output; add thresholds after baseline review.",
+            "Active gate",
+            "`make dead-code-gate` runs vulture over `src` and `tests`; baseline workflow still captures expanded output.",
         ],
         [
             "Dependency architecture",
-            "Report-only baseline",
-            "`quality-baseline.yml` captures `importlinter` and `deptry`; add thresholds after baseline review.",
+            "Active gate",
+            "`make architecture-gate` and `make dependency-hygiene-gate` run import-linter and deptry.",
         ],
         [
             "Security depth",

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ENFORCED_WORKFLOWS = [
+    Path(".github/workflows/feature-lane.yml"),
+    Path(".github/workflows/pr-merge-gate.yml"),
+    Path(".github/workflows/main-releasability.yml"),
+]
+
+QUALITY_GATE_NAMES = [
+    "Architecture Gate",
+    "Complexity Gate",
+    "Dependency Hygiene Gate",
+    "Dead Code Gate",
+]
+
+
+def _step_block(workflow_text: str, gate_name: str) -> str:
+    marker = f"- name: {gate_name}"
+    start = workflow_text.index(marker)
+    next_step = workflow_text.find("\n      - name:", start + len(marker))
+    if next_step == -1:
+        return workflow_text[start:]
+    return workflow_text[start:next_step]
+
+
+def test_feature_pr_and_main_quality_gates_are_enforced() -> None:
+    for workflow_path in ENFORCED_WORKFLOWS:
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        for gate_name in QUALITY_GATE_NAMES:
+            block = _step_block(workflow_text, gate_name)
+            assert "continue-on-error" not in block, (
+                f"{workflow_path.as_posix()} keeps {gate_name} advisory; "
+                "remediated quality gates must fail the lane."
+            )

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -121,6 +121,8 @@ def test_quality_scorecard_separates_active_gates_from_planned_gates() -> None:
     assert "# lotus-manage Quality Scorecard" in scorecard
     assert "| OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |" in scorecard
     assert "| Service boundary | Active gate | `scripts/service_boundary_gate.py`. |" in scorecard
+    assert "| Dependency architecture | Active gate |" in scorecard
+    assert "| Dead code | Active gate |" in scorecard
     assert "| Complexity | Report-only baseline |" in scorecard
     assert (
         "| 4 - enterprise-readiness gates | Block release on full readiness posture." in scorecard


### PR DESCRIPTION
## Summary
- Promoted remediated `architecture-gate`, `complexity-gate`, `dependency-hygiene-gate`, and `dead-code-gate` from advisory `continue-on-error` to enforced CI steps in Feature Lane, PR Merge Gate, and Main Releasability.
- Added a unit guard that rejects reintroducing `continue-on-error` for those four gates in enforced workflows.
- Updated CI quality documentation, codebase review ledger, and generated quality reports to reflect the active gate posture.

## Validation
- `make check` (ruff, format check, monetary float guard, no-alias guard, mypy, OpenAPI quality gate, API vocabulary inventory, service boundary gate, domain-data-product contracts, trust telemetry contracts, observability contracts, 2638 unit tests)
- `python -m ruff check scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py tests/unit/test_ci_workflow_gate_enforcement.py`
- `python -m ruff format --check scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py tests/unit/test_ci_workflow_gate_enforcement.py`
- `python -m mypy --config-file mypy.ini scripts/engineering_health_report.py`
- `python -m pytest tests/unit/test_engineering_health_report.py tests/unit/test_ci_workflow_gate_enforcement.py -q`
- `make architecture-gate`
- `make complexity-gate`
- `make dependency-hygiene-gate`
- `make dead-code-gate`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- `git diff --check`
- wiki drift check: `DiffCount 0`
- pre-PR hygiene: no open PRs and no remote branches unmerged into `origin/main` before this branch was pushed

## Wiki
- No wiki source change required; this is repo-local CI enforcement and quality scorecard truth.