### PR TITLE
Refactor migration and lineage support helpers

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -51,6 +51,8 @@ jobs:
         run: make openapi-gate
       - name: API Vocabulary Gate
         run: make api-vocabulary-gate
+      - name: Service Boundary Gate
+        run: make service-boundary-gate
       - name: Migration Contract Smoke
         run: make migration-smoke
       - name: Architecture Gate

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21553,3 +21553,32 @@ and improves internal transaction-cost source posture maintainability only.
   behavior.
 - Wiki decision: no wiki source change required; this is internal application-service
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-869: Postgres migration application helpers
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/postgres_migrations.py` and
+  `tests/unit/shared/dependencies/test_postgres_migrations.py`.
+- Bank-buyable control area: architecture and testing.
+- Finding: `_apply_migrations_locked` still mixed schema-migration table creation, applied-row
+  normalization, checksum conflict detection, SQL execution, schema-migration metadata insertion,
+  and commit handling in one infrastructure helper. The behavior was correct, but the
+  forward-only migration contract was harder to review than necessary for production-safe schema
+  rollout.
+- Action: extracted helpers for schema-migration table creation, applied checksum loading,
+  checksum mismatch detection, and migration metadata insertion while preserving lock,
+  rollback, SQL execution, and commit behavior. Added direct tests for duplicate stored-version
+  checksum conflicts and namespace-scoped migration record insertion.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/postgres_migrations.py tests/unit/shared/dependencies/test_postgres_migrations.py`,
+  `python -m ruff format --check src/infrastructure/postgres_migrations.py tests/unit/shared/dependencies/test_postgres_migrations.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/postgres_migrations.py`,
+  `python -m pytest tests/unit/shared/dependencies/test_postgres_migrations.py -q`,
+  and `python -m radon cc src/infrastructure/postgres_migrations.py -s`; the focused Postgres
+  migration suite reported 6 passed and `_apply_migrations_locked` reduced from B(7) to A(3).
+- Residual risk: this slice improves internal migration maintainability only. It does not certify
+  global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench product
+  behavior.
+- Wiki decision: no wiki source change required; this is internal infrastructure migration
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21582,3 +21582,31 @@ and improves internal transaction-cost source posture maintainability only.
   behavior.
 - Wiki decision: no wiki source change required; this is internal infrastructure migration
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-870: Run lineage filtering helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/rebalance_runs/service.py` and
+  `tests/unit/dpm/supportability/test_dpm_lineage_service.py`.
+- Bank-buyable control area: architecture and testing.
+- Finding: `DpmRunSupportService.get_lineage_filtered` mixed repository read orchestration,
+  deterministic sorting, edge-type filtering, date-window filtering, cursor resolution, page
+  slicing, and next-cursor construction in one service method. The behavior was correct, but the
+  method concentrated lineage paging semantics in a harder-to-review supportability path.
+- Action: extracted lineage sorting, filter predicates, date-window filtering, and cursor paging
+  helpers while keeping repository access and response construction in the service method. Added
+  direct tests for deterministic edge ordering, edge-type/date-window filtering, cursor-after-edge
+  pagination, and missing-cursor empty-page behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance_runs/service.py tests/unit/dpm/supportability/test_dpm_lineage_service.py`,
+  `python -m ruff format --check src/core/rebalance_runs/service.py tests/unit/dpm/supportability/test_dpm_lineage_service.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance_runs/service.py`,
+  `python -m pytest tests/unit/dpm/supportability/test_dpm_lineage_service.py -q`,
+  and `python -m radon cc src/core/rebalance_runs/service.py -s`; the focused lineage suite
+  reported 3 passed and `DpmRunSupportService.get_lineage_filtered` reduced from C(15) to A(1).
+- Residual risk: this slice improves internal supportability lineage maintainability only. It does
+  not certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench
+  product behavior.
+- Wiki decision: no wiki source change required; this is internal supportability-service
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21610,3 +21610,25 @@ and improves internal transaction-cost source posture maintainability only.
   product behavior.
 - Wiki decision: no wiki source change required; this is internal supportability-service
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-871: Main releasability service-boundary enforcement
+
+- Date: 2026-06-13
+- Scope: `.github/workflows/main-releasability.yml`.
+- Bank-buyable control area: CI measurement and architecture enforcement.
+- Finding: the Feature Lane and PR Merge Gate enforced `make service-boundary-gate`, but the Main
+  Releasability Gate did not repeat the same service-boundary check after merge. That left a small
+  governance asymmetry in the final releasability lane for the already-remediated service-layer
+  boundary rule.
+- Action: added `Service Boundary Gate` to the Main Releasability lint/typecheck/security job,
+  directly after the OpenAPI and API vocabulary gates and before migration smoke, matching the
+  intended API/architecture governance sequence used in the PR lane.
+- Status: hardened.
+- Evidence: `python -c "import yaml; yaml.safe_load(open('.github/workflows/main-releasability.yml', encoding='utf-8')); print('YAML syntax ok')"`,
+  `python scripts/service_boundary_gate.py`, and `git diff --check` passed locally. Local
+  `actionlint` was not installed; GitHub workflow lint remains the authoritative actionlint
+  validation for the PR.
+- Residual risk: this improves CI enforcement alignment only. It does not certify global
+  bank-buyable readiness or replace GitHub Actions execution on the opened PR and merged `main`.
+- Wiki decision: no wiki source change required; this is internal CI enforcement alignment with no
+  operator-facing runbook or API contract change.

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T06:32:02+00:00`
+- Generated at: `2026-06-13T06:49:40+00:00`
 
-- Current ref: `f67f5b70`
+- Current ref: `ee34711e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _apply_migrations_locked | src/infrastructure/postgres_migrations.py | 7 | 59 |
-| 2 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 3 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
-| 4 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
-| 5 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
-| 6 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
-| 7 | _transaction_cost_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 49 |
-| 8 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
-| 9 | _sustainability_preference_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 47 |
-| 10 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
+| 1 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
+| 2 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
+| 3 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 4 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 5 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 6 | _transaction_cost_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 49 |
+| 7 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 8 | _sustainability_preference_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 47 |
+| 9 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
+| 10 | _client_restriction_source_analytics | src/core/proof_packs/source_analytics.py | 7 | 44 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T06:49:40+00:00`
+- Generated at: `2026-06-13T06:53:40+00:00`
 
-- Current ref: `ee34711e`
+- Current ref: `0109e36e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T06:32:02+00:00`
+- Generated at: `2026-06-13T06:49:40+00:00`
 
-- Current ref: `f67f5b70`
+- Current ref: `ee34711e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T06:49:40+00:00`
+- Generated at: `2026-06-13T06:53:40+00:00`
 
-- Current ref: `ee34711e`
+- Current ref: `0109e36e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T06:32:02+00:00`
+- Generated at: `2026-06-13T06:49:40+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `f67f5b70`
+- Current ref: `ee34711e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 170568 | 170776 | +208 |
-| Test functions | 2467 | 2473 | +6 |
+| Total Python LOC | 170776 | 170850 | +74 |
+| Test functions | 2473 | 2475 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T06:49:40+00:00`
+- Generated at: `2026-06-13T06:53:40+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `ee34711e`
+- Current ref: `0109e36e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 170776 | 170850 | +74 |
-| Test functions | 2473 | 2475 | +2 |
+| Total Python LOC | 170776 | 170986 | +210 |
+| Test functions | 2473 | 2477 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/rebalance_runs/service.py
+++ b/src/core/rebalance_runs/service.py
@@ -337,15 +337,7 @@ class DpmRunSupportService:
     def get_lineage(self, *, entity_id: str) -> DpmLineageResponse:
         self._cleanup_expired_supportability()
         edges = self._repository.list_lineage_edges(entity_id=entity_id)
