### PR TITLE
Refactor wave persistence and batch outcome helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21500,3 +21500,29 @@ and improves internal transaction-cost source posture maintainability only.
   product behavior.
 - Wiki decision: no wiki source change required; this is internal proof-pack builder
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-867: Postgres wave save helpers
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/waves/postgres.py` and
+  `tests/unit/dpm/waves/test_wave_domain.py`.
+- Bank-buyable control area: architecture and testing.
+- Finding: `PostgresDpmWaveRepository.save_wave` still mixed idempotency conflict detection,
+  durable wave insertion, idempotency marker insertion, event insertion, and commit orchestration in
+  one repository method. The behavior was correct, but the persistence contract was harder to
+  review than necessary for durable DPM wave creation and replay safety.
+- Action: extracted repository-local helpers for idempotency conflict detection, durable wave row
+  insertion, and idempotency marker insertion while leaving transaction orchestration in
+  `save_wave`. Added focused helper tests for no-key idempotency behavior, durable create payload
+  persistence, event persistence, and duplicate wave-id rejection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/waves/postgres.py tests/unit/dpm/waves/test_wave_domain.py`,
+  `python -m pytest tests/unit/dpm/waves/test_wave_domain.py -q`,
+  and `python -m radon cc src/infrastructure/waves/postgres.py -s`; the focused wave domain suite
+  reported 21 passed and `PostgresDpmWaveRepository.save_wave` reduced from B(7) to A(1).
+- Residual risk: this slice improves internal DPM wave persistence maintainability only. It does
+  not certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench
+  product behavior.
+- Wiki decision: no wiki source change required; this is internal infrastructure maintainability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21526,3 +21526,30 @@ and improves internal transaction-cost source posture maintainability only.
   product behavior.
 - Wiki decision: no wiki source change required; this is internal infrastructure maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-868: Batch scenario execution outcome helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/rebalance_batch_execution.py` and
+  `tests/unit/api/test_runtime_request_model_and_service_edges.py`.
+- Bank-buyable control area: architecture and testing.
+- Finding: `execute_batch_scenarios` still combined scenario option validation, scenario execution,
+  failed-scenario mapping, result collection, and telemetry summary in one application-service
+  function. The behavior was correct, but the per-scenario outcome handling was harder to review
+  than the batch analysis contract requires.
+- Action: extracted a typed `BatchScenarioOutcome`, a per-scenario execution helper, and a result
+  recorder helper while keeping the public batch orchestration contract unchanged. Added direct
+  helper tests for invalid scenario options, execution exceptions, and failure outcome recording.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/rebalance_batch_execution.py tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  `python -m ruff format --check src/api/services/rebalance_batch_execution.py tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/rebalance_batch_execution.py`,
+  `python -m pytest tests/unit/api/test_runtime_request_model_and_service_edges.py -q`,
+  and `python -m radon cc src/api/services/rebalance_batch_execution.py -s`; the focused runtime
+  service-edge suite reported 44 passed and `execute_batch_scenarios` reduced from B(7) to A(5).
+- Residual risk: this slice improves internal batch execution maintainability only. It does not
+  certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench product
+  behavior.
+- Wiki decision: no wiki source change required; this is internal application-service
+  maintainability hardening with no operator-facing contract change.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T06:03:45+00:00`
+- Generated at: `2026-06-13T06:26:54+00:00`
 
-- Current ref: `b745e696`
+- Current ref: `df27fd30`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | save_wave | src/infrastructure/waves/postgres.py | 7 | 62 |
-| 2 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
-| 3 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
-| 4 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 5 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
-| 6 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
-| 7 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
-| 8 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
-| 9 | _transaction_cost_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 49 |
-| 10 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 1 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
+| 2 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
+| 3 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 4 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
+| 5 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 6 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 7 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 8 | _transaction_cost_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 49 |
+| 9 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 10 | _sustainability_preference_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 47 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T06:26:54+00:00`
+- Generated at: `2026-06-13T06:32:02+00:00`
 
-- Current ref: `df27fd30`
+- Current ref: `f67f5b70`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | execute_batch_scenarios | src/api/services/rebalance_batch_execution.py | 7 | 60 |
-| 2 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
-| 3 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 4 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
-| 5 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
-| 6 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
-| 7 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
-| 8 | _transaction_cost_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 49 |
-| 9 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
-| 10 | _sustainability_preference_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 47 |
+| 1 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
+| 2 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 3 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
+| 4 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 5 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 6 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 7 | _transaction_cost_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 49 |
+| 8 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 9 | _sustainability_preference_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 47 |
+| 10 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T06:03:45+00:00`
+- Generated at: `2026-06-13T06:26:54+00:00`
 
