### PR TITLE
Opt artifact workflows into Node 24 runtime

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -93,7 +93,7 @@ jobs:
           COVERAGE_FILE: .coverage.${{ matrix.suite }}
         run: python -m pytest ${{ matrix.path }} --cov=src --cov-report=
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-data-${{ matrix.suite }}
           path: .coverage.${{ matrix.suite }}
@@ -113,7 +113,7 @@ jobs:
       - name: Install
         run: make install-ci
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-data-*
           merge-multiple: true
@@ -123,7 +123,7 @@ jobs:
           python -m coverage combine coverage-data
           python -m coverage report --fail-under=${{ env.COVERAGE_FAIL_UNDER }}
       - name: Upload coverage summary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: main-releasability-coverage-data
           path: |

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -93,7 +93,7 @@ jobs:
           COVERAGE_FILE: .coverage.${{ matrix.suite }}
         run: python -m pytest ${{ matrix.path }} --cov=src --cov-report=
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-data-${{ matrix.suite }}
           path: .coverage.${{ matrix.suite }}
@@ -113,7 +113,7 @@ jobs:
       - name: Install
         run: make install-ci
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-data-*
           merge-multiple: true

--- a/.github/workflows/quality-baseline.yml
+++ b/.github/workflows/quality-baseline.yml
@@ -26,9 +26,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Python Quality Tooling
         run: |
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload Quality Baseline Logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quality-baseline
           path: |

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -21992,3 +21992,33 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal proof-pack source-analytics
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-884: GitHub artifact actions Node 24 runtime
+
+- Date: 2026-06-13
+- Scope: `.github/workflows/pr-merge-gate.yml`, `.github/workflows/main-releasability.yml`,
+  `.github/workflows/quality-baseline.yml`, and
+  `tests/unit/test_ci_workflow_gate_enforcement.py`.
+- Bank-buyable control area: CI measurement, release evidence, and operational maintainability.
+- Finding: post-merge Main Releasability Gate emitted GitHub Actions deprecation annotations for
+  artifact upload/download steps and `setup-node` running on the Node 20 JavaScript action
+  runtime. The checks passed, but the warning creates avoidable CI noise ahead of GitHub's Node 24
+  default transition.
+- Action: upgraded artifact-producing and artifact-consuming workflows to native Node 24 action
+  majors (`actions/upload-artifact@v7`, `actions/download-artifact@v8`) and moved the Quality
+  Baseline Node setup to `actions/setup-node@v6` with Node 24. Added workflow regression tests
+  proving artifact workflows no longer use the Node 20 artifact action majors and Quality Baseline
+  no longer uses `setup-node@v4` or Node 20.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check tests/unit/test_ci_workflow_gate_enforcement.py`,
+  `python -m ruff format --check tests/unit/test_ci_workflow_gate_enforcement.py`,
+  `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q`, and
+  `python scripts/engineering_health_report.py`; the focused workflow test suite reported
+  3 passed. Local `make workflow-lint` is not a repository target, so GitHub Feature Lane and PR
+  Merge Gate workflow-lint jobs remain the workflow-syntax proof for this slice.
+- Residual risk: this slice remediates the observed artifact-action runtime warning only. It does
+  not certify all possible future GitHub-hosted runner deprecations or change application runtime
+  behavior.
+- Wiki decision: no wiki source change required; this is CI warning remediation with no
+  operator-facing product contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T10:35:16+00:00`
+- Generated at: `2026-06-13T10:58:56+00:00`
 
-- Report source snapshot: `d3d5360f+worktree`
+- Report source snapshot: `bf8fba18+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171881 |
-| Test functions | 2489 |
+| Total Python LOC | 171906 |
+| Test functions | 2491 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T10:35:16+00:00`
+- Generated at: `2026-06-13T10:58:56+00:00`
 
-- Report source snapshot: `d3d5360f+worktree`
+- Report source snapshot: `bf8fba18+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T10:35:16+00:00`
+- Generated at: `2026-06-13T10:58:56+00:00`
 
