### PR TITLE
Harden source hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22885,3 +22885,33 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal OpenAPI enrichment helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-914: Integration capability publishability guards
+
+- Date: 2026-06-14
+- Scope: `src/api/services/integration_capabilities_service.py` and
+  `tests/unit/dpm/test_integration_capabilities_service.py`.
+- Bank-buyable control area: API quality, integration capability governance, and testing.
+- Finding: `stateful_execution_publishable` combined portfolio-id input-mode publication,
+  stateful Core sourcing enablement, Core base URL presence, and legacy resolver-route blocking
+  in one boolean expression. The behavior was correct, but capability publication should expose
+  each fail-closed guard as a named rule.
+- Action: extracted `_stateful_portfolio_id_input_mode_enabled`,
+  `_stateful_core_sourcing_enabled`, `_core_base_url_configured`, and
+  `_uses_legacy_monolithic_resolver_path`, then kept `stateful_execution_publishable` as a small
+  guard aggregator. Added direct tests for the flag guards, Core base URL trimming, and legacy
+  resolver-route detection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/integration_capabilities_service.py tests/unit/dpm/test_integration_capabilities_service.py`,
+  `python -m ruff format --check src/api/services/integration_capabilities_service.py tests/unit/dpm/test_integration_capabilities_service.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/integration_capabilities_service.py`,
+  `python -m pytest tests/unit/dpm/test_integration_capabilities_service.py -q`,
+  and `python -m radon cc src/api/services/integration_capabilities_service.py -s`; the focused
+  integration capability service suite reported 8 passed, the report-only complexity baseline had
+  listed `stateful_execution_publishable` at B(7), and current radon reports it at A(2).
+- Residual risk: this slice improves integration capability publication maintainability only. It
+  does not change capability response semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal integration-capability service
+  helper maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22825,3 +22825,31 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal campaign assignment helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-912: Construction authority context status dispatch
+
+- Date: 2026-06-14
+- Scope: `src/api/services/construction_supportability_application.py` and
+  `tests/unit/dpm/construction/test_supportability_application.py`.
+- Bank-buyable control area: architecture, construction supportability governance, and testing.
+- Finding: `authority_context_status` combined liquidity, currency-overlay, and regime-stress
+  authority context status checks in one conditional sequence. The behavior was correct, but
+  method-specific source authority readiness should be reviewable as named supportability rules.
+- Action: extracted `_liquidity_authority_context_status`,
+  `_currency_overlay_authority_context_status`, and `_regime_stress_authority_context_status`,
+  then routed `authority_context_status` through a method-to-selector map. Added direct helper
+  tests for present-context status projection and missing-context `None` fallback.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/construction_supportability_application.py tests/unit/dpm/construction/test_supportability_application.py`,
+  `python -m ruff format --check src/api/services/construction_supportability_application.py tests/unit/dpm/construction/test_supportability_application.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/construction_supportability_application.py`,
+  `python -m pytest tests/unit/dpm/construction/test_supportability_application.py -q`,
+  and `python -m radon cc src/api/services/construction_supportability_application.py -s`; the
+  focused construction supportability application suite reported 16 passed and
+  `authority_context_status` reduced from B(7) to A(2) under radon.
+- Residual risk: this slice improves construction supportability authority-context
+  maintainability only. It does not change construction semantics, certify global bank-buyable
+  readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal construction supportability
+  helper maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22846,10 +22846,42 @@ and improves internal transaction-cost source posture maintainability only.
   `python -m mypy --config-file mypy.ini src/api/services/construction_supportability_application.py`,
   `python -m pytest tests/unit/dpm/construction/test_supportability_application.py -q`,
   and `python -m radon cc src/api/services/construction_supportability_application.py -s`; the
