### PR TITLE
Clarify quality report source provenance

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21809,3 +21809,29 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal portfolio-memory
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-878: Quality report source-snapshot provenance
+
+- Date: 2026-06-13
+- Scope: `scripts/engineering_health_report.py`, `tests/unit/test_engineering_health_report.py`,
+  and generated `quality/` reports.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: generated quality reports labelled their measured worktree as `Current ref`, which can
+  look like a committed SHA even when the report necessarily includes uncommitted code and report
+  changes before the slice commit exists. That made before/after evidence less precise than the
+  bank-buyable reporting standard requires.
+- Action: added explicit report source-snapshot provenance. The report generator now emits the
+  short `HEAD` when the tree is clean and `HEAD+worktree` when measured files include uncommitted
+  worktree content. Refreshed the baseline, scorecard, refactor-health, and complexity reports to
+  use `Report source snapshot` wording instead of implying a final committed ref.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py`,
+  `python -m ruff format --check scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py`,
+  `python -m mypy --config-file mypy.ini scripts/engineering_health_report.py`, and
+  `python -m pytest tests/unit/test_engineering_health_report.py -q`; the focused reporting suite
+  reported 8 passed.
+- Residual risk: this improves report provenance only. It does not certify global bank-buyable
+  readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal quality-evidence hardening with
+  no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T07:45:42+00:00`
+- Generated at: `2026-06-13T08:02:23+00:00`
 
-- Baseline commit: `75009458`
+- Report source snapshot: `9aa359aa+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171356 |
-| Test functions | 2482 |
+| Total Python LOC | 171389 |
+| Test functions | 2483 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T07:45:42+00:00`
+- Generated at: `2026-06-13T08:02:23+00:00`
 
-- Current ref: `75009458`
+- Report source snapshot: `9aa359aa+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T07:45:42+00:00`
+- Generated at: `2026-06-13T08:02:23+00:00`
 
-- Current ref: `75009458`
+- Report source snapshot: `9aa359aa+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T07:45:42+00:00`
+- Generated at: `2026-06-13T08:02:23+00:00`
 
 - Baseline ref: `origin/main`
 
