### PR TITLE
Refactor wave and portfolio-memory helper hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21721,3 +21721,32 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal proof-pack source-analytics
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-875: Wave supportability payload classification helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/wave_supportability_payload.py` and
+  `tests/unit/dpm/waves/test_wave_supportability_payload.py`.
+- Bank-buyable control area: architecture and testing.
+- Finding: `wave_supportability_payload` combined supportability issue collection, severity
+  aggregation, state/reason classification, and payload assembly in one helper. The behavior was
+  correct, but the wave supportability read model was harder to review and test directly than the
+  bank-buyable supportability posture expects.
+- Action: extracted `_wave_supportability_issues`, `_issue_counts_by_severity`, and
+  `_supportability_state_reason` while preserving the public payload shape and operator-action
+  behavior. Added a direct helper test covering issue collection, severity counts, and blocked /
+  degraded / ready state precedence.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/wave_supportability_payload.py tests/unit/dpm/waves/test_wave_supportability_payload.py`,
+  `python -m ruff format --check src/api/services/wave_supportability_payload.py tests/unit/dpm/waves/test_wave_supportability_payload.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/wave_supportability_payload.py`,
+  `python -m pytest tests/unit/dpm/waves/test_wave_supportability_payload.py -q`, and
+  `python -m radon cc src/api/services/wave_supportability_payload.py -s`; the focused wave
+  supportability suite reported 5 passed and `wave_supportability_payload` reduced from C(11) to
+  A(1).
+- Residual risk: this slice improves internal wave supportability payload maintainability only.
+  It does not certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal supportability read-model
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21779,3 +21779,33 @@ and improves internal transaction-cost source posture maintainability only.
   product behavior.
 - Wiki decision: no wiki source change required; this is internal read-model maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-877: Portfolio-memory candidate source-family helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/portfolio_memory/candidate_portfolios.py` and
+  `tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py`.
+- Bank-buyable control area: architecture and testing.
+- Finding: `candidate_portfolio_ids_from_sources` aggregated explicit portfolio ids, proof-pack
+  portfolios, wave item portfolios, outcome reviews, mandate monitoring exceptions, campaign
+  candidates, and PM-quality book-scope evidence in one function. The behavior was correct, but the
+  source-family boundaries were harder to inspect than the portfolio-memory search contract
+  requires.
+- Action: extracted one helper per candidate source family plus an explicit-input cleanup helper,
+  leaving the public candidate merge and sorting behavior unchanged. Added a direct helper test for
+  manual-id normalization, mandate exception candidates, campaign definition candidates, and
+  PM-quality member-scope candidates.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/portfolio_memory/candidate_portfolios.py tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py`,
+  `python -m ruff format --check src/core/portfolio_memory/candidate_portfolios.py tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py`,
+  `python -m mypy --config-file mypy.ini src/core/portfolio_memory/candidate_portfolios.py`,
+  `python -m pytest tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py -q`, and
+  `python -m radon cc src/core/portfolio_memory/candidate_portfolios.py -s`; the focused
+  portfolio-memory candidate suite reported 6 passed and `candidate_portfolio_ids_from_sources`
+  reduced from C(17) to A(1).
+- Residual risk: this slice improves internal portfolio-memory source aggregation
+  maintainability only. It does not certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal portfolio-memory
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21750,3 +21750,32 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal supportability read-model
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-876: Wave proof-pack posture projection helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/wave_proof_pack_posture.py` and
+  `tests/unit/dpm/waves/test_wave_proof_pack_posture.py`.
+- Bank-buyable control area: architecture and testing.
+- Finding: `proof_pack_posture_for_wave` combined proof-pack ref projection, ready/degraded
+  counts, external-execution claim detection, and boundary payload assembly in one helper. The
+  behavior was correct, but the proof-pack posture read model was harder to review than the
+  no-execution/no-client-communication boundary evidence deserves.
+- Action: extracted proof-pack ref, ref collection, count, and external-execution claim helpers
+  while preserving the public posture payload. Added a direct helper test proving linked/state-only
+  ref projection, ready/degraded counts, omission of unlinked items without proof-pack posture, and
+  external-execution claim detection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/wave_proof_pack_posture.py tests/unit/dpm/waves/test_wave_proof_pack_posture.py`,
+  `python -m ruff format --check src/api/services/wave_proof_pack_posture.py tests/unit/dpm/waves/test_wave_proof_pack_posture.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/wave_proof_pack_posture.py`,
+  `python -m pytest tests/unit/dpm/waves/test_wave_proof_pack_posture.py -q`, and
+  `python -m radon cc src/api/services/wave_proof_pack_posture.py -s`; the focused wave
+  proof-pack posture suite reported 4 passed and `proof_pack_posture_for_wave` reduced from C(12)
+  to A(3).
+- Residual risk: this slice improves internal wave proof-pack posture maintainability only. It
+  does not certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench
+  product behavior.
+- Wiki decision: no wiki source change required; this is internal read-model maintainability
+  hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T07:42:07+00:00`
+- Generated at: `2026-06-13T07:45:42+00:00`
 
-- Baseline commit: `180feb77`
+- Baseline commit: `75009458`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171278 |
-| Test functions | 2481 |
+| Total Python LOC | 171356 |
+| Test functions | 2482 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T05:17:02+00:00`
+- Generated at: `2026-06-13T07:38:53+00:00`
 