-  focused construction supportability application suite reported 16 passed and
-  `authority_context_status` reduced from B(7) to A(2) under radon.
+  focused construction supportability application suite reported 16 passed, the report-only
+  complexity baseline had listed `authority_context_status` at B(7), and current radon reports it
+  at A(2).
 - Residual risk: this slice improves construction supportability authority-context
   maintainability only. It does not change construction semantics, certify global bank-buyable
   readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal construction supportability
   helper maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-913: OpenAPI documentable property extraction
+
+- Date: 2026-06-14
+- Scope: `src/api/openapi_enrichment.py` and
+  `tests/unit/api/test_openapi_enrichment_helpers.py`.
+- Bank-buyable control area: API quality, OpenAPI governance, and testing.
+- Finding: `_model_documentable_properties` combined model-name validation, model-schema shape
+  checks, properties collection validation, and property-fragment filtering in one helper. The
+  generated OpenAPI behavior was correct, but schema documentation enrichment should keep model
+  and property filtering rules independently reviewable.
+- Action: extracted `_model_property_schemas` and `_documentable_property_schema` so model-level
+  eligibility and property-fragment eligibility are separate, directly testable rules before
+  documentation enrichment applies generated descriptions and examples. Added direct tests for
+  valid fragments, non-string property names, non-dict schemas, invalid models, and invalid
+  properties collections.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`,
+  `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q`,
+  and `python -m radon cc src/api/openapi_enrichment.py -s`; the focused OpenAPI enrichment
+  helper suite reported 35 passed, the report-only complexity baseline had listed
+  `_model_documentable_properties` at B(7), and current radon reports it at A(3) with the
+  extracted `_model_property_schemas` helper at A(5).
+- Residual risk: this slice improves OpenAPI schema documentation helper maintainability only. It
+  does not change OpenAPI output semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal OpenAPI enrichment helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T16:22:48+00:00`
+- Generated at: `2026-06-13T16:25:34+00:00`
 
-- Report source snapshot: `b6d2921d`
+- Report source snapshot: `ef1ce9ec`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174192 |
-| Test functions | 2544 |
+| Total Python LOC | 174242 |
+| Test functions | 2546 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T16:04:00+00:00`
+- Generated at: `2026-06-13T16:22:48+00:00`
 
-- Report source snapshot: `9b000d28`
+- Report source snapshot: `b6d2921d`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174125 |
-| Test functions | 2542 |
+| Total Python LOC | 174192 |
+| Test functions | 2544 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T16:25:34+00:00`
+- Generated at: `2026-06-13T16:28:02+00:00`
 
-- Report source snapshot: `ef1ce9ec`
+- Report source snapshot: `8fe9311b`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174242 |
-| Test functions | 2546 |
+| Total Python LOC | 174283 |
+| Test functions | 2548 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T16:22:48+00:00`
+- Generated at: `2026-06-13T16:25:34+00:00`
 
-- Report source snapshot: `b6d2921d`
+- Report source snapshot: `ef1ce9ec`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
-| 2 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 3 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 4 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 5 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 6 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 7 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 8 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 9 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
-| 10 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
+| 1 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
+| 2 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 3 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 4 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 5 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 6 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 7 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 8 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
+| 9 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
+| 10 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T16:25:34+00:00`
+- Generated at: `2026-06-13T16:28:02+00:00`
 
-- Report source snapshot: `ef1ce9ec`
+- Report source snapshot: `8fe9311b`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 2 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 3 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 4 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 5 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 6 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 7 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 8 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
-| 9 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
-| 10 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
+| 1 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 2 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 3 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 4 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 5 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 6 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 7 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
+| 8 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
+| 9 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
+| 10 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T16:04:00+00:00`
+- Generated at: `2026-06-13T16:22:48+00:00`
 
-- Report source snapshot: `9b000d28`
+- Report source snapshot: `b6d2921d`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | authority_context_status | src/api/services/construction_supportability_application.py | 7 | 12 |
-| 2 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
-| 3 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
-| 4 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 5 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 6 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 7 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 8 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 9 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 10 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
+| 1 | _model_documentable_properties | src/api/openapi_enrichment.py | 7 | 11 |
+| 2 | stateful_execution_publishable | src/api/services/integration_capabilities_service.py | 7 | 11 |
+| 3 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
+| 4 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 5 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 6 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 7 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 8 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 9 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
+| 10 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T16:22:48+00:00`
+- Generated at: `2026-06-13T16:25:34+00:00`
 