-- Current ref: `75009458`
+- Report source snapshot: `9aa359aa+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171163 | 171356 | +193 |
-| Test functions | 2479 | 2482 | +3 |
+| Total Python LOC | 171356 | 171389 | +33 |
+| Test functions | 2482 | 2483 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -97,6 +97,16 @@ def _git(*args: str) -> str:
     return completed.stdout
 
 
+def _git_status_porcelain() -> str:
+    return _git("status", "--porcelain")
+
+
+def _report_source_snapshot() -> str:
+    short_head = _git("rev-parse", "--short", "HEAD").strip()
+    suffix = "+worktree" if _git_status_porcelain().strip() else ""
+    return f"{short_head}{suffix}"
+
+
 def _python_paths_from_worktree() -> list[str]:
     paths: list[str] = []
     for root in PYTHON_ROOTS:
@@ -413,7 +423,7 @@ def _report_context(base_ref: str = DEFAULT_BASE_REF) -> HealthReportContext:
     return HealthReportContext(
         generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
         base_ref=base_ref,
-        current_ref=_git("rev-parse", "--short", "HEAD").strip(),
+        current_ref=_report_source_snapshot(),
         base=base,
         current=current,
         openapi=_openapi_metrics(),
@@ -428,7 +438,7 @@ def build_refactor_report(context: HealthReportContext) -> str:
         "# lotus-manage Refactor Health Report",
         f"- Generated at: `{context.generated_at}`",
         f"- Baseline ref: `{context.base_ref}`",
-        f"- Current ref: `{context.current_ref}`",
+        f"- Report source snapshot: `{context.current_ref}`",
         "- Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.",
         "## Scorecard",
         _metric_summary(base, current),
@@ -482,7 +492,7 @@ def build_baseline_report(context: HealthReportContext) -> str:
     sections = [
         "# lotus-manage Baseline Quality Report",
         f"- Generated at: `{context.generated_at}`",
-        f"- Baseline commit: `{context.current_ref}`",
+        f"- Report source snapshot: `{context.current_ref}`",
         "- Mode: report-only baseline. This records current posture; it does not enforce "
         "thresholds by itself.",
         "## Current Code Size",
@@ -616,7 +626,7 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
     sections = [
         "# lotus-manage Quality Scorecard",
         f"- Generated at: `{context.generated_at}`",
-        f"- Current ref: `{context.current_ref}`",
+        f"- Report source snapshot: `{context.current_ref}`",
         "- Purpose: make enterprise-readiness progress measurable without pretending report-only "
         "baselines are mature enforcement gates.",
         _table(["Area", "Status", "Evidence / next gate"], rows),
@@ -660,7 +670,7 @@ def build_complexity_report(context: HealthReportContext) -> str:
     sections = [
         "# lotus-manage Complexity Report",
         f"- Generated at: `{context.generated_at}`",
-        f"- Current ref: `{context.current_ref}`",
+        f"- Report source snapshot: `{context.current_ref}`",
         "- Mode: report-only maintainability baseline using dependency-free AST branch counting.",
         "## Summary",
         _table(

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -82,6 +82,26 @@ def test_python_texts_from_git_reads_python_files_from_one_archive(monkeypatch) 
     }
 
 
+def test_report_source_snapshot_marks_dirty_worktree(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_git(*args: str) -> str:
+        calls.append(args)
+        if args == ("rev-parse", "--short", "HEAD"):
+            return "abc1234\n"
+        if args == ("status", "--porcelain"):
+            return " M scripts/engineering_health_report.py\n"
+        raise AssertionError(args)
+
+    monkeypatch.setattr(ehr, "_git", fake_git)
+
+    assert ehr._report_source_snapshot() == "abc1234+worktree"
+    assert calls == [
+        ("rev-parse", "--short", "HEAD"),
+        ("status", "--porcelain"),
+    ]
+
+
 def _context() -> HealthReportContext:
     return HealthReportContext(
         generated_at="2026-06-02T00:00:00+00:00",
@@ -107,6 +127,7 @@ def test_baseline_report_declares_report_only_quality_coverage() -> None:
     report = build_baseline_report(_context())
 
     assert "# lotus-manage Baseline Quality Report" in report
+    assert "- Report source snapshot: `abc1234`" in report
     assert "| Python files | 3 |" in report
     assert "| Router infrastructure imports | 1 |" in report
     assert (
@@ -119,6 +140,7 @@ def test_quality_scorecard_separates_active_gates_from_planned_gates() -> None:
     scorecard = build_quality_scorecard(_context())
 
     assert "# lotus-manage Quality Scorecard" in scorecard
+    assert "- Report source snapshot: `abc1234`" in scorecard
     assert "| OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |" in scorecard
     assert "| Service boundary | Active gate | `scripts/service_boundary_gate.py`. |" in scorecard
     assert "| Dependency architecture | Active gate |" in scorecard
@@ -157,6 +179,7 @@ def test_complexity_report_is_report_only() -> None:
     report = build_complexity_report(_context())
 
     assert "# lotus-manage Complexity Report" in report
+    assert "- Report source snapshot: `abc1234`" in report
     assert "| Highest complexity | 4 | 4 | +0 |" in report
     assert "### Most Complex Current Source Functions" in report
     assert "### Most Complex Current Test Functions" in report


### PR DESCRIPTION
## Summary
- Clarifies quality-report provenance by replacing ambiguous `Current ref` labels with `Report source snapshot`.
- Marks generated report source as `HEAD+worktree` when the measured snapshot includes uncommitted worktree content, which is the truthful state before the slice commit exists.
- Refreshes the quality scorecard, baseline, complexity, and refactor-health reports and records ledger entry `BACKEND-REVIEW-20260613-878`.

## Bank-Buyable Control Area
- CI measurement and operational evidence.
- This is evidence-quality hardening only; it does not claim global bank-buyable readiness.

## Validation
- `python -m ruff check scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py` passed.
- `python -m ruff format --check scripts/engineering_health_report.py tests/unit/test_engineering_health_report.py` passed.
- `python -m mypy --config-file mypy.ini scripts/engineering_health_report.py` passed.
- `python -m pytest tests/unit/test_engineering_health_report.py -q` passed: 8 passed.
- `python scripts/openapi_quality_gate.py` passed.
- `python scripts/api_vocabulary_inventory.py --validate-only` passed: no drift.
- `python scripts/service_boundary_gate.py` passed.
- Service leakage scan returned no findings.
- `git diff --check` passed.
- `make check` passed: 2660 passed.
- Wiki drift check passed: `DiffCount 0`.

## Stranded Truth
- `git branch -r --no-merged origin/main` shows only this active branch.
- No open PRs existed before this PR was opened.

## Wiki Decision
- No wiki source change required; this is internal quality-evidence hardening with no operator-facing contract change.

## Residual Risk
- This improves report provenance only. Runtime readiness, downstream Gateway/Workbench behavior, and full bank-buyable readiness remain broader follow-up work.