### PR TITLE
Harden manage source hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22321,3 +22321,32 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal API-governance helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-895: Risk concentration response section normalization
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/risk_authority/client.py` and
+  `tests/unit/dpm/infrastructure/test_risk_authority_client.py`.
+- Bank-buyable control area: architecture, downstream boundary clarity, and testing.
+- Finding: `_risk_context_from_concentration_response` combined source response section extraction,
+  supportability defaulting, source fingerprint preservation, issuer coverage projection, breach
+  counting, and `AuthoritativeRiskContext` construction. The behavior was correct, but the mapper
+  remained a top source hotspot and made the risk-authority boundary harder to review.
+- Action: extracted `_ConcentrationResponseSections` and `_concentration_response_sections` so
+  source-response shape and supportability defaults are normalized before context construction.
+  Added direct tests for populated source metadata and missing supportability defaults.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/risk_authority/client.py tests/unit/dpm/infrastructure/test_risk_authority_client.py`,
+  `python -m ruff format --check src/infrastructure/risk_authority/client.py tests/unit/dpm/infrastructure/test_risk_authority_client.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/risk_authority/client.py`,
+  `python -m pytest tests/unit/dpm/infrastructure/test_risk_authority_client.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/infrastructure/risk_authority/client.py -s`; the focused risk-authority
+  suite reported 31 passed, `_risk_context_from_concentration_response` reduced from B(7) to B(6)
+  under radon, and the refreshed quality report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves source-owned concentration response mapping maintainability
+  only. It does not change source methodology, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal risk-authority mapping
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22290,3 +22290,34 @@ and improves internal transaction-cost source posture maintainability only.
   behavior.
 - Wiki decision: no wiki source change required; this is internal API-governance helper
   correctness hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-894: OpenAPI operation example enrichment helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/openapi_enrichment.py` and
+  `tests/unit/api/test_openapi_enrichment_helpers.py`.
+- Bank-buyable control area: API quality, contract governance, and testing.
+- Finding: `_ensure_operation_examples` still coordinated request-body example enrichment,
+  response-body example enrichment, and error-response content enrichment directly. The behavior was
+  correct, but the generated OpenAPI operation example path remained a top source hotspot in the
+  quality report and was harder to review than the API governance layer should be.
+- Action: extracted `_ensure_request_body_example` and `_ensure_response_body_example` so request
+  and response enrichment can be reviewed and tested independently while preserving the existing
+  operation-level orchestration. Added direct helper coverage for JSON request enrichment,
+  non-JSON no-op behavior, success response examples, and structured error response examples.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`,
+  `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q`,
+  `python scripts/openapi_quality_gate.py`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/api/openapi_enrichment.py -s`; the focused OpenAPI enrichment helper
+  suite reported 33 passed, `_ensure_operation_examples` reduced to A(3) under radon, and the
+  refreshed quality report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves OpenAPI enrichment maintainability only. It does not change
+  API schema truth, certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal API-governance helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22350,3 +22350,33 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal risk-authority mapping
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-896: Single-position target cap helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/rebalance/targets.py` and
+  `tests/unit/dpm/engine/coverage/test_engine_target_generation.py`.
+- Bank-buyable control area: architecture, deterministic target generation, and testing.
+- Finding: `_apply_single_position_max_weight` combined overweight-target capping, released-weight
+  calculation, buyable-recipient selection, proportional redistribution, and pending-review
+  classification in one helper. The behavior was correct, but this made a core target-generation
+  guard harder to review and kept it in the top source hotspot report.
+- Action: extracted `_cap_single_position_targets` and `_redistribute_single_position_excess` so
+  capping and redistribution can be tested independently while preserving the existing
+  `READY`/`PENDING_REVIEW` behavior and Decimal arithmetic. Added direct tests for released-weight
+  calculation and unplaced redistribution remainder.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/targets.py tests/unit/dpm/engine/coverage/test_engine_target_generation.py`,
+  `python -m ruff format --check src/core/rebalance/targets.py tests/unit/dpm/engine/coverage/test_engine_target_generation.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/targets.py`,
+  `python -m pytest tests/unit/dpm/engine/coverage/test_engine_target_generation.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/core/rebalance/targets.py -s`; the focused target-generation suite
+  reported 24 passed, `_apply_single_position_max_weight` reduced to A(3) under radon, and the
+  refreshed quality report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves deterministic target-generation maintainability only. It does
+  not change rebalance policy semantics, certify global bank-buyable readiness, runtime evidence,
+  or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal target-generation helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T11:55:24+00:00`
+- Generated at: `2026-06-13T12:24:16+00:00`
 
