### PR TITLE
Refactor mandate health source readiness

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21835,3 +21835,31 @@ and improves internal transaction-cost source posture maintainability only.
   readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal quality-evidence hardening with
   no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-879: Mandate health source-readiness projection helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/mandates.py` and `tests/unit/dpm/core/test_mandate_health.py`.
+- Bank-buyable control area: architecture and testing.
+- Finding: `build_health_input_from_core_sources` combined market-data readiness projection,
+  unavailable optional-source degradation, target-weight projection, source-backed restriction and
+  sustainability signals, projected cashflow fields, and health-input assembly in one helper. The
+  behavior was correct, but the source-readiness precedence was harder to review directly than the
+  mandate-health supportability contract requires.
+- Action: extracted `_market_data_source_readiness` and `_health_input_source_readiness` with an
+  explicit typed projection object while preserving the public health-input payload. Added direct
+  tests proving missing/stale market-data projection, degraded market-data family tagging, and
+  optional-source unavailability degrading only an otherwise ready source posture.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py`,
+  `python -m ruff format --check src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py`,
+  `python -m mypy --config-file mypy.ini src/core/mandates.py`,
+  `python -m pytest tests/unit/dpm/core/test_mandate_health.py -q`, and
+  `python -m radon cc src/core/mandates.py -s`; the focused mandate-health suite reported
+  40 passed and `build_health_input_from_core_sources` reduced from B(8) to A(4).
+- Residual risk: this slice improves internal mandate-health source-readiness maintainability only.
+  It does not certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal domain helper maintainability
+  hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T08:02:23+00:00`
+- Generated at: `2026-06-13T09:52:20+00:00`
 
-- Report source snapshot: `9aa359aa+worktree`
+- Report source snapshot: `41500362+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171389 |
-| Test functions | 2483 |
+| Total Python LOC | 171487 |
+| Test functions | 2485 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T08:02:23+00:00`
+- Generated at: `2026-06-13T09:52:20+00:00`
 
-- Report source snapshot: `9aa359aa+worktree`
+- Report source snapshot: `41500362+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -33,15 +33,15 @@
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
 | 1 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 2 | build_health_input_from_core_sources | src/core/mandates.py | 7 | 57 |
