### PR TITLE
Refactor manage supportability source hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21897,3 +21897,37 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal operational-evidence helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-881: Stateful source-context resolver helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/rebalance_stateful_source_context.py` and
+  `tests/unit/api/test_runtime_request_model_and_service_edges.py`.
+- Bank-buyable control area: architecture, observability, and testing.
+- Finding: `resolve_stateful_source_context` combined stateful-input gating, resolver
+  construction/invocation, failure-to-domain-error mapping, resolver supportability metric
+  emission, success reason projection, context hashing, and response assembly in one helper. The
+  behavior was correct, but the stateful sourcing boundary was harder to review than the core
+  resolver observability and fail-closed supportability contract requires.
+- Action: extracted stateful-input gating, core resolver execution/error mapping, resolver failure
+  metric emission, success metric emission, and success supportability-state/reason projection
+  helpers while preserving the public resolver response. Added direct helper coverage proving
+  stateful-input gating and ready/degraded success reason projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/rebalance_stateful_source_context.py tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  `python -m ruff format --check src/api/services/rebalance_stateful_source_context.py tests/unit/api/test_runtime_request_model_and_service_edges.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/rebalance_stateful_source_context.py`,
+  `python -m pytest tests/unit/api/test_runtime_request_model_and_service_edges.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/service_boundary_gate.py`,
+  service leakage scan, `git diff --check`, and
+  `python -m radon cc src/api/services/rebalance_stateful_source_context.py -s`; the focused
+  runtime request/service-edge suite reported 45 passed, `make check` reported 2664 passed, and
+  `resolve_stateful_source_context` reduced from B(7) to A(1).
+- Residual risk: this slice improves internal stateful source-context maintainability only. It
+  does not certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal API-service helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21863,3 +21863,37 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal domain helper maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-880: Rebalance-run support-bundle projection helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/rebalance_runs/service.py` and
+  `tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py`.
+- Bank-buyable control area: architecture, operational evidence, and testing.
+- Finding: `get_run_support_bundle` combined required-run lookup, optional artifact resolution,
+  async-operation projection, idempotency-history projection, workflow-history ordering, lineage
+  ordering, and response assembly in one method. The behavior was correct, but the support-bundle
+  evidence path was harder to review than the action-register supportability contract deserves.
+- Action: extracted optional support-bundle repository lookups and pure projection helpers for
+  async operation, idempotency history, workflow history, and lineage evidence while preserving the
+  public response shape. Added direct helper coverage proving optional-section omission,
+  executable async-operation projection, idempotency-history ordering, workflow-decision ordering,
+  and deterministic lineage ordering.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance_runs/service.py tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py`,
+  `python -m ruff format --check src/core/rebalance_runs/service.py tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance_runs/service.py`,
+  `python -m pytest tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/api_vocabulary_inventory.py --validate-only`,
+  `python scripts/service_boundary_gate.py`,
+  service leakage scan, `git diff --check`, and
+  `python -m radon cc src/core/rebalance_runs/service.py -s`; the focused supportability suite
+  reported 7 passed, `make check` reported 2663 passed, and `get_run_support_bundle` reduced
+  from B(7) to A(2).
+- Residual risk: this slice improves internal rebalance-run support-bundle maintainability only.
+  It does not certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal operational-evidence helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T10:09:36+00:00`
+- Generated at: `2026-06-13T10:13:32+00:00`
 
-- Report source snapshot: `0fa63555+worktree`
+- Report source snapshot: `4c6cf8f2+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171679 |
-| Test functions | 2486 |
+| Total Python LOC | 171761 |
+| Test functions | 2487 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T09:52:20+00:00`
+- Generated at: `2026-06-13T10:09:36+00:00`
 
-- Report source snapshot: `41500362+worktree`
+- Report source snapshot: `0fa63555+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171487 |
-| Test functions | 2485 |
+| Total Python LOC | 171679 |
+| Test functions | 2486 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T10:09:36+00:00`
+- Generated at: `2026-06-13T10:13:32+00:00`
 
