### PR TITLE
Harden manage hotspot helper boundaries

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22679,3 +22679,33 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal infrastructure adapter helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-907: Command-center supportability posture helpers
+
+- Date: 2026-06-13
+- Scope: `src/api/services/mandate_command_center.py` and
+  `tests/unit/dpm/mandates/test_mandate_command_center.py`.
+- Bank-buyable control area: architecture, command-center supportability, and testing.
+- Finding: `command_center_supportability_state` combined empty-result handling, source-readiness
+  fail-closed posture, partial-data reason selection, and ready-state defaulting in one policy
+  mapper. The behavior was correct, but the command-center supportability contract was harder to
+  review than an operator-facing supportability surface should be.
+- Action: extracted `_empty_command_center_supportability` and
+  `_partial_command_center_supportability` so empty and partial posture decisions are named and
+  directly testable before source-readiness and ready-state roll-up. Added direct tests for empty
+  latest-run handling, explicit empty completeness, partial reason preservation, fallback partial
+  reason selection, and complete-state pass-through.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python -m ruff format --check src/api/services/mandate_command_center.py tests/unit/dpm/mandates/test_mandate_command_center.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/mandate_command_center.py`,
+  `python -m pytest tests/unit/dpm/mandates/test_mandate_command_center.py -q`,
+  and `python -m radon cc src/api/services/mandate_command_center.py -s`; the focused mandate
+  command-center suite reported 15 passed and `command_center_supportability_state` reduced from
+  B(7) to A(5) under radon.
+- Residual risk: this slice improves command-center supportability maintainability only. It does
+  not change command-center API semantics, certify global bank-buyable readiness, runtime evidence,
+  or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal command-center supportability
+  helper maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22709,3 +22709,32 @@ and improves internal transaction-cost source posture maintainability only.
   or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal command-center supportability
   helper maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-908: PM-quality fairness scope mismatch predicates
+
+- Date: 2026-06-13
+- Scope: `src/core/pm_quality/scoring.py` and
+  `tests/unit/dpm/pm_quality/test_pm_operating_quality.py`.
+- Bank-buyable control area: architecture, PM operating-quality governance, and testing.
+- Finding: `_score_run_scope_mismatch_reasons` combined policy identity matching, as-of date
+  matching, scorable-state filtering, and reason-code deduplication in one fairness guard loop.
+  The behavior was correct, but the cross-segment fairness eligibility rules were harder to review
+  than PM-quality governance should be.
+- Action: extracted `_score_run_policy_mismatched`, `_score_run_as_of_date_mismatched`, and
+  `_score_run_not_scorable` so each fairness eligibility rule is independently testable before
+  mismatch reason aggregation. Added direct tests for policy, date, blocked/scorable state, and
+  deduplicated mismatch reason output.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m ruff format --check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m mypy --config-file mypy.ini src/core/pm_quality/scoring.py`,
+  `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py -q`,
+  and `python -m radon cc src/core/pm_quality/scoring.py -s`; the focused PM operating-quality
+  suite reported 31 passed and `_score_run_scope_mismatch_reasons` reduced from B(7) to A(5)
+  under radon.
+- Residual risk: this slice improves PM-quality fairness eligibility maintainability only. It
+  does not change fairness analysis semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal PM-quality fairness helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22650,3 +22650,32 @@ and improves internal transaction-cost source posture maintainability only.
   runtime evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal PM-quality helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-906: Risk-event cohort response metadata helpers
