### PR TITLE
Harden manage infrastructure source helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22442,3 +22442,33 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal workflow helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-899: Proof pack persistence guard helpers
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/proof_packs/in_memory.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_repository.py`.
+- Bank-buyable control area: architecture, immutable evidence persistence, and testing.
+- Finding: `save_proof_pack` combined immutable content-hash enforcement, idempotency conflict
+  detection, proof-pack cloning, and retention metadata construction in one repository method. The
+  behavior was correct, but the evidence-store guardrails were harder to review than a governed
+  proof-pack persistence boundary should be.
+- Action: extracted `_ensure_proof_pack_content_is_immutable`, `_idempotency_binding`, and
+  `_retention_metadata` so immutable proof-pack and retention decisions are independently testable
+  before repository mutation. Added direct tests for matching-content replay, changed-content
+  rejection, optional idempotency binding, idempotency conflicts, and optional retention expiry.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/proof_packs/in_memory.py tests/unit/dpm/proof_packs/test_proof_pack_repository.py`,
+  `python -m ruff format --check src/infrastructure/proof_packs/in_memory.py tests/unit/dpm/proof_packs/test_proof_pack_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/proof_packs/in_memory.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_repository.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/infrastructure/proof_packs/in_memory.py -s`; the focused proof-pack
+  repository suite reported 9 passed, `save_proof_pack` reduced to A(3) under radon, and the
+  refreshed quality report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves in-memory proof-pack persistence maintainability only. It does
+  not change PostgreSQL proof-pack persistence semantics, certify global bank-buyable readiness,
+  runtime evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal repository helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22410,3 +22410,35 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal repository helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-898: Campaign assignment action page state helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/waves/campaign_assignment_actions.py` and
+  `tests/unit/dpm/waves/test_campaign_discovery.py`.
+- Bank-buyable control area: architecture, workflow supportability, and testing.
+- Finding: `build_bulk_review_campaign_definition_assignment_action_page` combined assignment
+  action sorting, pagination, latest-action derivation, resolved-state actor clearing, escalation
+  posture, SLA posture, and page construction. The behavior was correct, but the workflow page
+  state projection was harder to review than a governed maker/checker supportability surface should
+  be.
+- Action: extracted `_AssignmentActionPageState`, `_sorted_assignment_actions`, and
+  `_assignment_action_page_state` so current assignment posture is independently testable before
+  page construction. Added direct tests for latest-action ordering, active escalation state,
+  empty defaults, and resolved-action actor clearing.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_assignment_actions.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_assignment_actions.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_actions.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/core/waves/campaign_assignment_actions.py -s`; the focused campaign
+  discovery suite reported 86 passed, `build_bulk_review_campaign_definition_assignment_action_page`
+  reduced to A(1) under radon, and the refreshed quality report no longer lists it in the top source
+  hotspots.
+- Residual risk: this slice improves assignment-action page-state maintainability only. It does not
+  change campaign workflow semantics, certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal workflow helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22380,3 +22380,33 @@ and improves internal transaction-cost source posture maintainability only.
   or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal target-generation helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-897: In-memory mandate retention key selectors
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/mandates/in_memory.py` and
+  `tests/unit/dpm/supportability/test_dpm_mandate_repository.py`.
+- Bank-buyable control area: architecture, retention supportability, and testing.
+- Finding: `purge_mandate_records_before` combined retention cutoff normalization, stale mandate,
+  health, monitoring-run, and resolved-exception key selection, dictionary mutation, and purged-row
+  counting in one repository method. The behavior was correct, but the retention rules were harder
+  to review than an operational supportability repository should be.
+- Action: extracted `_stale_mandate_keys`, `_stale_health_snapshot_keys`,
+  `_stale_monitoring_run_keys`, and `_stale_resolved_exception_keys` so retention selection rules
+  are independently testable before mutation. Added direct tests for stale/current mandate, health,
+  and run selection plus the rule that old active exceptions are retained until resolved.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python -m ruff format --check src/infrastructure/mandates/in_memory.py tests/unit/dpm/supportability/test_dpm_mandate_repository.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/mandates/in_memory.py`,
+  `python -m pytest tests/unit/dpm/supportability/test_dpm_mandate_repository.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/infrastructure/mandates/in_memory.py -s`; the focused mandate repository
+  suite reported 18 passed, `purge_mandate_records_before` reduced to A(5) under radon, and the
+  refreshed quality report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves in-memory retention maintainability only. It does not change
+  PostgreSQL retention semantics, certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal repository helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T12:52:03+00:00`
+- Generated at: `2026-06-13T12:56:00+00:00`
 
-- Report source snapshot: `a12d37b6+worktree`
+- Report source snapshot: `5509a558+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 173057 |
-| Test functions | 2515 |
+| Total Python LOC | 173154 |
+| Test functions | 2519 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T12:47:17+00:00`
+- Generated at: `2026-06-13T12:52:03+00:00`
 
-- Report source snapshot: `7c9905c0+worktree`
+- Report source snapshot: `a12d37b6+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 172949 |
-| Test functions | 2513 |
+| Total Python LOC | 173057 |
+| Test functions | 2515 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T12:30:06+00:00`
+- Generated at: `2026-06-13T12:47:17+00:00`
 
-- Report source snapshot: `0c71efda+worktree`
+- Report source snapshot: `7c9905c0+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 172853 |
-| Test functions | 2511 |
+| Total Python LOC | 172949 |
+| Test functions | 2513 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T12:52:03+00:00`
+- Generated at: `2026-06-13T12:56:00+00:00`
 
-- Report source snapshot: `a12d37b6+worktree`
+- Report source snapshot: `5509a558+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
-| 2 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
-| 3 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
-| 4 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 5 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
-| 6 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
-| 7 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
-| 8 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
-| 9 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
-| 10 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
+| 1 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
+| 2 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
+| 3 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
+| 4 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 5 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 6 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
+| 7 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
+| 8 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
+| 9 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
+| 10 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T12:47:17+00:00`
+- Generated at: `2026-06-13T12:52:03+00:00`
 
-- Report source snapshot: `7c9905c0+worktree`
+- Report source snapshot: `a12d37b6+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
-| 2 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
-| 3 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
-| 4 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
-| 5 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 6 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
-| 7 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
-| 8 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
-| 9 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
-| 10 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
+| 1 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
+| 2 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
+| 3 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
+| 4 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
+| 5 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 6 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 7 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
+| 8 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
+| 9 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
+| 10 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T12:30:06+00:00`
+- Generated at: `2026-06-13T12:47:17+00:00`
 
-- Report source snapshot: `0c71efda+worktree`
+- Report source snapshot: `7c9905c0+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | purge_mandate_records_before | src/infrastructure/mandates/in_memory.py | 7 | 31 |
-| 2 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
-| 3 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
-| 4 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
-| 5 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
-| 6 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 7 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
-| 8 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
-| 9 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
-| 10 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
+| 1 | build_bulk_review_campaign_definition_assignment_action_page | src/core/waves/campaign_assignment_actions.py | 7 | 27 |
+| 2 | save_proof_pack | src/infrastructure/proof_packs/in_memory.py | 7 | 24 |
+| 3 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
+| 4 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
+| 5 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
+| 6 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 7 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 8 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
+| 9 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
+| 10 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T12:30:06+00:00`
+- Generated at: `2026-06-13T12:47:17+00:00`
 
-- Report source snapshot: `0c71efda+worktree`
+- Report source snapshot: `7c9905c0+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T12:52:03+00:00`
+- Generated at: `2026-06-13T12:56:00+00:00`
 
-- Report source snapshot: `a12d37b6+worktree`
+- Report source snapshot: `5509a558+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T12:47:17+00:00`
+- Generated at: `2026-06-13T12:52:03+00:00`
 
-- Report source snapshot: `7c9905c0+worktree`
+- Report source snapshot: `a12d37b6+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T12:47:17+00:00`
+- Generated at: `2026-06-13T12:52:03+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `7c9905c0+worktree`
+- Report source snapshot: `a12d37b6+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 172853 | 172949 | +96 |
-| Test functions | 2511 | 2513 | +2 |
+| Total Python LOC | 172853 | 173057 | +204 |
+| Test functions | 2511 | 2515 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -55,8 +55,8 @@
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2815 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2426 |
+| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2500 |
+| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/core/proof_packs/builder.py | 1807 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T12:52:03+00:00`
+- Generated at: `2026-06-13T12:56:00+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `a12d37b6+worktree`
+- Report source snapshot: `5509a558+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 172853 | 173057 | +204 |
-| Test functions | 2511 | 2515 | +4 |
+| Total Python LOC | 172853 | 173154 | +301 |
+| Test functions | 2511 | 2519 | +8 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T12:30:06+00:00`
+- Generated at: `2026-06-13T12:47:17+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `0c71efda+worktree`
+- Report source snapshot: `7c9905c0+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 172627 | 172853 | +226 |
-| Test functions | 2504 | 2511 | +7 |
+| Total Python LOC | 172853 | 172949 | +96 |
+| Test functions | 2511 | 2513 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/waves/campaign_assignment_actions.py
+++ b/src/core/waves/campaign_assignment_actions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Literal
 
@@ -31,6 +32,14 @@ class _AssignmentActionRequest(BaseModel):
     action_reason: str
     assigned_actor_ids: list[str]
     correlation_id: str
+
+
+@dataclass(frozen=True)
+class _AssignmentActionPageState:
+    latest_action_type: CampaignAssignmentActionType | None
+    current_assigned_actor_ids: list[str]
+    current_escalation_tier: CampaignAssignmentEscalationTier
+    current_sla_posture: CampaignAssignmentSlaPosture
 
 
 class DpmBulkReviewCampaignDefinitionAssignmentActionPage(BaseModel):
@@ -182,26 +191,51 @@ def build_bulk_review_campaign_definition_assignment_action_page(
     limit: int = 50,
     offset: int = 0,
 ) -> DpmBulkReviewCampaignDefinitionAssignmentActionPage:
-    actions = sorted(
-        definition.assignment_actions,
-        key=lambda action: action.recorded_at,
-        reverse=True,
-    )
+    actions = _sorted_assignment_actions(definition)
     page = actions[offset : offset + limit]
-    latest = actions[0] if actions else None
+    state = _assignment_action_page_state(actions)
     return DpmBulkReviewCampaignDefinitionAssignmentActionPage(
         campaign_id=definition.campaign_id,
         campaign_version=definition.campaign_version,
         assignment_actions=page,
-        latest_action_type=latest.action_type if latest else None,
-        current_assigned_actor_ids=[]
-        if latest is None or latest.action_type == "RESOLVED"
-        else latest.assigned_actor_ids,
-        current_escalation_tier=latest.escalation_tier if latest else "NONE",
-        current_sla_posture=latest.sla_posture if latest else "ON_TRACK",
+        latest_action_type=state.latest_action_type,
+        current_assigned_actor_ids=state.current_assigned_actor_ids,
+        current_escalation_tier=state.current_escalation_tier,
+        current_sla_posture=state.current_sla_posture,
         count=len(page),
         limit=limit,
         offset=offset,
+    )
+
+
+def _sorted_assignment_actions(
+    definition: DpmBulkReviewCampaignDefinition,
+) -> list[DpmBulkReviewCampaignDefinitionAssignmentAction]:
+    return sorted(
+        definition.assignment_actions,
+        key=lambda action: action.recorded_at,
+        reverse=True,
+    )
+
+
+def _assignment_action_page_state(
+    actions: list[DpmBulkReviewCampaignDefinitionAssignmentAction],
+) -> _AssignmentActionPageState:
+    latest = actions[0] if actions else None
+    if latest is None:
+        return _AssignmentActionPageState(
+            latest_action_type=None,
+            current_assigned_actor_ids=[],
+            current_escalation_tier="NONE",
+            current_sla_posture="ON_TRACK",
+        )
+    return _AssignmentActionPageState(
+        latest_action_type=latest.action_type,
+        current_assigned_actor_ids=[]
+        if latest.action_type == "RESOLVED"
+        else latest.assigned_actor_ids,
+        current_escalation_tier=latest.escalation_tier,
+        current_sla_posture=latest.sla_posture,
     )
 
 

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -172,29 +172,14 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
     def purge_mandate_records_before(self, *, cutoff: datetime) -> int:
         cutoff_utc = cutoff.astimezone(timezone.utc)
         with self._lock:
-            mandate_keys = [
-                key
-                for key, twin in self._mandates_by_key.items()
-                if datetime.combine(twin.as_of_date, datetime.min.time(), timezone.utc) < cutoff_utc
-            ]
-            health_keys = [
-                key
-                for key, snapshot in self._health_snapshots.items()
-                if snapshot.calculated_at < cutoff_utc
-            ]
-            exception_keys = [
-                key
-                for key, exception in self._exceptions.items()
-                if exception.detected_at < cutoff_utc
-                and (exception.state == "RESOLVED" or exception.resolved_at is not None)
-            ]
+            mandate_keys = _stale_mandate_keys(self._mandates_by_key, cutoff_utc)
+            health_keys = _stale_health_snapshot_keys(self._health_snapshots, cutoff_utc)
+            run_keys = _stale_monitoring_run_keys(self._monitoring_runs, cutoff_utc)
+            exception_keys = _stale_resolved_exception_keys(self._exceptions, cutoff_utc)
             for mandate_key in mandate_keys:
                 self._mandates_by_key.pop(mandate_key, None)
             for health_key in health_keys:
                 self._health_snapshots.pop(health_key, None)
-            run_keys = [
-                key for key, run in self._monitoring_runs.items() if run.requested_at < cutoff_utc
-            ]
             for run_key in run_keys:
                 self._monitoring_runs.pop(run_key, None)
             for exception_key in exception_keys:
@@ -204,6 +189,43 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
 
 def _latest_twin(rows: list[DpmMandateDigitalTwin]) -> DpmMandateDigitalTwin:
     return max(rows, key=lambda row: (row.as_of_date, row.mandate_version))
+
+
+def _stale_mandate_keys(
+    mandates: dict[tuple[str, str], DpmMandateDigitalTwin],
+    cutoff_utc: datetime,
+) -> list[tuple[str, str]]:
+    return [
+        key
+        for key, twin in mandates.items()
+        if datetime.combine(twin.as_of_date, datetime.min.time(), timezone.utc) < cutoff_utc
+    ]
+
+
+def _stale_health_snapshot_keys(
+    snapshots: dict[str, DpmMandateHealthSnapshot],
+    cutoff_utc: datetime,
+) -> list[str]:
+    return [key for key, snapshot in snapshots.items() if snapshot.calculated_at < cutoff_utc]
+
+
+def _stale_monitoring_run_keys(
+    runs: dict[str, DpmMonitoringRun],
+    cutoff_utc: datetime,
+) -> list[str]:
+    return [key for key, run in runs.items() if run.requested_at < cutoff_utc]
+
+
+def _stale_resolved_exception_keys(
+    exceptions: dict[str, DpmMonitoringException],
+    cutoff_utc: datetime,
+) -> list[str]:
+    return [
+        key
+        for key, exception in exceptions.items()
+        if exception.detected_at < cutoff_utc
+        and (exception.state == "RESOLVED" or exception.resolved_at is not None)
+    ]
 
 
 def _filtered_monitoring_exceptions(

--- a/src/infrastructure/proof_packs/in_memory.py
+++ b/src/infrastructure/proof_packs/in_memory.py
@@ -17,6 +17,42 @@ from src.core.proof_packs.repository import (
 RETENTION_POLICY_PRE_TRADE_PROOF_PACK = "DPM_PRE_TRADE_PROOF_PACK_7Y"
 
 
+def _ensure_proof_pack_content_is_immutable(
+    *,
+    existing: DpmPreTradeProofPack | None,
+    proof_pack: DpmPreTradeProofPack,
+) -> None:
+    if existing is not None and existing.content_hash != proof_pack.content_hash:
+        raise DpmProofPackConflictError("DPM_PROOF_PACK_IMMUTABLE_CONFLICT")
+
+
+def _idempotency_binding(
+    *,
+    idempotency_key: str | None,
+    existing_proof_pack_id: str | None,
+    proof_pack_id: str,
+) -> tuple[str, str] | None:
+    if idempotency_key is None:
+        return None
+    if existing_proof_pack_id is not None and existing_proof_pack_id != proof_pack_id:
+        raise DpmProofPackConflictError("DPM_PROOF_PACK_IDEMPOTENCY_CONFLICT")
+    return idempotency_key, proof_pack_id
+
+
+def _retention_metadata(
+    *,
+    proof_pack_id: str,
+    retention_expires_at: datetime | None,
+) -> DpmProofPackRetentionMetadata:
+    return DpmProofPackRetentionMetadata(
+        proof_pack_id=proof_pack_id,
+        retention_policy=RETENTION_POLICY_PRE_TRADE_PROOF_PACK,
+        retention_expires_at=(
+            retention_expires_at.isoformat() if retention_expires_at is not None else None
+        ),
+    )
+
+
 class InMemoryDpmProofPackRepository(DpmProofPackRepository):
     def __init__(self) -> None:
         self._lock = Lock()
@@ -34,20 +70,22 @@ class InMemoryDpmProofPackRepository(DpmProofPackRepository):
     ) -> None:
         with self._lock:
             existing = self._proof_packs.get(proof_pack.proof_pack_id)
-            if existing is not None and existing.content_hash != proof_pack.content_hash:
-                raise DpmProofPackConflictError("DPM_PROOF_PACK_IMMUTABLE_CONFLICT")
-            if idempotency_key is not None:
-                existing_id = self._idempotency_index.get(idempotency_key)
-                if existing_id is not None and existing_id != proof_pack.proof_pack_id:
-                    raise DpmProofPackConflictError("DPM_PROOF_PACK_IDEMPOTENCY_CONFLICT")
-                self._idempotency_index[idempotency_key] = proof_pack.proof_pack_id
-            self._proof_packs[proof_pack.proof_pack_id] = deepcopy(proof_pack)
-            self._retention[proof_pack.proof_pack_id] = DpmProofPackRetentionMetadata(
-                proof_pack_id=proof_pack.proof_pack_id,
-                retention_policy=RETENTION_POLICY_PRE_TRADE_PROOF_PACK,
-                retention_expires_at=(
-                    retention_expires_at.isoformat() if retention_expires_at is not None else None
+            _ensure_proof_pack_content_is_immutable(existing=existing, proof_pack=proof_pack)
+            binding = _idempotency_binding(
+                idempotency_key=idempotency_key,
+                existing_proof_pack_id=(
+                    self._idempotency_index.get(idempotency_key)
+                    if idempotency_key is not None
+                    else None
                 ),
+                proof_pack_id=proof_pack.proof_pack_id,
+            )
+            if binding is not None:
+                self._idempotency_index[binding[0]] = binding[1]
+            self._proof_packs[proof_pack.proof_pack_id] = deepcopy(proof_pack)
+            self._retention[proof_pack.proof_pack_id] = _retention_metadata(
+                proof_pack_id=proof_pack.proof_pack_id,
+                retention_expires_at=retention_expires_at,
             )
 
     def get_proof_pack(self, *, proof_pack_id: str) -> DpmPreTradeProofPack | None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_repository.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_repository.py
@@ -10,6 +10,11 @@ from src.core.proof_packs.repository import DpmProofPackConflictError
 from src.core.rebalance.engine import run_simulation
 from src.core.rebalance_runs.models import DpmRunRecord
 from src.infrastructure.proof_packs import InMemoryDpmProofPackRepository
+from src.infrastructure.proof_packs.in_memory import (
+    _ensure_proof_pack_content_is_immutable,
+    _idempotency_binding,
+    _retention_metadata,
+)
 from tests.shared.factories import (
     cash,
     market_data_snapshot,
@@ -145,6 +150,60 @@ def test_in_memory_repository_rejects_idempotency_conflict() -> None:
             idempotency_key="idem-proof-pack-repository",
             retention_expires_at=RETENTION_EXPIRES_AT,
         )
+
+
+def test_proof_pack_immutability_helper_allows_matching_content_hash() -> None:
+    proof_pack = _proof_pack()
+    replay = proof_pack.model_copy(deep=True)
+
+    _ensure_proof_pack_content_is_immutable(existing=proof_pack, proof_pack=replay)
+
+
+def test_proof_pack_immutability_helper_rejects_changed_content_hash() -> None:
+    proof_pack = _proof_pack(reason="Initial rationale.")
+    mutated = _proof_pack(reason="Changed rationale.")
+
+    with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IMMUTABLE_CONFLICT"):
+        _ensure_proof_pack_content_is_immutable(existing=proof_pack, proof_pack=mutated)
+
+
+def test_idempotency_binding_helper_returns_optional_binding_and_rejects_conflicts() -> None:
+    assert (
+        _idempotency_binding(
+            idempotency_key=None,
+            existing_proof_pack_id=None,
+            proof_pack_id="dpp_none",
+        )
+        is None
+    )
+    assert _idempotency_binding(
+        idempotency_key="idem-proof-pack-repository",
+        existing_proof_pack_id="dpp_repo_001",
+        proof_pack_id="dpp_repo_001",
+    ) == ("idem-proof-pack-repository", "dpp_repo_001")
+
+    with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IDEMPOTENCY_CONFLICT"):
+        _idempotency_binding(
+            idempotency_key="idem-proof-pack-repository",
+            existing_proof_pack_id="dpp_repo_001",
+            proof_pack_id="dpp_repo_002",
+        )
+
+
+def test_retention_metadata_helper_preserves_policy_and_optional_expiry() -> None:
+    expiring = _retention_metadata(
+        proof_pack_id="dpp_repo_001",
+        retention_expires_at=RETENTION_EXPIRES_AT,
+    )
+    non_expiring = _retention_metadata(
+        proof_pack_id="dpp_repo_002",
+        retention_expires_at=None,
+    )
+
+    assert expiring.retention_policy == "DPM_PRE_TRADE_PROOF_PACK_7Y"
+    assert expiring.retention_expires_at == RETENTION_EXPIRES_AT.isoformat()
+    assert non_expiring.retention_policy == "DPM_PRE_TRADE_PROOF_PACK_7Y"
+    assert non_expiring.retention_expires_at is None
 
 
 def test_in_memory_repository_appends_refs_without_mutating_body() -> None:

--- a/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
@@ -19,6 +19,12 @@ from src.core.mandates import (
 from src.infrastructure.mandates import InMemoryDpmMandateRepository
 import src.infrastructure.mandates.in_memory as mandate_in_memory
 import src.infrastructure.mandates.postgres as mandate_postgres
+from src.infrastructure.mandates.in_memory import (
+    _stale_health_snapshot_keys,
+    _stale_mandate_keys,
+    _stale_monitoring_run_keys,
+    _stale_resolved_exception_keys,
+)
 from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository
 from src.infrastructure.mandates.serialization import dump_model_json, load_model_json
 
@@ -418,6 +424,74 @@ def test_repository_retention_keeps_active_exceptions_but_purges_old_resolved_re
         cursor=None,
     )
     assert rows == []
+
+
+def test_in_memory_retention_key_helpers_select_only_stale_records() -> None:
+    cutoff = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    old_twin = _twin(version="old", as_of=date(2024, 1, 1))
+    current_twin = _twin(version="current", as_of=date(2026, 1, 1))
+    old_snapshot = _health_snapshot(old_twin).model_copy(
+        update={"health_snapshot_id": "health_old", "calculated_at": cutoff - timedelta(days=1)}
+    )
+    current_snapshot = _health_snapshot(current_twin).model_copy(
+        update={"health_snapshot_id": "health_current", "calculated_at": cutoff}
+    )
+    old_run = _monitoring_run(run_id="run_old", requested_at=cutoff - timedelta(seconds=1))
+    current_run = _monitoring_run(run_id="run_current", requested_at=cutoff)
+
+    assert _stale_mandate_keys(
+        {
+            (old_twin.mandate_id, old_twin.mandate_version): old_twin,
+            (current_twin.mandate_id, current_twin.mandate_version): current_twin,
+        },
+        cutoff,
+    ) == [(old_twin.mandate_id, old_twin.mandate_version)]
+    assert _stale_health_snapshot_keys(
+        {
+            old_snapshot.health_snapshot_id: old_snapshot,
+            current_snapshot.health_snapshot_id: current_snapshot,
+        },
+        cutoff,
+    ) == [old_snapshot.health_snapshot_id]
+    assert _stale_monitoring_run_keys(
+        {
+            old_run.monitoring_run_id: old_run,
+            current_run.monitoring_run_id: current_run,
+        },
+        cutoff,
+    ) == [old_run.monitoring_run_id]
+
+
+def test_in_memory_retention_exception_helper_keeps_active_exceptions() -> None:
+    cutoff = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    twin = _twin(as_of=date(2024, 1, 1))
+    base_exception = monitoring_exceptions_from_health(
+        calculate_mandate_health(
+            DpmMandateHealthInput(
+                twin=twin,
+                cash_weight=Decimal("0.50"),
+                current_weights={"EQ_US_AAPL": Decimal("0.60")},
+                target_weights={"EQ_US_AAPL": Decimal("0.60")},
+            )
+        ),
+        source_lineage=[],
+    )[0].model_copy(update={"detected_at": cutoff - timedelta(days=1)})
+    active_exception = base_exception.model_copy(update={"exception_id": "active_old"})
+    resolved_exception = base_exception.model_copy(
+        update={
+            "exception_id": "resolved_old",
+            "state": "RESOLVED",
+            "resolved_at": cutoff - timedelta(hours=1),
+        }
+    )
+
+    assert _stale_resolved_exception_keys(
+        {
+            active_exception.exception_id: active_exception,
+            resolved_exception.exception_id: resolved_exception,
+        },
+        cutoff,
+    ) == [resolved_exception.exception_id]
 
 
 def test_repository_persists_pages_and_purges_monitoring_runs() -> None:

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -55,8 +55,10 @@ from src.core.waves.campaign_workflow_automation import (
 )
 from src.core.waves.campaign_assignment_actions import (
     DpmBulkReviewCampaignDefinitionAssignmentActionPage,
+    _assignment_action_page_state,
     _assignment_action_replay_result,
     _assignment_action_request,
+    _sorted_assignment_actions,
     build_bulk_review_campaign_definition_assignment_action_page,
     record_bulk_review_campaign_definition_assignment_action,
 )
@@ -757,6 +759,78 @@ def test_campaign_assignment_actions_record_append_only_posture() -> None:
     assert page.current_assigned_actor_ids == ["governance_ops"]
     assert page.current_escalation_tier == "GOVERNANCE"
     assert page.current_sla_posture == "ATTENTION"
+
+
+def test_campaign_assignment_action_page_state_tracks_latest_action() -> None:
+    assigned = record_bulk_review_campaign_definition_assignment_action(
+        definition=_definition(),
+        action_type="ASSIGNED",
+        action_ref="BRC-ASSIGN-2026-05-001",
+        recorded_by="ops",
+        action_reason="Route ready campaign to assigned PM.",
+        assigned_actor_ids=["pm_001"],
+        escalation_tier="PM",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-action-001",
+    )
+    escalated = record_bulk_review_campaign_definition_assignment_action(
+        definition=assigned,
+        action_type="ESCALATED",
+        action_ref="BRC-ASSIGN-2026-05-002",
+        recorded_by="ops",
+        action_reason="Approval evidence requires governance attention.",
+        assigned_actor_ids=["governance_ops"],
+        escalation_tier="GOVERNANCE",
+        sla_posture="ATTENTION",
+        correlation_id="corr-campaign-assignment-action-002",
+    )
+
+    actions = _sorted_assignment_actions(escalated)
+    state = _assignment_action_page_state(actions)
+
+    assert [action.action_ref for action in actions] == [
+        "BRC-ASSIGN-2026-05-002",
+        "BRC-ASSIGN-2026-05-001",
+    ]
+    assert state.latest_action_type == "ESCALATED"
+    assert state.current_assigned_actor_ids == ["governance_ops"]
+    assert state.current_escalation_tier == "GOVERNANCE"
+    assert state.current_sla_posture == "ATTENTION"
+
+
+def test_campaign_assignment_action_page_state_defaults_and_resolved_actions() -> None:
+    empty_state = _assignment_action_page_state([])
+    assigned = record_bulk_review_campaign_definition_assignment_action(
+        definition=_definition(),
+        action_type="ASSIGNED",
+        action_ref="BRC-ASSIGN-2026-05-001",
+        recorded_by="ops",
+        action_reason="Route ready campaign to assigned PM.",
+        assigned_actor_ids=["pm_001"],
+        escalation_tier="PM",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-action-001",
+    )
+    resolved = record_bulk_review_campaign_definition_assignment_action(
+        definition=assigned,
+        action_type="RESOLVED",
+        action_ref="BRC-ASSIGN-2026-05-002",
+        recorded_by="ops",
+        action_reason="Assignment completed.",
+        assigned_actor_ids=[],
+        escalation_tier="NONE",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-action-002",
+    )
+    resolved_state = _assignment_action_page_state(_sorted_assignment_actions(resolved))
+
+    assert empty_state.latest_action_type is None
+    assert empty_state.current_assigned_actor_ids == []
+    assert empty_state.current_escalation_tier == "NONE"
+    assert empty_state.current_sla_posture == "ON_TRACK"
+    assert resolved_state.latest_action_type == "RESOLVED"
+    assert resolved_state.current_assigned_actor_ids == []
+    assert resolved_state.current_escalation_tier == "NONE"
 
 
 def test_campaign_assignment_actions_validate_conflicts_and_resolved_state() -> None:


### PR DESCRIPTION
## Summary
- Extract mandate retention key selectors for in-memory supportability cleanup rules.
- Extract campaign assignment action page-state helpers for governed workflow projections.
- Extract proof-pack persistence guard helpers for immutable content, idempotency, and retention metadata decisions.
- Refresh codebase review ledger entries BACKEND-REVIEW-20260613-897 through BACKEND-REVIEW-20260613-899 and quality reports.

## Local Validation
- `python -m ruff check <touched files>` per slice
- `python -m ruff format --check <touched files>` per slice
- `python -m mypy --config-file mypy.ini <touched src files>` per slice
- Focused pytest suites per slice: mandate repository 18 passed, campaign discovery 86 passed, proof-pack repository 9 passed
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- service leakage scan against `src/api/services` returned no matches
- `git diff --check origin/main...HEAD`
- `make check` passed: 2699 passed

## Governance / Hygiene
- `git fetch origin --prune` completed before PR.
- `git branch -r --no-merged origin/main` returned no unmerged remote branches before this PR branch.
- `gh pr list --state open` returned no open PRs before creating this PR.
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reported DiffCount 0.

## Residual Risk
This PR improves maintainability and testability of internal helpers only. It does not claim global bank-buyable readiness, alter runtime semantics, certify downstream Gateway/Workbench behavior, or change operator-facing wiki truth.