-- Report source snapshot: `0fa63555+worktree`
+- Report source snapshot: `4c6cf8f2+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
-| 2 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
-| 3 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
-| 4 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
-| 5 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
-| 6 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
-| 7 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
-| 8 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
-| 9 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
-| 10 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
+| 1 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 2 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 3 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 4 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
+| 5 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
+| 6 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
+| 7 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 8 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
+| 9 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
+| 10 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T09:52:20+00:00`
+- Generated at: `2026-06-13T10:09:36+00:00`
 
-- Report source snapshot: `41500362+worktree`
+- Report source snapshot: `0fa63555+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | get_run_support_bundle | src/core/rebalance_runs/service.py | 7 | 58 |
-| 2 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
-| 3 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
-| 4 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
-| 5 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
-| 6 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
-| 7 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
-| 8 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
-| 9 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
-| 10 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
+| 1 | resolve_stateful_source_context | src/api/services/rebalance_stateful_source_context.py | 7 | 54 |
+| 2 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
+| 3 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 4 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 5 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
+| 6 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
+| 7 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
+| 8 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 9 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
+| 10 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T09:52:20+00:00`
+- Generated at: `2026-06-13T10:09:36+00:00`
 
-- Report source snapshot: `41500362+worktree`
+- Report source snapshot: `0fa63555+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T10:09:36+00:00`
+- Generated at: `2026-06-13T10:13:32+00:00`
 