-- Report source snapshot: `240df935+worktree`
+- Report source snapshot: `252e02be+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 172611 |
-| Test functions | 2503 |
+| Total Python LOC | 172720 |
+| Test functions | 2507 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T12:26:52+00:00`
+- Generated at: `2026-06-13T12:30:06+00:00`
 
-- Report source snapshot: `9361ae05+worktree`
+- Report source snapshot: `0c71efda+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 172781 |
-| Test functions | 2509 |
+| Total Python LOC | 172853 |
+| Test functions | 2511 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T12:24:16+00:00`
+- Generated at: `2026-06-13T12:26:52+00:00`
 
-- Report source snapshot: `252e02be+worktree`
+- Report source snapshot: `9361ae05+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 172720 |
-| Test functions | 2507 |
+| Total Python LOC | 172781 |
+| Test functions | 2509 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T12:24:16+00:00`
+- Generated at: `2026-06-13T12:26:52+00:00`
 
-- Report source snapshot: `252e02be+worktree`
+- Report source snapshot: `9361ae05+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
-| 2 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
-| 3 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
-| 4 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
-| 5 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
-| 6 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
-| 7 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
-| 8 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 9 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
-| 10 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 1 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
+| 2 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
+| 3 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
+| 4 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
+| 5 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
+| 6 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
+| 7 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
+| 8 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 9 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 10 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T11:55:24+00:00`
+- Generated at: `2026-06-13T12:24:16+00:00`
 
-- Report source snapshot: `240df935+worktree`
+- Report source snapshot: `252e02be+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _ensure_operation_examples | src/api/openapi_enrichment.py | 7 | 33 |
-| 2 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
-| 3 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
-| 4 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
-| 5 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
-| 6 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
-| 7 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
-| 8 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
-| 9 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 10 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 1 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 7 | 33 |
+| 2 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
+| 3 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
+| 4 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
+| 5 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
+| 6 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
+| 7 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
+| 8 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
+| 9 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 10 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T12:26:52+00:00`
+- Generated at: `2026-06-13T12:30:06+00:00`
 
-- Report source snapshot: `9361ae05+worktree`
+- Report source snapshot: `0c71efda+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _apply_single_position_max_weight | src/core/rebalance/targets.py | 7 | 31 |
-| 2 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
-| 3 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
-| 4 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
-| 5 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
-| 6 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
-| 7 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 8 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
-| 9 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
-| 10 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
+| 1 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
+| 2 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
+| 3 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
+| 4 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
+| 5 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
+| 6 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
+| 7 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 8 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 9 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
+| 10 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T12:26:52+00:00`
+- Generated at: `2026-06-13T12:30:06+00:00`
 
-- Report source snapshot: `9361ae05+worktree`
+- Report source snapshot: `0c71efda+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T12:24:16+00:00`
+- Generated at: `2026-06-13T12:26:52+00:00`
 
-- Report source snapshot: `252e02be+worktree`
+- Report source snapshot: `9361ae05+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T11:55:24+00:00`
+- Generated at: `2026-06-13T12:24:16+00:00`
 
