### PR TITLE
Harden manage transition helper hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22796,3 +22796,32 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal proof-pack helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-911: Campaign assignment transition requirement predicates
+
+- Date: 2026-06-13
+- Scope: `src/core/waves/campaign_assignment_tasks.py` and
+  `tests/unit/dpm/waves/test_campaign_discovery.py`.
+- Bank-buyable control area: architecture, campaign workflow controls, and testing.
+- Finding: `_validate_transition_field_requirements` combined open-task assignee requirements,
+  reassignment/escalation actor-id requirements, and due-date transition requirements in one
+  conditional sequence. The behavior was correct, but controlled assignment-task transitions are
+  easier to review when each required-field rule is named.
+- Action: extracted `_transition_requires_open_assignees`, `_transition_requires_actor_ids`, and
+  `_transition_requires_due_at` so each transition guard predicate is independently testable
+  before error-code mapping. Expanded direct helper tests for open/closed assignee requirements,
+  reassignment actor-id requirements, non-reassignment pass-through, and due-date requirements.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_tasks.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q`,
+  and `python -m radon cc src/core/waves/campaign_assignment_tasks.py -s`; the focused campaign
+  discovery suite reported 86 passed and `_validate_transition_field_requirements` reduced from
+  B(7) to A(4) under radon.
+- Residual risk: this slice improves campaign assignment transition maintainability only. It
+  does not change assignment-task semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal campaign assignment helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22738,3 +22738,33 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal PM-quality fairness helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-909: Bulk-review campaign definition structural guards
+
+- Date: 2026-06-13
+- Scope: `src/core/waves/campaign_definitions.py` and
+  `tests/unit/dpm/waves/test_campaign_definition_repository.py`.
+- Bank-buyable control area: architecture, campaign governance, and testing.
+- Finding: `validate_definition` combined lifecycle validation, eligible portfolio type presence,
+  candidate presence, deterministic content-hash validation, and hash assignment in one model
+  validator. The behavior was correct, but the bulk-review campaign definition governance
+  contract was harder to review than an immutable campaign definition guard should be.
+- Action: extracted `_validate_campaign_definition_structure`,
+  `_has_eligible_portfolio_type`, and `_apply_campaign_definition_content_hash` so structural
+  required fields and content-hash binding are named and directly testable after lifecycle
+  validation. Added direct helper tests for eligible portfolio type detection, missing structural
+  scope, missing candidates, content-hash assignment, and mismatch rejection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_definitions.py tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `python -m ruff format --check src/core/waves/campaign_definitions.py tests/unit/dpm/waves/test_campaign_definition_repository.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_definitions.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_definition_repository.py -q`,
+  and `python -m radon cc src/core/waves/campaign_definitions.py -s`; the focused campaign
+  definition repository suite reported 53 passed and `validate_definition` reduced from B(7) to
+  A(3) under radon.
+- Residual risk: this slice improves bulk-review campaign definition maintainability only. It
+  does not change campaign definition semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal campaign definition helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22768,3 +22768,31 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal campaign definition helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260613-910: Proof-pack correlation fallback helpers
+
+- Date: 2026-06-13
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, proof-pack lineage, and testing.
+- Finding: `_resolve_proof_pack_correlation_id` encoded explicit, selected-alternative,
+  rebalance-run, and generated correlation fallback order as one nested expression. The behavior
+  was correct, but proof-pack lineage correlation should be reviewable as named fallback rules.
+- Action: extracted `_selection_correlation_id`, `_run_correlation_id`, and
+  `_generated_proof_pack_correlation_id` so each fallback source is directly named before the
+  resolver chooses the first available value. Added a direct fallback-order test covering explicit,
+  selection, run, and generated proof-pack correlation ids.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`,
+  and `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder
+  suite reported 96 passed and `_resolve_proof_pack_correlation_id` reduced from B(7) to A(3)
+  under radon.
+- Residual risk: this slice improves proof-pack correlation fallback maintainability only. It
+  does not change proof-pack lineage semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal proof-pack helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T15:38:15+00:00`
+- Generated at: `2026-06-13T15:56:58+00:00`
 
-- Report source snapshot: `ba4c34fa`
+- Report source snapshot: `3a3394b4+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 173967 |
-| Test functions | 2539 |
+| Total Python LOC | 174016 |
+| Test functions | 2541 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T15:56:58+00:00`
+- Generated at: `2026-06-13T15:59:47+00:00`
 