-        edges = sorted(
-            edges,
-            key=lambda edge: (
-                edge.created_at,
-                edge.source_entity_id,
-                edge.edge_type,
-                edge.target_entity_id,
-            ),
-        )
+        edges = _sort_lineage_edges(edges)
         return to_lineage_response(entity_id=entity_id, edges=edges, next_cursor=None)
 
     def get_lineage_filtered(
@@ -360,34 +352,13 @@ class DpmRunSupportService:
     ) -> DpmLineageResponse:
         self._cleanup_expired_supportability()
         edges = self._repository.list_lineage_edges(entity_id=entity_id)
-        edges = sorted(
-            edges,
-            key=lambda edge: (
-                edge.created_at,
-                edge.source_entity_id,
-                edge.edge_type,
-                edge.target_entity_id,
-            ),
+        edges = _filter_lineage_edges(
+            edges=_sort_lineage_edges(edges),
+            edge_type=edge_type,
+            created_from=created_from,
+            created_to=created_to,
         )
-        if edge_type is not None:
-            edges = [edge for edge in edges if edge.edge_type == edge_type]
-        if created_from is not None:
-            edges = [edge for edge in edges if edge.created_at >= created_from]
-        if created_to is not None:
-            edges = [edge for edge in edges if edge.created_at <= created_to]
-
-        if cursor is not None:
-            cursor_index = next(
-                (index for index, row in enumerate(edges) if lineage_cursor(row) == cursor),
-                None,
-            )
-            if cursor_index is None:
-                edges = []
-            else:
-                edges = edges[cursor_index + 1 :]
-
-        page = edges[:limit]
-        next_cursor = lineage_cursor(page[-1]) if len(edges) > limit else None
+        page, next_cursor = _page_lineage_edges(edges=edges, cursor=cursor, limit=limit)
         return to_lineage_response(entity_id=entity_id, edges=page, next_cursor=next_cursor)
 
     def get_supportability_summary(
@@ -882,6 +853,75 @@ class DpmRunSupportService:
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _sort_lineage_edges(edges: list[DpmLineageEdgeRecord]) -> list[DpmLineageEdgeRecord]:
+    return sorted(
+        edges,
+        key=lambda edge: (
+            edge.created_at,
+            edge.source_entity_id,
+            edge.edge_type,
+            edge.target_entity_id,
+        ),
+    )
+
+
+def _filter_lineage_edges(
+    *,
+    edges: list[DpmLineageEdgeRecord],
+    edge_type: Optional[str],
+    created_from: Optional[datetime],
+    created_to: Optional[datetime],
+) -> list[DpmLineageEdgeRecord]:
+    return [
+        edge
+        for edge in edges
+        if _matches_lineage_edge_type(edge=edge, edge_type=edge_type)
+        and _is_lineage_edge_in_window(
+            edge=edge,
+            created_from=created_from,
+            created_to=created_to,
+        )
+    ]
+
+
+def _matches_lineage_edge_type(
+    *,
+    edge: DpmLineageEdgeRecord,
+    edge_type: Optional[str],
+) -> bool:
+    return edge_type is None or edge.edge_type == edge_type
+
+
+def _is_lineage_edge_in_window(
+    *,
+    edge: DpmLineageEdgeRecord,
+    created_from: Optional[datetime],
+    created_to: Optional[datetime],
+) -> bool:
+    if created_from is not None and edge.created_at < created_from:
+        return False
+    if created_to is not None and edge.created_at > created_to:
+        return False
+    return True
+
+
+def _page_lineage_edges(
+    *,
+    edges: list[DpmLineageEdgeRecord],
+    cursor: Optional[str],
+    limit: int,
+) -> tuple[list[DpmLineageEdgeRecord], Optional[str]]:
+    if cursor is not None:
+        cursor_index = next(
+            (index for index, row in enumerate(edges) if lineage_cursor(row) == cursor),
+            None,
+        )
+        edges = [] if cursor_index is None else edges[cursor_index + 1 :]
+    page = edges[:limit]
+    next_cursor = lineage_cursor(page[-1]) if len(edges) > limit else None
+    return page, next_cursor
 
 
 def _resolve_action_register_supportability(

--- a/src/infrastructure/postgres_migrations.py
+++ b/src/infrastructure/postgres_migrations.py
@@ -31,6 +31,29 @@ def apply_postgres_migrations(*, connection: Any, namespace: str) -> None:
 
 def _apply_migrations_locked(*, connection: Any, namespace: str) -> None:
     migrations = _load_migrations(namespace=namespace)
+    _ensure_schema_migrations_table(connection=connection)
+    applied = _load_applied_migration_checksums(connection=connection, namespace=namespace)
+    for migration in migrations:
+        existing_checksum = applied.get(migration.version)
+        if existing_checksum is not None:
+            _raise_if_checksum_changed(
+                namespace=namespace,
+                version=migration.version,
+                stored_checksum=existing_checksum,
+                expected_checksum=migration.checksum,
+            )
+            continue
+        sql = migration.sql_path.read_text(encoding="utf-8")
+        _execute_sql_statements(connection=connection, sql=sql)
+        _insert_schema_migration_record(
+            connection=connection,
+            namespace=namespace,
+            migration=migration,
+        )
+    connection.commit()
+
+
+def _ensure_schema_migrations_table(*, connection: Any) -> None:
     connection.execute(
         """
         CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -41,6 +64,9 @@ def _apply_migrations_locked(*, connection: Any, namespace: str) -> None:
         )
         """
     )
+
+
+def _load_applied_migration_checksums(*, connection: Any, namespace: str) -> dict[str, str]:
     rows = connection.execute(
         """
         SELECT version, checksum
@@ -58,36 +84,50 @@ def _apply_migrations_locked(*, connection: Any, namespace: str) -> None:
         )
         checksum = str(row["checksum"])
         existing_checksum = applied.get(version)
-        if existing_checksum is not None and existing_checksum != checksum:
-            raise RuntimeError(f"POSTGRES_MIGRATION_CHECKSUM_MISMATCH:{namespace}:{version}")
-        applied[version] = checksum
-    for migration in migrations:
-        existing_checksum = applied.get(migration.version)
         if existing_checksum is not None:
-            if existing_checksum != migration.checksum:
-                raise RuntimeError(
-                    f"POSTGRES_MIGRATION_CHECKSUM_MISMATCH:{namespace}:{migration.version}"
-                )
-            continue
-        sql = migration.sql_path.read_text(encoding="utf-8")
-        _execute_sql_statements(connection=connection, sql=sql)
-        connection.execute(
-            """
-            INSERT INTO schema_migrations (
-                version,
-                namespace,
-                checksum,
-                applied_at
-            ) VALUES (%s, %s, %s, %s)
-            """,
-            (
-                _stored_version(namespace=namespace, version=migration.version),
-                namespace,
-                migration.checksum,
-                datetime.now(timezone.utc).isoformat(),
-            ),
-        )
-    connection.commit()
+            _raise_if_checksum_changed(
+                namespace=namespace,
+                version=version,
+                stored_checksum=existing_checksum,
+                expected_checksum=checksum,
+            )
+        applied[version] = checksum
+    return applied
+
+
+def _raise_if_checksum_changed(
+    *,
+    namespace: str,
+    version: str,
+    stored_checksum: str,
+    expected_checksum: str,
+) -> None:
+    if stored_checksum != expected_checksum:
+        raise RuntimeError(f"POSTGRES_MIGRATION_CHECKSUM_MISMATCH:{namespace}:{version}")
+
+
+def _insert_schema_migration_record(
+    *,
+    connection: Any,
+    namespace: str,
+    migration: PostgresMigration,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO schema_migrations (
+            version,
+            namespace,
+            checksum,
+            applied_at
+        ) VALUES (%s, %s, %s, %s)
+        """,
+        (
+            _stored_version(namespace=namespace, version=migration.version),
+            namespace,
+            migration.checksum,
+            datetime.now(timezone.utc).isoformat(),
+        ),
+    )
 
 
 def _execute_sql_statements(*, connection: Any, sql: str) -> None:

--- a/tests/unit/dpm/supportability/test_dpm_lineage_service.py
+++ b/tests/unit/dpm/supportability/test_dpm_lineage_service.py
@@ -1,6 +1,10 @@
 from decimal import Decimal
+from datetime import datetime, timezone
 
 from src.core.rebalance.engine import run_simulation
+import src.core.rebalance_runs.service as run_service_module
+from src.core.rebalance_runs.models import DpmLineageEdgeRecord
+from src.core.rebalance_runs.serializers import lineage_cursor
 from src.core.rebalance_runs.service import DpmRunSupportService
 from src.core.models import EngineOptions
 from src.infrastructure.rebalance_runs import InMemoryDpmRunRepository
@@ -13,6 +17,22 @@ from tests.shared.factories import (
     shelf_entry,
     target,
 )
+
+
+def _edge(
+    *,
+    source: str,
+    edge_type: str,
+    target: str,
+    created_at: datetime,
+) -> DpmLineageEdgeRecord:
+    return DpmLineageEdgeRecord(
+        source_entity_id=source,
+        edge_type=edge_type,
+        target_entity_id=target,
+        created_at=created_at,
+        metadata_json={"source": source},
+    )
 
 
 def _simulate_result():
@@ -56,3 +76,79 @@ def test_lineage_edges_are_recorded_for_run_idempotency_and_operation():
     assert len(by_operation.edges) == 1
     assert by_operation.edges[0].edge_type == "OPERATION_TO_CORRELATION"
     assert by_operation.edges[0].target_entity_id == "corr-op-lineage-1"
+
+
+def test_lineage_helpers_sort_and_filter_edges():
+    early = datetime(2026, 5, 1, 9, tzinfo=timezone.utc)
+    middle = datetime(2026, 5, 1, 10, tzinfo=timezone.utc)
+    late = datetime(2026, 5, 1, 11, tzinfo=timezone.utc)
+    edges = [
+        _edge(
+            source="idem-1",
+            edge_type="IDEMPOTENCY_TO_RUN",
+            target="rr-2",
+            created_at=late,
+        ),
+        _edge(
+            source="corr-1",
+            edge_type="CORRELATION_TO_RUN",
+            target="rr-1",
+            created_at=early,
+        ),
+        _edge(
+            source="op-1",
+            edge_type="OPERATION_TO_CORRELATION",
+            target="corr-1",
+            created_at=middle,
+        ),
+    ]
+
+    sorted_edges = run_service_module._sort_lineage_edges(edges)  # noqa: SLF001
+    filtered = run_service_module._filter_lineage_edges(  # noqa: SLF001
+        edges=sorted_edges,
+        edge_type="OPERATION_TO_CORRELATION",
+        created_from=middle,
+        created_to=late,
+    )
+
+    assert [edge.source_entity_id for edge in sorted_edges] == ["corr-1", "op-1", "idem-1"]
+    assert filtered == [sorted_edges[1]]
+
+
+def test_lineage_paging_uses_cursor_after_matching_edge():
+    edges = [
+        _edge(
+            source="corr-1",
+            edge_type="CORRELATION_TO_RUN",
+            target="rr-1",
+            created_at=datetime(2026, 5, 1, 9, tzinfo=timezone.utc),
+        ),
+        _edge(
+            source="corr-2",
+            edge_type="CORRELATION_TO_RUN",
+            target="rr-2",
+            created_at=datetime(2026, 5, 1, 10, tzinfo=timezone.utc),
+        ),
+        _edge(
+            source="corr-3",
+            edge_type="CORRELATION_TO_RUN",
+            target="rr-3",
+            created_at=datetime(2026, 5, 1, 11, tzinfo=timezone.utc),
+        ),
+    ]
+
+    page, next_cursor = run_service_module._page_lineage_edges(  # noqa: SLF001
+        edges=edges,
+        cursor=lineage_cursor(edges[0]),
+        limit=1,
+    )
+    missing_page, missing_cursor = run_service_module._page_lineage_edges(  # noqa: SLF001
+        edges=edges,
+        cursor="missing-cursor",
+        limit=1,
+    )
+
+    assert page == [edges[1]]
+    assert next_cursor == lineage_cursor(edges[1])
+    assert missing_page == []
+    assert missing_cursor is None

--- a/tests/unit/shared/dependencies/test_postgres_migrations.py
+++ b/tests/unit/shared/dependencies/test_postgres_migrations.py
@@ -97,6 +97,40 @@ def test_apply_postgres_migrations_detects_checksum_mismatch(monkeypatch, tmp_pa
     assert connection.unlock_calls == [_migration_lock_key(namespace="custom")]
 
 
+def test_load_applied_migration_checksums_detects_duplicate_version_conflict():
+    class _DuplicateRowConnection:
+        def execute(self, *_args, **_kwargs):
+            return _FakeCursor(
+                rows=[
+                    {"version": "dpm:0001", "checksum": "checksum-old"},
+                    {"version": "dpm:0001", "checksum": "checksum-new"},
+                ]
+            )
+
+    with pytest.raises(RuntimeError) as exc:
+        migrations_module._load_applied_migration_checksums(  # noqa: SLF001
+            connection=_DuplicateRowConnection(),
+            namespace="dpm",
+        )
+
+    assert str(exc.value) == "POSTGRES_MIGRATION_CHECKSUM_MISMATCH:dpm:0001"
+
+
+def test_insert_schema_migration_record_stores_namespace_scoped_version(tmp_path: Path):
+    sql_path = tmp_path / "0002_test.sql"
+    sql_path.write_text("CREATE TABLE sample_table (id TEXT PRIMARY KEY);")
+    migration = PostgresMigration(version="0002", sql_path=sql_path, checksum="checksum-2")
+    connection = _FakeConnection()
+
+    migrations_module._insert_schema_migration_record(  # noqa: SLF001
+        connection=connection,
+        namespace="custom",
+        migration=migration,
+    )
+
+    assert connection.schema_migrations[("custom", "custom:0002")] == "checksum-2"
+
+
 def test_migration_lock_key_is_stable_and_namespace_scoped():
     assert _migration_lock_key(namespace="dpm") == _migration_lock_key(namespace="dpm")
     assert _migration_lock_key(namespace="dpm") != _migration_lock_key(namespace="policy_packs")


### PR DESCRIPTION
## Summary
- Extracted Postgres migration application helpers to isolate table setup, checksum loading, checksum-change rejection, and migration-record inserts.
- Extracted run-lineage sorting, filtering, date-window predicates, and cursor paging helpers while keeping service orchestration behavior unchanged.
- Added the service-boundary gate to Main Releasability so the final main lane enforces the same remediated service-layer boundary rule as Feature Lane and PR Merge Gate.
- Refreshed the codebase review ledger and quality reports with residual risk stated explicitly.

## Evidence
- `python -m pytest tests\unit\shared\dependencies\test_postgres_migrations.py -q` -> 6 passed.
- `python -m pytest tests\unit\dpm\supportability\test_dpm_lineage_service.py -q` -> 3 passed.
- `python -m ruff check src\infrastructure\postgres_migrations.py tests\unit\shared\dependencies\test_postgres_migrations.py src\core\rebalance_runs\service.py tests\unit\dpm\supportability\test_dpm_lineage_service.py` -> passed.
- `python -m ruff format --check src\infrastructure\postgres_migrations.py tests\unit\shared\dependencies\test_postgres_migrations.py src\core\rebalance_runs\service.py tests\unit\dpm\supportability\test_dpm_lineage_service.py` -> passed.
- `python -m mypy --config-file mypy.ini src\infrastructure\postgres_migrations.py src\core\rebalance_runs\service.py` -> passed.
- `python scripts\openapi_quality_gate.py` -> passed.
- `python scripts\api_vocabulary_inventory.py --validate-only` -> passed.
- `python scripts\service_boundary_gate.py` -> passed.
- `make complexity-gate` -> passed.
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/main-releasability.yml', encoding='utf-8')); print('YAML syntax ok')"` -> passed.
- `git diff --check` -> passed.
- Service leakage scan over `src/api/services` -> passed with no findings.
- `make check` -> passed; includes ruff, format check, no-alias, mypy, OpenAPI, API vocabulary, service boundary, contract validators, and 2,653 unit tests.
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0.
- Stranded truth: `git branch -r --no-merged origin/main` listed only `origin/feat/manage-hotspot-hardening-20260613-41`.

## Complexity Movement
- `_apply_migrations_locked`: B(7) -> A(3).
- `DpmRunSupportService.get_lineage_filtered`: C(15) -> A(1).

## Risk And Scope
- Behavior is intended to be preserved; changes are helper extractions plus CI enforcement alignment.
- This PR does not claim global bank-buyable readiness. Existing C-grade hotspots remain and are tracked by the refreshed complexity reports.
- No wiki publication is required because no operator-facing wiki truth changed.