-- Current ref: `b745e696`
+- Current ref: `df27fd30`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T06:26:54+00:00`
+- Generated at: `2026-06-13T06:32:02+00:00`
 
-- Current ref: `df27fd30`
+- Current ref: `f67f5b70`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T06:26:54+00:00`
+- Generated at: `2026-06-13T06:32:02+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `df27fd30`
+- Current ref: `f67f5b70`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 170568 | 170647 | +79 |
-| Test functions | 2467 | 2470 | +3 |
+| Total Python LOC | 170568 | 170776 | +208 |
+| Test functions | 2467 | 2473 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T06:03:45+00:00`
+- Generated at: `2026-06-13T06:26:54+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `b745e696`
+- Current ref: `df27fd30`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 170442 | 170568 | +126 |
-| Test functions | 2464 | 2467 | +3 |
+| Total Python LOC | 170568 | 170647 | +79 |
+| Test functions | 2467 | 2470 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -38,13 +38,13 @@
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/test_documentation_current_state.py | 2721 |
-| 4 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2545 |
+| 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2638 |
+| 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2426 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/infrastructure/core_sourcing/client.py | 1752 |
+| 10 | src/core/proof_packs/builder.py | 1774 |
 
 ### current branch
 

--- a/src/api/services/rebalance_batch_execution.py
+++ b/src/api/services/rebalance_batch_execution.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -20,8 +21,17 @@ from src.core.dpm_source_context import DpmResolvedSourceContext
 from src.core.models import (
     BatchRebalanceRequest,
     BatchRebalanceResult,
+    BatchScenarioMetric,
+    RebalanceResult,
 )
 from src.core.rebalance.policy_packs import DpmPolicyPackDefinition
+
+
+@dataclass(frozen=True)
+class BatchScenarioOutcome:
+    result: RebalanceResult | None = None
+    comparison_metric: BatchScenarioMetric | None = None
+    error: str | None = None
 
 
 def execute_batch_scenarios(
@@ -35,36 +45,30 @@ def execute_batch_scenarios(
     record_for_support: RecordForSupportFn,
     current_logger: logging.Logger | Any,
 ) -> BatchRebalanceResult:
-    results = {}
-    comparison_metrics = {}
-    failed_scenarios = {}
-    warnings = []
+    results: dict[str, RebalanceResult] = {}
+    comparison_metrics: dict[str, BatchScenarioMetric] = {}
+    failed_scenarios: dict[str, str] = {}
+    warnings: list[str] = []
 
     for scenario_name in sorted(request.scenarios.keys()):
-        scenario = request.scenarios[scenario_name]
-        try:
-            options = validate_batch_scenario_options(scenario)
-        except ValidationError as exc:
-            failed_scenarios[scenario_name] = to_invalid_options_error(exc)
-            continue
-
-        try:
-            scenario_result, scenario_metric = execute_valid_batch_scenario(
-                request=request,
-                scenario_name=scenario_name,
-                options=options,
-                batch_id=batch_id,
-                correlation_id=correlation_id,
-                policy_definition=policy_definition,
-                source_context=source_context,
-                run_simulation_fn=run_simulation_fn,
-                record_for_support=record_for_support,
-            )
-            results[scenario_name] = scenario_result
-            comparison_metrics[scenario_name] = scenario_metric
-        except (ValidationError, RuntimeError, ValueError) as exc:
-            current_logger.exception("Scenario execution failed")
-            failed_scenarios[scenario_name] = f"SCENARIO_EXECUTION_ERROR: {type(exc).__name__}"
+        outcome = _execute_batch_scenario(
+            request=request,
+            scenario_name=scenario_name,
+            batch_id=batch_id,
+            correlation_id=correlation_id,
+            policy_definition=policy_definition,
+            source_context=source_context,
+            run_simulation_fn=run_simulation_fn,
+            record_for_support=record_for_support,
+            current_logger=current_logger,
+        )
+        _record_batch_scenario_outcome(
+            scenario_name=scenario_name,
+            outcome=outcome,
+            results=results,
+            comparison_metrics=comparison_metrics,
+            failed_scenarios=failed_scenarios,
+        )
 
     if failed_scenarios:
         warnings.append("PARTIAL_BATCH_FAILURE")
@@ -84,6 +88,58 @@ def execute_batch_scenarios(
         failed_scenarios=failed_scenarios,
         warnings=warnings,
     )
+
+
+def _execute_batch_scenario(
+    *,
+    request: BatchRebalanceRequest,
+    scenario_name: str,
+    batch_id: str,
+    correlation_id: Optional[str],
+    policy_definition: Optional[DpmPolicyPackDefinition],
+    source_context: Optional[DpmResolvedSourceContext],
+    run_simulation_fn: RunSimulationFn,
+    record_for_support: RecordForSupportFn,
+    current_logger: logging.Logger | Any,
+) -> BatchScenarioOutcome:
+    try:
+        options = validate_batch_scenario_options(request.scenarios[scenario_name])
+    except ValidationError as exc:
+        return BatchScenarioOutcome(error=to_invalid_options_error(exc))
+
+    try:
+        scenario_result, scenario_metric = execute_valid_batch_scenario(
+            request=request,
+            scenario_name=scenario_name,
+            options=options,
+            batch_id=batch_id,
+            correlation_id=correlation_id,
+            policy_definition=policy_definition,
+            source_context=source_context,
+            run_simulation_fn=run_simulation_fn,
+            record_for_support=record_for_support,
+        )
+    except (ValidationError, RuntimeError, ValueError) as exc:
+        current_logger.exception("Scenario execution failed")
+        return BatchScenarioOutcome(error=f"SCENARIO_EXECUTION_ERROR: {type(exc).__name__}")
+
+    return BatchScenarioOutcome(result=scenario_result, comparison_metric=scenario_metric)
+
+
+def _record_batch_scenario_outcome(
+    *,
+    scenario_name: str,
+    outcome: BatchScenarioOutcome,
+    results: dict[str, RebalanceResult],
+    comparison_metrics: dict[str, BatchScenarioMetric],
+    failed_scenarios: dict[str, str],
+) -> None:
+    if outcome.error is not None:
+        failed_scenarios[scenario_name] = outcome.error
+        return
+    if outcome.result is not None and outcome.comparison_metric is not None:
+        results[scenario_name] = outcome.result
+        comparison_metrics[scenario_name] = outcome.comparison_metric
 
 
 __all__ = ["execute_batch_scenarios"]

--- a/src/infrastructure/waves/postgres.py
+++ b/src/infrastructure/waves/postgres.py
@@ -33,58 +33,19 @@ class PostgresDpmWaveRepository:
         request_hash: str | None,
     ) -> None:
         with closing(self._connect()) as connection:
-            if idempotency_key is not None:
-                existing = connection.execute(
-                    """
-                    SELECT wave_id, request_hash
-                    FROM dpm_rebalance_wave_idempotency
-                    WHERE idempotency_key = %s
-                    """,
-                    (idempotency_key,),
-                ).fetchone()
-                if existing is not None and (
-                    existing["wave_id"] != wave.wave_id or existing["request_hash"] != request_hash
-                ):
-                    raise DpmWaveIdempotencyConflictError("DPM_WAVE_IDEMPOTENCY_CONFLICT")
-
-            result = connection.execute(
-                """
-                INSERT INTO dpm_rebalance_waves (
-                    wave_id,
-                    state,
-                    trigger_type,
-                    as_of_date,
-                    created_at,
-                    created_by,
-                    correlation_id,
-                    version,
-                    wave_json,
-                    retention_policy
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (wave_id) DO NOTHING
-                """,
-                _wave_row_args(wave),
+            _raise_if_idempotency_conflict(
+                connection=connection,
+                wave=wave,
+                idempotency_key=idempotency_key,
+                request_hash=request_hash,
             )
-            if result.rowcount != 1:
-                raise DpmWaveAlreadyExistsError("DPM_WAVE_ALREADY_EXISTS")
-            if idempotency_key is not None:
-                connection.execute(
-                    """
-                    INSERT INTO dpm_rebalance_wave_idempotency (
-                        idempotency_key,
-                        wave_id,
-                        request_hash,
-                        created_at
-                    ) VALUES (%s, %s, %s, %s)
-                    ON CONFLICT (idempotency_key) DO NOTHING
-                    """,
-                    (
-                        idempotency_key,
-                        wave.wave_id,
-                        request_hash,
-                        datetime.now(timezone.utc),
-                    ),
-                )
+            _insert_wave_row(connection=connection, wave=wave)
+            _insert_idempotency_marker(
+                connection=connection,
+                wave=wave,
+                idempotency_key=idempotency_key,
+                request_hash=request_hash,
+            )
             _insert_new_events(connection=connection, wave=wave)
             connection.commit()
 
@@ -199,6 +160,80 @@ def _wave_row_args(wave: DpmRebalanceWave) -> tuple[Any, ...]:
         wave.version,
         dump_model_json(wave),
         wave.retention_policy,
+    )
+
+
+def _raise_if_idempotency_conflict(
+    *,
+    connection: Any,
+    wave: DpmRebalanceWave,
+    idempotency_key: str | None,
+    request_hash: str | None,
+) -> None:
+    if idempotency_key is None:
+        return
+    existing = connection.execute(
+        """
+        SELECT wave_id, request_hash
+        FROM dpm_rebalance_wave_idempotency
+        WHERE idempotency_key = %s
+        """,
+        (idempotency_key,),
+    ).fetchone()
+    if existing is not None and (
+        existing["wave_id"] != wave.wave_id or existing["request_hash"] != request_hash
+    ):
+        raise DpmWaveIdempotencyConflictError("DPM_WAVE_IDEMPOTENCY_CONFLICT")
+
+
+def _insert_wave_row(*, connection: Any, wave: DpmRebalanceWave) -> None:
+    result = connection.execute(
+        """
+        INSERT INTO dpm_rebalance_waves (
+            wave_id,
+            state,
+            trigger_type,
+            as_of_date,
+            created_at,
+            created_by,
+            correlation_id,
+            version,
+            wave_json,
+            retention_policy
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (wave_id) DO NOTHING
+        """,
+        _wave_row_args(wave),
+    )
+    if result.rowcount != 1:
+        raise DpmWaveAlreadyExistsError("DPM_WAVE_ALREADY_EXISTS")
+
+
+def _insert_idempotency_marker(
+    *,
+    connection: Any,
+    wave: DpmRebalanceWave,
+    idempotency_key: str | None,
+    request_hash: str | None,
+) -> None:
+    if idempotency_key is None:
+        return
+    connection.execute(
+        """
+        INSERT INTO dpm_rebalance_wave_idempotency (
+            idempotency_key,
+            wave_id,
+            request_hash,
+            created_at
+        ) VALUES (%s, %s, %s, %s)
+        ON CONFLICT (idempotency_key) DO NOTHING
+        """,
+        (
+            idempotency_key,
+            wave.wave_id,
+            request_hash,
+            datetime.now(timezone.utc),
+        ),
     )
 
 

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -822,6 +822,79 @@ def test_rebalance_batch_execution_reports_invalid_options_without_running_engin
     assert result.warnings == ["PARTIAL_BATCH_FAILURE"]
 
 
+def test_rebalance_batch_scenario_helper_reports_invalid_options() -> None:
+    batch_payload = valid_api_payload()
+    batch_payload.pop("options")
+    batch_payload["scenarios"] = {"invalid_case": {"options": {"max_turnover_pct": "bad"}}}
+    request = BatchRebalanceRequest.model_validate(batch_payload)
+
+    outcome = batch_execution._execute_batch_scenario(  # noqa: SLF001
+        request=request,
+        scenario_name="invalid_case",
+        batch_id="batch_test",
+        correlation_id="corr_batch",
+        policy_definition=None,
+        source_context=None,
+        run_simulation_fn=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("invalid options should fail before engine execution")
+        ),
+        record_for_support=lambda **_kwargs: None,
+        current_logger=SimpleNamespace(exception=lambda *_args, **_kwargs: None),
+    )
+
+    assert outcome.result is None
+    assert outcome.comparison_metric is None
+    assert outcome.error is not None
+    assert outcome.error.startswith("INVALID_OPTIONS:")
+
+
+def test_rebalance_batch_scenario_helper_reports_execution_errors() -> None:
+    batch_payload = valid_api_payload()
+    batch_payload.pop("options")
+    batch_payload["scenarios"] = {"baseline": {"options": {}}}
+    request = BatchRebalanceRequest.model_validate(batch_payload)
+    logged: list[str] = []
+
+    outcome = batch_execution._execute_batch_scenario(  # noqa: SLF001
+        request=request,
+        scenario_name="baseline",
+        batch_id="batch_test",
+        correlation_id="corr_batch",
+        policy_definition=None,
+        source_context=None,
+        run_simulation_fn=lambda **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("engine unavailable")
+        ),
+        record_for_support=lambda **_kwargs: None,
+        current_logger=SimpleNamespace(exception=lambda message: logged.append(message)),
+    )
+
+    assert outcome.result is None
+    assert outcome.comparison_metric is None
+    assert outcome.error == "SCENARIO_EXECUTION_ERROR: RuntimeError"
+    assert logged == ["Scenario execution failed"]
+
+
+def test_rebalance_batch_scenario_outcome_recorder_routes_failures() -> None:
+    results: dict[str, object] = {}
+    metrics: dict[str, object] = {}
+    failed: dict[str, str] = {}
+
+    batch_execution._record_batch_scenario_outcome(  # noqa: SLF001
+        scenario_name="baseline",
+        outcome=batch_execution.BatchScenarioOutcome(
+            error="SCENARIO_EXECUTION_ERROR: RuntimeError"
+        ),
+        results=results,
+        comparison_metrics=metrics,
+        failed_scenarios=failed,
+    )
+
+    assert results == {}
+    assert metrics == {}
+    assert failed == {"baseline": "SCENARIO_EXECUTION_ERROR: RuntimeError"}
+
+
 def test_batch_scenario_execution_ids_are_deterministic() -> None:
     assert batch_scenario_execution.build_batch_scenario_execution_ids(
         batch_id="batch_test",

--- a/tests/unit/dpm/waves/test_wave_domain.py
+++ b/tests/unit/dpm/waves/test_wave_domain.py
@@ -345,6 +345,50 @@ def _postgres_repository(fake: _FakeWaveConnection) -> PostgresDpmWaveRepository
     return repository
 
 
+def test_postgres_wave_idempotency_conflict_helper_is_noop_without_key() -> None:
+    fake = _FakeWaveConnection()
+
+    postgres_module._raise_if_idempotency_conflict(  # noqa: SLF001
+        connection=fake,
+        wave=_wave(),
+        idempotency_key=None,
+        request_hash=None,
+    )
+
+    assert fake.queries == []
+
+
+def test_postgres_wave_insert_helpers_preserve_durable_create_contract() -> None:
+    fake = _FakeWaveConnection()
+    wave = apply_wave_transition(
+        wave=_wave(),
+        to_state="PREVIEWED",
+        event=_event("DRAFT", "PREVIEWED"),
+    )
+
+    postgres_module._insert_wave_row(connection=fake, wave=wave)  # noqa: SLF001
+    postgres_module._insert_idempotency_marker(  # noqa: SLF001
+        connection=fake,
+        wave=wave,
+        idempotency_key="idem-1",
+        request_hash="hash-1",
+    )
+    postgres_module._insert_new_events(connection=fake, wave=wave)  # noqa: SLF001
+
+    assert fake.waves[wave.wave_id]["state"] == "PREVIEWED"
+    assert fake.idempotency["idem-1"]["wave_id"] == wave.wave_id
+    assert sorted(fake.events) == ["evt-draft-previewed"]
+
+
+def test_postgres_wave_insert_helper_rejects_duplicate_wave_id() -> None:
+    fake = _FakeWaveConnection()
+    wave = _wave()
+    postgres_module._insert_wave_row(connection=fake, wave=wave)  # noqa: SLF001
+
+    with pytest.raises(DpmWaveAlreadyExistsError):
+        postgres_module._insert_wave_row(connection=fake, wave=wave)  # noqa: SLF001
+
+
 def test_postgres_wave_repository_roundtrip_idempotency_and_update() -> None:
     fake = _FakeWaveConnection()
     repository = _postgres_repository(fake)


### PR DESCRIPTION
## Summary

- Extracted Postgres DPM wave save helpers for idempotency conflict checks, durable wave row insertion, and idempotency marker insertion while preserving transaction orchestration.
- Extracted typed batch scenario outcome handling helpers so batch orchestration separates validation/execution failures from result collection.
- Added direct helper coverage and updated the codebase review ledger plus generated quality reports.

## Bank-Buyable Control Areas

- Architecture: reduced two current source hotspots without changing external contracts.
- Testing: added focused helper tests for persistence create behavior, duplicate wave rejection, invalid batch options, execution errors, and outcome recording.
- CI measurement: refreshed `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and `quality/complexity_report.md`.

