### PR TITLE
Harden proof-pack evidence helper structure

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21931,3 +21931,33 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal API-service helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-882: Proof-pack pre-run section dispatch helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, operational evidence, and testing.
+- Finding: `_pre_run_section_payload` mixed fixed pre-run proof-pack section dispatch with
+  source-analytics and adapter dispatch. The behavior was correct, but the proof-pack evidence
+  builder made it harder to distinguish stable core sections from optional source-owned evidence
+  and adapter contracts.
+- Action: extracted `_pre_run_core_section_payload` for decision summary, mandate context, source
+  readiness, and selected-alternative section dispatch while keeping source analytics and adapter
+  dispatch in the existing specialized helpers. Added direct helper coverage proving core
+  decision-summary dispatch preserves actor, rationale, source-run status, metrics, and reason-code
+  behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`,
+  and `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder
+  suite reported 91 passed, `_pre_run_section_payload` reduced from B(7) to A(4), and the extracted
+  `_pre_run_core_section_payload` is A(5).
+- Residual risk: this slice improves internal proof-pack builder maintainability only. It does not
+  certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench product
+  behavior.
+- Wiki decision: no wiki source change required; this is internal proof-pack helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21961,3 +21961,34 @@ and improves internal transaction-cost source posture maintainability only.
   behavior.
 - Wiki decision: no wiki source change required; this is internal proof-pack helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-883: Regime-stress proof-pack evidence posture tables
+
+- Date: 2026-06-13
+- Scope: `src/core/proof_packs/source_analytics.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, source-owner evidence preservation, and testing.
+- Finding: `_regime_stress_evidence_posture` encoded missing governance evidence and
+  source-reason posture effects as branch-heavy local control flow. The behavior was correct, but
+  future source-owned scenario/posture additions would be harder to review against the
+  RegimeScenarioPackEvaluation boundary.
+- Action: extracted table-backed helpers for missing governance evidence reason codes and
+  source-reason posture effects while preserving the existing state precedence, facts, and sorted
+  reason-code behavior. Added direct helper coverage for missing CIO approval/effective-period/
+  applicability evidence and READY, inapplicable, effective-period exception, and partial
+  contribution source-reason posture effects.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/source_analytics.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/source_analytics.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/source_analytics.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/core/proof_packs/source_analytics.py -s`; the focused proof-pack
+  builder suite reported 95 passed, `_regime_stress_evidence_posture` reduced from B(7) to A(2)
+  under radon, and the refreshed complexity report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves proof-pack source-analytics maintainability only. It does not
+  change source-owner methodology, certify global bank-buyable readiness, or promote additional
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal proof-pack source-analytics
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T10:33:03+00:00`
+- Generated at: `2026-06-13T10:35:16+00:00`
 
-- Report source snapshot: `d895d6cc+worktree`
+- Report source snapshot: `d3d5360f+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171823 |
-| Test functions | 2488 |
+| Total Python LOC | 171881 |
+| Test functions | 2489 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T10:13:32+00:00`
+- Generated at: `2026-06-13T10:33:03+00:00`
 
-- Report source snapshot: `4c6cf8f2+worktree`
+- Report source snapshot: `d895d6cc+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171761 |
-| Test functions | 2487 |
+| Total Python LOC | 171823 |
+| Test functions | 2488 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T10:13:32+00:00`
+- Generated at: `2026-06-13T10:33:03+00:00`
 
-- Report source snapshot: `4c6cf8f2+worktree`
+- Report source snapshot: `d895d6cc+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _pre_run_section_payload | src/core/proof_packs/builder.py | 7 | 51 |
-| 2 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
-| 3 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
-| 4 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
-| 5 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
-| 6 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
-| 7 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
-| 8 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
-| 9 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
-| 10 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
+| 1 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
+| 2 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 3 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
+| 4 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
+| 5 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
+| 6 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 7 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
+| 8 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
+| 9 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
+| 10 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 7 | 35 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T10:33:03+00:00`
+- Generated at: `2026-06-13T10:35:16+00:00`
 
-- Report source snapshot: `d895d6cc+worktree`
+- Report source snapshot: `d3d5360f+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -41,7 +41,7 @@
 | 7 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
 | 8 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
 | 9 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