-- Report source snapshot: `b6d2921d`
+- Report source snapshot: `ef1ce9ec`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T16:04:00+00:00`
+- Generated at: `2026-06-13T16:22:48+00:00`
 
-- Report source snapshot: `9b000d28`
+- Report source snapshot: `b6d2921d`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T16:25:34+00:00`
+- Generated at: `2026-06-13T16:28:02+00:00`
 
-- Report source snapshot: `ef1ce9ec`
+- Report source snapshot: `8fe9311b`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T16:25:34+00:00`
+- Generated at: `2026-06-13T16:28:02+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `ef1ce9ec`
+- Report source snapshot: `8fe9311b`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174125 | 174242 | +117 |
-| Test functions | 2542 | 2546 | +4 |
+| Total Python LOC | 174125 | 174283 | +158 |
+| Test functions | 2542 | 2548 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T16:22:48+00:00`
+- Generated at: `2026-06-13T16:25:34+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `b6d2921d`
+- Report source snapshot: `ef1ce9ec`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174125 | 174192 | +67 |
-| Test functions | 2542 | 2544 | +2 |
+| Total Python LOC | 174125 | 174242 | +117 |
+| Test functions | 2542 | 2546 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T16:04:00+00:00`
+- Generated at: `2026-06-13T16:22:48+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `9b000d28`
+- Report source snapshot: `b6d2921d`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 173967 | 174125 | +158 |
-| Test functions | 2539 | 2542 | +3 |
+| Total Python LOC | 174125 | 174192 | +67 |
+| Test functions | 2542 | 2544 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,14 +37,14 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2815 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2866 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2500 |
+| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2512 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
-| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2377 |
+| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/core/proof_packs/builder.py | 1807 |
+| 10 | src/core/proof_packs/builder.py | 1823 |
 
 ### current branch
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -676,14 +676,33 @@ def _schema_component_schemas(schema: dict[str, Any]) -> dict[str, Any] | None:
 def _model_documentable_properties(
     *, model_name: Any, model_schema: Any
 ) -> Iterator[tuple[str, str, dict[str, Any]]]:
-    if not isinstance(model_name, str) or not isinstance(model_schema, dict):
+    if not isinstance(model_name, str):
+        return
+    for prop_name, prop_schema in _model_property_schemas(model_schema):
+        yield model_name, prop_name, prop_schema
+
+
+def _model_property_schemas(model_schema: Any) -> Iterator[tuple[str, dict[str, Any]]]:
+    if not isinstance(model_schema, dict):
         return
     properties = model_schema.get("properties", {})
     if not isinstance(properties, dict):
         return
     for prop_name, prop_schema in properties.items():