-- Report source snapshot: `3a3394b4+worktree`
+- Report source snapshot: `6ca8fced+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174016 |
-| Test functions | 2541 |
+| Total Python LOC | 174083 |
+| Test functions | 2542 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T16:02:50+00:00`
+- Generated at: `2026-06-13T16:04:00+00:00`
 
-- Report source snapshot: `f161bf92+worktree`
+- Report source snapshot: `9b000d28`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T15:59:47+00:00`
+- Generated at: `2026-06-13T16:02:50+00:00`
 
-- Report source snapshot: `6ca8fced+worktree`
+- Report source snapshot: `f161bf92+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,7 +11,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174083 |
+| Total Python LOC | 174125 |
 | Test functions | 2542 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T15:56:58+00:00`
+- Generated at: `2026-06-13T15:59:47+00:00`
 
-- Report source snapshot: `3a3394b4+worktree`
+- Report source snapshot: `6ca8fced+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
-| 2 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
-| 3 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
-| 4 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
-| 5 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 6 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 7 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 8 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 9 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 10 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 1 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
+| 2 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
+| 3 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
+| 4 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
+| 5 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 6 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 7 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 8 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 9 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 10 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T16:02:50+00:00`
+- Generated at: `2026-06-13T16:04:00+00:00`
 
-- Report source snapshot: `f161bf92+worktree`
+- Report source snapshot: `9b000d28`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T15:38:15+00:00`
+- Generated at: `2026-06-13T15:56:58+00:00`
 
-- Report source snapshot: `ba4c34fa`
+- Report source snapshot: `3a3394b4+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | validate_definition | src/core/waves/campaign_definitions.py | 7 | 16 |
-| 2 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
-| 3 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
-| 4 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
-| 5 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
-| 6 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 7 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 8 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 9 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 10 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 1 | _resolve_proof_pack_correlation_id | src/core/proof_packs/builder.py | 7 | 15 |
+| 2 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
+| 3 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
+| 4 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
+| 5 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
+| 6 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 7 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 8 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 9 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 10 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T15:59:47+00:00`
+- Generated at: `2026-06-13T16:02:50+00:00`
 
-- Report source snapshot: `6ca8fced+worktree`
+- Report source snapshot: `f161bf92+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _validate_transition_field_requirements | src/core/waves/campaign_assignment_tasks.py | 7 | 14 |
-| 2 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
-| 3 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
-| 4 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 5 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 6 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 7 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 8 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 9 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 10 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 1 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
+| 2 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
+| 3 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
+| 4 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 5 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 6 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 7 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 8 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 9 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 10 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T15:59:47+00:00`
+- Generated at: `2026-06-13T16:02:50+00:00`
 
-- Report source snapshot: `6ca8fced+worktree`
+- Report source snapshot: `f161bf92+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T15:38:15+00:00`
+- Generated at: `2026-06-13T15:56:58+00:00`
 
-- Report source snapshot: `ba4c34fa`
+- Report source snapshot: `3a3394b4+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T15:56:58+00:00`
+- Generated at: `2026-06-13T15:59:47+00:00`
 
-- Report source snapshot: `3a3394b4+worktree`
+- Report source snapshot: `6ca8fced+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T16:02:50+00:00`
+- Generated at: `2026-06-13T16:04:00+00:00`
 
-- Report source snapshot: `f161bf92+worktree`
+- Report source snapshot: `9b000d28`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T16:02:50+00:00`
+- Generated at: `2026-06-13T16:04:00+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `f161bf92+worktree`
+- Report source snapshot: `9b000d28`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T15:38:15+00:00`
+- Generated at: `2026-06-13T15:56:58+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `ba4c34fa`
+- Report source snapshot: `3a3394b4+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 173769 | 173967 | +198 |
-| Test functions | 2534 | 2539 | +5 |
+| Total Python LOC | 173967 | 174016 | +49 |
+| Test functions | 2539 | 2541 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2500 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
+| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/core/proof_packs/builder.py | 1807 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T15:59:47+00:00`
+- Generated at: `2026-06-13T16:02:50+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `6ca8fced+worktree`
+- Report source snapshot: `f161bf92+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 173967 | 174083 | +116 |
+| Total Python LOC | 173967 | 174125 | +158 |
 | Test functions | 2539 | 2542 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