+
+- Date: 2026-06-13
+- Scope: `src/infrastructure/risk_authority/client.py` and
+  `tests/unit/dpm/infrastructure/test_risk_authority_client.py`.
+- Bank-buyable control area: architecture, resilience, source-authority integration, and testing.
+- Finding: `_risk_event_cohort_from_response` combined response metadata defaulting, required
+  cohort identifier extraction, source reason-code projection, and affected-portfolio mapping in
+  one infrastructure response mapper. The behavior was correct, but the fail-closed
+  lotus-risk authority boundary was harder to review than an external authority adapter should be.
+- Action: extracted `_RiskEventCohortMetadata`, `_risk_event_cohort_metadata`, `_metadata_text`,
+  and `_required_text` so metadata fallback and required identifier rules are independently
+  testable before cohort assembly. Added direct tests for missing metadata defaults and required
+  response identifier projection/failure.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/risk_authority/client.py tests/unit/dpm/infrastructure/test_risk_authority_client.py`,
+  `python -m ruff format --check src/infrastructure/risk_authority/client.py tests/unit/dpm/infrastructure/test_risk_authority_client.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/risk_authority/client.py`,
+  `python -m pytest tests/unit/dpm/infrastructure/test_risk_authority_client.py -q`,
+  and `python -m radon cc src/infrastructure/risk_authority/client.py -s`; the focused
+  risk-authority client suite reported 33 passed and `_risk_event_cohort_from_response` reduced
+  from B(7) to A(2) under radon.
+- Residual risk: this slice improves lotus-risk authority response mapping maintainability only.
+  It does not change risk-event cohort semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal infrastructure adapter helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T15:36:02+00:00`
+- Generated at: `2026-06-13T15:38:15+00:00`
 
-- Report source snapshot: `485abf74+worktree`
+- Report source snapshot: `ba4c34fa`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T15:28:39+00:00`
+- Generated at: `2026-06-13T15:31:47+00:00`
 
-- Report source snapshot: `503deb05+worktree`
+- Report source snapshot: `16764567+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 173833 |
-| Test functions | 2536 |
+| Total Python LOC | 173898 |
+| Test functions | 2537 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T15:08:26+00:00`
+- Generated at: `2026-06-13T15:28:39+00:00`
 
-- Report source snapshot: `511926ec`
+- Report source snapshot: `503deb05+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 173769 |
-| Test functions | 2534 |
+| Total Python LOC | 173833 |
+| Test functions | 2536 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T15:31:47+00:00`
+- Generated at: `2026-06-13T15:36:02+00:00`
 
-- Report source snapshot: `16764567+worktree`
+- Report source snapshot: `485abf74+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 173898 |
-| Test functions | 2537 |
+| Total Python LOC | 173967 |
+| Test functions | 2539 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T15:08:26+00:00`
+- Generated at: `2026-06-13T15:28:39+00:00`
 
-- Report source snapshot: `511926ec`
+- Report source snapshot: `503deb05+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _risk_event_cohort_from_response | src/infrastructure/risk_authority/client.py | 7 | 18 |
-| 2 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
-| 3 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
-| 4 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
-| 5 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
-| 6 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
-| 7 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
-| 8 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
-| 9 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 10 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 1 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
+| 2 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
+| 3 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
+| 4 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
+| 5 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
+| 6 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
+| 7 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
+| 8 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
+| 9 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 10 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T15:36:02+00:00`
+- Generated at: `2026-06-13T15:38:15+00:00`
 
-- Report source snapshot: `485abf74+worktree`
+- Report source snapshot: `ba4c34fa`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T15:28:39+00:00`
+- Generated at: `2026-06-13T15:31:47+00:00`
 
-- Report source snapshot: `503deb05+worktree`
+- Report source snapshot: `16764567+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | command_center_supportability_state | src/api/services/mandate_command_center.py | 7 | 17 |
-| 2 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
-| 3 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
-| 4 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
-| 5 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
-| 6 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
-| 7 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
-| 8 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 9 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 10 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 1 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
+| 2 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
+| 3 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
+| 4 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
+| 5 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
+| 6 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
+| 7 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
+| 8 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 9 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 10 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T15:31:47+00:00`
+- Generated at: `2026-06-13T15:36:02+00:00`
 
-- Report source snapshot: `16764567+worktree`
+- Report source snapshot: `485abf74+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _score_run_scope_mismatch_reasons | src/core/pm_quality/scoring.py | 7 | 16 |
-| 2 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
-| 3 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
-| 4 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
-| 5 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
-| 6 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
-| 7 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 8 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 9 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 10 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 1 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
+| 2 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
+| 3 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
+| 4 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
+| 5 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
+| 6 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
+| 7 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 8 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 9 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 10 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T15:08:26+00:00`
+- Generated at: `2026-06-13T15:28:39+00:00`
 
-- Report source snapshot: `511926ec`
+- Report source snapshot: `503deb05+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T15:36:02+00:00`
+- Generated at: `2026-06-13T15:38:15+00:00`
 