-| 10 | _regime_stress_evidence_posture | src/core/proof_packs/source_analytics.py | 7 | 35 |
+| 10 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T10:13:32+00:00`
+- Generated at: `2026-06-13T10:33:03+00:00`
 
-- Report source snapshot: `4c6cf8f2+worktree`
+- Report source snapshot: `d895d6cc+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T10:33:03+00:00`
+- Generated at: `2026-06-13T10:35:16+00:00`
 
-- Report source snapshot: `d895d6cc+worktree`
+- Report source snapshot: `d3d5360f+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T10:13:32+00:00`
+- Generated at: `2026-06-13T10:33:03+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `4c6cf8f2+worktree`
+- Report source snapshot: `d895d6cc+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171487 | 171761 | +274 |
-| Test functions | 2485 | 2487 | +2 |
+| Total Python LOC | 171761 | 171823 | +62 |
+| Test functions | 2487 | 2488 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -52,14 +52,14 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2755 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2784 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2426 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/core/proof_packs/builder.py | 1774 |
+| 10 | src/core/proof_packs/builder.py | 1807 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T10:33:03+00:00`
+- Generated at: `2026-06-13T10:35:16+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `d895d6cc+worktree`
+- Report source snapshot: `d3d5360f+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171761 | 171823 | +62 |
-| Test functions | 2487 | 2488 | +1 |
+| Total Python LOC | 171761 | 171881 | +120 |
+| Test functions | 2487 | 2489 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -52,7 +52,7 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2784 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2815 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -1142,7 +1142,7 @@ def _pre_run_adapter_payload(
     )
 
 