-        if isinstance(prop_name, str) and isinstance(prop_schema, dict):
-            yield model_name, prop_name, prop_schema
+        property_schema = _documentable_property_schema(prop_name, prop_schema)
+        if property_schema is not None:
+            yield property_schema
+
+
+def _documentable_property_schema(
+    prop_name: Any,
+    prop_schema: Any,
+) -> tuple[str, dict[str, Any]] | None:
+    if not isinstance(prop_name, str):
+        return None
+    if not isinstance(prop_schema, dict):
+        return None
+    return prop_name, prop_schema
 
 
 def _ensure_property_documentation(

--- a/src/api/services/construction_supportability_application.py
+++ b/src/api/services/construction_supportability_application.py
@@ -29,6 +29,10 @@ _EnrichmentStatusSelector = Callable[
     [ConstructionEnrichmentSummary],
     ConstructionMethodStatus,
 ]
+_AuthorityContextStatusSelector = Callable[
+    [ConstructionAuthorityContext],
+    ConstructionMethodStatus | None,
+]
 
 _METHOD_ENRICHMENT_STATUS_SELECTORS: dict[
     ConstructionMethod,
@@ -40,6 +44,40 @@ _METHOD_ENRICHMENT_STATUS_SELECTORS: dict[
     ConstructionMethod.LIQUIDITY_AWARE: lambda enrichment: enrichment.liquidity_status,
     ConstructionMethod.CURRENCY_OVERLAY: lambda enrichment: enrichment.fx_status,
     ConstructionMethod.RISK_AWARE: lambda enrichment: enrichment.risk_status,
+}
+
+
+def _liquidity_authority_context_status(
+    authority_context: ConstructionAuthorityContext,
+) -> ConstructionMethodStatus | None:
+    if authority_context.liquidity_context is None:
+        return None
+    return authority_context.liquidity_context.supportability_status
+
+
+def _currency_overlay_authority_context_status(
+    authority_context: ConstructionAuthorityContext,
+) -> ConstructionMethodStatus | None:
+    if authority_context.currency_overlay_context is None:
+        return None
+    return authority_context.currency_overlay_context.supportability_status
+
+
+def _regime_stress_authority_context_status(
+    authority_context: ConstructionAuthorityContext,
+) -> ConstructionMethodStatus | None:
+    if authority_context.regime_stress_context is None:
+        return None
+    return authority_context.regime_stress_context.supportability_status
+
+
+_AUTHORITY_CONTEXT_STATUS_SELECTORS: dict[
+    ConstructionMethod,
+    _AuthorityContextStatusSelector,
+] = {
+    ConstructionMethod.LIQUIDITY_AWARE: _liquidity_authority_context_status,
+    ConstructionMethod.CURRENCY_OVERLAY: _currency_overlay_authority_context_status,
+    ConstructionMethod.REGIME_STRESS_AWARE: _regime_stress_authority_context_status,
 }
 
 
@@ -202,13 +240,10 @@ def authority_context_status(
     method: ConstructionMethod,
     authority_context: ConstructionAuthorityContext,
 ) -> ConstructionMethodStatus | None:
-    if method == ConstructionMethod.LIQUIDITY_AWARE and authority_context.liquidity_context:
-        return authority_context.liquidity_context.supportability_status
-    if method == ConstructionMethod.CURRENCY_OVERLAY and authority_context.currency_overlay_context:
-        return authority_context.currency_overlay_context.supportability_status
-    if method == ConstructionMethod.REGIME_STRESS_AWARE and authority_context.regime_stress_context:
-        return authority_context.regime_stress_context.supportability_status
-    return None
+    selector = _AUTHORITY_CONTEXT_STATUS_SELECTORS.get(method)
+    if selector is None:
+        return None
+    return selector(authority_context)
 
 
 __all__ = [

--- a/src/api/services/integration_capabilities_service.py
+++ b/src/api/services/integration_capabilities_service.py
@@ -28,17 +28,31 @@ def supported_input_modes(
     return supported_modes
 
 
+def _stateful_portfolio_id_input_mode_enabled(*, env_get: EnvGetter) -> bool:
+    return env_bool("DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED", False, env_get=env_get)
+
+
+def _stateful_core_sourcing_enabled(*, env_get: EnvGetter) -> bool:
+    return env_bool("DPM_STATEFUL_CORE_SOURCING_ENABLED", False, env_get=env_get)
+
+
+def _core_base_url_configured(*, env_get: EnvGetter) -> bool:
+    return bool((env_get("DPM_CORE_BASE_URL") or "").strip())
+
+
+def _uses_legacy_monolithic_resolver_path(resolver_path_template: str) -> bool:
+    return bool(resolver_path_template) and "dpm-execution-context" in resolver_path_template
+
+
 def stateful_execution_publishable(*, env_get: EnvGetter) -> bool:
     resolver_path_template = (env_get("DPM_CORE_RESOLVER_PATH_TEMPLATE") or "").strip()
-    uses_legacy_monolithic_resolver = (
-        bool(resolver_path_template) and "dpm-execution-context" in resolver_path_template
-    )
-    return (
-        env_bool("DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED", False, env_get=env_get)
-        and env_bool("DPM_STATEFUL_CORE_SOURCING_ENABLED", False, env_get=env_get)
-        and bool((env_get("DPM_CORE_BASE_URL") or "").strip())
-        and not uses_legacy_monolithic_resolver
-    )
+    publish_guards = [
+        _stateful_portfolio_id_input_mode_enabled(env_get=env_get),
+        _stateful_core_sourcing_enabled(env_get=env_get),
+        _core_base_url_configured(env_get=env_get),
+        not _uses_legacy_monolithic_resolver_path(resolver_path_template),
+    ]
+    return all(publish_guards)
 
 
 def build_feature_capabilities(

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -2,6 +2,7 @@ from src.api.openapi_enrichment import (
     _composite_example_from_schema,
     _collection_example_from_schema,
     _description_context,
+    _documentable_property_schema,
     _enum_example,
     _example_from_schema,
     _ensure_metrics_path_examples,
@@ -17,6 +18,7 @@ from src.api.openapi_enrichment import (
     _is_error_status_code,
     _is_http_operation_method,
     _model_documentable_properties,
+    _model_property_schemas,
     _number_example_for_key,
     _operation_has_error_response,
     _operation_tag_for_path,
@@ -643,6 +645,35 @@ def test_openapi_enrichment_schema_documentable_properties_filters_fragments() -
         list(_model_documentable_properties(model_name="Payload", model_schema={"properties": []}))
         == []
     )
+
+
+def test_openapi_enrichment_model_property_schemas_filters_property_fragments() -> None:
+    custom_property = {"type": "string"}
+
+    assert list(
+        _model_property_schemas(
+            {
+                "properties": {
+                    "customId": custom_property,
+                    42: {"type": "string"},
+                    "bad": [],
+                }
+            }
+        )
+    ) == [("customId", custom_property)]
+    assert list(_model_property_schemas([])) == []
+    assert list(_model_property_schemas({"properties": []})) == []
+
+
+def test_openapi_enrichment_documentable_property_schema_filters_invalid_fragments() -> None:
+    custom_property = {"type": "string"}
+
+    assert _documentable_property_schema("customId", custom_property) == (
+        "customId",
+        custom_property,
+    )
+    assert _documentable_property_schema(42, custom_property) is None
+    assert _documentable_property_schema("customId", []) is None
 
 
 def test_openapi_enrichment_property_documentation_preserves_existing_values() -> None:

--- a/tests/unit/dpm/construction/test_supportability_application.py
+++ b/tests/unit/dpm/construction/test_supportability_application.py
@@ -4,6 +4,9 @@ from typing import Any, cast
 
 from src.api.request_models import RebalanceRequest
 from src.api.services.construction_supportability_application import (
+    _currency_overlay_authority_context_status,
+    _liquidity_authority_context_status,
+    _regime_stress_authority_context_status,
     apply_construction_supportability,
     authority_context_status,
     enrichment_summary_diagnostics,
@@ -436,6 +439,35 @@ def test_authority_context_status_ignores_context_for_unrelated_method() -> None
         )
         is None
     )
+
+
+def test_authority_context_status_helpers_project_available_context_status() -> None:
+    assert (
+        _liquidity_authority_context_status(
+            ConstructionAuthorityContext(liquidity_context=_liquidity_context())
+        )
+        == ConstructionMethodStatus.READY
+    )
+    assert (
+        _currency_overlay_authority_context_status(
+            ConstructionAuthorityContext(currency_overlay_context=_blocked_currency_context())
+        )
+        == ConstructionMethodStatus.BLOCKED
+    )
+    assert (
+        _regime_stress_authority_context_status(
+            ConstructionAuthorityContext(regime_stress_context=_blocked_regime_context())
+        )
+        == ConstructionMethodStatus.BLOCKED
+    )
+
+
+def test_authority_context_status_helpers_return_none_without_matching_context() -> None:
+    authority_context = ConstructionAuthorityContext()
+
+    assert _liquidity_authority_context_status(authority_context) is None
+    assert _currency_overlay_authority_context_status(authority_context) is None
+    assert _regime_stress_authority_context_status(authority_context) is None
 
 
 def test_method_enrichment_statuses_project_method_specific_enrichment() -> None:

--- a/tests/unit/dpm/test_integration_capabilities_service.py
+++ b/tests/unit/dpm/test_integration_capabilities_service.py
@@ -1,6 +1,10 @@
 from datetime import date
 
 from src.api.services.integration_capabilities_service import (
+    _core_base_url_configured,
+    _stateful_core_sourcing_enabled,
+    _stateful_portfolio_id_input_mode_enabled,
+    _uses_legacy_monolithic_resolver_path,
     build_capabilities_response,
     stateful_execution_publishable,
     supported_input_modes,
@@ -48,6 +52,29 @@ def test_stateful_execution_publishable_is_true_when_all_requirements_match() ->
             "DPM_CORE_RESOLVER_PATH_TEMPLATE": "/integration/portfolios/{portfolio_id}/core-snapshot",
         }.get(name)
     )
+
+
+def test_stateful_execution_publishable_guard_helpers_resolve_required_flags() -> None:
+    env_values = {
+        "DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED": "true",
+        "DPM_STATEFUL_CORE_SOURCING_ENABLED": "true",
+        "DPM_CORE_BASE_URL": " http://core.example ",
+    }
+
+    assert _stateful_portfolio_id_input_mode_enabled(env_get=env_values.get)
+    assert _stateful_core_sourcing_enabled(env_get=env_values.get)
+    assert _core_base_url_configured(env_get=env_values.get)
+    assert not _core_base_url_configured(env_get=lambda name: "   ")
+
+
+def test_stateful_execution_publishable_guard_detects_legacy_resolver_path() -> None:
+    assert _uses_legacy_monolithic_resolver_path(
+        "/integration/portfolios/{portfolio_id}/dpm-execution-context"
+    )
+    assert not _uses_legacy_monolithic_resolver_path(
+        "/integration/portfolios/{portfolio_id}/core-snapshot"
+    )
+    assert not _uses_legacy_monolithic_resolver_path("")
 
 
 def test_build_capabilities_response_applies_defaults_and_supplies_all_sections() -> None:


### PR DESCRIPTION
## Summary
- Extract construction authority-context status dispatch helpers and direct helper tests.
- Extract OpenAPI documentable-property filtering helpers and direct helper tests.
- Extract integration-capability stateful publishability guards and direct helper tests.
- Refresh codebase review ledger entries BACKEND-REVIEW-20260614-912 through 914 and quality reports.

## Validation
- `python -m ruff check src/api/services/construction_supportability_application.py tests/unit/dpm/construction/test_supportability_application.py src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py src/api/services/integration_capabilities_service.py tests/unit/dpm/test_integration_capabilities_service.py`
- `python -m ruff format --check src/api/services/construction_supportability_application.py tests/unit/dpm/construction/test_supportability_application.py src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py src/api/services/integration_capabilities_service.py tests/unit/dpm/test_integration_capabilities_service.py`
- `python -m mypy --config-file mypy.ini src/api/services/construction_supportability_application.py src/api/openapi_enrichment.py src/api/services/integration_capabilities_service.py`
- `python -m pytest tests/unit/dpm/construction/test_supportability_application.py tests/unit/api/test_openapi_enrichment_helpers.py tests/unit/dpm/test_integration_capabilities_service.py -q` (59 passed)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- service leakage scan returned no matches
- `git diff --check origin/main...HEAD`
- `make check` (2733 passed)
- wiki drift check: `DiffCount 0`

## Residual risk
- This PR improves maintainability and evidence for three source hotspots only. It does not certify global bank-buyable readiness, runtime evidence, or downstream Gateway/Workbench behavior.