### PR TITLE
Harden manage source hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22502,3 +22502,33 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal outcome-evidence helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-901: Wave source analytics reference metadata helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/waves/source_analytics.py` and
+  `tests/unit/dpm/waves/test_source_analytics.py`.
+- Bank-buyable control area: architecture, source-owned analytics lineage, and testing.
+- Finding: `_analytics_source_ref` combined source product type defaulting, fallback source id
+  selection, optional version projection, supportability defaulting, and optional content-hash
+  projection in one mapper. The behavior was correct, but the source-reference metadata rules were
+  harder to review than source-owned wave analytics lineage should be.
+- Action: extracted `_analytics_source_type`, `_source_context_value_or_fallback`, and
+  `_optional_source_context_value` so source-reference metadata decisions are independently
+  testable. Added direct tests for explicit source-product metadata and risk/performance defaulted
+  reference metadata.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/source_analytics.py tests/unit/dpm/waves/test_source_analytics.py`,
+  `python -m ruff format --check src/core/waves/source_analytics.py tests/unit/dpm/waves/test_source_analytics.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/source_analytics.py`,
+  `python -m pytest tests/unit/dpm/waves/test_source_analytics.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/core/waves/source_analytics.py -s`; the focused source-analytics suite
+  reported 6 passed, `_analytics_source_ref` reduced to A(1) under radon, and the refreshed quality
+  report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves wave source-analytics lineage maintainability only. It does
+  not change source-analytics semantics, certify global bank-buyable readiness, runtime evidence,
+  or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal wave source-analytics helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22472,3 +22472,33 @@ and improves internal transaction-cost source posture maintainability only.
   runtime evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal repository helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-900: Expected outcome handoff linkage helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/outcomes/snapshots.py` and
+  `tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`.
+- Bank-buyable control area: architecture, outcome evidence lineage, and testing.
+- Finding: `_resolve_handoff` combined optional handoff lookup preconditions, wave handoff search,
+  wave identity validation, selected-item membership validation, and the no-external-execution
+  boundary in one helper. The behavior was correct, but the expected-outcome handoff guardrails
+  were harder to review than source-backed outcome evidence assembly should be.
+- Action: extracted `_handoff_lookup_required`, `_find_handoff`, and
+  `_validate_handoff_linkage` so lookup and boundary decisions are independently testable before
+  snapshot assembly continues. Added direct tests for optional lookup, missing handoffs, valid
+  linkage, missing selected-item membership, and external execution claims.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m ruff format --check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/snapshots.py`,
+  `python -m pytest tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/core/outcomes/snapshots.py -s`; the focused expected-outcome snapshot
+  suite reported 26 passed, `_resolve_handoff` reduced to A(5) under radon, and the refreshed
+  quality report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves expected-outcome handoff lineage maintainability only. It does
+  not change outcome-review semantics, certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal outcome-evidence helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22532,3 +22532,34 @@ and improves internal transaction-cost source posture maintainability only.
   or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal wave source-analytics helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-902: Liquidity status policy helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/construction_liquidity_supportability.py` and
+  `tests/unit/dpm/construction/test_liquidity_supportability.py`.
+- Bank-buyable control area: architecture, construction supportability, and testing.
+- Finding: `liquidity_status` combined missing-context defaulting, blocking cash diagnostics,
+  minimum-cash policy review pressure, cashflow projection status, and final supportability
+  roll-up in one classifier. The behavior was correct, but the liquidity supportability decision
+  path was harder to review than a construction policy support surface should be.
+- Action: extracted `_has_blocking_cash_diagnostics` and `_minimum_cash_weight_status` so
+  hard-blocking cash diagnostics and minimum-cash policy pressure are independently testable before
+  cashflow projection roll-up. Added direct tests for non-blocking and blocking diagnostics,
+  above-policy cash, below-policy pending-review pressure, and preservation of an already-blocked
+  status.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_liquidity_supportability.py tests/unit/dpm/construction/test_liquidity_supportability.py`,
+  `python -m ruff format --check src/api/services/construction_liquidity_supportability.py tests/unit/dpm/construction/test_liquidity_supportability.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_liquidity_supportability.py`,
+  `python -m pytest tests/unit/dpm/construction/test_liquidity_supportability.py -q`,
+  `python scripts/engineering_health_report.py`, and
+  `python -m radon cc src/api/services/construction_liquidity_supportability.py -s`; the focused
+  liquidity supportability suite reported 10 passed, `liquidity_status` reduced to A(4) under
+  radon, and the refreshed quality report no longer lists it in the top source hotspots.
+- Residual risk: this slice improves construction liquidity supportability maintainability only.
+  It does not change liquidity policy semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal supportability helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T13:16:58+00:00`
+- Generated at: `2026-06-13T13:20:01+00:00`
 
-- Report source snapshot: `8942328b+worktree`
+- Report source snapshot: `679f4428+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 173329 |
-| Test functions | 2524 |
+| Total Python LOC | 173391 |
+| Test functions | 2525 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T13:13:35+00:00`
+- Generated at: `2026-06-13T13:16:58+00:00`
 
-- Report source snapshot: `dcd1a5c5+worktree`
+- Report source snapshot: `8942328b+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 173252 |
-| Test functions | 2522 |
+| Total Python LOC | 173329 |
+| Test functions | 2524 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T12:56:00+00:00`
+- Generated at: `2026-06-13T13:13:35+00:00`
 
-- Report source snapshot: `5509a558+worktree`
+- Report source snapshot: `dcd1a5c5+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 818 |
-| Total Python LOC | 173154 |
-| Test functions | 2519 |
+| Total Python LOC | 173252 |
+| Test functions | 2522 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T13:13:35+00:00`
+- Generated at: `2026-06-13T13:16:58+00:00`
 
-- Report source snapshot: `dcd1a5c5+worktree`
+- Report source snapshot: `8942328b+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
-| 2 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 3 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
-| 4 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
-| 5 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
-| 6 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
-| 7 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
-| 8 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
-| 9 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
-| 10 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
+| 1 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
+| 2 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 3 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 4 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
+| 5 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
+| 6 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
+| 7 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
+| 8 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
+| 9 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
+| 10 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T13:16:58+00:00`
+- Generated at: `2026-06-13T13:20:01+00:00`
 
-- Report source snapshot: `8942328b+worktree`
+- Report source snapshot: `679f4428+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 2 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
-| 3 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
-| 4 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
-| 5 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
-| 6 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
-| 7 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
-| 8 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
-| 9 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
-| 10 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
+| 1 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 2 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 3 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
+| 4 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
+| 5 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
+| 6 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
+| 7 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
+| 8 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
+| 9 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
+| 10 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T12:56:00+00:00`
+- Generated at: `2026-06-13T13:13:35+00:00`
 
-- Report source snapshot: `5509a558+worktree`
+- Report source snapshot: `dcd1a5c5+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _resolve_handoff | src/core/outcomes/snapshots.py | 7 | 23 |
-| 2 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
-| 3 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
-| 4 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
-| 5 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
-| 6 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
-| 7 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
-| 8 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
-| 9 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
-| 10 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
+| 1 | _analytics_source_ref | src/core/waves/source_analytics.py | 7 | 22 |
+| 2 | liquidity_status | src/api/services/construction_liquidity_supportability.py | 7 | 21 |
+| 3 | source_analytics_for_context | src/core/proof_packs/source_analytics.py | 7 | 20 |
+| 4 | sustainability_allocation_breaches | src/api/services/construction_sustainability_supportability.py | 7 | 19 |
+| 5 | _validate_summary_invocation_inputs | src/core/pm_quality/summary_history.py | 7 | 18 |
+| 6 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
+| 7 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
+| 8 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
+| 9 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
+| 10 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T13:16:58+00:00`
+- Generated at: `2026-06-13T13:20:01+00:00`
 
-- Report source snapshot: `8942328b+worktree`
+- Report source snapshot: `679f4428+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T12:56:00+00:00`
+- Generated at: `2026-06-13T13:13:35+00:00`
 
-- Report source snapshot: `5509a558+worktree`
+- Report source snapshot: `dcd1a5c5+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T13:13:35+00:00`
+- Generated at: `2026-06-13T13:16:58+00:00`
 
-- Report source snapshot: `dcd1a5c5+worktree`
+- Report source snapshot: `8942328b+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T13:16:58+00:00`
+- Generated at: `2026-06-13T13:20:01+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `8942328b+worktree`
+- Report source snapshot: `679f4428+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 173154 | 173329 | +175 |
-| Test functions | 2519 | 2524 | +5 |
+| Total Python LOC | 173154 | 173391 | +237 |
+| Test functions | 2519 | 2525 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T13:13:35+00:00`
+- Generated at: `2026-06-13T13:16:58+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `dcd1a5c5+worktree`
+- Report source snapshot: `8942328b+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 173154 | 173252 | +98 |
-| Test functions | 2519 | 2522 | +3 |
+| Total Python LOC | 173154 | 173329 | +175 |
+| Test functions | 2519 | 2524 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T12:56:00+00:00`
+- Generated at: `2026-06-13T13:13:35+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `5509a558+worktree`
+- Report source snapshot: `dcd1a5c5+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 818 | 818 | +0 |
-| Total Python LOC | 172853 | 173154 | +301 |
-| Test functions | 2511 | 2519 | +8 |
+| Total Python LOC | 173154 | 173252 | +98 |
+| Test functions | 2519 | 2522 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -40,8 +40,8 @@
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2815 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 6 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 7 | tests/unit/dpm/waves/test_campaign_discovery.py | 2426 |
+| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2500 |
+| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
 | 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/core/proof_packs/builder.py | 1807 |

--- a/src/api/services/construction_liquidity_supportability.py
+++ b/src/api/services/construction_liquidity_supportability.py
@@ -18,11 +18,14 @@ def liquidity_status(
     if context is None:
         return ConstructionMethodStatus.DEGRADED
     status = context.supportability_status
-    if result.diagnostics.cash_ladder_breaches or result.diagnostics.insufficient_cash:
+    if _has_blocking_cash_diagnostics(result=result):
         return ConstructionMethodStatus.BLOCKED
     cash_weight = post_trade_cash_weight(result=result)
-    if cash_weight is not None and cash_weight < context.minimum_cash_weight:
-        status = lowest_construction_status([status, ConstructionMethodStatus.PENDING_REVIEW])
+    status = _minimum_cash_weight_status(
+        status=status,
+        cash_weight=cash_weight,
+        minimum_cash_weight=context.minimum_cash_weight,
+    )
     cashflow_status = cashflow_projection_status(
         result=result,
         context=context,
@@ -31,6 +34,21 @@ def liquidity_status(
     if cashflow_status is None:
         return status
     return lowest_construction_status([status, cashflow_status])
+
+
+def _has_blocking_cash_diagnostics(*, result: RebalanceResult) -> bool:
+    return bool(result.diagnostics.cash_ladder_breaches or result.diagnostics.insufficient_cash)
+
+
+def _minimum_cash_weight_status(
+    *,
+    status: ConstructionMethodStatus,
+    cash_weight: Decimal | None,
+    minimum_cash_weight: Decimal,
+) -> ConstructionMethodStatus:
+    if cash_weight is None or cash_weight >= minimum_cash_weight:
+        return status
+    return lowest_construction_status([status, ConstructionMethodStatus.PENDING_REVIEW])
 
 
 def cashflow_projection_status(

--- a/src/core/outcomes/snapshots.py
+++ b/src/core/outcomes/snapshots.py
@@ -296,15 +296,52 @@ def _resolve_handoff(
     wave_item: DpmRebalanceWaveItem | None,
     handoff_ref_id: str | None,
 ) -> DpmWaveHandoffRef | None:
-    if not handoff_ref_id:
+    if not _handoff_lookup_required(
+        wave=wave,
+        wave_item=wave_item,
+        handoff_ref_id=handoff_ref_id,
+    ):
         return None
+    assert wave is not None
+    assert wave_item is not None
+    assert handoff_ref_id is not None
+    handoff = _find_handoff(wave=wave, handoff_ref_id=handoff_ref_id)
+    _validate_handoff_linkage(handoff=handoff, wave=wave, wave_item=wave_item)
+    return handoff
+
+
+def _handoff_lookup_required(
+    *,
+    wave: DpmRebalanceWave | None,
+    wave_item: DpmRebalanceWaveItem | None,
+    handoff_ref_id: str | None,
+) -> bool:
+    if not handoff_ref_id:
+        return False
     if wave is None or wave_item is None:
         msg = "handoff_ref_id requires wave and wave_item evidence"
         raise DpmExpectedSnapshotAssemblyError(msg)
-    handoff = next((ref for ref in wave.handoff_refs if ref.handoff_ref_id == handoff_ref_id), None)
-    if handoff is None:
-        msg = "handoff_ref_id does not exist in wave"
-        raise DpmExpectedSnapshotAssemblyError(msg)
+    return True
+
+
+def _find_handoff(
+    *,
+    wave: DpmRebalanceWave,
+    handoff_ref_id: str,
+) -> DpmWaveHandoffRef:
+    for handoff in wave.handoff_refs:
+        if handoff.handoff_ref_id == handoff_ref_id:
+            return handoff
+    msg = "handoff_ref_id does not exist in wave"
+    raise DpmExpectedSnapshotAssemblyError(msg)
+
+
+def _validate_handoff_linkage(
+    *,
+    handoff: DpmWaveHandoffRef,
+    wave: DpmRebalanceWave,
+    wave_item: DpmRebalanceWaveItem,
+) -> None:
     _require_equal("handoff.wave_id", handoff.wave_id, wave.wave_id)
     if wave_item.wave_item_id not in handoff.item_ids:
         msg = "handoff_ref_id does not include the selected wave item"
@@ -312,7 +349,6 @@ def _resolve_handoff(
     if handoff.external_execution_claimed:
         msg = "manage handoff evidence cannot claim external execution"
         raise DpmExpectedSnapshotAssemblyError(msg)
-    return handoff
 
 
 def _expected_values_from_alternative(

--- a/src/core/waves/source_analytics.py
+++ b/src/core/waves/source_analytics.py
@@ -199,21 +199,51 @@ def _analytics_source_ref(
     family: str,
     fallback_id: str,
 ) -> DpmWaveSourceRef:
-    source_type = str(
-        source_context.get("source_product_name")
-        or ("RISK_AUTHORITY_CONTEXT" if family == "risk" else "PERFORMANCE_AUTHORITY_CONTEXT")
-    )
-    source_version = source_context.get("source_product_version")
     return DpmWaveSourceRef(
         source_system=source_system,
-        source_type=source_type,
-        source_id=str(source_context.get("source_id") or fallback_id),
-        source_version=str(source_version) if source_version is not None else None,
-        supportability_state=str(source_context.get("supportability_status") or "DEGRADED"),
-        content_hash=(
-            str(source_context.get("content_hash")) if source_context.get("content_hash") else None
+        source_type=_analytics_source_type(source_context=source_context, family=family),
+        source_id=_source_context_value_or_fallback(
+            source_context=source_context,
+            key="source_id",
+            fallback=fallback_id,
+        ),
+        source_version=_optional_source_context_value(
+            source_context=source_context,
+            key="source_product_version",
+        ),
+        supportability_state=_source_context_value_or_fallback(
+            source_context=source_context,
+            key="supportability_status",
+            fallback="DEGRADED",
+        ),
+        content_hash=_optional_source_context_value(
+            source_context=source_context, key="content_hash"
         ),
     )
+
+
+def _analytics_source_type(*, source_context: dict[str, object], family: str) -> str:
+    return _source_context_value_or_fallback(
+        source_context=source_context,
+        key="source_product_name",
+        fallback=(
+            "RISK_AUTHORITY_CONTEXT" if family == "risk" else "PERFORMANCE_AUTHORITY_CONTEXT"
+        ),
+    )
+
+
+def _source_context_value_or_fallback(
+    *,
+    source_context: dict[str, object],
+    key: str,
+    fallback: str,
+) -> str:
+    return str(source_context.get(key) or fallback)
+
+
+def _optional_source_context_value(*, source_context: dict[str, object], key: str) -> str | None:
+    value = source_context.get(key)
+    return str(value) if value else None
 
 
 def _source_measures(

--- a/tests/unit/dpm/construction/test_liquidity_supportability.py
+++ b/tests/unit/dpm/construction/test_liquidity_supportability.py
@@ -7,6 +7,8 @@ from src.api.services.construction_liquidity_supportability import (
     _cashflow_projection_currency_mismatch,
     _cashflow_projection_is_usable,
     _cashflow_projection_usability_reason_codes,
+    _has_blocking_cash_diagnostics,
+    _minimum_cash_weight_status,
     _post_trade_total_value_unavailable,
     cashflow_projection_reason_codes,
     cashflow_projection_status,
@@ -19,7 +21,7 @@ from src.api.services.construction_liquidity_supportability import (
 from src.api.services.construction_liquidity_source_context import source_liquidity_context
 from src.core.construction.models import AuthoritativeLiquidityCashflowProjection
 from src.core.construction.vocabulary import ConstructionMethodStatus
-from src.core.models import EngineOptions, RebalanceResult
+from src.core.models import EngineOptions, InsufficientCashEntry, RebalanceResult
 from src.core.rebalance.engine import run_simulation
 from tests.shared.factories import (
     cash,
@@ -77,6 +79,48 @@ def test_liquidity_supportability_uses_manage_settlement_policy_context() -> Non
     assert "LIQUIDITY_POLICY_DERIVED_FROM_MANAGE_SETTLEMENT_RULES" in liquidity_reason_codes(
         result=result,
         context=context,
+    )
+
+
+def test_liquidity_status_policy_helpers_classify_cash_blockers_and_minimum_cash() -> None:
+    result = _trade_result()
+    blocked_result = result.model_copy(
+        update={
+            "diagnostics": result.diagnostics.model_copy(
+                update={
+                    "insufficient_cash": [
+                        InsufficientCashEntry(currency="USD", deficit=Decimal("10"))
+                    ]
+                }
+            )
+        }
+    )
+
+    assert not _has_blocking_cash_diagnostics(result=result)
+    assert _has_blocking_cash_diagnostics(result=blocked_result)
+    assert (
+        _minimum_cash_weight_status(
+            status=ConstructionMethodStatus.READY,
+            cash_weight=Decimal("0.03"),
+            minimum_cash_weight=Decimal("0.02"),
+        )
+        == ConstructionMethodStatus.READY
+    )
+    assert (
+        _minimum_cash_weight_status(
+            status=ConstructionMethodStatus.READY,
+            cash_weight=Decimal("0.01"),
+            minimum_cash_weight=Decimal("0.02"),
+        )
+        == ConstructionMethodStatus.PENDING_REVIEW
+    )
+    assert (
+        _minimum_cash_weight_status(
+            status=ConstructionMethodStatus.BLOCKED,
+            cash_weight=Decimal("0.01"),
+            minimum_cash_weight=Decimal("0.02"),
+        )
+        == ConstructionMethodStatus.BLOCKED
     )
 
 

--- a/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
+++ b/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
@@ -13,9 +13,12 @@ from src.core.construction.vocabulary import ConstructionMethod, ConstructionMet
 from src.core.models import Money
 from src.core.outcomes.snapshots import (
     DpmExpectedSnapshotAssemblyError,
+    _find_handoff,
     _find_wave_item,
+    _handoff_lookup_required,
     _highest_construction_outcome_state,
     _proof_pack_state,
+    _validate_handoff_linkage,
     _wave_item_lookup_required,
     assemble_expected_outcome_snapshot,
     build_expected_snapshot_calculation_trace,
@@ -485,6 +488,65 @@ def test_find_wave_item_helper_returns_matching_wave_item_or_fails_closed() -> N
     assert _find_wave_item(wave=wave, wave_item_id="dwi_outcome_001") == wave.items[0]
     with pytest.raises(DpmExpectedSnapshotAssemblyError, match="wave_item_id does not exist"):
         _find_wave_item(wave=wave, wave_item_id="dwi_missing")
+
+
+def test_handoff_lookup_required_helper_validates_lookup_inputs() -> None:
+    wave = _wave()
+
+    assert _handoff_lookup_required(wave=None, wave_item=None, handoff_ref_id=None) is False
+    assert (
+        _handoff_lookup_required(
+            wave=wave,
+            wave_item=wave.items[0],
+            handoff_ref_id="dwh_outcome_001",
+        )
+        is True
+    )
+
+    with pytest.raises(
+        DpmExpectedSnapshotAssemblyError,
+        match="handoff_ref_id requires wave and wave_item evidence",
+    ):
+        _handoff_lookup_required(
+            wave=None,
+            wave_item=None,
+            handoff_ref_id="dwh_outcome_001",
+        )
+
+
+def test_find_handoff_helper_returns_matching_handoff_or_fails_closed() -> None:
+    wave = _wave()
+
+    assert _find_handoff(wave=wave, handoff_ref_id="dwh_outcome_001") == wave.handoff_refs[0]
+    with pytest.raises(DpmExpectedSnapshotAssemblyError, match="handoff_ref_id does not exist"):
+        _find_handoff(wave=wave, handoff_ref_id="dwh_missing")
+
+
+def test_validate_handoff_linkage_helper_rejects_item_and_execution_boundary_gaps() -> None:
+    wave = _wave()
+    handoff = wave.handoff_refs[0]
+
+    _validate_handoff_linkage(handoff=handoff, wave=wave, wave_item=wave.items[0])
+
+    with pytest.raises(
+        DpmExpectedSnapshotAssemblyError,
+        match="handoff_ref_id does not include the selected wave item",
+    ):
+        _validate_handoff_linkage(
+            handoff=handoff.model_copy(update={"item_ids": ["dwi_other"]}),
+            wave=wave,
+            wave_item=wave.items[0],
+        )
+
+    with pytest.raises(
+        DpmExpectedSnapshotAssemblyError,
+        match="manage handoff evidence cannot claim external execution",
+    ):
+        _validate_handoff_linkage(
+            handoff=handoff.model_copy(update={"external_execution_claimed": True}),
+            wave=wave,
+            wave_item=wave.items[0],
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/dpm/waves/test_source_analytics.py
+++ b/tests/unit/dpm/waves/test_source_analytics.py
@@ -225,6 +225,53 @@ def test_family_item_source_analytics_skips_missing_and_non_mapping_diagnostics(
     ) == [{"supportability_state": "READY"}]
 
 
+def test_analytics_source_ref_preserves_source_product_metadata() -> None:
+    source_ref = source_analytics_module._analytics_source_ref(
+        source_context={
+            "source_product_name": "ConcentrationRiskReport",
+            "source_product_version": "v1",
+            "source_id": "risk-concentration-001",
+            "supportability_status": "READY",
+            "content_hash": "sha256:risk-001",
+        },
+        source_system="lotus-risk",
+        family="risk",
+        fallback_id="cas_source_analytics_001",
+    )
+
+    assert source_ref == DpmWaveSourceRef(
+        source_system="lotus-risk",
+        source_type="ConcentrationRiskReport",
+        source_id="risk-concentration-001",
+        source_version="v1",
+        supportability_state="READY",
+        content_hash="sha256:risk-001",
+    )
+
+
+def test_analytics_source_ref_defaults_missing_metadata_by_family() -> None:
+    risk_ref = source_analytics_module._analytics_source_ref(
+        source_context={},
+        source_system="lotus-risk",
+        family="risk",
+        fallback_id="cas_source_analytics_001",
+    )
+    performance_ref = source_analytics_module._analytics_source_ref(
+        source_context={"content_hash": ""},
+        source_system="lotus-performance",
+        family="performance",
+        fallback_id="cas_source_analytics_001",
+    )
+
+    assert risk_ref.source_type == "RISK_AUTHORITY_CONTEXT"
+    assert risk_ref.source_id == "cas_source_analytics_001"
+    assert risk_ref.source_version is None
+    assert risk_ref.supportability_state == "DEGRADED"
+    assert risk_ref.content_hash is None
+    assert performance_ref.source_type == "PERFORMANCE_AUTHORITY_CONTEXT"
+    assert performance_ref.content_hash is None
+
+
 def _alternative(
     alternative_id: str,
     diagnostics: dict[str, object],


### PR DESCRIPTION
## Summary
- Extract expected-outcome handoff lookup and linkage guards.
- Extract wave source-analytics reference metadata helpers.
- Extract liquidity supportability policy helpers for blocking diagnostics and minimum-cash review pressure.
- Refresh codebase review ledger entries BACKEND-REVIEW-20260613-900 through BACKEND-REVIEW-20260613-902 and quality reports.

## Measured Improvement
- `_resolve_handoff` reduced to A(5) under radon and removed from top source hotspots.
- `_analytics_source_ref` reduced to A(1) under radon and removed from top source hotspots.
- `liquidity_status` reduced to A(4) under radon and removed from top source hotspots.

## Local Validation
- Focused per-slice `ruff check`, `ruff format --check`, `mypy`, `pytest`, `radon`, and `python scripts/engineering_health_report.py`
- Expected outcome snapshot suite: 26 passed
- Wave source analytics suite: 6 passed
- Liquidity supportability suite: 10 passed
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- Service leakage scan against `src/api/services` returned no matches
- `git diff --check origin/main...HEAD`
- `make check` passed: 2705 passed

## Governance / Hygiene
- `git fetch origin --prune` completed before PR.
- `git branch -r --no-merged origin/main` returned no unmerged remote branches before this PR branch.
- `gh pr list --state open` returned no open PRs before creating this PR.
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reported DiffCount 0.

## Residual Risk
This PR improves maintainability and testability of internal source/supportability helpers only. It does not claim global bank-buyable readiness, alter runtime semantics, certify downstream Gateway/Workbench behavior, or change operator-facing wiki truth.