-- Report source snapshot: `0fa63555+worktree`
+- Report source snapshot: `4c6cf8f2+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T09:52:20+00:00`
+- Generated at: `2026-06-13T10:09:36+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `41500362+worktree`
+- Report source snapshot: `0fa63555+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171389 | 171487 | +98 |
-| Test functions | 2483 | 2485 | +2 |
+| Total Python LOC | 171487 | 171679 | +192 |
+| Test functions | 2485 | 2486 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T10:09:36+00:00`
+- Generated at: `2026-06-13T10:13:32+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `0fa63555+worktree`
+- Report source snapshot: `4c6cf8f2+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171487 | 171679 | +192 |
-| Test functions | 2485 | 2486 | +1 |
+| Total Python LOC | 171487 | 171761 | +274 |
+| Test functions | 2485 | 2487 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/services/rebalance_stateful_source_context.py
+++ b/src/api/services/rebalance_stateful_source_context.py
@@ -41,53 +41,100 @@ def resolve_stateful_source_context(
     stateful_enabled: bool,
     resolver_factory: CoreResolverFactory,
 ) -> DpmResolvedSourceContext:
-    if envelope.stateful_input is None:
-        raise DpmRebalanceEnvelopeValidationError("DPM_STATEFUL_INPUT_REQUIRED")
-    if not stateful_enabled:
-        raise DpmRebalanceStatefulInputDisabledError("DPM_STATEFUL_INPUT_DISABLED")
-
-    try:
-        resolver = resolver_factory()
-        context = resolver.resolve_execution_context(
-            stateful_input=envelope.stateful_input,
-            correlation_id=correlation_id,
-        )
-    except CoreResolverUnavailableError as exc:
-        record_core_resolver_call(
-            operation=DPM_CORE_RESOLVER_OPERATION,
-            outcome="unavailable",
-            supportability_state="unavailable",
-            reason="resolver_unavailable",
-        )
-        raise DpmRebalanceCoreResolverUnavailableError("DPM_CORE_RESOLVER_UNAVAILABLE") from exc
-    except ValidationError as exc:
-        record_core_resolver_call(
-            operation=DPM_CORE_RESOLVER_OPERATION,
-            outcome="incomplete",
-            supportability_state="unknown",
-            reason="invalid_response",
-        )
-        raise DpmRebalanceCoreContextIncompleteError("DPM_CORE_CONTEXT_INCOMPLETE") from exc
-    except (DpmCoreContextIncompleteError, CoreResolverError) as exc:
-        record_core_resolver_call(
-            operation=DPM_CORE_RESOLVER_OPERATION,
-            outcome="incomplete",
-            supportability_state="unknown",
-            reason="context_incomplete",
-        )
-        raise DpmRebalanceCoreContextIncompleteError("DPM_CORE_CONTEXT_INCOMPLETE") from exc
-    record_core_resolver_call(
-        operation=DPM_CORE_RESOLVER_OPERATION,
-        outcome="success",
-        supportability_state=context.supportability.state.lower(),
-        reason="degraded" if context.supportability.state == "DEGRADED" else "ready",
+    stateful_input = _stateful_source_input(
+        envelope=envelope,
+        stateful_enabled=stateful_enabled,
     )
+    context = _resolve_core_execution_context(
+        stateful_input=stateful_input,
+        correlation_id=correlation_id,
+        resolver_factory=resolver_factory,
+    )
+    _record_core_resolver_success(context=context)
 
     stateful_context_hash = hash_canonical_payload(context.model_dump(mode="json"))
     return DpmResolvedSourceContext(
         stateful_context_hash=stateful_context_hash,
         context=context,
     )
+
+
+def _stateful_source_input(
+    *,
+    envelope: RebalanceExecutionRequestEnvelope | BatchExecutionRequestEnvelope,
+    stateful_enabled: bool,
+) -> Any:
+    if envelope.stateful_input is None:
+        raise DpmRebalanceEnvelopeValidationError("DPM_STATEFUL_INPUT_REQUIRED")
+    if not stateful_enabled:
+        raise DpmRebalanceStatefulInputDisabledError("DPM_STATEFUL_INPUT_DISABLED")
+    return envelope.stateful_input
+
+
+def _resolve_core_execution_context(
+    *,
+    stateful_input: Any,
+    correlation_id: Optional[str],
+    resolver_factory: CoreResolverFactory,
+) -> Any:
+    try:
+        resolver = resolver_factory()
+        return resolver.resolve_execution_context(
+            stateful_input=stateful_input,
+            correlation_id=correlation_id,
+        )
+    except CoreResolverUnavailableError as exc:
+        _record_core_resolver_failure(
+            outcome="unavailable",
+            supportability_state="unavailable",
+            reason="resolver_unavailable",
+        )
+        raise DpmRebalanceCoreResolverUnavailableError("DPM_CORE_RESOLVER_UNAVAILABLE") from exc
+    except ValidationError as exc:
+        _record_core_resolver_failure(
+            outcome="incomplete",
+            supportability_state="unknown",
+            reason="invalid_response",
+        )
+        raise DpmRebalanceCoreContextIncompleteError("DPM_CORE_CONTEXT_INCOMPLETE") from exc
+    except (DpmCoreContextIncompleteError, CoreResolverError) as exc:
+        _record_core_resolver_failure(
+            outcome="incomplete",
+            supportability_state="unknown",
+            reason="context_incomplete",
+        )
+        raise DpmRebalanceCoreContextIncompleteError("DPM_CORE_CONTEXT_INCOMPLETE") from exc
+
+
+def _record_core_resolver_failure(
+    *,
+    outcome: str,
+    supportability_state: str,
+    reason: str,
+) -> None:
+    record_core_resolver_call(
+        operation=DPM_CORE_RESOLVER_OPERATION,
+        outcome=outcome,
+        supportability_state=supportability_state,
+        reason=reason,
+    )
+
+
+def _record_core_resolver_success(*, context: Any) -> None:
+    record_core_resolver_call(
+        operation=DPM_CORE_RESOLVER_OPERATION,
+        outcome="success",
+        supportability_state=_core_resolver_supportability_state(context=context),
+        reason=_core_resolver_success_reason(context=context),
+    )
+
+
+def _core_resolver_supportability_state(*, context: Any) -> str:
+    return str(context.supportability.state).lower()
+
+
+def _core_resolver_success_reason(*, context: Any) -> str:
+    return "degraded" if context.supportability.state == "DEGRADED" else "ready"
 
 
 __all__ = ["CoreResolverFactory", "resolve_stateful_source_context"]

--- a/src/core/rebalance_runs/service.py
+++ b/src/core/rebalance_runs/service.py
@@ -416,41 +416,29 @@ class DpmRunSupportService:
         if run is None:
             raise DpmRunNotFoundError("DPM_RUN_NOT_FOUND")
 
-        artifact = self._resolve_run_artifact(run=run) if include_artifact else None
-        async_operation = None
-        if include_async_operation:
-            operation = self._repository.get_operation_by_correlation(
-                correlation_id=run.correlation_id
-            )
-            if operation is not None:
-                async_operation = to_async_status(operation)
-
-        idempotency_history = None
-        if include_idempotency_history and run.idempotency_key is not None:
-            history = self._repository.list_idempotency_history(idempotency_key=run.idempotency_key)
-            idempotency_history = to_idempotency_history_response(
-                idempotency_key=run.idempotency_key,
-                history=history,
-            )
-
-        decisions = self._repository.list_workflow_decisions(rebalance_run_id=rebalance_run_id)
-        decisions = sorted(decisions, key=lambda item: item.decided_at)
-        workflow_history = DpmRunWorkflowHistoryResponse(
-            run_id=rebalance_run_id,
-            decisions=[to_workflow_decision_response(decision) for decision in decisions],
-        )
-
-        edges = self._repository.list_lineage_edges(entity_id=rebalance_run_id)
-        edges = sorted(
-            edges,
-            key=lambda edge: (
-                edge.created_at,
-                edge.source_entity_id,
-                edge.edge_type,
-                edge.target_entity_id,
+        artifact = self._support_bundle_artifact(run=run, include_artifact=include_artifact)
+        async_operation = _support_bundle_async_operation(
+            run=run,
+            operation=self._support_bundle_operation_record(
+                run=run,
+                include_async_operation=include_async_operation,
             ),
         )
-        lineage = to_lineage_response(entity_id=rebalance_run_id, edges=edges, next_cursor=None)
+        idempotency_history = _support_bundle_idempotency_history(
+            run=run,
+            history=self._support_bundle_idempotency_records(
+                run=run,
+                include_idempotency_history=include_idempotency_history,
+            ),
+        )
+        workflow_history = _support_bundle_workflow_history(
+            rebalance_run_id=rebalance_run_id,
+            decisions=self._repository.list_workflow_decisions(rebalance_run_id=rebalance_run_id),
+        )
+        lineage = _support_bundle_lineage(
+            rebalance_run_id=rebalance_run_id,
+            edges=self._repository.list_lineage_edges(entity_id=rebalance_run_id),
+        )
 
         return DpmRunSupportBundleResponse(
             run=to_lookup_response(run),
@@ -460,6 +448,33 @@ class DpmRunSupportService:
             lineage=lineage,
             idempotency_history=idempotency_history,
         )
+
+    def _support_bundle_artifact(
+        self, *, run: DpmRunRecord, include_artifact: bool
+    ) -> Optional[DpmRunArtifactResponse]:
+        if not include_artifact:
+            return None
+        return self._resolve_run_artifact(run=run)
+
+    def _support_bundle_operation_record(
+        self,
+        *,
+        run: DpmRunRecord,
+        include_async_operation: bool,
+    ) -> Optional[DpmAsyncOperationRecord]:
+        if not include_async_operation:
+            return None
+        return self._repository.get_operation_by_correlation(correlation_id=run.correlation_id)
+
+    def _support_bundle_idempotency_records(
+        self,
+        *,
+        run: DpmRunRecord,
+        include_idempotency_history: bool,
+    ) -> Optional[list[DpmRunIdempotencyHistoryRecord]]:
+        if not include_idempotency_history or run.idempotency_key is None:
+            return None
+        return self._repository.list_idempotency_history(idempotency_key=run.idempotency_key)
 
     def get_run_support_bundle_by_correlation(
         self,
@@ -853,6 +868,55 @@ class DpmRunSupportService:
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _support_bundle_async_operation(
+    *,
+    run: DpmRunRecord,
+    operation: Optional[DpmAsyncOperationRecord],
+) -> Optional[DpmAsyncOperationStatusResponse]:
+    if operation is None or operation.correlation_id != run.correlation_id:
+        return None
+    return to_async_status(operation)
+
+
+def _support_bundle_idempotency_history(
+    *,
+    run: DpmRunRecord,
+    history: Optional[list[DpmRunIdempotencyHistoryRecord]],
+) -> Optional[DpmRunIdempotencyHistoryResponse]:
+    if run.idempotency_key is None or history is None:
+        return None
+    return to_idempotency_history_response(
+        idempotency_key=run.idempotency_key,
+        history=history,
+    )
+
+
+def _support_bundle_workflow_history(
+    *,
+    rebalance_run_id: str,
+    decisions: list[DpmRunWorkflowDecisionRecord],
+) -> DpmRunWorkflowHistoryResponse:
+    return DpmRunWorkflowHistoryResponse(
+        run_id=rebalance_run_id,
+        decisions=[
+            to_workflow_decision_response(decision)
+            for decision in sorted(decisions, key=lambda item: item.decided_at)
+        ],
+    )
+
+
+def _support_bundle_lineage(
+    *,
+    rebalance_run_id: str,
+    edges: list[DpmLineageEdgeRecord],
+) -> DpmLineageResponse:
+    return to_lineage_response(
+        entity_id=rebalance_run_id,
+        edges=_sort_lineage_edges(edges),
+        next_cursor=None,
+    )
 
 
 def _sort_lineage_edges(edges: list[DpmLineageEdgeRecord]) -> list[DpmLineageEdgeRecord]:

--- a/tests/unit/api/test_runtime_request_model_and_service_edges.py
+++ b/tests/unit/api/test_runtime_request_model_and_service_edges.py
@@ -260,6 +260,41 @@ def test_stateful_source_context_helper_gates_before_resolver_call() -> None:
         )
 
 
+def test_stateful_source_context_helpers_project_gates_and_success_posture() -> None:
+    stateful_input = _stateful_input()
+    envelope = RebalanceExecutionRequestEnvelope.model_construct(
+        input_mode="stateful",
+        stateful_input=stateful_input,
+        stateless_input=None,
+        options_override={},
+    )
+
+    assert (
+        stateful_source_context._stateful_source_input(
+            envelope=envelope,
+            stateful_enabled=True,
+        )
+        == stateful_input
+    )
+    with pytest.raises(service.DpmRebalanceStatefulInputDisabledError):
+        stateful_source_context._stateful_source_input(
+            envelope=envelope,
+            stateful_enabled=False,
+        )
+
+    ready_context = SimpleNamespace(supportability=SimpleNamespace(state="READY"))
+    degraded_context = SimpleNamespace(supportability=SimpleNamespace(state="DEGRADED"))
+    assert (
+        stateful_source_context._core_resolver_supportability_state(context=ready_context)
+        == "ready"
+    )
+    assert stateful_source_context._core_resolver_success_reason(context=ready_context) == "ready"
+    assert (
+        stateful_source_context._core_resolver_success_reason(context=degraded_context)
+        == "degraded"
+    )
+
+
 def test_rebalance_request_envelope_resolution_handles_stateless_and_transform_failure() -> None:
     request = RebalanceRequest.model_validate(valid_api_payload())
     stateless_envelope = RebalanceExecutionRequestEnvelope(

--- a/tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py
+++ b/tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py
@@ -3,11 +3,21 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from src.core.rebalance.engine import run_simulation
-from src.core.rebalance_runs.models import DpmRunRecord
+from src.core.rebalance_runs.models import (
+    DpmAsyncOperationRecord,
+    DpmLineageEdgeRecord,
+    DpmRunIdempotencyHistoryRecord,
+    DpmRunRecord,
+    DpmRunWorkflowDecisionRecord,
+)
 from src.core.rebalance_runs.service import (
     DpmAsyncOperationConflictError,
     DpmRunNotFoundError,
     DpmRunSupportService,
+    _support_bundle_async_operation,
+    _support_bundle_idempotency_history,
+    _support_bundle_lineage,
+    _support_bundle_workflow_history,
 )
 from src.core.models import EngineOptions
 from src.infrastructure.rebalance_runs import InMemoryDpmRunRepository
@@ -217,3 +227,121 @@ def test_supportability_summary_posture_empty_ready_stale_and_degraded():
     assert degraded.supportability.state == "degraded"
     assert degraded.supportability.reason == "supportability_summary_degraded"
     assert degraded.supportability.freshness_bucket == "current"
+
+
+def test_support_bundle_helpers_project_optional_sections_and_sort_evidence():
+    now = datetime(2026, 2, 20, 12, 0, tzinfo=timezone.utc)
+    run = DpmRunRecord(
+        rebalance_run_id="rr_support_bundle_1",
+        correlation_id="corr_support_bundle_1",
+        request_hash="sha256:req-support-bundle-1",
+        idempotency_key="idem_support_bundle_1",
+        portfolio_id="pf_support_bundle_1",
+        created_at=now,
+        result_json=_sample_result().model_dump(mode="json"),
+    )
+
+    operation = DpmAsyncOperationRecord(
+        operation_id="dop_support_bundle_1",
+        operation_type="ANALYZE_SCENARIOS",
+        status="PENDING",
+        correlation_id=run.correlation_id,
+        created_at=now,
+        started_at=None,
+        finished_at=None,
+        result_json=None,
+        error_json=None,
+        request_json={"scenarios": {"baseline": {"options": {}}}},
+    )
+    async_operation = _support_bundle_async_operation(run=run, operation=operation)
+    assert async_operation is not None
+    assert async_operation.operation_id == "dop_support_bundle_1"
+    assert async_operation.is_executable is True
+    assert _support_bundle_async_operation(run=run, operation=None) is None
+
+    history = _support_bundle_idempotency_history(
+        run=run,
+        history=[
+            DpmRunIdempotencyHistoryRecord(
+                idempotency_key=run.idempotency_key,
+                rebalance_run_id=run.rebalance_run_id,
+                correlation_id=run.correlation_id,
+                request_hash=run.request_hash,
+                created_at=now + timedelta(minutes=1),
+            ),
+            DpmRunIdempotencyHistoryRecord(
+                idempotency_key=run.idempotency_key,
+                rebalance_run_id="rr_support_bundle_0",
+                correlation_id="corr_support_bundle_0",
+                request_hash="sha256:req-support-bundle-0",
+                created_at=now,
+            ),
+        ],
+    )
+    assert history is not None
+    assert history.idempotency_key == run.idempotency_key
+    assert [item.rebalance_run_id for item in history.history] == [
+        "rr_support_bundle_0",
+        run.rebalance_run_id,
+    ]
+    assert (
+        _support_bundle_idempotency_history(
+            run=run.model_copy(update={"idempotency_key": None}),
+            history=[],
+        )
+        is None
+    )
+
+    workflow_history = _support_bundle_workflow_history(
+        rebalance_run_id=run.rebalance_run_id,
+        decisions=[
+            DpmRunWorkflowDecisionRecord(
+                decision_id="dwd_later",
+                run_id=run.rebalance_run_id,
+                action="APPROVE",
+                reason_code="REVIEW_APPROVED",
+                comment=None,
+                actor_id="reviewer_1",
+                decided_at=now + timedelta(minutes=2),
+                correlation_id="corr_decision_later",
+            ),
+            DpmRunWorkflowDecisionRecord(
+                decision_id="dwd_earlier",
+                run_id=run.rebalance_run_id,
+                action="REQUEST_CHANGES",
+                reason_code="NEEDS_DETAIL",
+                comment=None,
+                actor_id="reviewer_2",
+                decided_at=now,
+                correlation_id="corr_decision_earlier",
+            ),
+        ],
+    )
+    assert [decision.decision_id for decision in workflow_history.decisions] == [
+        "dwd_earlier",
+        "dwd_later",
+    ]
+
+    lineage = _support_bundle_lineage(
+        rebalance_run_id=run.rebalance_run_id,
+        edges=[
+            DpmLineageEdgeRecord(
+                source_entity_id="idem_support_bundle_1",
+                edge_type="IDEMPOTENCY_TO_RUN",
+                target_entity_id=run.rebalance_run_id,
+                created_at=now + timedelta(minutes=1),
+                metadata_json={"request_hash": run.request_hash},
+            ),
+            DpmLineageEdgeRecord(
+                source_entity_id=run.correlation_id,
+                edge_type="CORRELATION_TO_RUN",
+                target_entity_id=run.rebalance_run_id,
+                created_at=now,
+                metadata_json={"request_hash": run.request_hash},
+            ),
+        ],
+    )
+    assert [edge.edge_type for edge in lineage.edges] == [
+        "CORRELATION_TO_RUN",
+        "IDEMPOTENCY_TO_RUN",
+    ]


### PR DESCRIPTION
## Summary
- Extracts rebalance-run support-bundle projection helpers for artifact, async operation, idempotency history, workflow history, and lineage evidence while preserving the public response shape.
- Extracts stateful source-context resolver gating, core resolver error mapping, and success supportability projection helpers while preserving fail-closed behavior and metric semantics.
- Refreshes quality reports and records review ledger entries `BACKEND-REVIEW-20260613-880` and `BACKEND-REVIEW-20260613-881`.

## Complexity Movement
- `get_run_support_bundle`: `B(7)` -> `A(2)`.
- `resolve_stateful_source_context`: `B(7)` -> `A(1)`.
- Both functions dropped out of the current top-ten source hotspot list in `quality/complexity_report.md`.

## Validation
- `python -m ruff check src/core/rebalance_runs/service.py tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py`
- `python -m ruff format --check src/core/rebalance_runs/service.py tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py`
- `python -m mypy --config-file mypy.ini src/core/rebalance_runs/service.py`
- `python -m pytest tests/unit/dpm/supportability/test_dpm_run_support_service_coverage.py -q` -> 7 passed
- `python -m radon cc src/core/rebalance_runs/service.py -s`
- `python -m ruff check src/api/services/rebalance_stateful_source_context.py tests/unit/api/test_runtime_request_model_and_service_edges.py`
- `python -m ruff format --check src/api/services/rebalance_stateful_source_context.py tests/unit/api/test_runtime_request_model_and_service_edges.py`
- `python -m mypy --config-file mypy.ini src/api/services/rebalance_stateful_source_context.py`
- `python -m pytest tests/unit/api/test_runtime_request_model_and_service_edges.py -q` -> 45 passed
- `python -m radon cc src/api/services/rebalance_stateful_source_context.py -s`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- service leakage scan: no matches
- `git diff --check`
- `make check` -> 2664 passed

## Stranded Truth / Wiki
- `git fetch origin --prune` completed.
- `git branch -r --no-merged origin/main` shows only this active feature branch.
- `gh pr list --state open --limit 100` showed no open PRs before this PR.
- Wiki drift check: `DiffCount 0`.
- No wiki source change required; this is internal maintainability hardening with no operator-facing contract change.

## Residual Risk
- This PR improves two internal supportability/source-context hotspots only.
- It does not claim global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench product behavior.