-- Baseline commit: `22e1497d`
+- Baseline commit: `2de3b203`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 170325 |
-| Test functions | 2462 |
+| Total Python LOC | 171202 |
+| Test functions | 2480 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T07:38:53+00:00`
+- Generated at: `2026-06-13T07:42:07+00:00`
 
-- Baseline commit: `2de3b203`
+- Baseline commit: `180feb77`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171202 |
-| Test functions | 2480 |
+| Total Python LOC | 171278 |
+| Test functions | 2481 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T07:21:43+00:00`
+- Generated at: `2026-06-13T07:38:53+00:00`
 
-- Current ref: `8d4c307e`
+- Current ref: `2de3b203`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T07:42:07+00:00`
+- Generated at: `2026-06-13T07:45:42+00:00`
 
-- Current ref: `180feb77`
+- Current ref: `75009458`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T07:38:53+00:00`
+- Generated at: `2026-06-13T07:42:07+00:00`
 
-- Current ref: `2de3b203`
+- Current ref: `180feb77`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T07:38:53+00:00`
+- Generated at: `2026-06-13T07:42:07+00:00`
 
-- Current ref: `2de3b203`
+- Current ref: `180feb77`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T07:42:07+00:00`
+- Generated at: `2026-06-13T07:45:42+00:00`
 