## Behavior

- Intended behavior change: none.
- API/schema change: none.
- Migration/configuration change: none.
- Wiki source change: none; wiki drift check reported `DiffCount 0`.

## Local Evidence

- `python -m ruff check --no-cache src/api/services/rebalance_batch_execution.py tests/unit/api/test_runtime_request_model_and_service_edges.py`: passed.
- `python -m ruff check src/infrastructure/waves/postgres.py tests/unit/dpm/waves/test_wave_domain.py`: passed.
- `python -m ruff format --check src/api/services/rebalance_batch_execution.py tests/unit/api/test_runtime_request_model_and_service_edges.py`: passed.
- `python -m ruff format --check src/infrastructure/waves/postgres.py tests/unit/dpm/waves/test_wave_domain.py`: passed.
- `python -m mypy --config-file mypy.ini src/api/services/rebalance_batch_execution.py`: passed.
- `python -m mypy --config-file mypy.ini src/infrastructure/waves/postgres.py`: passed.
- `python -m pytest tests/unit/api/test_runtime_request_model_and_service_edges.py -q`: 44 passed.
- `python -m pytest tests/unit/dpm/waves/test_wave_domain.py -q`: 21 passed.
- `python scripts/openapi_quality_gate.py`: passed.
- `python scripts/api_vocabulary_inventory.py --validate-only`: passed.
- `python scripts/service_boundary_gate.py`: passed.
- `make complexity-gate`: passed.
- `git diff --check`: passed.
- service leakage scan for FastAPI/router imports in `src/api/services`: passed.
- `make check`: 2649 passed.
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage`: `DiffCount 0`.

## Complexity Movement

- `PostgresDpmWaveRepository.save_wave`: B(7) -> A(1).
- `execute_batch_scenarios`: B(7) -> A(5).

## Stranded Truth

- `git fetch origin --prune`: passed.
- `git branch -r --no-merged origin/main`: only `origin/feat/manage-hotspot-hardening-20260613-40` (this PR branch).
- `gh pr list --state open --limit 100`: no open PRs before this PR.

## Residual Risk

- This PR improves two internal maintainability hotspots and does not certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
- Remaining source hotspots are recorded in `quality/complexity_report.md` for follow-up slices.