### PR TITLE
Harden manage source hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22082,3 +22082,34 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal API-service maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-887: Wave portfolio resolution dispatch table
+
+- Date: 2026-06-13
+- Scope: `src/api/routers/wave_portfolio_resolution.py` and
+  `tests/unit/api/test_wave_portfolio_resolution.py`.
+- Bank-buyable control area: architecture, API quality, and testing.
+- Finding: `resolve_portfolio_inputs_for_request` encoded each wave trigger branch directly in the
+  public router helper. The behavior was correct, but the dispatch structure made it harder to
+  distinguish trigger routing from the router-owned HTTP/source-authority error handling that must
+  remain near the API boundary.
+- Action: introduced `_PortfolioResolutionContext` and a trigger-handler table for explicit
+  portfolio lists, PM-book review, CIO model change, risk event, tactical house view, and bulk
+  review campaign resolution. Kept source-unavailable and source-dependency HTTP exception mapping
+  in the router helpers. Added direct public-entry coverage proving explicit-list dispatch
+  preserves the request portfolio payloads.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/wave_portfolio_resolution.py tests/unit/api/test_wave_portfolio_resolution.py`,
+  `python -m ruff format --check src/api/routers/wave_portfolio_resolution.py tests/unit/api/test_wave_portfolio_resolution.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/wave_portfolio_resolution.py`,
+  `python -m pytest tests/unit/api/test_wave_portfolio_resolution.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/api/routers/wave_portfolio_resolution.py -s`; the focused wave
+  portfolio-resolution suite reported 3 passed, and `resolve_portfolio_inputs_for_request`
+  reduced from B(9) to A(1) under radon.
+- Residual risk: this slice improves router dispatch maintainability only. It does not change wave
+  trigger semantics, certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal API router maintainability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22022,3 +22022,32 @@ and improves internal transaction-cost source posture maintainability only.
   behavior.
 - Wiki decision: no wiki source change required; this is CI warning remediation with no
   operator-facing product contract change.
+
+## BACKEND-REVIEW-20260613-885: Rebalance turnover budget selection helper
+
+- Date: 2026-06-13
+- Scope: `src/core/rebalance/turnover.py` and
+  `tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`.
+- Bank-buyable control area: architecture, testing, and portfolio execution supportability.
+- Finding: `apply_turnover_limit` combined turnover-cap policy dispatch, ranked selection,
+  dropped-intent diagnostic projection, and warning mutation in one function. The behavior was
+  correct, but the budget-selection rule was harder to review directly than a mandate execution
+  constraint should be.
+- Action: extracted a typed `_TurnoverSelection`, a pure `_select_turnover_budget_intents` helper,
+  and `_ranked_turnover_intents` while preserving the public turnover-cap behavior and diagnostic
+  payload shape. Added direct helper coverage proving ranked exact-fit selection, missing-notional
+  omission, dropped-intent projection, and governed base-currency notional evidence.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/turnover.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python -m ruff format --check src/core/rebalance/turnover.py tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/turnover.py`,
+  `python -m pytest tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py tests/unit/dpm/engine/test_engine_turnover_control.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/core/rebalance/turnover.py -s`; the focused turnover suites reported
+  18 passed, and `apply_turnover_limit` reduced from B(7) to A(4).
+- Residual risk: this slice improves internal turnover-control maintainability only. It does not
+  certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench product
+  behavior.
+- Wiki decision: no wiki source change required; this is internal execution-control helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22113,3 +22113,33 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal API router maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-888: PM operating-quality score-run builder helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/routers/pm_operating_quality_score_run_builder.py` and
+  `tests/unit/api/test_pm_operating_quality_score_run_builder.py`.
+- Bank-buyable control area: architecture, API quality, and testing.
+- Finding: `build_score_run` combined policy resolution, optional source-owned PM-book scope
+  materialization, inline evidence assembly, outcome-review lookup, missing-review HTTP mapping,
+  and core score-run validation mapping in one router helper. The behavior was correct, but the
+  evidence assembly and outcome-review lookup rules were harder to test directly than the
+  PM-operating-quality supportability contract deserves.
+- Action: extracted `_ScoreRunEvidenceInputs`, `_score_run_evidence_inputs`, and
+  `_outcome_reviews_for_request` while preserving router-owned HTTP exception mapping and core
+  PM-quality scoring behavior. Added focused helper tests proving inline evidence is copied without
+  PM-book materialization and missing outcome-review ids map to the existing bounded `404` detail.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/pm_operating_quality_score_run_builder.py tests/unit/api/test_pm_operating_quality_score_run_builder.py`,
+  `python -m ruff format --check src/api/routers/pm_operating_quality_score_run_builder.py tests/unit/api/test_pm_operating_quality_score_run_builder.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/pm_operating_quality_score_run_builder.py`,
+  `python -m pytest tests/unit/api/test_pm_operating_quality_score_run_builder.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/api/routers/pm_operating_quality_score_run_builder.py -s`; the focused
+  builder suite reported 2 passed, and `build_score_run` reduced from B(7) to A(4).
+- Residual risk: this slice improves internal PM-quality score-run builder maintainability only.
+  It does not certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal API router helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22051,3 +22051,34 @@ and improves internal transaction-cost source posture maintainability only.
   behavior.
 - Wiki decision: no wiki source change required; this is internal execution-control helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-886: Cashflow projection policy input helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/construction_liquidity_supportability.py` and
+  `tests/unit/dpm/construction/test_liquidity_supportability.py`.
+- Bank-buyable control area: architecture, testing, and construction supportability.
+- Finding: `_cashflow_projection_policy_assessment` combined source projection availability,
+  currency/total-value guardrails, effective cash-weight derivation, projected cash-weight
+  calculation, adjusted-policy thresholding, and status assembly in one function. The behavior was
+  correct, but the source-owned cashflow projection policy semantics were harder to review directly
+  than the construction supportability contract deserves.
+- Action: extracted `_CashflowProjectionPolicyInputs`, `_cashflow_projection_policy_inputs`, and
+  `_adjusted_cash_below_policy` so the assessment reads as policy assembly rather than low-level
+  guard evaluation. Added direct helper coverage for effective cash-weight derivation and adjusted
+  cash-policy threshold behavior while preserving existing source-posture tests.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_liquidity_supportability.py tests/unit/dpm/construction/test_liquidity_supportability.py`,
+  `python -m ruff format --check src/api/services/construction_liquidity_supportability.py tests/unit/dpm/construction/test_liquidity_supportability.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_liquidity_supportability.py`,
+  `python -m pytest tests/unit/dpm/construction/test_liquidity_supportability.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/api/services/construction_liquidity_supportability.py -s`; the focused
+  liquidity supportability suite reported 9 passed, and
+  `_cashflow_projection_policy_assessment` reduced from B(7) to A(2).
+- Residual risk: this slice improves internal construction-liquidity supportability
+  maintainability only. It does not certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal API-service maintainability
+  hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T11:23:25+00:00`
+- Generated at: `2026-06-13T11:26:13+00:00`
 
-- Report source snapshot: `9384f6d9+worktree`
+- Report source snapshot: `2166aecf+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171977 |
-| Test functions | 2492 |
+| Total Python LOC | 172046 |
+| Test functions | 2493 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T11:26:13+00:00`
+- Generated at: `2026-06-13T11:28:43+00:00`
 
-- Report source snapshot: `2166aecf+worktree`
+- Report source snapshot: `3cc7e135+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 172046 |
-| Test functions | 2493 |
+| Total Python LOC | 172125 |
+| Test functions | 2494 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T10:58:56+00:00`
+- Generated at: `2026-06-13T11:23:25+00:00`
 
-- Report source snapshot: `bf8fba18+worktree`
+- Report source snapshot: `9384f6d9+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 817 |
-| Total Python LOC | 171906 |
-| Test functions | 2491 |
+| Total Python LOC | 171977 |
+| Test functions | 2492 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T11:28:43+00:00`
+- Generated at: `2026-06-13T11:31:13+00:00`
 
-- Report source snapshot: `3cc7e135+worktree`
+- Report source snapshot: `0eb99cb3+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -10,9 +10,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 817 |
-| Total Python LOC | 172125 |
-| Test functions | 2494 |
+| Python files | 818 |
+| Total Python LOC | 172249 |
+| Test functions | 2496 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T11:26:13+00:00`
+- Generated at: `2026-06-13T11:28:43+00:00`
 
-- Report source snapshot: `2166aecf+worktree`
+- Report source snapshot: `3cc7e135+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
-| 2 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
-| 3 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
-| 4 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
-| 5 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
-| 6 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
-| 7 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
-| 8 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
-| 9 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
-| 10 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
+| 1 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
+| 2 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
+| 3 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 4 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
+| 5 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
+| 6 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
+| 7 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
+| 8 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
+| 9 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
+| 10 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T10:58:56+00:00`
+- Generated at: `2026-06-13T11:23:25+00:00`
 
-- Report source snapshot: `bf8fba18+worktree`
+- Report source snapshot: `9384f6d9+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | apply_turnover_limit | src/core/rebalance/turnover.py | 7 | 51 |
-| 2 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
-| 3 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
-| 4 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
-| 5 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
-| 6 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
-| 7 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
-| 8 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
-| 9 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
-| 10 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
+| 1 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
+| 2 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
+| 3 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
+| 4 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
+| 5 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 6 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
+| 7 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
+| 8 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
+| 9 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
+| 10 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T11:23:25+00:00`
+- Generated at: `2026-06-13T11:26:13+00:00`
 
-- Report source snapshot: `9384f6d9+worktree`
+- Report source snapshot: `2166aecf+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _cashflow_projection_policy_assessment | src/api/services/construction_liquidity_supportability.py | 7 | 47 |
-| 2 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
-| 3 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
-| 4 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
-| 5 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
-| 6 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
-| 7 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
-| 8 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
-| 9 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
-| 10 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
+| 1 | resolve_portfolio_inputs_for_request | src/api/routers/wave_portfolio_resolution.py | 7 | 46 |
+| 2 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
+| 3 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
+| 4 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 5 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
+| 6 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
+| 7 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
+| 8 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
+| 9 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
+| 10 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T11:28:43+00:00`
+- Generated at: `2026-06-13T11:31:13+00:00`
 
-- Report source snapshot: `3cc7e135+worktree`
+- Report source snapshot: `0eb99cb3+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_score_run | src/api/routers/pm_operating_quality_score_run_builder.py | 7 | 43 |
-| 2 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
-| 3 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
-| 4 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
-| 5 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
-| 6 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
-| 7 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
-| 8 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
-| 9 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
-| 10 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
+| 1 | _governance_evidence | src/core/pm_quality/scoring.py | 7 | 43 |
+| 2 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 7 | 38 |
+| 3 | build_run_filter_query | src/infrastructure/rebalance_runs/run_query.py | 7 | 38 |
+| 4 | _example_from_schema | src/api/openapi_enrichment.py | 7 | 37 |
+| 5 | _append_settlement_ladder_points | src/core/rebalance/execution.py | 7 | 36 |
+| 6 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
+| 7 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
+| 8 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
+| 9 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
+| 10 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T11:28:43+00:00`
+- Generated at: `2026-06-13T11:31:13+00:00`
 
-- Report source snapshot: `3cc7e135+worktree`
+- Report source snapshot: `0eb99cb3+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T11:23:25+00:00`
+- Generated at: `2026-06-13T11:26:13+00:00`
 
-- Report source snapshot: `9384f6d9+worktree`
+- Report source snapshot: `2166aecf+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T11:26:13+00:00`
+- Generated at: `2026-06-13T11:28:43+00:00`
 
-- Report source snapshot: `2166aecf+worktree`
+- Report source snapshot: `3cc7e135+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T10:58:56+00:00`
+- Generated at: `2026-06-13T11:23:25+00:00`
 
-- Report source snapshot: `bf8fba18+worktree`
+- Report source snapshot: `9384f6d9+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T11:23:25+00:00`
+- Generated at: `2026-06-13T11:26:13+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `9384f6d9+worktree`
+- Report source snapshot: `2166aecf+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171906 | 171977 | +71 |
-| Test functions | 2491 | 2492 | +1 |
+| Total Python LOC | 171906 | 172046 | +140 |
+| Test functions | 2491 | 2493 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T11:28:43+00:00`
+- Generated at: `2026-06-13T11:31:13+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `3cc7e135+worktree`
+- Report source snapshot: `0eb99cb3+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 817 | 817 | +0 |
-| Total Python LOC | 171906 | 172125 | +219 |
-| Test functions | 2491 | 2494 | +3 |
+| Python files | 817 | 818 | +1 |
+| Total Python LOC | 171906 | 172249 | +343 |
+| Test functions | 2491 | 2496 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T11:26:13+00:00`
+- Generated at: `2026-06-13T11:28:43+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `2166aecf+worktree`
+- Report source snapshot: `3cc7e135+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171906 | 172046 | +140 |
-| Test functions | 2491 | 2493 | +2 |
+| Total Python LOC | 171906 | 172125 | +219 |
+| Test functions | 2491 | 2494 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T10:58:56+00:00`
+- Generated at: `2026-06-13T11:23:25+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `bf8fba18+worktree`
+- Report source snapshot: `9384f6d9+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 817 | 817 | +0 |
-| Total Python LOC | 171881 | 171906 | +25 |
-| Test functions | 2489 | 2491 | +2 |
+| Total Python LOC | 171906 | 171977 | +71 |
+| Test functions | 2491 | 2492 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/routers/pm_operating_quality_score_run_builder.py
+++ b/src/api/routers/pm_operating_quality_score_run_builder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from fastapi import HTTPException, status
@@ -14,13 +15,22 @@ from src.api.routers.pm_operating_quality_models import (
     DpmPmOperatingQualityScorePreviewRequest,
 )
 from src.api.routers.pm_operating_quality_policy_resolution import resolve_policy