-| 3 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
-| 4 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
-| 5 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
-| 6 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
-| 7 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
-| 8 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
-| 9 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
-| 10 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 2 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 3 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 4 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 5 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 6 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
+| 7 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
+| 8 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
+| 9 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 10 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T08:02:23+00:00`
+- Generated at: `2026-06-13T09:52:20+00:00`
 
-- Report source snapshot: `9aa359aa+worktree`
+- Report source snapshot: `41500362+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T08:02:23+00:00`
+- Generated at: `2026-06-13T09:52:20+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `9aa359aa+worktree`
+- Report source snapshot: `41500362+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171356 | 171389 | +33 |
-| Test functions | 2482 | 2483 | +1 |
+| Total Python LOC | 171389 | 171487 | +98 |
+| Test functions | 2483 | 2485 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/mandates.py
+++ b/src/core/mandates.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal, ROUND_HALF_UP
 from enum import Enum
@@ -78,6 +79,15 @@ _DigitalTwinLineageSourceProduct: TypeAlias = (
     | DpmCoreLiquidityReserveRequirementResponse
     | DpmCorePlannedWithdrawalScheduleResponse
 )
+_SourceReadinessState: TypeAlias = Literal["READY", "DEGRADED", "INCOMPLETE", "UNAVAILABLE"]
+
+
+@dataclass(frozen=True)
+class _MandateSourceReadinessProjection:
+    state: _SourceReadinessState
+    missing_source_families: list[str]
+    degraded_source_families: list[str]
+    stale_source_families: list[str]
 
 
 def _bounded_ratio(value: Decimal, *, field_name: str) -> Decimal:
@@ -866,6 +876,53 @@ def compile_mandate_digital_twin_from_core(
     )
 
 
+def _market_data_source_readiness(
+    market_data_coverage: Optional[DpmCoreMarketDataCoverageWindowResponse],
+) -> _MandateSourceReadinessProjection:
+    if market_data_coverage is None:
+        return _MandateSourceReadinessProjection(
+            state="READY",
+            missing_source_families=[],
+            degraded_source_families=[],
+            stale_source_families=[],
+        )
+    supportability = market_data_coverage.supportability
+    degraded_sources = ["MARKET_DATA_COVERAGE"] if supportability.state == "DEGRADED" else []
+    return _MandateSourceReadinessProjection(
+        state=supportability.state,
+        missing_source_families=[
+            *supportability.missing_instrument_ids,
+            *supportability.missing_currency_pairs,
+        ],
+        degraded_source_families=degraded_sources,
+        stale_source_families=[
+            *supportability.stale_instrument_ids,
+            *supportability.stale_currency_pairs,
+        ],
+    )
+
+
+def _health_input_source_readiness(
+    *,
+    market_data_coverage: Optional[DpmCoreMarketDataCoverageWindowResponse],
+    unavailable_source_families: Optional[list[str]],
+) -> _MandateSourceReadinessProjection:
+    market_data_readiness = _market_data_source_readiness(market_data_coverage)
+    unavailable_families = unavailable_source_families or []
+    state = market_data_readiness.state
+    if unavailable_families and state == "READY":
+        state = "DEGRADED"
+    return _MandateSourceReadinessProjection(
+        state=state,
+        missing_source_families=market_data_readiness.missing_source_families,
+        degraded_source_families=[
+            *market_data_readiness.degraded_source_families,
+            *unavailable_families,
+        ],
+        stale_source_families=market_data_readiness.stale_source_families,
+    )
+
+
 def build_health_input_from_core_sources(
     *,
     twin: DpmMandateDigitalTwin,
@@ -878,32 +935,20 @@ def build_health_input_from_core_sources(
     portfolio_cashflow_projection: Optional[DpmCorePortfolioCashflowProjectionResponse] = None,
     unavailable_source_families: Optional[list[str]] = None,
 ) -> DpmMandateHealthInput:
-    missing_sources: list[str] = []
-    degraded_sources: list[str] = []
-    stale_sources: list[str] = []
-    readiness_state: Literal["READY", "DEGRADED", "INCOMPLETE", "UNAVAILABLE"] = "READY"
-    if market_data_coverage is not None:
-        readiness_state = market_data_coverage.supportability.state
-        missing_sources.extend(market_data_coverage.supportability.missing_instrument_ids)
-        missing_sources.extend(market_data_coverage.supportability.missing_currency_pairs)
-        stale_sources.extend(market_data_coverage.supportability.stale_instrument_ids)
-        stale_sources.extend(market_data_coverage.supportability.stale_currency_pairs)
-        if readiness_state == "DEGRADED":
-            degraded_sources.append("MARKET_DATA_COVERAGE")
-    if unavailable_source_families:
-        degraded_sources.extend(unavailable_source_families)
-        if readiness_state == "READY":
-            readiness_state = "DEGRADED"
+    source_readiness = _health_input_source_readiness(
+        market_data_coverage=market_data_coverage,
+        unavailable_source_families=unavailable_source_families,
+    )
 
     return DpmMandateHealthInput(
         twin=twin,
         target_weights={
             target.instrument_id: target.target_weight for target in model_targets.targets
         },
-        source_readiness_state=readiness_state,
-        missing_source_families=missing_sources,
-        degraded_source_families=degraded_sources,
-        stale_source_families=stale_sources,
+        source_readiness_state=source_readiness.state,
+        missing_source_families=source_readiness.missing_source_families,
+        degraded_source_families=source_readiness.degraded_source_families,
+        stale_source_families=source_readiness.stale_source_families,
         restricted_target_instruments=_restricted_model_targets(
             model_targets=model_targets,
             client_restriction_profile=client_restriction_profile,

--- a/tests/unit/dpm/core/test_mandate_health.py
+++ b/tests/unit/dpm/core/test_mandate_health.py
@@ -32,12 +32,14 @@ from src.core.mandates import (
     _benchmark_assignment_source_lineage,
     _benchmark_assignment_source_record_id,
     _build_digital_twin_source_lineage,
+    _health_input_source_readiness,
     _mandate_twin_constraint_set,
     _mandate_binding_profile_gap_codes,
     _mandate_twin_preferences,
     _mandate_optional_source_product_gap_codes,
     _mandate_source_schedule_gap_codes,
     _mandate_twin_field_gap_codes,
+    _market_data_source_readiness,
     _optional_digital_twin_source_lineage,
     calculate_mandate_health,
     build_health_input_from_core_sources,
@@ -838,6 +840,57 @@ def test_build_health_input_from_market_data_coverage_preserves_degraded_sources
     assert health_input.source_readiness_state == "DEGRADED"
     assert health_input.degraded_source_families == ["MARKET_DATA_COVERAGE"]
     assert health_input.stale_source_families == ["EQ_US_AAPL", "USD/SGD"]
+
+
+def test_market_data_source_readiness_projects_missing_stale_and_degraded_sources() -> None:
+    readiness = _market_data_source_readiness(
+        _market_data_coverage(
+            supportability={
+                "state": "DEGRADED",
+                "reason": "MARKET_DATA_PARTIAL",
+                "requested_price_count": 2,
+                "resolved_price_count": 1,
+                "requested_fx_count": 1,
+                "resolved_fx_count": 0,
+                "missing_instrument_ids": ["FI_US_TREASURY_10Y"],
+                "missing_currency_pairs": ["USD/SGD"],
+                "stale_instrument_ids": ["EQ_US_AAPL"],
+                "stale_currency_pairs": ["EUR/SGD"],
+            }
+        )
+    )
+
+    assert readiness.state == "DEGRADED"
+    assert readiness.missing_source_families == ["FI_US_TREASURY_10Y", "USD/SGD"]
+    assert readiness.degraded_source_families == ["MARKET_DATA_COVERAGE"]
+    assert readiness.stale_source_families == ["EQ_US_AAPL", "EUR/SGD"]
+
+
+def test_health_input_source_readiness_degrades_ready_only_for_unavailable_optionals() -> None:
+    ready_readiness = _health_input_source_readiness(
+        market_data_coverage=None,
+        unavailable_source_families=["CLIENT_RESTRICTION_PROFILE"],
+    )
+    incomplete_readiness = _health_input_source_readiness(
+        market_data_coverage=_market_data_coverage(
+            supportability={
+                "state": "INCOMPLETE",
+                "reason": "PRICE_MISSING",
+                "requested_price_count": 2,
+                "resolved_price_count": 1,
+                "requested_fx_count": 0,
+                "resolved_fx_count": 0,
+                "missing_instrument_ids": ["EQ_US_AAPL"],
+            }
+        ),
+        unavailable_source_families=["SUSTAINABILITY_PREFERENCE_PROFILE"],
+    )
+
+    assert ready_readiness.state == "DEGRADED"
+    assert ready_readiness.degraded_source_families == ["CLIENT_RESTRICTION_PROFILE"]
+    assert incomplete_readiness.state == "INCOMPLETE"
+    assert incomplete_readiness.missing_source_families == ["EQ_US_AAPL"]
+    assert incomplete_readiness.degraded_source_families == ["SUSTAINABILITY_PREFERENCE_PROFILE"]
 
 
 def test_build_health_input_uses_source_backed_profile_and_cashflow_risk_signals() -> None:


### PR DESCRIPTION
## Summary
- Extracts mandate-health source-readiness projection helpers from `build_health_input_from_core_sources`.
- Preserves market-data missing/stale/degraded source behavior and optional-source unavailable-family precedence.
- Adds direct helper tests and refreshes quality reports plus ledger entry `BACKEND-REVIEW-20260613-879`.

## Bank-Buyable Control Area
- Architecture and testing.
- This is internal domain-helper maintainability hardening only; it does not claim global bank-buyable readiness.

## Complexity Movement
- `build_health_input_from_core_sources`: B(8) -> A(4) by `python -m radon cc src/core/mandates.py -s`.
- New helpers: `_market_data_source_readiness` A(3), `_health_input_source_readiness` A(4).

## Validation
- `python -m ruff check src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py` passed.
- `python -m ruff format --check src/core/mandates.py tests/unit/dpm/core/test_mandate_health.py` passed.
- `python -m mypy --config-file mypy.ini src/core/mandates.py` passed.
- `python -m pytest tests/unit/dpm/core/test_mandate_health.py -q` passed: 40 passed.
- `python -m radon cc src/core/mandates.py -s` confirmed complexity movement above.
- `python scripts/openapi_quality_gate.py` passed.
- `python scripts/api_vocabulary_inventory.py --validate-only` passed: no drift.
- `python scripts/service_boundary_gate.py` passed.
- Service leakage scan returned no findings.
- `git diff --check` passed.
- `make check` passed: 2662 passed.
- Wiki drift check passed: `DiffCount 0`.

## Stranded Truth
- `git branch -r --no-merged origin/main` shows only this active branch.
- No open PRs existed before this PR was opened.

## Wiki Decision
- No wiki source change required; this is internal domain helper maintainability hardening with no operator-facing contract change.

## Residual Risk
- This improves mandate-health source-readiness maintainability only. Runtime evidence, downstream Gateway/Workbench product behavior, and full bank-buyable readiness remain broader follow-up work.