@@ -55,7 +55,7 @@
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2866 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2500 |
+| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2512 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T15:56:58+00:00`
+- Generated at: `2026-06-13T15:59:47+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `3a3394b4+worktree`
+- Report source snapshot: `6ca8fced+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 173967 | 174016 | +49 |
-| Test functions | 2539 | 2541 | +2 |
+| Total Python LOC | 173967 | 174083 | +116 |
+| Test functions | 2539 | 2542 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -52,14 +52,14 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2815 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2866 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2500 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/core/proof_packs/builder.py | 1807 |
+| 10 | src/core/proof_packs/builder.py | 1823 |
 
 ## Largest Functions
 

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -411,14 +411,30 @@ def _resolve_proof_pack_correlation_id(
     run: DpmRunRecord | None,
     created_at: datetime,
 ) -> str:
-    return (
-        correlation_id
-        or (
-            selection.correlation_id if selection is not None and selection.correlation_id else None
-        )
-        or (run.correlation_id if run is not None else None)
-        or f"proof-pack-{created_at.strftime('%Y%m%d%H%M%S')}"
+    return next(
+        candidate
+        for candidate in [
+            correlation_id,
+            _selection_correlation_id(selection),
+            _run_correlation_id(run),
+            _generated_proof_pack_correlation_id(created_at),
+        ]
+        if candidate
     )
+
+
+def _selection_correlation_id(selection: ConstructionAlternativeSelection | None) -> str | None:
+    if selection is None or not selection.correlation_id:
+        return None
+    return selection.correlation_id
+
+
+def _run_correlation_id(run: DpmRunRecord | None) -> str | None:
+    return run.correlation_id if run is not None else None
+
+
+def _generated_proof_pack_correlation_id(created_at: datetime) -> str:
+    return f"proof-pack-{created_at.strftime('%Y%m%d%H%M%S')}"
 
 
 def _proof_pack_sections(

--- a/src/core/waves/campaign_assignment_tasks.py
+++ b/src/core/waves/campaign_assignment_tasks.py
@@ -504,12 +504,42 @@ def _validate_transition_field_requirements(
     assigned_actor_ids: list[str] | None,
     due_at: datetime | None,
 ) -> None:
-    if next_status not in _CLOSED_STATUSES and not next_assignees:
+    if _transition_requires_open_assignees(
+        next_status=next_status,
+        next_assignees=next_assignees,
+    ):
         raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ASSIGNEES_REQUIRED")
-    if transition_type in {"REASSIGNED", "ESCALATED"} and assigned_actor_ids is None:
+    if _transition_requires_actor_ids(
+        transition_type=transition_type,
+        assigned_actor_ids=assigned_actor_ids,
+    ):
         raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ASSIGNEES_REQUIRED")
-    if transition_type == "DUE_DATE_CHANGED" and due_at is None:
+    if _transition_requires_due_at(transition_type=transition_type, due_at=due_at):
         raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_DUE_AT_REQUIRED")
+
+
+def _transition_requires_open_assignees(
+    *,
+    next_status: CampaignAssignmentTaskStatus,
+    next_assignees: list[str],
+) -> bool:
+    return next_status not in _CLOSED_STATUSES and not next_assignees
+
+
+def _transition_requires_actor_ids(
+    *,
+    transition_type: CampaignAssignmentTaskTransitionType,
+    assigned_actor_ids: list[str] | None,
+) -> bool:
+    return transition_type in {"REASSIGNED", "ESCALATED"} and assigned_actor_ids is None
+
+
+def _transition_requires_due_at(
+    *,
+    transition_type: CampaignAssignmentTaskTransitionType,
+    due_at: datetime | None,
+) -> bool:
+    return transition_type == "DUE_DATE_CHANGED" and due_at is None
 
 
 def _next_status(

--- a/src/core/waves/campaign_definitions.py
+++ b/src/core/waves/campaign_definitions.py
@@ -589,15 +589,31 @@ class DpmBulkReviewCampaignDefinition(BaseModel):
             self._validate_retired_lifecycle()
         else:
             self._validate_superseded_lifecycle()
-        if not [value for value in self.eligible_portfolio_types if value.strip()]:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPES_REQUIRED")
-        if not self.candidates:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_CANDIDATE_PORTFOLIOS_REQUIRED")
-        expected_hash = bulk_review_campaign_definition_hash(self, include_hash=False)
-        if self.content_hash and self.content_hash != expected_hash:
-            raise ValueError("BULK_REVIEW_CAMPAIGN_DEFINITION_HASH_MISMATCH")
-        self.content_hash = expected_hash
+        _validate_campaign_definition_structure(self)
+        _apply_campaign_definition_content_hash(self)
         return self
+
+
+def _validate_campaign_definition_structure(
+    definition: DpmBulkReviewCampaignDefinition,
+) -> None:
+    if not _has_eligible_portfolio_type(definition.eligible_portfolio_types):
+        raise ValueError("BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPES_REQUIRED")
+    if not definition.candidates:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_CANDIDATE_PORTFOLIOS_REQUIRED")
+
+
+def _has_eligible_portfolio_type(eligible_portfolio_types: list[str]) -> bool:
+    return any(portfolio_type.strip() for portfolio_type in eligible_portfolio_types)
+
+
+def _apply_campaign_definition_content_hash(
+    definition: DpmBulkReviewCampaignDefinition,
+) -> None:
+    expected_hash = bulk_review_campaign_definition_hash(definition, include_hash=False)
+    if definition.content_hash and definition.content_hash != expected_hash:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_DEFINITION_HASH_MISMATCH")
+    definition.content_hash = expected_hash
 
 
 def bulk_review_campaign_definition_hash(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -1577,6 +1577,57 @@ def test_proof_pack_build_context_prefers_explicit_correlation_then_falls_back_t
     assert run_fallback.correlation_id == result.correlation_id
 
 
+def test_proof_pack_correlation_id_helper_uses_ordered_fallbacks() -> None:
+    result = _ready_rebalance_result()
+    run = _run_record(result=result)
+    selection = ConstructionAlternativeSelection(
+        selection_id="sel_context_corr",
+        alternative_set_id="cas_context_corr",
+        alternative_id="alt_context_corr",
+        selected_at=CREATED_AT,
+        actor_id="pm_001",
+        reason_code="MODEL_DRIFT_REVIEW",
+        correlation_id="corr-selection-context",
+    )
+
+    assert (
+        builder_module._resolve_proof_pack_correlation_id(
+            correlation_id="corr-explicit-context",
+            selection=selection,
+            run=run,
+            created_at=CREATED_AT,
+        )
+        == "corr-explicit-context"
+    )
+    assert (
+        builder_module._resolve_proof_pack_correlation_id(
+            correlation_id=None,
+            selection=selection,
+            run=run,
+            created_at=CREATED_AT,
+        )
+        == "corr-selection-context"
+    )
+    assert (
+        builder_module._resolve_proof_pack_correlation_id(
+            correlation_id=None,
+            selection=selection.model_copy(update={"correlation_id": None}),
+            run=run,
+            created_at=CREATED_AT,
+        )
+        == result.correlation_id
+    )
+    assert (
+        builder_module._resolve_proof_pack_correlation_id(
+            correlation_id=None,
+            selection=None,
+            run=None,
+            created_at=CREATED_AT,
+        )
+        == "proof-pack-20260503093000"
+    )
+
+
 def test_proof_pack_build_context_attaches_direct_regime_source_hashes_and_refs() -> None:
     result = _ready_rebalance_result()
     alternative = build_rebalance_result_alternative(result=result)

--- a/tests/unit/dpm/waves/test_campaign_definition_repository.py
+++ b/tests/unit/dpm/waves/test_campaign_definition_repository.py
@@ -56,6 +56,9 @@ from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionCandidate,
     DpmBulkReviewCampaignDefinitionGovernance,
+    _apply_campaign_definition_content_hash,
+    _has_eligible_portfolio_type,
+    _validate_campaign_definition_structure,
     _validate_lifecycle_fields_absent,
     _validate_required_lifecycle_value,
     bulk_review_campaign_definition_hash,
@@ -163,6 +166,36 @@ def test_campaign_definition_validation_rejects_bad_candidates_and_hash() -> Non
             correlation_id="corr-campaign-definition-001",
             content_hash="sha256:bad",
         )
+
+
+def test_campaign_definition_structure_helpers_require_scope_and_candidates() -> None:
+    assert _has_eligible_portfolio_type([" ", "DISCRETIONARY"])
+    assert not _has_eligible_portfolio_type([" ", ""])
+
+    valid_definition = _definition()
+    _validate_campaign_definition_structure(valid_definition)
+
+    missing_portfolio_types = _definition().model_copy(
+        update={"eligible_portfolio_types": [" ", ""]}
+    )
+    with pytest.raises(ValueError, match="BULK_REVIEW_CAMPAIGN_PORTFOLIO_TYPES_REQUIRED"):
+        _validate_campaign_definition_structure(missing_portfolio_types)
+
+    missing_candidates = _definition().model_copy(update={"candidates": []})
+    with pytest.raises(ValueError, match="BULK_REVIEW_CAMPAIGN_CANDIDATE_PORTFOLIOS_REQUIRED"):
+        _validate_campaign_definition_structure(missing_candidates)
+
+
+def test_campaign_definition_content_hash_helper_applies_and_rejects_mismatch() -> None:
+    definition = _definition().model_copy(update={"content_hash": ""})
+
+    _apply_campaign_definition_content_hash(definition)
+
+    assert definition.content_hash == bulk_review_campaign_definition_hash(definition)
+
+    mismatched = _definition().model_copy(update={"content_hash": "sha256:bad"})
+    with pytest.raises(ValueError, match="BULK_REVIEW_CAMPAIGN_DEFINITION_HASH_MISMATCH"):
+        _apply_campaign_definition_content_hash(mismatched)
 
 
 def test_campaign_definition_hash_preserves_pre_approval_decision_payloads() -> None:

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -74,6 +74,9 @@ from src.core.waves.campaign_assignment_tasks import (
     _transition_due_at_replay_match,
     _transition_escalation_tier_replay_match,
     _transition_next_assignees,
+    _transition_requires_actor_ids,
+    _transition_requires_due_at,
+    _transition_requires_open_assignees,
     _transition_sla_posture_replay_match,
     _transition_task_fields,
     _validate_transition_field_requirements,
@@ -1963,6 +1966,15 @@ def test_campaign_assignment_task_transition_replay_helper_returns_definition_or
 def test_campaign_assignment_task_transition_field_requirement_helper_rejects_missing_fields() -> (
     None
 ):
+    assert _transition_requires_open_assignees(next_status="OPEN", next_assignees=[])
+    assert not _transition_requires_open_assignees(next_status="RESOLVED", next_assignees=[])
+    assert _transition_requires_actor_ids(transition_type="REASSIGNED", assigned_actor_ids=None)
+    assert not _transition_requires_actor_ids(
+        transition_type="ACKNOWLEDGED",
+        assigned_actor_ids=None,
+    )
+    assert _transition_requires_due_at(transition_type="DUE_DATE_CHANGED", due_at=None)
+
     with pytest.raises(
         ValueError,
         match="BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ASSIGNEES_REQUIRED",


### PR DESCRIPTION
## Summary
- Extracted bulk-review campaign definition structural/content-hash guards with direct helper tests.
- Extracted proof-pack correlation fallback helpers with direct fallback-order coverage.
- Extracted campaign assignment transition requirement predicates with direct guard coverage.
- Refreshed codebase review ledger entries `BACKEND-REVIEW-20260613-909` through `BACKEND-REVIEW-20260613-911` and generated quality reports.

## Evidence
- Focused targeted validation:
  - `python -m ruff check src/core/waves/campaign_definitions.py tests/unit/dpm/waves/test_campaign_definition_repository.py src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`
  - `python -m ruff format --check src/core/waves/campaign_definitions.py tests/unit/dpm/waves/test_campaign_definition_repository.py src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`
  - `python -m mypy --config-file mypy.ini src/core/waves/campaign_definitions.py src/core/proof_packs/builder.py src/core/waves/campaign_assignment_tasks.py`
  - `python -m pytest tests/unit/dpm/waves/test_campaign_definition_repository.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py tests/unit/dpm/waves/test_campaign_discovery.py -q` -> 235 passed
- Governance gates:
  - `python scripts/openapi_quality_gate.py`
  - `python scripts/api_vocabulary_inventory.py --validate-only`
  - `python scripts/service_boundary_gate.py`
  - service leakage scan for FastAPI/Starlette/router imports under `src/api/services` -> no matches
  - `git diff --check origin/main...HEAD`
- Full local gate: `make check` -> 2727 passed
- Wiki drift check -> `DiffCount 0`

## Quality Movement
- `validate_definition` reduced from B(7) to A(3).
- `_resolve_proof_pack_correlation_id` reduced from B(7) to A(3).
- `_validate_transition_field_requirements` reduced from B(7) to A(4).
- Current source hotspot list now starts at `authority_context_status` in `src/api/services/construction_supportability_application.py`.

## Governance Notes
- No API route, OpenAPI contract, runtime contract, README, or wiki truth changes.
- This PR is a focused maintainability slice toward the Lotus Bank-Buyable Engineering Contract. It does not claim full bank-buyable readiness.