+from src.core.outcomes import DpmPostTradeOutcomeReview
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
 from src.core.pm_quality import (
     DpmPmOperatingQualityScoreRun,
+    DpmPmQualityBookScopeEvidence,
+    DpmPmQualityEvidenceItem,
     DpmPmQualityPolicyRepository,
     DpmPmQualityValidationError,
     build_pm_operating_quality_score_run,
 )
+
+
+@dataclass(frozen=True)
+class _ScoreRunEvidenceInputs:
+    evidence_items: list[DpmPmQualityEvidenceItem]
+    book_scope_evidence: DpmPmQualityBookScopeEvidence | None
 
 
 def build_score_run(
@@ -32,37 +42,70 @@ def build_score_run(
     core_resolver_factory: Callable[[], Any],
 ) -> DpmPmOperatingQualityScoreRun:
     policy = resolve_policy(request=request, repository=policy_repository)
-    evidence_items = list(request.evidence_items)
-    book_scope_evidence = None
-    if request.pm_book_scope is not None:
-        book_scope_evidence = resolve_pm_book_scope_evidence(
-            request=request,
-            scope=request.pm_book_scope,
-            correlation_id=x_correlation_id or request.actor_id,
-            core_resolver_factory=core_resolver_factory,
-        )
-        evidence_items.append(book_scope_signal(book_scope_evidence))
-    outcome_reviews = []
-    for outcome_review_id in request.outcome_review_ids:
-        review = outcome_repository.get_outcome_review(outcome_review_id=outcome_review_id)
-        if review is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"OUTCOME_REVIEW_NOT_FOUND:{outcome_review_id}",
-            )
-        outcome_reviews.append(review)
+    evidence_inputs = _score_run_evidence_inputs(
+        request=request,
+        correlation_id=x_correlation_id or request.actor_id,
+        core_resolver_factory=core_resolver_factory,
+    )
+    outcome_reviews = _outcome_reviews_for_request(
+        request=request,
+        repository=outcome_repository,
+    )
     try:
         score_run = build_pm_operating_quality_score_run(
             pm_id=request.pm_id,
             book_id=request.book_id,
             as_of_date=request.as_of_date,
             policy=policy,
-            evidence_items=evidence_items,
+            evidence_items=evidence_inputs.evidence_items,
             outcome_reviews=outcome_reviews,
-            book_scope_evidence=book_scope_evidence,
+            book_scope_evidence=evidence_inputs.book_scope_evidence,
             generated_by=request.actor_id,
             correlation_id=x_correlation_id or request.actor_id,
         )
     except DpmPmQualityValidationError as exc:
         raise pm_quality_validation_http_exception(exc) from exc
     return score_run