-- Current ref: `180feb77`
+- Current ref: `75009458`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T07:21:43+00:00`
+- Generated at: `2026-06-13T07:38:53+00:00`
 
-- Current ref: `8d4c307e`
+- Current ref: `2de3b203`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T07:21:43+00:00`
+- Generated at: `2026-06-13T07:38:53+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `8d4c307e`
+- Current ref: `2de3b203`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 170986 | 171163 | +177 |
-| Test functions | 2477 | 2479 | +2 |
+| Total Python LOC | 171163 | 171202 | +39 |
+| Test functions | 2479 | 2480 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,8 +37,8 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/test_documentation_current_state.py | 2721 |
-| 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2638 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2755 |
+| 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2426 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T07:42:07+00:00`
+- Generated at: `2026-06-13T07:45:42+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `180feb77`
+- Current ref: `75009458`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171163 | 171278 | +115 |
-| Test functions | 2479 | 2481 | +2 |
+| Total Python LOC | 171163 | 171356 | +193 |
+| Test functions | 2479 | 2482 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T07:38:53+00:00`
+- Generated at: `2026-06-13T07:42:07+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `2de3b203`
+- Current ref: `180feb77`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171163 | 171202 | +39 |
-| Test functions | 2479 | 2480 | +1 |
+| Total Python LOC | 171163 | 171278 | +115 |
+| Test functions | 2479 | 2481 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/services/wave_proof_pack_posture.py
+++ b/src/api/services/wave_proof_pack_posture.py
@@ -2,39 +2,53 @@ from src.api.services.wave_boundary_evidence import (
     client_communication_boundary,
     external_execution_boundary,
 )
-from src.core.waves import DpmRebalanceWave
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
 
 
-def proof_pack_posture_for_wave(*, wave: DpmRebalanceWave) -> dict[str, object]:
-    proof_pack_refs = [
-        {
-            "wave_item_id": item.wave_item_id,
-            "proof_pack_id": item.proof_pack_id,
-            "item_state": item.state,
-            "proof_pack_state": item.diagnostics.get("proof_pack_state"),
-            "selected_alternative_id": item.selected_alternative_id,
-        }
+def _proof_pack_ref(item: DpmRebalanceWaveItem) -> dict[str, object]:
+    return {
+        "wave_item_id": item.wave_item_id,
+        "proof_pack_id": item.proof_pack_id,
+        "item_state": item.state,
+        "proof_pack_state": item.diagnostics.get("proof_pack_state"),
+        "selected_alternative_id": item.selected_alternative_id,
+    }
+
+
+def _proof_pack_refs(wave: DpmRebalanceWave) -> list[dict[str, object]]:
+    return [
+        _proof_pack_ref(item)
         for item in wave.items
         if item.proof_pack_id is not None or item.diagnostics.get("proof_pack_state") is not None
     ]
-    ready_count = sum(
+
+
+def _ready_proof_pack_count(wave: DpmRebalanceWave) -> int:
+    return sum(
         1
         for item in wave.items
         if item.proof_pack_id is not None and item.diagnostics.get("proof_pack_state") != "DEGRADED"
     )
-    degraded_count = sum(
-        1 for item in wave.items if item.diagnostics.get("proof_pack_state") == "DEGRADED"
-    )
-    external_execution_claimed = any(
-        handoff.external_execution_claimed for handoff in wave.handoff_refs
-    )
+
+
+def _degraded_proof_pack_count(wave: DpmRebalanceWave) -> int:
+    return sum(1 for item in wave.items if item.diagnostics.get("proof_pack_state") == "DEGRADED")
+
+
+def _external_execution_claimed(wave: DpmRebalanceWave) -> bool:
+    return any(handoff.external_execution_claimed for handoff in wave.handoff_refs)
+
+
+def proof_pack_posture_for_wave(*, wave: DpmRebalanceWave) -> dict[str, object]:
+    proof_pack_refs = _proof_pack_refs(wave)
+    external_execution_claimed = _external_execution_claimed(wave)
     return {
         "wave_id": wave.wave_id,
         "wave_state": wave.state,
         "item_count": len(wave.items),
         "linked_item_count": sum(1 for item in wave.items if item.proof_pack_id is not None),
-        "ready_proof_pack_count": ready_count,
-        "degraded_proof_pack_count": degraded_count,
+        "ready_proof_pack_count": _ready_proof_pack_count(wave),
+        "degraded_proof_pack_count": _degraded_proof_pack_count(wave),
         "proof_pack_refs": proof_pack_refs,
         "handoff_refs": wave.handoff_refs,
         "external_execution_claimed": external_execution_claimed,

--- a/src/api/services/wave_supportability_payload.py
+++ b/src/api/services/wave_supportability_payload.py
@@ -4,36 +4,44 @@ from src.api.services.wave_supportability_diagnostics import (
 )
 from src.core.waves import DpmRebalanceWave
 
+_ISSUE_SEVERITIES = ("CRITICAL", "WARNING", "INFO")
 
-def wave_supportability_payload(wave: DpmRebalanceWave) -> dict[str, object]:
-    issues = [
+
+def _wave_supportability_issues(wave: DpmRebalanceWave) -> list[dict[str, object]]:
+    return [
         issue
         for index, item in enumerate(wave.items, start=1)
         if (issue := supportability_issue(wave_id=wave.wave_id, item=item, item_index=index))
         is not None
     ]
-    blocked_count = sum(1 for issue in issues if issue["severity"] == "CRITICAL")
-    degraded_count = sum(1 for issue in issues if issue["severity"] == "WARNING")
-    if blocked_count:
-        state = "blocked"
-        reason = "wave_blocked_items"
-    elif degraded_count:
-        state = "degraded"
-        reason = "wave_degraded_items"
-    else:
-        state = "ready"
-        reason = "wave_supportability_ready"
+
+
+def _issue_counts_by_severity(issues: list[dict[str, object]]) -> dict[str, int]:
+    return {
+        severity.lower(): sum(1 for issue in issues if issue["severity"] == severity)
+        for severity in _ISSUE_SEVERITIES
+    }
+
+
+def _supportability_state_reason(issue_counts: dict[str, int]) -> tuple[str, str]:
+    if issue_counts["critical"]:
+        return "blocked", "wave_blocked_items"
+    if issue_counts["warning"]:
+        return "degraded", "wave_degraded_items"
+    return "ready", "wave_supportability_ready"
+
+
+def wave_supportability_payload(wave: DpmRebalanceWave) -> dict[str, object]:
+    issues = _wave_supportability_issues(wave)
+    issue_counts = _issue_counts_by_severity(issues)
+    state, reason = _supportability_state_reason(issue_counts)
     return {
         "wave_id": wave.wave_id,
         "wave_state": wave.state,
         "supportability_state": state,
         "reason": reason,
         "item_count": len(wave.items),
-        "issue_counts": {
-            "critical": blocked_count,
-            "warning": degraded_count,
-            "info": sum(1 for issue in issues if issue["severity"] == "INFO"),
-        },
+        "issue_counts": issue_counts,
         "issues": issues,
         "operator_actions": operator_actions(state=state, issues=issues),
     }

--- a/src/core/portfolio_memory/candidate_portfolios.py
+++ b/src/core/portfolio_memory/candidate_portfolios.py
@@ -47,51 +47,98 @@ def candidate_portfolio_ids_from_sources(
     source_scan_limit = validate_portfolio_memory_source_scan_limit(
         source_scan_limit=source_scan_limit
     )
-    candidates: set[str] = {
-        portfolio_id.strip() for portfolio_id in (portfolio_ids or []) if portfolio_id.strip()
-    }
-    candidates.update(
+    candidates = _explicit_candidate_ids(portfolio_ids)
+    candidates.update(_proof_pack_candidate_ids(repositories, source_scan_limit))
+    candidates.update(_wave_candidate_ids(repositories, source_scan_limit))
+    candidates.update(_outcome_review_candidate_ids(repositories, source_scan_limit))
+    candidates.update(_mandate_exception_candidate_ids(repositories, source_scan_limit))
+    candidates.update(_campaign_definition_candidate_ids(repositories, source_scan_limit))
+    candidates.update(_pm_quality_candidate_ids(repositories, source_scan_limit))
+    return sorted(candidates)
+
+
+def _explicit_candidate_ids(portfolio_ids: list[str] | None) -> set[str]:
+    return {portfolio_id.strip() for portfolio_id in (portfolio_ids or []) if portfolio_id.strip()}
+
+
+def _proof_pack_candidate_ids(
+    repositories: PortfolioMemorySourceRepositories,
+    source_scan_limit: int,
+) -> set[str]:
+    return {
         proof_pack.portfolio_id
         for proof_pack in repositories.proof_pack_repository.list_proof_packs(
             limit=source_scan_limit
         )
-    )
-    candidates.update(
+    }
+
+
+def _wave_candidate_ids(
+    repositories: PortfolioMemorySourceRepositories,
+    source_scan_limit: int,
+) -> set[str]:
+    return {
         item.portfolio_id
         for wave in repositories.wave_repository.list_waves(limit=source_scan_limit)
         for item in wave.items
-    )
-    candidates.update(
+    }
+
+
+def _outcome_review_candidate_ids(
+    repositories: PortfolioMemorySourceRepositories,
+    source_scan_limit: int,
+) -> set[str]:
+    return {
         review.portfolio_id
         for review in repositories.outcome_review_repository.list_outcome_reviews(
             limit=source_scan_limit
         )
+    }
+
+
+def _mandate_exception_candidate_ids(
+    repositories: PortfolioMemorySourceRepositories,
+    source_scan_limit: int,
+) -> set[str]:
+    if repositories.mandate_repository is None:
+        return set()
+    exceptions, _cursor = repositories.mandate_repository.list_monitoring_exceptions(
+        monitoring_run_id=None,
+        mandate_id=None,
+        portfolio_id=None,
+        state=None,
+        limit=source_scan_limit,
+        cursor=None,
     )
-    if repositories.mandate_repository is not None:
-        exceptions, _cursor = repositories.mandate_repository.list_monitoring_exceptions(
-            monitoring_run_id=None,
-            mandate_id=None,
-            portfolio_id=None,
-            state=None,
-            limit=source_scan_limit,
-            cursor=None,
+    return {exception.portfolio_id for exception in exceptions}
+
+
+def _campaign_definition_candidate_ids(
+    repositories: PortfolioMemorySourceRepositories,
+    source_scan_limit: int,
+) -> set[str]:
+    if repositories.campaign_definition_repository is None:
+        return set()
+    return {
+        candidate.portfolio_id
+        for definition in repositories.campaign_definition_repository.list_definitions(
+            limit=source_scan_limit
         )
-        candidates.update(exception.portfolio_id for exception in exceptions)
-    if repositories.campaign_definition_repository is not None:
-        candidates.update(
-            candidate.portfolio_id
-            for definition in repositories.campaign_definition_repository.list_definitions(
-                limit=source_scan_limit
-            )
-            for candidate in definition.candidates
+        for candidate in definition.candidates
+    }
+
+
+def _pm_quality_candidate_ids(
+    repositories: PortfolioMemorySourceRepositories,
+    source_scan_limit: int,
+) -> set[str]:
+    if repositories.pm_quality_score_run_repository is None:
+        return set()
+    return {
+        portfolio_id
+        for score_run in repositories.pm_quality_score_run_repository.list_score_runs(
+            limit=source_scan_limit
         )
-    if repositories.pm_quality_score_run_repository is not None:
-        candidates.update(
-            portfolio_id
-            for score_run in repositories.pm_quality_score_run_repository.list_score_runs(
-                limit=source_scan_limit
-            )
-            if score_run.book_scope_evidence is not None
-            for portfolio_id in score_run.book_scope_evidence.member_portfolio_ids
-        )
-    return sorted(candidates)
+        if score_run.book_scope_evidence is not None
+        for portfolio_id in score_run.book_scope_evidence.member_portfolio_ids
+    }

--- a/tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py
+++ b/tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py
@@ -1,6 +1,10 @@
 import pytest
 
 from src.core.portfolio_memory.candidate_portfolios import (
+    _campaign_definition_candidate_ids,
+    _explicit_candidate_ids,
+    _mandate_exception_candidate_ids,
+    _pm_quality_candidate_ids,
     candidate_portfolio_ids,
     candidate_portfolio_ids_from_sources,
 )
@@ -75,6 +79,33 @@ def test_candidate_portfolio_ids_default_optional_repositories_to_empty_sources(
     )
 
     assert candidates == [PORTFOLIO_ID]
+
+
+def test_candidate_portfolio_source_helpers_preserve_family_boundaries() -> None:
+    proof_pack_repository, wave_repository, outcome_repository, mandate_repository = _repositories()
+    campaign_repository = InMemoryDpmBulkReviewCampaignDefinitionRepository()
+    campaign_repository.save_definition(definition=_campaign_definition())
+    pm_quality_repository = InMemoryDpmPmQualityScoreRunRepository()
+    pm_quality_repository.save_score_run(score_run=_pm_quality_score_run())
+    repositories = PortfolioMemorySourceRepositories(
+        proof_pack_repository=proof_pack_repository,
+        wave_repository=wave_repository,
+        outcome_review_repository=outcome_repository,
+        mandate_repository=mandate_repository,
+        campaign_definition_repository=campaign_repository,
+        pm_quality_score_run_repository=pm_quality_repository,
+    )
+
+    assert _explicit_candidate_ids([" PB_MANUAL_001 ", "", "PB_MANUAL_002"]) == {
+        "PB_MANUAL_001",
+        "PB_MANUAL_002",
+    }
+    assert _mandate_exception_candidate_ids(repositories, 100) == {PORTFOLIO_ID}
+    assert _campaign_definition_candidate_ids(repositories, 100) == {PORTFOLIO_ID}
+    assert _pm_quality_candidate_ids(repositories, 100) == {
+        PORTFOLIO_ID,
+        "PB_SG_GLOBAL_INC_002",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/dpm/waves/test_wave_proof_pack_posture.py
+++ b/tests/unit/dpm/waves/test_wave_proof_pack_posture.py
@@ -1,4 +1,10 @@
-from src.api.services.wave_proof_pack_posture import proof_pack_posture_for_wave
+from src.api.services.wave_proof_pack_posture import (
+    _degraded_proof_pack_count,
+    _external_execution_claimed,
+    _proof_pack_refs,
+    _ready_proof_pack_count,
+    proof_pack_posture_for_wave,
+)
 from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem, DpmWaveHandoffRef
 
 
@@ -90,6 +96,62 @@ def test_proof_pack_posture_omits_unlinked_items_without_state() -> None:
             "selected_alternative_id": None,
         }
     ]
+
+
+def test_proof_pack_posture_helpers_project_refs_counts_and_execution_claims() -> None:
+    wave = DpmRebalanceWave.model_construct(
+        wave_id="dwv_posture",
+        state="HANDOFF_READY",
+        items=[
+            DpmRebalanceWaveItem(
+                wave_item_id="dwi_ready",
+                portfolio_id="PB_SG_READY",
+                state="HANDOFF_READY",
+                proof_pack_id="dpp_ready",
+                diagnostics={"proof_pack_state": "READY"},
+                selected_alternative_id="alt_ready",
+            ),
+            DpmRebalanceWaveItem(
+                wave_item_id="dwi_degraded",
+                portfolio_id="PB_SG_DEGRADED",
+                state="PROOF_PACK_READY",
+                proof_pack_id="dpp_degraded",
+                diagnostics={"proof_pack_state": "DEGRADED"},
+            ),
+            DpmRebalanceWaveItem(
+                wave_item_id="dwi_state_only",
+                portfolio_id="PB_SG_STATE_ONLY",
+                state="PROOF_PACK_READY",
+                diagnostics={"proof_pack_state": "READY"},
+            ),
+            DpmRebalanceWaveItem(
+                wave_item_id="dwi_unlinked",
+                portfolio_id="PB_SG_UNLINKED",
+                state="CANDIDATE",
+            ),
+        ],
+        handoff_refs=[
+            DpmWaveHandoffRef.model_construct(
+                handoff_ref_id="dwh_safe",
+                external_execution_claimed=False,
+            ),
+            DpmWaveHandoffRef.model_construct(
+                handoff_ref_id="dwh_unsafe",
+                external_execution_claimed=True,
+            ),
+        ],
+    )
+
+    refs = _proof_pack_refs(wave)
+
+    assert [ref["wave_item_id"] for ref in refs] == [
+        "dwi_ready",
+        "dwi_degraded",
+        "dwi_state_only",
+    ]
+    assert _ready_proof_pack_count(wave) == 1
+    assert _degraded_proof_pack_count(wave) == 1
+    assert _external_execution_claimed(wave) is True
 
 
 def test_wave_proof_pack_posture_exports_only_posture_builder() -> None:

--- a/tests/unit/dpm/waves/test_wave_supportability_payload.py
+++ b/tests/unit/dpm/waves/test_wave_supportability_payload.py
@@ -1,4 +1,9 @@
-from src.api.services.wave_supportability_payload import wave_supportability_payload
+from src.api.services.wave_supportability_payload import (
+    _issue_counts_by_severity,
+    _supportability_state_reason,
+    _wave_supportability_issues,
+    wave_supportability_payload,
+)
 from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveItem
 
 
@@ -67,6 +72,32 @@ def test_wave_supportability_payload_reports_degraded_without_blocked_issues() -
     assert payload["supportability_state"] == "degraded"
     assert payload["reason"] == "wave_degraded_items"
     assert payload["issue_counts"] == {"critical": 0, "warning": 1, "info": 0}
+
+
+def test_wave_supportability_helpers_collect_count_and_classify_issues() -> None:
+    issues = _wave_supportability_issues(
+        _wave(
+            [
+                _item(state="SOURCE_BLOCKED", reason_codes=["MANDATE_MISSING"]),
+                _item(state="SELECTED"),
+                _item(state="CANDIDATE", reason_codes=["SOURCE_CHECK_PENDING"]),
+            ]
+        )
+    )
+
+    counts = _issue_counts_by_severity(issues)
+
+    assert [issue["severity"] for issue in issues] == ["CRITICAL", "WARNING", "INFO"]
+    assert counts == {"critical": 1, "warning": 1, "info": 1}
+    assert _supportability_state_reason(counts) == ("blocked", "wave_blocked_items")
+    assert _supportability_state_reason({"critical": 0, "warning": 1, "info": 0}) == (
+        "degraded",
+        "wave_degraded_items",
+    )
+    assert _supportability_state_reason({"critical": 0, "warning": 0, "info": 1}) == (
+        "ready",
+        "wave_supportability_ready",
+    )
 
 
 def test_wave_supportability_payload_exports_only_payload_builder() -> None:


### PR DESCRIPTION
## Summary

Refactors three remaining source hotspot helpers into clearer, directly tested supportability/source-family helpers:

- split wave supportability issue collection, severity counting, and state/reason classification
- split wave proof-pack posture ref projection, ready/degraded counts, and external-execution claim detection
- split portfolio-memory candidate portfolio aggregation by explicit input, proof packs, waves, outcomes, mandates, campaigns, and PM-quality source families

Behavior is intended to be preserved. This is internal architecture/read-model maintainability hardening only; it does not claim global bank-buyable readiness or new product capability.

## Evidence

Focused gates:

- `python -m ruff check src/api/services/wave_supportability_payload.py src/api/services/wave_proof_pack_posture.py tests/unit/dpm/waves/test_wave_supportability_payload.py tests/unit/dpm/waves/test_wave_proof_pack_posture.py`
- `python -m ruff format --check src/api/services/wave_supportability_payload.py src/api/services/wave_proof_pack_posture.py tests/unit/dpm/waves/test_wave_supportability_payload.py tests/unit/dpm/waves/test_wave_proof_pack_posture.py`
- `python -m mypy --config-file mypy.ini src/api/services/wave_supportability_payload.py src/api/services/wave_proof_pack_posture.py`
- `python -m pytest tests/unit/dpm/waves/test_wave_supportability_payload.py tests/unit/dpm/waves/test_wave_proof_pack_posture.py -q` -> 9 passed
- `python -m radon cc src/api/services/wave_supportability_payload.py src/api/services/wave_proof_pack_posture.py -s`
- `python -m ruff check src/core/portfolio_memory/candidate_portfolios.py tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py`
- `python -m ruff format --check src/core/portfolio_memory/candidate_portfolios.py tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py`
- `python -m mypy --config-file mypy.ini src/core/portfolio_memory/candidate_portfolios.py`
- `python -m pytest tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py -q` -> 6 passed
- `python -m radon cc src/core/portfolio_memory/candidate_portfolios.py -s`

Governance/local gates:

- `python scripts/openapi_quality_gate.py` -> passed
- `python scripts/api_vocabulary_inventory.py --validate-only` -> passed, no drift
- `python scripts/service_boundary_gate.py` -> passed
- service leakage scan over `src/api/services` -> no findings
- `make complexity-gate` -> passed; remaining C-grade entries are pre-existing unrelated hotspots
- `git diff --check` -> passed
- `make check` -> passed, including `2659 passed`

Pre-PR hygiene:

- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> only `origin/feat/manage-hotspot-hardening-20260613-43` active for this PR
- `gh pr list --state open --limit 100` -> no open PRs before this PR
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0

## Complexity movement

- `wave_supportability_payload`: C(11) -> A(1)
- `proof_pack_posture_for_wave`: C(12) -> A(3)
- `candidate_portfolio_ids_from_sources`: C(17) -> A(1)

## Docs / wiki

- Updated `docs/architecture/CODEBASE-REVIEW-LEDGER.md` through `BACKEND-REVIEW-20260613-877`.
- Refreshed quality scorecard/report artifacts.
- No wiki source change required; this is internal maintainability hardening with no operator-facing contract change.

## Residual Risk

This improves internal source/read-model maintainability and direct helper test coverage. It does not certify full bank-buyable readiness, runtime behavior, or downstream Gateway/Workbench product behavior.