-- Report source snapshot: `240df935+worktree`
+- Report source snapshot: `252e02be+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T12:26:52+00:00`
+- Generated at: `2026-06-13T12:30:06+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `9361ae05+worktree`
+- Report source snapshot: `0c71efda+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 172627 | 172781 | +154 |
-| Test functions | 2504 | 2509 | +5 |
+| Total Python LOC | 172627 | 172853 | +226 |
+| Test functions | 2504 | 2511 | +7 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T12:24:16+00:00`
+- Generated at: `2026-06-13T12:26:52+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `252e02be+worktree`
+- Report source snapshot: `9361ae05+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 172627 | 172720 | +93 |
-| Test functions | 2504 | 2507 | +3 |
+| Total Python LOC | 172627 | 172781 | +154 |
+| Test functions | 2504 | 2509 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T11:55:24+00:00`
+- Generated at: `2026-06-13T12:24:16+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `240df935+worktree`
+- Report source snapshot: `252e02be+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 172249 | 172611 | +362 |
-| Test functions | 2496 | 2503 | +7 |
+| Total Python LOC | 172627 | 172720 | +93 |
+| Test functions | 2504 | 2507 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -436,6 +436,47 @@ def _ensure_error_response_content(
         )
 
 
+def _ensure_request_body_example(
+    *,
+    operation: dict[str, Any],
+    schemas: dict[str, Any],
+    example_name: str,
+) -> None:
+    request_content = operation.get("requestBody", {}).get("content", {}).get(_JSON_MEDIA_TYPE)
+    if not isinstance(request_content, dict):
+        return
+    _ensure_json_content_example(
+        content=request_content,
+        schemas=schemas,
+        name=example_name,
+        summary="Example request payload.",
+    )
+
+
+def _ensure_response_body_example(
+    *,
+    response: dict[str, Any],
+    status_code: str,
+    schemas: dict[str, Any],
+    example_name: str,
+) -> None:
+    normalized_status_code = str(status_code)
+    if _is_error_status_code(normalized_status_code):
+        _ensure_error_response_content(
+            response=response,
+            status_code=normalized_status_code,
+        )
+    response_content = response.get("content", {}).get(_JSON_MEDIA_TYPE)
+    if not isinstance(response_content, dict):
+        return
+    _ensure_json_content_example(
+        content=response_content,
+        schemas=schemas,
+        name=example_name,
+        summary="Example response payload.",
+    )
+
+
 def _ensure_operation_examples(
     *,
     method: str,
@@ -443,32 +484,21 @@ def _ensure_operation_examples(
     operation: dict[str, Any],
     schemas: dict[str, Any],
 ) -> None:
-    request_content = operation.get("requestBody", {}).get("content", {}).get(_JSON_MEDIA_TYPE)
-    if isinstance(request_content, dict):
-        _ensure_json_content_example(
-            content=request_content,
-            schemas=schemas,
-            name=f"{method}_{path}_request",
-            summary="Example request payload.",
-        )
+    _ensure_request_body_example(
+        operation=operation,
+        schemas=schemas,
+        example_name=f"{method}_{path}_request",
+    )
 
     for status_code, response in operation.get("responses", {}).items():
         if not isinstance(response, dict):
             continue
-        normalized_status_code = str(status_code)
-        if normalized_status_code.startswith(("4", "5")) or normalized_status_code == "default":
-            _ensure_error_response_content(
-                response=response,
-                status_code=normalized_status_code,
-            )
-        response_content = response.get("content", {}).get(_JSON_MEDIA_TYPE)
-        if isinstance(response_content, dict):
-            _ensure_json_content_example(
-                content=response_content,
-                schemas=schemas,
-                name=f"{method}_{path}_{status_code}_response",
-                summary="Example response payload.",
-            )
+        _ensure_response_body_example(
+            response=response,
+            status_code=str(status_code),
+            schemas=schemas,
+            example_name=f"{method}_{path}_{status_code}_response",
+        )
 
 
 def _is_http_operation_method(method: str) -> bool:

--- a/src/core/rebalance/targets.py
+++ b/src/core/rebalance/targets.py
@@ -357,21 +357,53 @@ def _apply_single_position_max_weight(
     buy_set: set[str],
     max_weight: Decimal,
 ) -> Literal["READY", "PENDING_REVIEW"]:
-    excess = sum(max(Decimal("0.0"), weight - max_weight) for weight in eligible_targets.values())
-    for instrument_id in eligible_targets:
-        eligible_targets[instrument_id] = min(eligible_targets[instrument_id], max_weight)
-
+    excess = _cap_single_position_targets(
+        eligible_targets=eligible_targets,
+        max_weight=max_weight,
+    )
     if excess <= Decimal("0.0"):
         return "READY"
 
+    remainder = _redistribute_single_position_excess(
+        eligible_targets=eligible_targets,
+        buy_set=buy_set,
+        max_weight=max_weight,
+        excess=excess,
+    )
+    if remainder > Decimal("0.001"):
+        return "PENDING_REVIEW"
+    return "READY"
+
+
+def _cap_single_position_targets(
+    *,
+    eligible_targets: dict[str, Decimal],
+    max_weight: Decimal,
+) -> Decimal:
+    excess = sum(
+        (max(Decimal("0.0"), weight - max_weight) for weight in eligible_targets.values()),
+        Decimal("0.0"),
+    )
+    for instrument_id in eligible_targets:
+        eligible_targets[instrument_id] = min(eligible_targets[instrument_id], max_weight)
+    return excess
+
+
+def _redistribute_single_position_excess(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+    max_weight: Decimal,
+    excess: Decimal,
+) -> Decimal:
     candidates = {
         instrument_id: weight
         for instrument_id, weight in eligible_targets.items()
         if instrument_id in buy_set and weight < max_weight
     }
-    total_candidate_weight = sum(candidates.values())
+    total_candidate_weight = sum(candidates.values(), Decimal("0.0"))
     if total_candidate_weight <= Decimal("0.0"):
-        return "PENDING_REVIEW"
+        return excess
 
     remainder = excess
     for instrument_id, weight in candidates.items():
@@ -379,9 +411,7 @@ def _apply_single_position_max_weight(
         eligible_targets[instrument_id] += share
         remainder -= share
 
-    if remainder > Decimal("0.001"):
-        return "PENDING_REVIEW"
-    return "READY"
+    return remainder
 
 
 def _apply_min_cash_buffer(

--- a/src/infrastructure/risk_authority/client.py
+++ b/src/infrastructure/risk_authority/client.py
@@ -67,6 +67,18 @@ class _ConcentrationBreachInputs:
     hhi_proposed: Decimal
 
 
+@dataclass(frozen=True)
+class _ConcentrationResponseSections:
+    metadata: dict[str, Any]
+    risk_proxy: dict[str, Any]
+    single_position: dict[str, Any]
+    issuer: dict[str, Any]
+    supportability_state: str
+    supportability_reason: str
+    request_fingerprint: str
+    issuer_coverage_status: Any
+
+
 class LotusRiskAuthorityClient:
     """Bounded client for lotus-risk authority outputs used by construction.
 
@@ -253,37 +265,51 @@ def _regime_scenario_payload(
 
 
 def _risk_context_from_concentration_response(body: dict[str, Any]) -> AuthoritativeRiskContext:
-    metadata = _dict_section(body, "metadata")
-    supportability = _dict_section(metadata, "calculation_supportability")
-    request_fingerprint = str(metadata.get("request_fingerprint") or "")
-    risk_proxy = _dict_section(body, "risk_proxy")
-    single_position = _dict_section(body, "single_position_concentration")
-    issuer = _dict_section(body, "issuer_concentration")
-    state = str(supportability.get("state", "degraded"))
-    reason = str(supportability.get("reason", "calculation_supportability_missing"))
-    coverage_status = issuer.get("coverage_status")
+    sections = _concentration_response_sections(body)
     breach_inputs = _concentration_breach_inputs(
-        risk_proxy=risk_proxy,
-        single_position=single_position,
-        issuer=issuer,
+        risk_proxy=sections.risk_proxy,
+        single_position=sections.single_position,
+        issuer=sections.issuer,
     )
     breaches = _concentration_breach_count(breach_inputs)
     return AuthoritativeRiskContext(
-        supportability_status=_risk_status_from_supportability(state),
+        supportability_status=_risk_status_from_supportability(sections.supportability_state),
         source_system=str(body.get("source_service") or "lotus-risk"),
         source_product_name="ConcentrationAnalysis",
-        source_product_version=str(metadata.get("methodology_version") or "v1"),
-        source_id=request_fingerprint or None,
-        content_hash=request_fingerprint or None,
+        source_product_version=str(sections.metadata.get("methodology_version") or "v1"),
+        source_id=sections.request_fingerprint or None,
+        content_hash=sections.request_fingerprint or None,
         concentration_breaches=breaches,
-        concentration_hhi_delta=Decimal(str(risk_proxy.get("hhi_delta", "0"))),
+        concentration_hhi_delta=Decimal(str(sections.risk_proxy.get("hhi_delta", "0"))),
         top_position_weight_proposed=breach_inputs.top_position_weight_proposed,
-        issuer_coverage_status=str(coverage_status) if coverage_status is not None else None,
+        issuer_coverage_status=(
+            str(sections.issuer_coverage_status)
+            if sections.issuer_coverage_status is not None
+            else None
+        ),
         reason_codes=_concentration_reason_codes(
-            supportability_reason=reason,
-            issuer_coverage_status=coverage_status,
+            supportability_reason=sections.supportability_reason,
+            issuer_coverage_status=sections.issuer_coverage_status,
             breaches=breaches,
         ),
+    )
+
+
+def _concentration_response_sections(body: dict[str, Any]) -> _ConcentrationResponseSections:
+    metadata = _dict_section(body, "metadata")
+    supportability = _dict_section(metadata, "calculation_supportability")
+    issuer = _dict_section(body, "issuer_concentration")
+    return _ConcentrationResponseSections(
+        metadata=metadata,
+        risk_proxy=_dict_section(body, "risk_proxy"),
+        single_position=_dict_section(body, "single_position_concentration"),
+        issuer=issuer,
+        supportability_state=str(supportability.get("state", "degraded")),
+        supportability_reason=str(
+            supportability.get("reason", "calculation_supportability_missing")
+        ),
+        request_fingerprint=str(metadata.get("request_fingerprint") or ""),
+        issuer_coverage_status=issuer.get("coverage_status"),
     )
 
 

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -9,6 +9,8 @@ from src.api.openapi_enrichment import (
     _ensure_operation_default_error_response,
     _ensure_operation_examples,
     _ensure_metrics_paths_examples,
+    _ensure_request_body_example,
+    _ensure_response_body_example,
     _ensure_property_documentation,
     _infer_description,
     _infer_example,
@@ -387,6 +389,67 @@ def test_openapi_enrichment_resolved_schema_example_preserves_declared_null() ->
         )
         is None
     )
+
+
+def test_openapi_enrichment_request_body_example_helper_enriches_json_content() -> None:
+    operation = {
+        "requestBody": {
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Payload"}}}
+        }
+    }
+
+    _ensure_request_body_example(
+        operation=operation,
+        schemas={"Payload": {"type": "object", "properties": {"portfolio_id": {"type": "string"}}}},
+        example_name="custom_request",
+    )
+
+    assert operation["requestBody"]["content"]["application/json"]["examples"]["default"] == {
+        "summary": "Example request payload.",
+        "value": {"portfolio_id": "DEMO_DPM_EUR_001"},
+    }
+
+
+def test_openapi_enrichment_request_body_example_helper_skips_non_json_content() -> None:
+    operation = {"requestBody": {"content": {"text/plain": {"schema": {"type": "string"}}}}}
+
+    _ensure_request_body_example(
+        operation=operation,
+        schemas={},
+        example_name="plain_request",
+    )
+
+    assert operation == {"requestBody": {"content": {"text/plain": {"schema": {"type": "string"}}}}}
+
+
+def test_openapi_enrichment_response_body_example_helper_enriches_success_and_errors() -> None:
+    success_response = {"content": {"application/json": {"schema": {"type": "string"}}}}
+    conflict_response = {"description": "Conflict detected."}
+
+    _ensure_response_body_example(
+        response=success_response,
+        status_code="200",
+        schemas={},
+        example_name="success_response",
+    )
+    _ensure_response_body_example(
+        response=conflict_response,
+        status_code="409",
+        schemas={},
+        example_name="conflict_response",
+    )
+
+    assert success_response["content"]["application/json"]["examples"]["default"] == {
+        "summary": "Example response payload.",
+        "value": "sample_success_response",
+    }
+    assert conflict_response["content"]["application/json"]["examples"]["default"]["value"] == {
+        "type": "about:blank",
+        "title": "Conflict",
+        "status": 409,
+        "detail": "Conflict detected.",
+        "correlation_id": "corr_1234abcd",
+    }
 
 
 def test_openapi_enrichment_adds_operation_level_examples_and_errors() -> None:

--- a/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_target_generation.py
@@ -7,10 +7,12 @@ from src.core.common.target_redistribution import redistribute_sell_only_excess
 from src.core.rebalance.targets import (
     _apply_min_cash_buffer,
     _apply_single_position_max_weight,
+    _cap_single_position_targets,
     _cap_tradeable_targets_to_available_weight,
     _constraint_key_parts,
     _group_constraint_members,
     _redistribute_group_constraint_excess,
+    _redistribute_single_position_excess,
 )
 from src.core.rebalance.engine import _apply_group_constraints, _generate_targets, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, GroupConstraint, ShelfEntry
@@ -177,6 +179,46 @@ class TestTargetGeneration:
         }
         assert eligible_targets["FI_A"] == Decimal("0.450")
         assert eligible_targets["FI_B"] == Decimal("0.150")
+
+    def test_cap_single_position_targets_returns_released_weight(self):
+        eligible_targets = {
+            "BUY_A": Decimal("0.80"),
+            "BUY_B": Decimal("0.20"),
+            "LOCKED": Decimal("0.60"),
+        }
+
+        excess = _cap_single_position_targets(
+            eligible_targets=eligible_targets,
+            max_weight=Decimal("0.50"),
+        )
+
+        assert excess == Decimal("0.40")
+        assert eligible_targets == {
+            "BUY_A": Decimal("0.50"),
+            "BUY_B": Decimal("0.20"),
+            "LOCKED": Decimal("0.50"),
+        }
+
+    def test_redistribute_single_position_excess_returns_unplaced_remainder(self):
+        eligible_targets = {
+            "BUY_A": Decimal("0.50"),
+            "BUY_B": Decimal("0.40"),
+            "LOCKED": Decimal("0.50"),
+        }
+
+        remainder = _redistribute_single_position_excess(
+            eligible_targets=eligible_targets,
+            buy_set={"BUY_A", "BUY_B"},
+            max_weight=Decimal("0.50"),
+            excess=Decimal("0.30"),
+        )
+
+        assert remainder == Decimal("0.20")
+        assert eligible_targets == {
+            "BUY_A": Decimal("0.50"),
+            "BUY_B": Decimal("0.50"),
+            "LOCKED": Decimal("0.50"),
+        }
 
     def test_apply_single_position_max_weight_caps_and_redistributes_excess(self):
         eligible_targets = {

--- a/tests/unit/dpm/infrastructure/test_risk_authority_client.py
+++ b/tests/unit/dpm/infrastructure/test_risk_authority_client.py
@@ -15,6 +15,7 @@ from src.infrastructure.risk_authority.client import (
     _concentration_breach_count,
     _concentration_breach_inputs,
     _concentration_reason_codes,
+    _concentration_response_sections,
     _post_with_retries,
     _risk_event_affected_portfolios,
     _risk_event_cohort_from_response,
@@ -200,6 +201,40 @@ def test_concentration_breach_helpers_count_source_threshold_breaches() -> None:
     assert inputs.top_issuer_weight_proposed == Decimal("0.41")
     assert inputs.hhi_proposed == Decimal("2600")
     assert _concentration_breach_count(inputs) == 3
+
+
+def test_concentration_response_sections_preserve_source_metadata() -> None:
+    response = _risk_response(coverage_status="partial")
+    metadata = response["metadata"]
+    assert isinstance(metadata, dict)
+    metadata["methodology_version"] = "concentration.v3"
+    metadata["request_fingerprint"] = "sha256:concentration-request"
+
+    sections = _concentration_response_sections(response)
+
+    assert sections.metadata["methodology_version"] == "concentration.v3"
+    assert sections.request_fingerprint == "sha256:concentration-request"
+    assert sections.supportability_state == "ready"
+    assert sections.supportability_reason == "calculation_complete"
+    assert sections.issuer_coverage_status == "partial"
+    assert sections.risk_proxy["hhi_delta"] == 100.0
+
+
+def test_concentration_response_sections_default_missing_supportability() -> None:
+    response = _risk_response()
+    metadata = response["metadata"]
+    assert isinstance(metadata, dict)
+    metadata.pop("calculation_supportability")
+    issuer = response["issuer_concentration"]
+    assert isinstance(issuer, dict)
+    issuer.pop("coverage_status")
+
+    sections = _concentration_response_sections(response)
+
+    assert sections.supportability_state == "degraded"
+    assert sections.supportability_reason == "calculation_supportability_missing"
+    assert sections.request_fingerprint == ""
+    assert sections.issuer_coverage_status is None
 
 
 def test_concentration_reason_codes_project_supportability_coverage_and_breaches() -> None:


### PR DESCRIPTION
## Summary
- Extracted OpenAPI request/response operation example enrichment helpers and added direct helper coverage.
- Extracted risk authority concentration response section normalization and added source metadata/defaulting coverage.
- Extracted single-position target cap and redistribution helpers and added direct Decimal/remainder coverage.
- Refreshed quality reports and recorded ledger entries BACKEND-REVIEW-20260613-894 through BACKEND-REVIEW-20260613-896.

## Measured quality movement
- `_ensure_operation_examples` reduced to A(3) under radon and no longer appears in the top source hotspot list.
- `_risk_context_from_concentration_response` reduced from B(7) to B(6) under radon and no longer appears in the top source hotspot list.
- `_apply_single_position_max_weight` reduced to A(3) under radon and no longer appears in the top source hotspot list.

## Local validation
- `python -m ruff check <touched files>` per slice.
- `python -m ruff format --check <touched files>` per slice.
- `python -m mypy --config-file mypy.ini <touched src files>` per slice.
- Focused pytest suites per slice: OpenAPI enrichment helpers, risk authority client, target generation coverage.
- `python scripts/openapi_quality_gate.py`.
- `python scripts/api_vocabulary_inventory.py --validate-only`.
- `python scripts/service_boundary_gate.py`.
- Service leakage scan: no matches for router/FastAPI/Starlette/HTTPException imports in `src/api/services`.
- `git diff --check origin/main...HEAD`.
- `make check`: 2691 passed.

## Branch and wiki hygiene
- `git fetch origin --prune` completed before PR.
- `git branch -r --no-merged origin/main`: no unmerged remote branches reported before PR.
- Wiki drift check: `DiffCount 0` for `lotus-manage`.

## Residual risk
- This PR improves helper boundaries, focused coverage, and quality evidence only. It does not claim complete Lotus Bank-Buyable readiness, runtime certification, or downstream Gateway/Workbench certification.
- No operator-facing wiki truth changed; no wiki source update required.