+
+
+def _score_run_evidence_inputs(
+    *,
+    request: DpmPmOperatingQualityScorePreviewRequest,
+    correlation_id: str,
+    core_resolver_factory: Callable[[], Any],
+) -> _ScoreRunEvidenceInputs:
+    evidence_items = list(request.evidence_items)
+    if request.pm_book_scope is None:
+        return _ScoreRunEvidenceInputs(
+            evidence_items=evidence_items,
+            book_scope_evidence=None,
+        )
+
+    book_scope_evidence = resolve_pm_book_scope_evidence(
+        request=request,
+        scope=request.pm_book_scope,
+        correlation_id=correlation_id,
+        core_resolver_factory=core_resolver_factory,
+    )
+    evidence_items.append(book_scope_signal(book_scope_evidence))
+    return _ScoreRunEvidenceInputs(
+        evidence_items=evidence_items,
+        book_scope_evidence=book_scope_evidence,
+    )
+
+
+def _outcome_reviews_for_request(
+    *,
+    request: DpmPmOperatingQualityScorePreviewRequest,
+    repository: DpmOutcomeReviewRepository,
+) -> list[DpmPostTradeOutcomeReview]:
+    outcome_reviews: list[DpmPostTradeOutcomeReview] = []
+    for outcome_review_id in request.outcome_review_ids:
+        review = repository.get_outcome_review(outcome_review_id=outcome_review_id)
+        if review is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"OUTCOME_REVIEW_NOT_FOUND:{outcome_review_id}",
+            )
+        outcome_reviews.append(review)
+    return outcome_reviews