-def _pre_run_section_payload(
+def _pre_run_core_section_payload(
     *,
     section_type: ProofPackSectionType,
     result: RebalanceResult | None,
@@ -1155,7 +1155,6 @@ def _pre_run_section_payload(
     mandate_health: DpmMandateHealthSnapshot | None,
     mandate_evidence_gap_codes: list[str],
     created_by: str,
-    source_analytics: dict[str, ProofPackSourceAnalytics],
 ) -> _SectionPayload | None:
     if section_type == "decision_summary":
         return _decision_summary_section_payload(
@@ -1181,6 +1180,40 @@ def _pre_run_section_payload(
             selected_alternative=selected_alternative,
             selection=selection,
         )
+    return None
+
+
+def _pre_run_section_payload(
+    *,
+    section_type: ProofPackSectionType,
+    result: RebalanceResult | None,
+    alternative_set: ConstructionAlternativeSet | None,
+    selected_alternative: ConstructionAlternative | None,
+    selection: ConstructionAlternativeSelection | None,
+    reason: str | None,
+    mandate_id: str | None,
+    mandate_twin: DpmMandateDigitalTwin | None,
+    mandate_health: DpmMandateHealthSnapshot | None,
+    mandate_evidence_gap_codes: list[str],
+    created_by: str,
+    source_analytics: dict[str, ProofPackSourceAnalytics],
+) -> _SectionPayload | None:
+    core_payload = _pre_run_core_section_payload(
+        section_type=section_type,
+        result=result,
+        alternative_set=alternative_set,
+        selected_alternative=selected_alternative,
+        selection=selection,
+        reason=reason,
+        mandate_id=mandate_id,
+        mandate_twin=mandate_twin,
+        mandate_health=mandate_health,
+        mandate_evidence_gap_codes=mandate_evidence_gap_codes,
+        created_by=created_by,
+    )
+    if core_payload is not None:
+        return core_payload
+
     source_analytics_payload = _pre_run_source_analytics_payload(
         section_type=section_type,
         source_analytics=source_analytics,

--- a/src/core/proof_packs/source_analytics.py
+++ b/src/core/proof_packs/source_analytics.py
@@ -33,6 +33,25 @@ _EFFECTIVE_PERIOD_REASON_MARKERS = (
     "OUTSIDE_EFFECTIVE",
     "EFFECTIVE_PERIOD_EXCEPTION",
 )
+_MISSING_REGIME_STRESS_GOVERNANCE_REASONS: dict[str, str] = {
+    "cio_approval": "REGIME_SCENARIO_CIO_APPROVAL_EVIDENCE_MISSING",
+    "effective_period": "REGIME_SCENARIO_EFFECTIVE_PERIOD_EVIDENCE_MISSING",
+    "applicability": "REGIME_SCENARIO_APPLICABILITY_EVIDENCE_MISSING",
+}
+_REGIME_SOURCE_REASON_POSTURE_EFFECTS: dict[
+    _RegimeStressSourceReasonPosture,
+    tuple[ProofPackSectionState, str],
+] = {
+    "INAPPLICABLE": ("BLOCKED", "REGIME_SCENARIO_APPLICABILITY_NOT_CONFIRMED"),
+    "EFFECTIVE_PERIOD_EXCEPTION": (
+        "DEGRADED",
+        "REGIME_SCENARIO_EFFECTIVE_PERIOD_EXCEPTION",
+    ),
+    "CONTRIBUTION_PARTIAL": (
+        "PENDING_REVIEW",
+        "REGIME_SCENARIO_CONTRIBUTION_EVIDENCE_PARTIAL",
+    ),
+}
 _RegimeStressSourceReasonClassifier = tuple[
     _RegimeStressSourceReasonPosture,
     Callable[[str], bool],
@@ -517,33 +536,41 @@ def _regime_stress_evidence_posture(
     posture_states: list[ProofPackSectionState] = ["READY"]
 
     missing_governance_evidence = _missing_regime_stress_governance_evidence(context)
-    if "cio_approval" in missing_governance_evidence:
-        reason_codes.add("REGIME_SCENARIO_CIO_APPROVAL_EVIDENCE_MISSING")
-        posture_states.append("PENDING_REVIEW")
-    if "effective_period" in missing_governance_evidence:
-        reason_codes.add("REGIME_SCENARIO_EFFECTIVE_PERIOD_EVIDENCE_MISSING")
-        posture_states.append("PENDING_REVIEW")
-    if "applicability" in missing_governance_evidence:
-        reason_codes.add("REGIME_SCENARIO_APPLICABILITY_EVIDENCE_MISSING")
-        posture_states.append("PENDING_REVIEW")
+    missing_governance_reason_codes = _missing_regime_stress_governance_reason_codes(
+        missing_governance_evidence
+    )
+    reason_codes.update(missing_governance_reason_codes)
+    posture_states.extend(["PENDING_REVIEW"] * len(missing_governance_reason_codes))
 
     source_reason_posture = _regime_source_reason_posture(context.reason_codes)
     posture_facts["source_reason_posture"] = source_reason_posture
-    if source_reason_posture == "INAPPLICABLE":
-        reason_codes.add("REGIME_SCENARIO_APPLICABILITY_NOT_CONFIRMED")
-        posture_states.append("BLOCKED")
-    elif source_reason_posture == "EFFECTIVE_PERIOD_EXCEPTION":
-        reason_codes.add("REGIME_SCENARIO_EFFECTIVE_PERIOD_EXCEPTION")
-        posture_states.append("DEGRADED")
-    elif source_reason_posture == "CONTRIBUTION_PARTIAL":
-        reason_codes.add("REGIME_SCENARIO_CONTRIBUTION_EVIDENCE_PARTIAL")
-        posture_states.append("PENDING_REVIEW")
+    source_reason_effect = _regime_source_reason_posture_effect(source_reason_posture)
+    if source_reason_effect is not None:
+        source_state, source_reason_code = source_reason_effect
+        reason_codes.add(source_reason_code)
+        posture_states.append(source_state)
 
     return {
         "state": _lowest_section_state(posture_states),
         "reason_codes": sorted(reason_codes),
         "facts": posture_facts,
     }
+
+
+def _missing_regime_stress_governance_reason_codes(
+    missing_governance_evidence: set[str],
+) -> set[str]:
+    return {
+        reason_code
+        for evidence_key, reason_code in _MISSING_REGIME_STRESS_GOVERNANCE_REASONS.items()
+        if evidence_key in missing_governance_evidence
+    }
+
+
+def _regime_source_reason_posture_effect(
+    source_reason_posture: _RegimeStressSourceReasonPosture,
+) -> tuple[ProofPackSectionState, str] | None:
+    return _REGIME_SOURCE_REASON_POSTURE_EFFECTS.get(source_reason_posture)
 
 
 def _regime_stress_governance_posture_facts(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -51,8 +51,10 @@ from src.core.proof_packs.source_analytics import (
     _authority_source_ref,
     _degraded_context_reason_codes,
     _missing_regime_stress_governance_evidence,
+    _missing_regime_stress_governance_reason_codes,
     _performance_source_facts,
     _performance_source_metrics,
+    _regime_source_reason_posture_effect,
     _regime_source_reason_posture,
     _regime_stress_governance_posture_facts,
     _regime_stress_source_facts,
@@ -2557,6 +2559,13 @@ def test_regime_stress_governance_posture_helpers_project_missing_evidence() -> 
         "effective_period",
         "applicability",
     }
+    assert _missing_regime_stress_governance_reason_codes(
+        {"cio_approval", "effective_period", "applicability"}
+    ) == {
+        "REGIME_SCENARIO_CIO_APPROVAL_EVIDENCE_MISSING",
+        "REGIME_SCENARIO_EFFECTIVE_PERIOD_EVIDENCE_MISSING",
+        "REGIME_SCENARIO_APPLICABILITY_EVIDENCE_MISSING",
+    }
 
 
 def test_regime_stress_source_helpers_project_facts_and_metrics() -> None:
@@ -2631,6 +2640,28 @@ def test_regime_source_reason_posture_classifies_source_reason_codes(
     expected_posture: str,
 ) -> None:
     assert _regime_source_reason_posture(source_reason_codes) == expected_posture
+
+
+@pytest.mark.parametrize(
+    ("source_reason_posture", "expected_effect"),
+    [
+        ("READY", None),
+        ("INAPPLICABLE", ("BLOCKED", "REGIME_SCENARIO_APPLICABILITY_NOT_CONFIRMED")),
+        (
+            "EFFECTIVE_PERIOD_EXCEPTION",
+            ("DEGRADED", "REGIME_SCENARIO_EFFECTIVE_PERIOD_EXCEPTION"),
+        ),
+        (
+            "CONTRIBUTION_PARTIAL",
+            ("PENDING_REVIEW", "REGIME_SCENARIO_CONTRIBUTION_EVIDENCE_PARTIAL"),
+        ),
+    ],
+)
+def test_regime_source_reason_posture_effect_maps_section_state_and_reason(
+    source_reason_posture: str,
+    expected_effect: tuple[str, str] | None,
+) -> None:
+    assert _regime_source_reason_posture_effect(source_reason_posture) == expected_effect
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -284,6 +284,35 @@ def test_pre_run_adapter_payload_dispatches_configured_adapter_contract() -> Non
     assert reason_codes == []
 
 
+def test_pre_run_core_section_payload_dispatches_decision_summary() -> None:
+    result = _ready_rebalance_result()
+
+    state, summary, facts, metrics, reason_codes = builder_module._pre_run_core_section_payload(
+        section_type="decision_summary",
+        result=result,
+        alternative_set=None,
+        selected_alternative=None,
+        selection=None,
+        reason="Approve governed rebalance.",
+        mandate_id=None,
+        mandate_twin=None,
+        mandate_health=None,
+        mandate_evidence_gap_codes=[],
+        created_by="pm_001",
+    )
+
+    assert state == "READY"
+    assert summary == "Decision evidence assembled from manage run and actor rationale."
+    assert facts == {
+        "actor": "pm_001",
+        "reason": "Approve governed rebalance.",
+        "source_run_status": result.status,
+        "selected_alternative_id": None,
+    }
+    assert metrics == {}
+    assert reason_codes == []
+
+
 def test_pre_run_section_payload_returns_decision_summary_missing_reason() -> None:
     result = _ready_rebalance_result()
 


### PR DESCRIPTION
## Summary
- Extracted proof-pack pre-run core section dispatch so fixed sections are separate from source-analytics and adapter dispatch.
- Table-drove regime-stress proof-pack evidence posture reason/state mapping for missing governance evidence and source-owned reason posture.
- Added direct helper tests and refreshed quality reports plus codebase review ledger entries BACKEND-REVIEW-20260613-882 and BACKEND-REVIEW-20260613-883.

## Bank-Buyable Controls Improved
- Architecture and maintainability: proof-pack evidence helpers now separate stable dispatch and source-owned evidence posture rules.
- Testing: focused direct helper coverage added for the extracted dispatch and posture mapping helpers.
- Operational evidence: quality reports and review ledger updated with measurable complexity movement.

## Behavior
- Intended behavior change: none. This is internal refactoring with preserved proof-pack evidence output semantics.
- Wiki decision: no wiki source change required; no operator-facing truth changed.

## Local Evidence
- `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` -> 91 passed for first slice, 95 passed after second slice
- `python -m radon cc src/core/proof_packs/builder.py -s`: `_pre_run_section_payload` B(7) -> A(4); `_pre_run_core_section_payload` A(5)
- `python -m radon cc src/core/proof_packs/source_analytics.py -s`: `_regime_stress_evidence_posture` B(7) -> A(2)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- service leakage scan: no matches
- `git diff --check`
- `make check` -> 2669 passed
- Wiki drift check: `DiffCount 0`

## Residual Risk
- This PR improves proof-pack maintainability only. It does not certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
- Remaining source hotspots include `apply_turnover_limit`, `_cashflow_projection_policy_assessment`, `resolve_portfolio_inputs_for_request`, `build_score_run`, and `_governance_evidence`.