-- Report source snapshot: `485abf74+worktree`
+- Report source snapshot: `ba4c34fa`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T15:28:39+00:00`
+- Generated at: `2026-06-13T15:31:47+00:00`
 
-- Report source snapshot: `503deb05+worktree`
+- Report source snapshot: `16764567+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T15:31:47+00:00`
+- Generated at: `2026-06-13T15:36:02+00:00`
 
-- Report source snapshot: `16764567+worktree`
+- Report source snapshot: `485abf74+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T15:08:26+00:00`
+- Generated at: `2026-06-13T15:28:39+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `511926ec`
+- Report source snapshot: `503deb05+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 818 | 819 | +1 |
-| Total Python LOC | 173391 | 173769 | +378 |
-| Test functions | 2525 | 2534 | +9 |
+| Python files | 819 | 819 | +0 |
+| Total Python LOC | 173769 | 173833 | +64 |
+| Test functions | 2534 | 2536 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T15:36:02+00:00`
+- Generated at: `2026-06-13T15:38:15+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `485abf74+worktree`
+- Report source snapshot: `ba4c34fa`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T15:28:39+00:00`
+- Generated at: `2026-06-13T15:31:47+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `503deb05+worktree`
+- Report source snapshot: `16764567+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 173769 | 173833 | +64 |
-| Test functions | 2534 | 2536 | +2 |
+| Total Python LOC | 173769 | 173898 | +129 |
+| Test functions | 2534 | 2537 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T15:31:47+00:00`
+- Generated at: `2026-06-13T15:36:02+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `16764567+worktree`
+- Report source snapshot: `485abf74+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 173769 | 173898 | +129 |
-| Test functions | 2534 | 2537 | +3 |
+| Total Python LOC | 173769 | 173967 | +198 |
+| Test functions | 2534 | 2539 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/services/mandate_command_center.py
+++ b/src/api/services/mandate_command_center.py
@@ -36,17 +36,46 @@ def command_center_supportability_state(
     completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"],
     partial_reasons: list[str],
 ) -> CommandCenterSupportabilityPosture:
-    if latest_run is None or completeness == "EMPTY":
-        return "EMPTY", "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
+    empty_posture = _empty_command_center_supportability(
+        latest_run=latest_run,
+        completeness=completeness,
+    )
+    if empty_posture is not None:
+        return empty_posture
+    assert latest_run is not None
 
     source_posture = _source_readiness_supportability_posture(
         source_readiness_summary=latest_run.source_readiness_summary
     )
     if source_posture is not None:
         return source_posture
+    partial_posture = _partial_command_center_supportability(
+        completeness=completeness,
+        partial_reasons=partial_reasons,
+    )
+    if partial_posture is not None:
+        return partial_posture
+    return "READY", "COMMAND_CENTER_READY"
+
+
+def _empty_command_center_supportability(
+    *,
+    latest_run: DpmMonitoringRun | None,
+    completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"],
+) -> CommandCenterSupportabilityPosture | None:
+    if latest_run is None or completeness == "EMPTY":
+        return "EMPTY", "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS"
+    return None
+
+
+def _partial_command_center_supportability(
+    *,
+    completeness: Literal["COMPLETE", "PARTIAL", "EMPTY"],
+    partial_reasons: list[str],
+) -> CommandCenterSupportabilityPosture | None:
     if completeness == "PARTIAL" or partial_reasons:
         return "PARTIAL", partial_reasons[0] if partial_reasons else "COMMAND_CENTER_PARTIAL"
-    return "READY", "COMMAND_CENTER_READY"
+    return None
 
 
 def _source_readiness_supportability_posture(

--- a/src/core/pm_quality/scoring.py
+++ b/src/core/pm_quality/scoring.py
@@ -722,13 +722,38 @@ def _score_run_scope_mismatch_reasons(
 ) -> list[str]:
     reasons: set[str] = set()
     for score_run in score_runs:
-        if score_run.policy_id != policy_id or score_run.policy_version != policy_version:
+        if _score_run_policy_mismatched(
+            score_run=score_run,
+            policy_id=policy_id,
+            policy_version=policy_version,
+        ):
             reasons.add("PM_QUALITY_FAIRNESS_POLICY_MISMATCH")
-        if score_run.as_of_date != as_of_date:
+        if _score_run_as_of_date_mismatched(score_run=score_run, as_of_date=as_of_date):
             reasons.add("PM_QUALITY_FAIRNESS_AS_OF_DATE_MISMATCH")
-        if score_run.state in {"DISABLED", "BLOCKED"} or score_run.score is None:
+        if _score_run_not_scorable(score_run):
             reasons.add("PM_QUALITY_FAIRNESS_SCORE_RUN_NOT_SCORABLE")
     return sorted(reasons)
+
+
+def _score_run_policy_mismatched(
+    *,
+    score_run: DpmPmOperatingQualityScoreRun,
+    policy_id: str,
+    policy_version: str,
+) -> bool:
+    return score_run.policy_id != policy_id or score_run.policy_version != policy_version
+
+
+def _score_run_as_of_date_mismatched(
+    *,
+    score_run: DpmPmOperatingQualityScoreRun,
+    as_of_date: str,
+) -> bool:
+    return score_run.as_of_date != as_of_date
+
+
+def _score_run_not_scorable(score_run: DpmPmOperatingQualityScoreRun) -> bool:
+    return score_run.state in {"DISABLED", "BLOCKED"} or score_run.score is None
 
 
 def _score_run(

--- a/src/infrastructure/risk_authority/client.py
+++ b/src/infrastructure/risk_authority/client.py
@@ -79,6 +79,15 @@ class _ConcentrationResponseSections:
     issuer_coverage_status: Any
 
 
+@dataclass(frozen=True)
+class _RiskEventCohortMetadata:
+    product_name: str
+    product_version: str
+    source_service: str
+    request_fingerprint: str
+    calculation_supportability: str
+
+
 class LotusRiskAuthorityClient:
     """Bounded client for lotus-risk authority outputs used by construction.
 
@@ -427,22 +436,54 @@ def _regime_reason_codes(value: Any) -> list[str]:
 
 def _risk_event_cohort_from_response(body: dict[str, Any]) -> RiskEventAffectedCohort:
     try:
-        metadata = _dict_section(body, "metadata")
-        affected = _risk_event_affected_portfolios(body.get("affected_portfolios"))
+        metadata = _risk_event_cohort_metadata(body)
         return RiskEventAffectedCohort(
-            cohort_id=str(body["cohort_id"]),
-            risk_event_id=str(body["risk_event_id"]),
-            display_name=str(body["display_name"]),
-            product_name=str(metadata.get("product_name") or "RiskEventAffectedCohort"),
-            product_version=str(metadata.get("product_version") or "v1"),
-            source_service=str(metadata.get("source_service") or "lotus-risk"),
-            request_fingerprint=str(metadata.get("request_fingerprint") or ""),
-            calculation_supportability=str(metadata.get("calculation_supportability") or "blocked"),
+            cohort_id=_required_text(body=body, key="cohort_id"),
+            risk_event_id=_required_text(body=body, key="risk_event_id"),
+            display_name=_required_text(body=body, key="display_name"),
+            product_name=metadata.product_name,
+            product_version=metadata.product_version,
+            source_service=metadata.source_service,
+            request_fingerprint=metadata.request_fingerprint,
+            calculation_supportability=metadata.calculation_supportability,
             reason_codes=_risk_event_reason_codes(body.get("reason_codes")),
-            affected_portfolios=affected,
+            affected_portfolios=_risk_event_affected_portfolios(body.get("affected_portfolios")),
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise LotusRiskAuthorityUnavailableError("LOTUS_RISK_INVALID_RESPONSE") from exc
+
+
+def _risk_event_cohort_metadata(body: dict[str, Any]) -> _RiskEventCohortMetadata:
+    metadata = _dict_section(body, "metadata")
+    return _RiskEventCohortMetadata(
+        product_name=_metadata_text(
+            metadata=metadata,
+            key="product_name",
+            default="RiskEventAffectedCohort",
+        ),
+        product_version=_metadata_text(metadata=metadata, key="product_version", default="v1"),
+        source_service=_metadata_text(
+            metadata=metadata, key="source_service", default="lotus-risk"
+        ),
+        request_fingerprint=_metadata_text(
+            metadata=metadata,
+            key="request_fingerprint",
+            default="",
+        ),
+        calculation_supportability=_metadata_text(
+            metadata=metadata,
+            key="calculation_supportability",
+            default="blocked",
+        ),
+    )
+
+
+def _metadata_text(*, metadata: dict[str, Any], key: str, default: str) -> str:
+    return str(metadata.get(key) or default)
+
+
+def _required_text(*, body: dict[str, Any], key: str) -> str:
+    return str(body[key])
 
 
 def _risk_event_reason_codes(reason_codes: Any) -> tuple[str, ...]:

--- a/tests/unit/dpm/infrastructure/test_risk_authority_client.py
+++ b/tests/unit/dpm/infrastructure/test_risk_authority_client.py
@@ -19,6 +19,7 @@ from src.infrastructure.risk_authority.client import (
     _post_with_retries,
     _risk_event_affected_portfolios,
     _risk_event_cohort_from_response,
+    _risk_event_cohort_metadata,
     _risk_event_reason_codes,
     _regime_context_from_scenario_response,
     _regime_governance_date,
@@ -28,6 +29,7 @@ from src.infrastructure.risk_authority.client import (
     _regime_source_system,
     _scenario_bucket,
     _scenario_status_from_supportability,
+    _required_text,
 )
 from src.core.rebalance.engine import run_simulation
 from tests.shared.factories import valid_api_payload
@@ -355,6 +357,27 @@ def test_risk_event_cohort_helpers_project_reason_codes_and_affected_portfolios(
     assert affected[0].dominant_bucket == "FIXED_INCOME"
     assert _risk_event_reason_codes(body["reason_codes"]) == ("RISK_EVENT_AFFECTED_COHORT_READY",)
     assert _risk_event_reason_codes("not-a-list") == ("RISK_EVENT_COHORT_REASON_CODES_MISSING",)
+
+
+def test_risk_event_cohort_metadata_defaults_missing_source_metadata() -> None:
+    body = _risk_event_cohort_response()
+    body.pop("metadata")
+
+    metadata = _risk_event_cohort_metadata(body)
+
+    assert metadata.product_name == "RiskEventAffectedCohort"
+    assert metadata.product_version == "v1"
+    assert metadata.source_service == "lotus-risk"
+    assert metadata.request_fingerprint == ""
+    assert metadata.calculation_supportability == "blocked"
+
+
+def test_required_text_projects_required_response_identifiers() -> None:
+    body = _risk_event_cohort_response()
+
+    assert _required_text(body=body, key="cohort_id") == "risk_event_cohort_test"
+    with pytest.raises(KeyError):
+        _required_text(body=body, key="missing")
 
 
 def test_risk_event_affected_portfolios_rejects_invalid_payload_shape() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_command_center.py
+++ b/tests/unit/dpm/mandates/test_mandate_command_center.py
@@ -1,7 +1,9 @@
 from datetime import date, datetime, timezone
 
 from src.api.services.mandate_command_center import (
+    _empty_command_center_supportability,
     _normalized_source_readiness_states,
+    _partial_command_center_supportability,
     _source_readiness_blocks_command_center,
     _source_readiness_degrades_command_center,
     _source_readiness_supportability_posture,
@@ -98,6 +100,40 @@ def test_command_center_supportability_state_maps_empty_and_source_postures() ->
         completeness="COMPLETE",
         partial_reasons=[],
     ) == ("READY", "COMMAND_CENTER_READY")
+
+
+def test_command_center_empty_and_partial_supportability_helpers_preserve_reasons() -> None:
+    assert _empty_command_center_supportability(
+        latest_run=None,
+        completeness="COMPLETE",
+    ) == ("EMPTY", "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS")
+    assert _empty_command_center_supportability(
+        latest_run=_run(),
+        completeness="EMPTY",
+    ) == ("EMPTY", "NO_MONITORING_RUN_FOR_COMMAND_CENTER_FILTERS")
+    assert (
+        _empty_command_center_supportability(
+            latest_run=_run(),
+            completeness="COMPLETE",
+        )
+        is None
+    )
+
+    assert _partial_command_center_supportability(
+        completeness="PARTIAL",
+        partial_reasons=["PM_BOOK_DISCOVERY_NOT_YET_SOURCED"],
+    ) == ("PARTIAL", "PM_BOOK_DISCOVERY_NOT_YET_SOURCED")
+    assert _partial_command_center_supportability(
+        completeness="PARTIAL",
+        partial_reasons=[],
+    ) == ("PARTIAL", "COMMAND_CENTER_PARTIAL")
+    assert (
+        _partial_command_center_supportability(
+            completeness="COMPLETE",
+            partial_reasons=[],
+        )
+        is None
+    )
 
 
 def test_command_center_source_readiness_helpers_preserve_precedence() -> None:

--- a/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
+++ b/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
@@ -1336,6 +1336,50 @@ def test_pm_quality_fairness_analysis_classifies_blocked_pending_and_ready_postu
         )
 
 
+def test_pm_quality_score_run_scope_mismatch_helpers_classify_fairness_inputs() -> None:
+    ready = _ready_score_run()
+    policy_mismatch = _ready_score_run(policy_id="pmq_other")
+    date_mismatch = _ready_score_run(as_of_date="2026-05-11")
+    blocked = _ready_score_run(state="BLOCKED")
+
+    assert not scoring._score_run_policy_mismatched(
+        score_run=ready,
+        policy_id="pmq_sg_dpm",
+        policy_version="2026.05",
+    )
+    assert scoring._score_run_policy_mismatched(
+        score_run=policy_mismatch,
+        policy_id="pmq_sg_dpm",
+        policy_version="2026.05",
+    )
+    assert scoring._score_run_as_of_date_mismatched(
+        score_run=date_mismatch,
+        as_of_date="2026-05-12",
+    )
+    assert scoring._score_run_not_scorable(blocked)
+    assert not scoring._score_run_not_scorable(ready)
+
+
+def test_pm_quality_score_run_scope_mismatch_reasons_deduplicate_failures() -> None:
+    reasons = scoring._score_run_scope_mismatch_reasons(
+        score_runs=[
+            _ready_score_run(policy_id="pmq_other"),
+            _ready_score_run(as_of_date="2026-05-11"),
+            _ready_score_run(state="BLOCKED"),
+            _ready_score_run(state="DISABLED"),
+        ],
+        policy_id="pmq_sg_dpm",
+        policy_version="2026.05",
+        as_of_date="2026-05-12",
+    )
+
+    assert reasons == [
+        "PM_QUALITY_FAIRNESS_AS_OF_DATE_MISMATCH",
+        "PM_QUALITY_FAIRNESS_POLICY_MISMATCH",
+        "PM_QUALITY_FAIRNESS_SCORE_RUN_NOT_SCORABLE",
+    ]
+
+
 def test_pm_quality_fairness_analysis_blocks_segments_below_minimum_count() -> None:
     empty_segment = DpmPmQualityFairnessSegmentInput(
         segment_id="sg_dpm_empty",


### PR DESCRIPTION
## Summary
- Extracted risk-event cohort response metadata helpers in `src/infrastructure/risk_authority/client.py` and added direct unit coverage for missing/defaulted metadata and required identifiers.
- Extracted command-center supportability posture helpers in `src/api/services/mandate_command_center.py` with direct coverage for empty, partial, fallback, and pass-through posture cases.
- Extracted PM-quality fairness scope predicate helpers in `src/core/pm_quality/scoring.py` with direct coverage for policy mismatch, date mismatch, blocked/scorable states, and deduplicated mismatch reasons.
- Refreshed codebase review ledger entries `BACKEND-REVIEW-20260613-906` through `BACKEND-REVIEW-20260613-908` and generated quality reports.

## Evidence
- `python -m ruff check <touched files>`
- `python -m ruff format --check <touched files>`
- `python -m mypy --config-file mypy.ini src/infrastructure/risk_authority/client.py src/api/services/mandate_command_center.py src/core/pm_quality/scoring.py`
- `python -m pytest tests/unit/dpm/infrastructure/test_risk_authority_client.py tests/unit/dpm/mandates/test_mandate_command_center.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py -q` -> 79 passed
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- service leakage scan for FastAPI/Starlette/router imports under `src/api/services` -> no matches
- `git diff --check origin/main...HEAD`
- `make check` -> 2724 passed
- wiki drift check -> `DiffCount 0`

## Governance Notes
- No API route, OpenAPI contract, runtime contract, README, or wiki truth changes.
- Quality reports now show the previous selected B-grade helper hotspots removed from the top source hotspot list; `validate_definition` is the next leading source hotspot.
- This PR is a focused maintainability slice toward the Bank-Buyable Engineering Contract. It does not claim full bank-buyable readiness.