--- a/src/api/routers/wave_portfolio_resolution.py
+++ b/src/api/routers/wave_portfolio_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from decimal import Decimal
 
 from src.api.routers.wave_campaign_definition_resolution import (
@@ -45,6 +46,16 @@ from src.api.services.authority_client_service import (
 )
 
 
+@dataclass(frozen=True)
+class _PortfolioResolutionContext:
+    request: DpmWavePreviewRequest
+    correlation_id: str
+    advise_authority_client: AdviseAuthorityClient | None
+    risk_authority_client: RiskAuthorityClient | None
+    campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository
+    core_resolver_factory: Callable[[], object]
+
+
 def resolve_portfolio_inputs_for_request(
     *,
     request: DpmWavePreviewRequest,
@@ -54,43 +65,92 @@ def resolve_portfolio_inputs_for_request(
     campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository,
     core_resolver_factory: Callable[[], object],
 ) -> list[dict[str, object]]:
-    if request.trigger_type == "EXPLICIT_PORTFOLIO_LIST":
-        return [portfolio.model_dump(mode="json") for portfolio in request.portfolios]
-    if request.trigger_type == "PM_BOOK_REVIEW":
-        return resolve_pm_book_portfolios(
-            request=request,
-            correlation_id=correlation_id,
-            core_resolver_factory=core_resolver_factory,
-        )
-    if request.trigger_type == "CIO_MODEL_CHANGE":
-        return resolve_cio_model_change_portfolios(
-            request=request,
-            correlation_id=correlation_id,
-            core_resolver_factory=core_resolver_factory,
-        )
-    if request.trigger_type == "RISK_EVENT":
-        return _resolve_risk_event_portfolios(
-            request=request,
-            correlation_id=correlation_id,
-            risk_authority_client=risk_authority_client,
-        )
-    if request.trigger_type == "TACTICAL_HOUSE_VIEW":
-        return _resolve_tactical_house_view_portfolios(
-            request=request,
-            correlation_id=correlation_id,
-            advise_authority_client=advise_authority_client,
-        )
-    if request.trigger_type == "BULK_REVIEW_CAMPAIGN":
-        resolved_request = request_with_campaign_definition(
-            request=request,
-            repository=campaign_definition_repository,
-        )
-        return resolve_bulk_review_campaign_portfolios(
-            request=resolved_request,
-            correlation_id=correlation_id,
-            core_resolver_factory=core_resolver_factory,
-        )
-    return [portfolio.model_dump(mode="json") for portfolio in request.portfolios]
+    context = _PortfolioResolutionContext(
+        request=request,
+        correlation_id=correlation_id,
+        advise_authority_client=advise_authority_client,
+        risk_authority_client=risk_authority_client,
+        campaign_definition_repository=campaign_definition_repository,
+        core_resolver_factory=core_resolver_factory,
+    )
+    handler = _PORTFOLIO_RESOLUTION_HANDLERS.get(
+        request.trigger_type,
+        _resolve_explicit_request_portfolios,
+    )
+    return handler(context)
+
+
+def _resolve_explicit_request_portfolios(
+    context: _PortfolioResolutionContext,
+) -> list[dict[str, object]]:
+    return [portfolio.model_dump(mode="json") for portfolio in context.request.portfolios]
+
+
+def _resolve_pm_book_review_request_portfolios(
+    context: _PortfolioResolutionContext,
+) -> list[dict[str, object]]:
+    return resolve_pm_book_portfolios(
+        request=context.request,
+        correlation_id=context.correlation_id,
+        core_resolver_factory=context.core_resolver_factory,
+    )
+
+
+def _resolve_cio_model_change_request_portfolios(
+    context: _PortfolioResolutionContext,
+) -> list[dict[str, object]]:
+    return resolve_cio_model_change_portfolios(
+        request=context.request,
+        correlation_id=context.correlation_id,
+        core_resolver_factory=context.core_resolver_factory,
+    )
+
+
+def _resolve_risk_event_request_portfolios(
+    context: _PortfolioResolutionContext,
+) -> list[dict[str, object]]:
+    return _resolve_risk_event_portfolios(
+        request=context.request,
+        correlation_id=context.correlation_id,
+        risk_authority_client=context.risk_authority_client,
+    )
+
+
+def _resolve_tactical_house_view_request_portfolios(
+    context: _PortfolioResolutionContext,
+) -> list[dict[str, object]]:
+    return _resolve_tactical_house_view_portfolios(
+        request=context.request,
+        correlation_id=context.correlation_id,
+        advise_authority_client=context.advise_authority_client,
+    )
+
+
+def _resolve_bulk_review_campaign_request_portfolios(
+    context: _PortfolioResolutionContext,
+) -> list[dict[str, object]]:
+    resolved_request = request_with_campaign_definition(
+        request=context.request,
+        repository=context.campaign_definition_repository,
+    )
+    return resolve_bulk_review_campaign_portfolios(
+        request=resolved_request,
+        correlation_id=context.correlation_id,
+        core_resolver_factory=context.core_resolver_factory,
+    )
+
+
+_PORTFOLIO_RESOLUTION_HANDLERS: dict[
+    str,
+    Callable[[_PortfolioResolutionContext], list[dict[str, object]]],
+] = {
+    "EXPLICIT_PORTFOLIO_LIST": _resolve_explicit_request_portfolios,
+    "PM_BOOK_REVIEW": _resolve_pm_book_review_request_portfolios,
+    "CIO_MODEL_CHANGE": _resolve_cio_model_change_request_portfolios,
+    "RISK_EVENT": _resolve_risk_event_request_portfolios,
+    "TACTICAL_HOUSE_VIEW": _resolve_tactical_house_view_request_portfolios,
+    "BULK_REVIEW_CAMPAIGN": _resolve_bulk_review_campaign_request_portfolios,
+}
 
 
 def _resolve_tactical_house_view_portfolios(

--- a/src/api/services/construction_liquidity_supportability.py
+++ b/src/api/services/construction_liquidity_supportability.py
@@ -109,6 +109,14 @@ class _CashflowProjectionPolicyAssessment:
     adjusted_cash_below_policy: bool
 
 
+@dataclass(frozen=True)
+class _CashflowProjectionPolicyInputs:
+    projection: AuthoritativeLiquidityCashflowProjection
+    currency_mismatch: bool
+    total_value_unavailable: bool
+    effective_cash_weight: Decimal | None
+
+
 def _cashflow_projection_policy_assessment(
     *,
     result: RebalanceResult,
@@ -119,6 +127,46 @@ def _cashflow_projection_policy_assessment(
     projection = context.cashflow_projection
     if projection is None:
         return None
+    inputs = _cashflow_projection_policy_inputs(
+        result=result,
+        projection=projection,
+        cash_weight=cash_weight,
+        derive_cash_weight=derive_cash_weight,
+    )
+    projected_weight = _policy_projected_cashflow_weight(
+        result=result,
+        context=context,
+        cash_weight=inputs.effective_cash_weight,
+        currency_mismatch=inputs.currency_mismatch,
+        total_value_unavailable=inputs.total_value_unavailable,
+    )
+    below_policy = _adjusted_cash_below_policy(
+        cash_weight=inputs.effective_cash_weight,
+        projected_cash_weight=projected_weight,
+        minimum_cash_weight=context.minimum_cash_weight,
+    )
+    status = _cashflow_projection_assessed_status(
+        projection=inputs.projection,
+        currency_mismatch=inputs.currency_mismatch,
+        total_value_unavailable=inputs.total_value_unavailable,
+        below_policy=below_policy,
+    )
+    return _CashflowProjectionPolicyAssessment(
+        status=status,
+        currency_mismatch=inputs.currency_mismatch,
+        post_trade_total_value_unavailable=inputs.total_value_unavailable,
+        projected_cash_weight=projected_weight,
+        adjusted_cash_below_policy=below_policy,
+    )
+
+
+def _cashflow_projection_policy_inputs(
+    *,
+    result: RebalanceResult,
+    projection: AuthoritativeLiquidityCashflowProjection,
+    cash_weight: Decimal | None,
+    derive_cash_weight: bool,
+) -> _CashflowProjectionPolicyInputs:
     currency_mismatch = _cashflow_projection_currency_mismatch(
         result=result,
         projection=projection,
@@ -131,30 +179,24 @@ def _cashflow_projection_policy_assessment(
         if derive_cash_weight and cash_weight is None
         else cash_weight
     )
-    projected_weight = _policy_projected_cashflow_weight(
-        result=result,
-        context=context,
-        cash_weight=effective_cash_weight,
-        currency_mismatch=currency_mismatch,
-        total_value_unavailable=total_value_unavailable,
-    )
-    below_policy = (
-        effective_cash_weight is not None
-        and projected_weight is not None
-        and effective_cash_weight + projected_weight < context.minimum_cash_weight
-    )
-    status = _cashflow_projection_assessed_status(
+    return _CashflowProjectionPolicyInputs(
         projection=projection,
         currency_mismatch=currency_mismatch,
         total_value_unavailable=total_value_unavailable,
-        below_policy=below_policy,
+        effective_cash_weight=effective_cash_weight,
     )
-    return _CashflowProjectionPolicyAssessment(
-        status=status,
-        currency_mismatch=currency_mismatch,
-        post_trade_total_value_unavailable=total_value_unavailable,
-        projected_cash_weight=projected_weight,
-        adjusted_cash_below_policy=below_policy,
+
+
+def _adjusted_cash_below_policy(
+    *,
+    cash_weight: Decimal | None,
+    projected_cash_weight: Decimal | None,
+    minimum_cash_weight: Decimal,
+) -> bool:
+    return (
+        cash_weight is not None
+        and projected_cash_weight is not None
+        and cash_weight + projected_cash_weight < minimum_cash_weight
     )
 
 

--- a/src/core/rebalance/turnover.py
+++ b/src/core/rebalance/turnover.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from decimal import Decimal
 from src.core.models import (
     DiagnosticsData,
@@ -6,6 +7,12 @@ from src.core.models import (
     Money,
     SecurityTradeIntent,
 )
+
+
+@dataclass(frozen=True)
+class _TurnoverSelection:
+    selected: list[SecurityTradeIntent]
+    dropped: list[DroppedIntent]
 
 
 def calculate_turnover_score(intent: SecurityTradeIntent, portfolio_value_base: Decimal) -> Decimal:
@@ -36,38 +43,66 @@ def apply_turnover_limit(
     if proposed <= budget:
         return intents
 
-    ranked = sorted(
-        intents,
-        key=lambda intent: _turnover_rank_key(
-            intent=intent,
-            portfolio_value_base=portfolio_value_base,
-        ),
+    selection = _select_turnover_budget_intents(
+        intents=intents,
+        budget=budget,
+        portfolio_value_base=portfolio_value_base,
+        base_currency=base_currency,
     )
+    diagnostics.dropped_intents.extend(selection.dropped)
 
+    if diagnostics.dropped_intents:
+        diagnostics.warnings.append("PARTIAL_REBALANCE_TURNOVER_LIMIT")
+
+    return selection.selected
+
+
+def _select_turnover_budget_intents(
+    *,
+    intents: list[SecurityTradeIntent],
+    budget: Decimal,
+    portfolio_value_base: Decimal,
+    base_currency: str,
+) -> _TurnoverSelection:
     selected: list[SecurityTradeIntent] = []
+    dropped: list[DroppedIntent] = []
     used = Decimal("0")
-    for intent in ranked:
+
+    for intent in _ranked_turnover_intents(
+        intents=intents,
+        portfolio_value_base=portfolio_value_base,
+    ):
         if intent.notional_base is None:
             continue
         notional_abs = abs(intent.notional_base.amount)
         if used + notional_abs <= budget:
             selected.append(intent)
             used += notional_abs
-            continue
-
-        diagnostics.dropped_intents.append(
-            _dropped_turnover_intent(
-                intent=intent,
-                notional_abs=notional_abs,
-                portfolio_value_base=portfolio_value_base,
-                base_currency=base_currency,
+        else:
+            dropped.append(
+                _dropped_turnover_intent(
+                    intent=intent,
+                    notional_abs=notional_abs,
+                    portfolio_value_base=portfolio_value_base,
+                    base_currency=base_currency,
+                )
             )
-        )
 
-    if diagnostics.dropped_intents:
-        diagnostics.warnings.append("PARTIAL_REBALANCE_TURNOVER_LIMIT")
+    return _TurnoverSelection(selected=selected, dropped=dropped)
 
-    return selected
+
+def _ranked_turnover_intents(
+    *,
+    intents: list[SecurityTradeIntent],
+    portfolio_value_base: Decimal,
+) -> list[SecurityTradeIntent]:
+    return sorted(
+        intents,
+        key=lambda intent: _turnover_rank_key(
+            intent=intent,
+            portfolio_value_base=portfolio_value_base,
+        ),
+    )
 
 
 def _turnover_budget(*, portfolio_value_base: Decimal, max_turnover_pct: Decimal) -> Decimal:

--- a/tests/unit/api/test_pm_operating_quality_score_run_builder.py
+++ b/tests/unit/api/test_pm_operating_quality_score_run_builder.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.routers.pm_operating_quality_models import (
+    DpmPmOperatingQualityScorePreviewRequest,
+)
+from src.api.routers.pm_operating_quality_score_run_builder import (
+    _outcome_reviews_for_request,
+    _score_run_evidence_inputs,
+)
+from src.core.pm_quality import (
+    DpmPmOperatingQualityPolicy,
+    DpmPmQualityEvidenceItem,
+)
+
+
+class _MissingOutcomeRepository:
+    def get_outcome_review(self, *, outcome_review_id: str) -> None:
+        return None
+
+
+def _score_request(
+    *,
+    outcome_review_ids: list[str] | None = None,
+) -> DpmPmOperatingQualityScorePreviewRequest:
+    return DpmPmOperatingQualityScorePreviewRequest(
+        pm_id="pm_001",
+        book_id="sg_dpm_balanced_book",
+        as_of_date="2026-05-12",
+        policy=DpmPmOperatingQualityPolicy(
+            policy_id="pmq_sg_dpm",
+            policy_version="2026.05",
+            enabled=False,
+            as_of_date="2026-05-12",
+            access_purpose="SUPERVISORY_CONTROL_REVIEW",
+        ),
+        evidence_items=[
+            DpmPmQualityEvidenceItem(
+                indicator="SOURCE_QUALITY",
+                evidence_state="READY",
+                score=Decimal("95"),
+                source_system="lotus-risk",
+                source_type="RiskAttributionEvidence",
+                source_id="risk-pm-001",
+                reason_codes=["SOURCE_READY"],
+            )
+        ],
+        outcome_review_ids=outcome_review_ids or [],
+        actor_id="ops",
+    )
+
+
+def test_score_run_evidence_inputs_copy_inline_evidence_without_book_scope() -> None:
+    request = _score_request()
+
+    evidence_inputs = _score_run_evidence_inputs(
+        request=request,
+        correlation_id="corr-pmq-builder",
+        core_resolver_factory=object,
+    )
+
+    assert evidence_inputs.book_scope_evidence is None
+    assert evidence_inputs.evidence_items == request.evidence_items
+    assert evidence_inputs.evidence_items is not request.evidence_items
+
+
+def test_outcome_reviews_for_request_maps_missing_review_to_404() -> None:
+    request = _score_request(outcome_review_ids=["dor_missing"])
+
+    with pytest.raises(HTTPException) as exc_info:
+        _outcome_reviews_for_request(
+            request=request,
+            repository=_MissingOutcomeRepository(),
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "OUTCOME_REVIEW_NOT_FOUND:dor_missing"

--- a/tests/unit/api/test_wave_portfolio_resolution.py
+++ b/tests/unit/api/test_wave_portfolio_resolution.py
@@ -9,6 +9,7 @@ from src.api.routers.wave_portfolio_resolution import (
     _require_tactical_house_view_source_refs,
     _required_tactical_house_view,
     _tactical_house_view_authority_request_for_wave,
+    resolve_portfolio_inputs_for_request,
 )
 from src.api.routers.wave_request_models import DpmWavePreviewRequest
 from src.api.services import wave_service
@@ -86,6 +87,24 @@ def test_tactical_house_view_authority_request_for_wave_maps_source_context() ->
     assert authority_request.candidate_portfolios[0]["portfolio_id"] == ("PB_SG_GLOBAL_BAL_001")
     assert authority_request.eligible_portfolio_types == ["DISCRETIONARY", "DPM"]
     assert authority_request.min_exposure_weight == Decimal("0.05")
+
+
+def test_portfolio_resolution_dispatch_preserves_explicit_portfolio_payloads() -> None:
+    request = _tactical_house_view_request(
+        trigger_type="EXPLICIT_PORTFOLIO_LIST",
+        tactical_house_view=None,
+    )
+
+    resolved = resolve_portfolio_inputs_for_request(
+        request=request,
+        correlation_id="corr-wave-dispatch",
+        advise_authority_client=None,
+        risk_authority_client=None,
+        campaign_definition_repository=object(),
+        core_resolver_factory=object,
+    )
+
+    assert resolved == [portfolio.model_dump(mode="json") for portfolio in request.portfolios]
 
 
 def test_tactical_house_view_resolution_helpers_reject_missing_source_evidence() -> None:

--- a/tests/unit/dpm/construction/test_liquidity_supportability.py
+++ b/tests/unit/dpm/construction/test_liquidity_supportability.py
@@ -1,7 +1,9 @@
 from decimal import Decimal
 
 from src.api.services.construction_liquidity_supportability import (
+    _adjusted_cash_below_policy,
     _cashflow_projection_policy_assessment,
+    _cashflow_projection_policy_inputs,
     _cashflow_projection_currency_mismatch,
     _cashflow_projection_is_usable,
     _cashflow_projection_usability_reason_codes,
@@ -189,6 +191,33 @@ def test_cashflow_projection_policy_assessment_flags_projected_policy_pressure()
     assert assessment.adjusted_cash_below_policy
     assert "CASHFLOW_PROJECTION_ADJUSTED_CASH_BELOW_POLICY" in (
         cashflow_projection_reason_codes(result=result, context=source_context)
+    )
+
+
+def test_cashflow_projection_policy_input_helpers_project_effective_cash_weight() -> None:
+    result = _trade_result()
+    projection = _cashflow_projection()
+
+    inputs = _cashflow_projection_policy_inputs(
+        result=result,
+        projection=projection,
+        cash_weight=None,
+        derive_cash_weight=True,
+    )
+
+    assert inputs.projection == projection
+    assert not inputs.currency_mismatch
+    assert not inputs.total_value_unavailable
+    assert inputs.effective_cash_weight == post_trade_cash_weight(result=result)
+    assert _adjusted_cash_below_policy(
+        cash_weight=Decimal("0.01"),
+        projected_cash_weight=Decimal("-0.005"),
+        minimum_cash_weight=Decimal("0.02"),
+    )
+    assert not _adjusted_cash_below_policy(
+        cash_weight=Decimal("0.03"),
+        projected_cash_weight=Decimal("-0.005"),
+        minimum_cash_weight=Decimal("0.02"),
     )
 
 

--- a/tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py
@@ -103,6 +103,40 @@ def test_turnover_helper_calculates_budget_proposed_and_rank_key():
     ) == [high_score, low_notional, missing_notional]
 
 
+def test_turnover_budget_selection_is_pure_and_records_dropped_intents():
+    high_score = _security_intent(
+        intent_id="oi_high",
+        instrument_id="B",
+        notional_base=Decimal("200"),
+    )
+    exact_fit = _security_intent(
+        intent_id="oi_fit",
+        instrument_id="A",
+        notional_base=Decimal("100"),
+    )
+    over_budget = _security_intent(
+        intent_id="oi_drop",
+        instrument_id="C",
+        notional_base=Decimal("100"),
+    )
+    missing_notional = _security_intent(
+        intent_id="oi_missing",
+        instrument_id="D",
+        notional_base=None,
+    )
+
+    selection = turnover_module._select_turnover_budget_intents(
+        intents=[exact_fit, missing_notional, high_score, over_budget],
+        budget=Decimal("300"),
+        portfolio_value_base=Decimal("1000"),
+        base_currency="USD",
+    )
+
+    assert [intent.instrument_id for intent in selection.selected] == ["B", "A"]
+    assert [item.instrument_id for item in selection.dropped] == ["C"]
+    assert selection.dropped[0].potential_notional == Money(amount=Decimal("100"), currency="USD")
+
+
 def test_turnover_drop_helper_records_governed_diagnostic_payload():
     intent = _security_intent(
         intent_id="oi_drop",


### PR DESCRIPTION
## Summary
- Extracted turnover budget selection into typed pure helpers with direct coverage for ranked exact-fit selection and dropped-intent diagnostics.
- Split construction liquidity cashflow projection policy input derivation from final assessment, with helper tests for effective cash weight and adjusted cash policy pressure.
- Table-drove wave portfolio resolution trigger dispatch while keeping HTTP/source-authority exception mapping in router-owned helpers.
- Extracted PM operating-quality score-run evidence and outcome-review lookup helpers with focused 404 and evidence-copy coverage.
- Refreshed quality reports and codebase review ledger entries BACKEND-REVIEW-20260613-885 through 888.

## Evidence
- `python -m ruff check` / `python -m ruff format --check` on each touched slice
- `python -m mypy --config-file mypy.ini` on touched source files
- Focused pytest suites:
  - `tests/unit/dpm/engine/coverage/test_engine_tax_and_settlement_branches.py tests/unit/dpm/engine/test_engine_turnover_control.py` -> 18 passed
  - `tests/unit/dpm/construction/test_liquidity_supportability.py` -> 9 passed
  - `tests/unit/api/test_wave_portfolio_resolution.py` -> 3 passed
  - `tests/unit/api/test_pm_operating_quality_score_run_builder.py` -> 2 passed
- `python scripts/openapi_quality_gate.py` -> passed
- `python scripts/api_vocabulary_inventory.py --validate-only` -> passed
- `python scripts/service_boundary_gate.py` -> passed
- Service leakage scan -> no matches
- `git diff --check origin/main...HEAD` -> passed
- `make check` -> 2676 passed

## Measurable Maintainability
- `apply_turnover_limit`: B(7) -> A(4)
- `_cashflow_projection_policy_assessment`: B(7) -> A(2)
- `resolve_portfolio_inputs_for_request`: B(9) -> A(1) under radon
- `build_score_run`: B(7) -> A(4)
- Refreshed `quality/complexity_report.md`; the first four prior source hotspots no longer appear at the same top positions.

## Governance
- Stranded truth check: `git branch -r --no-merged origin/main` returned no branches before PR.
- Wiki drift: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned `DiffCount 0`; no wiki publication required.
- No API contract, vocabulary, runtime, or operator-facing wiki truth changed.
- This PR does not claim global bank-buyable readiness; it is a maintainability hardening slice with residual runtime/downstream certification risk unchanged.