-- Report source snapshot: `d3d5360f+worktree`
+- Report source snapshot: `bf8fba18+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T10:35:16+00:00`
+- Generated at: `2026-06-13T10:58:56+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `d3d5360f+worktree`
+- Report source snapshot: `bf8fba18+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171761 | 171881 | +120 |
-| Test functions | 2487 | 2489 | +2 |
+| Total Python LOC | 171881 | 171906 | +25 |
+| Test functions | 2489 | 2491 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,14 +37,14 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2755 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2815 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2426 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/core/proof_packs/builder.py | 1774 |
+| 10 | src/core/proof_packs/builder.py | 1807 |
 
 ### current branch
 

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -9,6 +9,12 @@ ENFORCED_WORKFLOWS = [
     Path(".github/workflows/main-releasability.yml"),
 ]
 
+ARTIFACT_WORKFLOWS = [
+    Path(".github/workflows/pr-merge-gate.yml"),
+    Path(".github/workflows/main-releasability.yml"),
+    Path(".github/workflows/quality-baseline.yml"),
+]
+
 QUALITY_GATE_NAMES = [
     "Architecture Gate",
     "Complexity Gate",
@@ -35,3 +41,22 @@ def test_feature_pr_and_main_quality_gates_are_enforced() -> None:
                 f"{workflow_path.as_posix()} keeps {gate_name} advisory; "
                 "remediated quality gates must fail the lane."
             )
+
+
+def test_artifact_workflows_opt_into_node24_action_runtime() -> None:
+    for workflow_path in ARTIFACT_WORKFLOWS:
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        assert "actions/upload-artifact@v7" in workflow_text or (
+            "actions/download-artifact@v8" in workflow_text
+        )
+        assert "actions/upload-artifact@v4" not in workflow_text
+        assert "actions/download-artifact@v4" not in workflow_text
+
+
+def test_quality_baseline_uses_node24_setup_node_action() -> None:
+    workflow_text = Path(".github/workflows/quality-baseline.yml").read_text(encoding="utf-8")
+
+    assert "actions/setup-node@v6" in workflow_text
+    assert 'node-version: "24"' in workflow_text
+    assert "actions/setup-node@v4" not in workflow_text
+    assert 'node-version: "20"' not in workflow_text


### PR DESCRIPTION
## Summary
- Upgraded artifact-producing and artifact-consuming GitHub workflows to native Node 24 action majors: `actions/upload-artifact@v7` and `actions/download-artifact@v8`.
- Moved Quality Baseline from `actions/setup-node@v4` with Node 20 to `actions/setup-node@v6` with Node 24.
- Added workflow regression tests so artifact workflows cannot drift back to Node 20 artifact action majors and Quality Baseline cannot drift back to setup-node v4 / Node 20.
- Recorded the CI warning remediation in `BACKEND-REVIEW-20260613-884` and refreshed quality reports.

## Why
Main Releasability on PR #519 passed but emitted GitHub annotations for Node 20 JavaScript action runtime usage. A force-flag opt-in still produced forced-runtime annotations, so this PR now uses native Node 24 action versions instead.

## Local Evidence
- `python -m ruff check tests/unit/test_ci_workflow_gate_enforcement.py`
- `python -m ruff format --check tests/unit/test_ci_workflow_gate_enforcement.py`
- `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q` -> 3 passed
- `python -m pytest tests/unit/test_engineering_health_report.py tests/unit/test_ci_workflow_gate_enforcement.py -q` -> 11 passed
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- service leakage scan: no matches
- `git diff --check`
- `make check` -> 2671 passed
- Wiki drift check before PR: `DiffCount 0`

## Residual Risk
- This remediates the observed GitHub Actions Node 20 warning source in artifact and Quality Baseline setup-node steps. It does not certify future GitHub-hosted runner deprecations or change application runtime behavior.
- Local `make workflow-lint` is not a repository target; GitHub Feature Lane and PR Merge Gate workflow-lint jobs are the workflow syntax proof.