### PR TITLE
Harden outcome source hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23007,3 +23007,29 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal realized outcome helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-918: PM-quality blank policy reference guard
+
+- Date: 2026-06-14
+- Scope: `src/api/routers/pm_operating_quality_models.py` and
+  `tests/unit/api/test_pm_operating_quality_api.py`.
+- Bank-buyable control area: API quality, fail-closed request validation, and testing.
+- Finding: PR review identified that `_has_complete_pm_quality_policy_reference` accepted empty
+  strings after the policy-selection helper extraction because it checked only for `None`.
+  The prior validator treated persisted policy references as complete only when both values were
+  truthy, so blank form/API fields could reach the service resolver as empty policy keys.
+- Action: restored truthy complete-reference semantics in
+  `_has_complete_pm_quality_policy_reference` and added direct regression assertions for blank
+  `policy_id` and blank `policy_version`.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/pm_operating_quality_models.py tests/unit/api/test_pm_operating_quality_api.py`,
+  `python -m ruff format --check src/api/routers/pm_operating_quality_models.py tests/unit/api/test_pm_operating_quality_api.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/pm_operating_quality_models.py`, and
+  `python -m pytest tests/unit/api/test_pm_operating_quality_api.py -q`; the focused PM
+  operating-quality API suite reported 37 passed.
+- Residual risk: this slice restores request-validation semantics for blank persisted policy
+  references only. It does not change service resolver behavior, certify global bank-buyable
+  readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal PM operating-quality API
+  validation hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22915,3 +22915,32 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal integration-capability service
   helper maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-915: Outcome comparison state rollup predicates
+
+- Date: 2026-06-14
+- Scope: `src/core/outcomes/comparison.py` and `tests/unit/core/test_outcome_comparison.py`.
+- Bank-buyable control area: architecture, outcome-review governance, and testing.
+- Finding: `_roll_up_state` combined empty-review handling, all-not-supported handling, blocked /
+  breached / pending-review precedence, and mixed degraded/not-supported downgrade rules in one
+  conditional sequence. The behavior was correct, but outcome-review supportability precedence is
+  easier to audit when each rollup rule is named.
+- Action: extracted `_all_states_not_supported`, `_first_comparison_state_by_precedence`, and
+  `_mixed_review_requires_degraded_rollup`, then kept `_roll_up_state` as the small orchestrator
+  for comparison supportability state. Added direct helper tests for all-not-supported handling,
+  blocked-before-breached-before-pending precedence, and mixed degraded/not-supported review
+  rollup.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py`,
+  `python -m ruff format --check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/comparison.py`,
+  `python -m pytest tests/unit/core/test_outcome_comparison.py -q`,
+  and `python -m radon cc src/core/outcomes/comparison.py -s`; the focused outcome comparison
+  suite reported 15 passed, the report-only complexity baseline had listed `_roll_up_state` at
+  B(7), and current radon reports it at A(5).
+- Residual risk: this slice improves outcome-review comparison state-rollup maintainability only.
+  It does not change comparison semantics, certify global bank-buyable readiness, runtime evidence,
+  or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal outcome-review helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22944,3 +22944,33 @@ and improves internal transaction-cost source posture maintainability only.
   or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal outcome-review helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-916: PM-quality policy-selection predicates
+
+- Date: 2026-06-14
+- Scope: `src/api/routers/pm_operating_quality_models.py` and
+  `tests/unit/api/test_pm_operating_quality_api.py`.
+- Bank-buyable control area: API quality, PM operating-quality governance, and testing.
+- Finding: `validate_policy_selection` combined inline-policy detection, partial persisted-policy
+  reference detection, complete persisted-policy reference detection, and conflict validation in
+  one model validator. The behavior was correct, but PM operating-quality score-run request
+  validation is easier to review when each allowed policy-selection shape is named.
+- Action: extracted `_has_inline_pm_quality_policy`,
+  `_has_pm_quality_policy_reference_fragment`, and `_has_complete_pm_quality_policy_reference`,
+  then kept `validate_policy_selection` as the request-level error mapper. Added direct helper
+  tests for inline policy, policy-id-only, policy-version-only, complete reference, and absent
+  reference inputs.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/pm_operating_quality_models.py tests/unit/api/test_pm_operating_quality_api.py`,
+  `python -m ruff format --check src/api/routers/pm_operating_quality_models.py tests/unit/api/test_pm_operating_quality_api.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/pm_operating_quality_models.py`,
+  `python -m pytest tests/unit/api/test_pm_operating_quality_api.py -q`,
+  and `python -m radon cc src/api/routers/pm_operating_quality_models.py -s`; the focused PM
+  operating-quality API suite reported 37 passed, the report-only complexity baseline had listed
+  `validate_policy_selection` at B(7), and current radon reports it at A(5).
+- Residual risk: this slice improves PM operating-quality request validation maintainability only.
+  It does not change API request semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal PM operating-quality API model
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -22974,3 +22974,36 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal PM operating-quality API model
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-917: Realized outcome source state predicates
+
+- Date: 2026-06-14
+- Scope: `src/core/outcomes/realized_sources.py` and
+  `tests/unit/core/test_realized_outcome_sources.py`.
+- Bank-buyable control area: architecture, outcome-review source lineage, and testing.
+- Finding: `_state_from_source` combined not-supported, blocked, degraded, and ready source-owner
+  posture classification in one conditional sequence, while the adjacent realized-source
+  `_roll_up_state` combined empty-set handling, all-not-supported handling, source-state
+  precedence, and mixed not-supported downgrade behavior. The behavior was correct, but realized
+  source supportability should make each source-owner posture rule explicit.
+- Action: extracted `_source_reports_not_supported`, `_source_reports_blocked`,
+  `_source_reports_degraded`, `_all_realized_states_not_supported`,
+  `_first_realized_state_by_precedence`, and `_realized_rollup_state_for_precedent`, then kept the
+  public assembly flow unchanged. Added direct helper tests for source posture classification,
+  ready fallback, state precedence, all-not-supported handling, and mixed not-supported downgrade
+  to degraded.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/realized_sources.py tests/unit/core/test_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/realized_sources.py tests/unit/core/test_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/realized_sources.py`,
+  `python -m pytest tests/unit/core/test_realized_outcome_sources.py -q`,
+  and `python -m radon cc src/core/outcomes/realized_sources.py -s`; the focused realized outcome
+  source suite reported 16 passed, the report-only complexity baseline had listed
+  `_state_from_source` at B(7), and current radon reports `_state_from_source` at A(4) and
+  `_roll_up_state` at A(4).
+- Residual risk: this slice improves realized outcome source supportability maintainability only.
+  It does not change source-lineage semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal realized outcome helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T16:28:02+00:00`
+- Generated at: `2026-06-13T16:45:55+00:00`
 
-- Report source snapshot: `8fe9311b`
+- Report source snapshot: `6f5e1429`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174283 |
-| Test functions | 2548 |
+| Total Python LOC | 174327 |
+| Test functions | 2550 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T16:45:55+00:00`
+- Generated at: `2026-06-13T16:49:02+00:00`
 
-- Report source snapshot: `6f5e1429`
+- Report source snapshot: `ca52b76b`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174327 |
-| Test functions | 2550 |
+| Total Python LOC | 174382 |
+| Test functions | 2551 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T16:49:02+00:00`
+- Generated at: `2026-06-13T16:52:07+00:00`
 
-- Report source snapshot: `ca52b76b`
+- Report source snapshot: `fddf0daf`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174382 |
-| Test functions | 2551 |
+| Total Python LOC | 174467 |
+| Test functions | 2553 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T16:49:02+00:00`
+- Generated at: `2026-06-13T16:52:07+00:00`
 
-- Report source snapshot: `ca52b76b`
+- Report source snapshot: `fddf0daf`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 2 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 3 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 4 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 5 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
-| 6 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
-| 7 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
-| 8 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
-| 9 | _attribution_value | src/core/outcomes/performance_sources.py | 6 | 65 |
-| 10 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 1 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 2 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 3 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 4 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
+| 5 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
+| 6 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
+| 7 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
+| 8 | _attribution_value | src/core/outcomes/performance_sources.py | 6 | 65 |
+| 9 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 10 | _state_from_health | src/core/waves/source_readiness.py | 6 | 64 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T16:45:55+00:00`
+- Generated at: `2026-06-13T16:49:02+00:00`
 
-- Report source snapshot: `6f5e1429`
+- Report source snapshot: `ca52b76b`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 2 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 3 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 4 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 5 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 6 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
-| 7 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
-| 8 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
-| 9 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
-| 10 | _attribution_value | src/core/outcomes/performance_sources.py | 6 | 65 |
+| 1 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 2 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 3 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 4 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 5 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
+| 6 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
+| 7 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
+| 8 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
+| 9 | _attribution_value | src/core/outcomes/performance_sources.py | 6 | 65 |
+| 10 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T16:28:02+00:00`
+- Generated at: `2026-06-13T16:45:55+00:00`
 
-- Report source snapshot: `8fe9311b`
+- Report source snapshot: `6f5e1429`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _roll_up_state | src/core/outcomes/comparison.py | 7 | 11 |
-| 2 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
-| 3 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
-| 4 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 5 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 6 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 7 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
-| 8 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
-| 9 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
-| 10 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
+| 1 | validate_policy_selection | src/api/routers/pm_operating_quality_models.py | 7 | 8 |
+| 2 | _state_from_source | src/core/outcomes/realized_sources.py | 7 | 8 |
+| 3 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
+| 4 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 5 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 6 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
+| 7 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
+| 8 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
+| 9 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
+| 10 | _attribution_value | src/core/outcomes/performance_sources.py | 6 | 65 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T16:28:02+00:00`
+- Generated at: `2026-06-13T16:45:55+00:00`
 
-- Report source snapshot: `8fe9311b`
+- Report source snapshot: `6f5e1429`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T16:49:02+00:00`
+- Generated at: `2026-06-13T16:52:07+00:00`
 
-- Report source snapshot: `ca52b76b`
+- Report source snapshot: `fddf0daf`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T16:45:55+00:00`
+- Generated at: `2026-06-13T16:49:02+00:00`
 
-- Report source snapshot: `6f5e1429`
+- Report source snapshot: `ca52b76b`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T16:49:02+00:00`
+- Generated at: `2026-06-13T16:52:07+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `ca52b76b`
+- Report source snapshot: `fddf0daf`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174283 | 174382 | +99 |
-| Test functions | 2548 | 2551 | +3 |
+| Total Python LOC | 174283 | 174467 | +184 |
+| Test functions | 2548 | 2553 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T16:28:02+00:00`
+- Generated at: `2026-06-13T16:45:55+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `8fe9311b`
+- Report source snapshot: `6f5e1429`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174125 | 174283 | +158 |
-| Test functions | 2542 | 2548 | +6 |
+| Total Python LOC | 174283 | 174327 | +44 |
+| Test functions | 2548 | 2550 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T16:45:55+00:00`
+- Generated at: `2026-06-13T16:49:02+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `6f5e1429`
+- Report source snapshot: `ca52b76b`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174283 | 174327 | +44 |
-| Test functions | 2548 | 2550 | +2 |
+| Total Python LOC | 174283 | 174382 | +99 |
+| Test functions | 2548 | 2551 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/routers/pm_operating_quality_models.py
+++ b/src/api/routers/pm_operating_quality_models.py
@@ -20,6 +20,26 @@ from src.core.pm_quality import (
 )
 
 
+def _has_inline_pm_quality_policy(policy: DpmPmOperatingQualityPolicy | None) -> bool:
+    return policy is not None
+
+
+def _has_pm_quality_policy_reference_fragment(
+    *,
+    policy_id: str | None,
+    policy_version: str | None,
+) -> bool:
+    return policy_id is not None or policy_version is not None
+
+
+def _has_complete_pm_quality_policy_reference(
+    *,
+    policy_id: str | None,
+    policy_version: str | None,
+) -> bool:
+    return policy_id is not None and policy_version is not None
+
+
 class DpmPmOperatingQualityPmBookScopeRequest(BaseModel):
     tenant_id: str | None = Field(
         default=None,
@@ -100,11 +120,18 @@ class DpmPmOperatingQualityScorePreviewRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_policy_selection(self) -> "DpmPmOperatingQualityScorePreviewRequest":
-        has_inline = self.policy is not None
-        has_ref = self.policy_id is not None or self.policy_version is not None
+        has_inline = _has_inline_pm_quality_policy(self.policy)
+        has_ref = _has_pm_quality_policy_reference_fragment(
+            policy_id=self.policy_id,
+            policy_version=self.policy_version,
+        )
         if has_inline and has_ref:
             raise ValueError("Supply either inline policy or persisted policy reference, not both")
-        if not has_inline and not (self.policy_id and self.policy_version):
+        has_complete_ref = _has_complete_pm_quality_policy_reference(
+            policy_id=self.policy_id,
+            policy_version=self.policy_version,
+        )
+        if not has_inline and not has_complete_ref:
             raise ValueError("Supply inline policy or both policy_id and policy_version")
         return self
 

--- a/src/api/routers/pm_operating_quality_models.py
+++ b/src/api/routers/pm_operating_quality_models.py
@@ -37,7 +37,7 @@ def _has_complete_pm_quality_policy_reference(
     policy_id: str | None,
     policy_version: str | None,
 ) -> bool:
-    return policy_id is not None and policy_version is not None
+    return bool(policy_id) and bool(policy_version)
 
 
 class DpmPmOperatingQualityPmBookScopeRequest(BaseModel):

--- a/src/core/outcomes/comparison.py
+++ b/src/core/outcomes/comparison.py
@@ -38,6 +38,11 @@ _PENDING_REASON: dict[OutcomeDimension, str] = {
 _BLOCKING_STATES: set[OutcomeDimensionState] = {"BLOCKED"}
 _DEGRADED_STATES: set[OutcomeDimensionState] = {"DEGRADED"}
 _NOT_SUPPORTED_STATES: set[OutcomeDimensionState] = {"NOT_SUPPORTED"}
+_COMPARISON_STATE_PRECEDENCE: tuple[OutcomeDimensionState, ...] = (
+    "BLOCKED",
+    "BREACHED",
+    "PENDING_REVIEW",
+)
 
 
 def compare_outcome_dimensions(
@@ -226,14 +231,31 @@ def _result(
 def _roll_up_state(states: list[OutcomeDimensionState]) -> OutcomeDimensionState:
     if not states:
         return "BLOCKED"
-    if all(state == "NOT_SUPPORTED" for state in states):
+    if _all_states_not_supported(states):
         return "NOT_SUPPORTED"
-    for candidate in ("BLOCKED", "BREACHED", "PENDING_REVIEW"):
-        if candidate in states:
-            return candidate
-    if "DEGRADED" in states or "NOT_SUPPORTED" in states:
+    precedent_state = _first_comparison_state_by_precedence(states)
+    if precedent_state is not None:
+        return precedent_state
+    if _mixed_review_requires_degraded_rollup(states):
         return "DEGRADED"
     return "READY"
+
+
+def _all_states_not_supported(states: list[OutcomeDimensionState]) -> bool:
+    return all(state == "NOT_SUPPORTED" for state in states)
+
+
+def _first_comparison_state_by_precedence(
+    states: list[OutcomeDimensionState],
+) -> OutcomeDimensionState | None:
+    for candidate in _COMPARISON_STATE_PRECEDENCE:
+        if candidate in states:
+            return candidate
+    return None
+
+
+def _mixed_review_requires_degraded_rollup(states: list[OutcomeDimensionState]) -> bool:
+    return "DEGRADED" in states or "NOT_SUPPORTED" in states
 
 
 def _roll_up_reason_codes(results: list[DpmOutcomeDimensionResult]) -> list[str]:

--- a/src/core/outcomes/realized_sources.py
+++ b/src/core/outcomes/realized_sources.py
@@ -18,6 +18,11 @@ from src.core.outcomes.models import (
 _BLOCKING_QUALITIES = {"MISSING", "MALFORMED", "CONFLICTING"}
 _DEGRADED_QUALITIES = {"STALE", "UNAVAILABLE", "PARTIAL"}
 _NOT_SUPPORTED_QUALITIES = {"NOT_SUPPORTED"}
+_REALIZED_STATE_PRECEDENCE: tuple[OutcomeDimensionState, ...] = (
+    "BLOCKED",
+    "DEGRADED",
+    "NOT_SUPPORTED",
+)
 
 
 def assemble_realized_outcome_snapshot(
@@ -197,24 +202,57 @@ def _conflicting_metric(
 
 
 def _state_from_source(snapshot: DpmRealizedSourceSnapshot) -> OutcomeDimensionState:
-    if snapshot.source_state == "NOT_SUPPORTED" or snapshot.quality in _NOT_SUPPORTED_QUALITIES:
+    if _source_reports_not_supported(snapshot):
         return "NOT_SUPPORTED"
-    if snapshot.source_state == "BLOCKED" or snapshot.quality in _BLOCKING_QUALITIES:
+    if _source_reports_blocked(snapshot):
         return "BLOCKED"
-    if snapshot.source_state == "DEGRADED" or snapshot.quality in _DEGRADED_QUALITIES:
+    if _source_reports_degraded(snapshot):
         return "DEGRADED"
     return "READY"
+
+
+def _source_reports_not_supported(snapshot: DpmRealizedSourceSnapshot) -> bool:
+    return snapshot.source_state == "NOT_SUPPORTED" or snapshot.quality in _NOT_SUPPORTED_QUALITIES
+
+
+def _source_reports_blocked(snapshot: DpmRealizedSourceSnapshot) -> bool:
+    return snapshot.source_state == "BLOCKED" or snapshot.quality in _BLOCKING_QUALITIES
+
+
+def _source_reports_degraded(snapshot: DpmRealizedSourceSnapshot) -> bool:
+    return snapshot.source_state == "DEGRADED" or snapshot.quality in _DEGRADED_QUALITIES
 
 
 def _roll_up_state(states: list[OutcomeDimensionState]) -> OutcomeDimensionState:
     if not states:
         return "BLOCKED"
-    if all(state == "NOT_SUPPORTED" for state in states):
+    if _all_realized_states_not_supported(states):
         return "NOT_SUPPORTED"
-    for candidate in ("BLOCKED", "DEGRADED", "NOT_SUPPORTED"):
-        if candidate in states:
-            return "DEGRADED" if candidate == "NOT_SUPPORTED" else candidate
+    precedent_state = _first_realized_state_by_precedence(states)
+    if precedent_state is not None:
+        return _realized_rollup_state_for_precedent(precedent_state)
     return "READY"
+
+
+def _all_realized_states_not_supported(states: list[OutcomeDimensionState]) -> bool:
+    return all(state == "NOT_SUPPORTED" for state in states)
+
+
+def _first_realized_state_by_precedence(
+    states: list[OutcomeDimensionState],
+) -> OutcomeDimensionState | None:
+    for candidate in _REALIZED_STATE_PRECEDENCE:
+        if candidate in states:
+            return candidate
+    return None
+
+
+def _realized_rollup_state_for_precedent(
+    state: OutcomeDimensionState,
+) -> OutcomeDimensionState:
+    if state == "NOT_SUPPORTED":
+        return "DEGRADED"
+    return state
 
 
 def _roll_up_reason_codes(

--- a/tests/unit/api/test_pm_operating_quality_api.py
+++ b/tests/unit/api/test_pm_operating_quality_api.py
@@ -415,6 +415,20 @@ def test_pm_operating_quality_policy_selection_helpers_classify_policy_inputs() 
         )
         is False
     )
+    assert (
+        _has_complete_pm_quality_policy_reference(
+            policy_id="",
+            policy_version="2026.05",
+        )
+        is False
+    )
+    assert (
+        _has_complete_pm_quality_policy_reference(
+            policy_id="pmq_sg_dpm",
+            policy_version="",
+        )
+        is False
+    )
 
 
 def test_pm_operating_quality_router_private_edges_fail_closed() -> None:

--- a/tests/unit/api/test_pm_operating_quality_api.py
+++ b/tests/unit/api/test_pm_operating_quality_api.py
@@ -20,6 +20,9 @@ from src.api.routers.pm_operating_quality_book_scope_builder import (
     _pm_book_scope_source_id,
 )
 from src.api.routers.pm_operating_quality_models import (
+    _has_complete_pm_quality_policy_reference,
+    _has_inline_pm_quality_policy,
+    _has_pm_quality_policy_reference_fragment,
     _optional_summary_text,
     _required_summary_text,
     _validate_summary_content_hash,
@@ -387,6 +390,31 @@ def test_pm_operating_quality_request_models_normalize_and_validate_scope_edges(
             actor_id="ops",
             segments=[segment, segment],
         )
+
+
+def test_pm_operating_quality_policy_selection_helpers_classify_policy_inputs() -> None:
+    assert _has_inline_pm_quality_policy(_policy())
+    assert _has_inline_pm_quality_policy(None) is False
+    assert _has_pm_quality_policy_reference_fragment(
+        policy_id="pmq_sg_dpm",
+        policy_version=None,
+    )
+    assert _has_pm_quality_policy_reference_fragment(
+        policy_id=None,
+        policy_version="2026.05",
+    )
+    assert _has_pm_quality_policy_reference_fragment(policy_id=None, policy_version=None) is False
+    assert _has_complete_pm_quality_policy_reference(
+        policy_id="pmq_sg_dpm",
+        policy_version="2026.05",
+    )
+    assert (
+        _has_complete_pm_quality_policy_reference(
+            policy_id="pmq_sg_dpm",
+            policy_version=None,
+        )
+        is False
+    )
 
 
 def test_pm_operating_quality_router_private_edges_fail_closed() -> None:

--- a/tests/unit/core/test_outcome_comparison.py
+++ b/tests/unit/core/test_outcome_comparison.py
@@ -235,6 +235,28 @@ def test_review_rollup_treats_mixed_ready_and_not_supported_as_degraded() -> Non
     assert "PERFORMANCE_OUTCOME_NOT_SUPPORTED" in comparison.supportability.reason_codes
 
 
+def test_review_rollup_helpers_preserve_comparison_state_precedence() -> None:
+    states = ["READY", "PENDING_REVIEW", "BREACHED", "BLOCKED"]
+
+    assert outcome_comparison._all_states_not_supported(["NOT_SUPPORTED"]) is True
+    assert outcome_comparison._all_states_not_supported(["NOT_SUPPORTED", "READY"]) is False
+    assert outcome_comparison._first_comparison_state_by_precedence(states) == "BLOCKED"
+    assert (
+        outcome_comparison._first_comparison_state_by_precedence(["READY", "PENDING_REVIEW"])
+        == "PENDING_REVIEW"
+    )
+    assert outcome_comparison._first_comparison_state_by_precedence(["READY"]) is None
+
+
+def test_mixed_review_degraded_rollup_helper_detects_source_quality_attention() -> None:
+    assert outcome_comparison._mixed_review_requires_degraded_rollup(["READY", "DEGRADED"])
+    assert outcome_comparison._mixed_review_requires_degraded_rollup(["READY", "NOT_SUPPORTED"])
+    assert (
+        outcome_comparison._mixed_review_requires_degraded_rollup(["READY", "PENDING_REVIEW"])
+        is False
+    )
+
+
 def test_tolerance_requires_hard_threshold_to_be_at_least_soft_threshold() -> None:
     with pytest.raises(ValidationError, match="hard tolerance"):
         DpmOutcomeTolerance(soft=Decimal("0.0100"), hard=Decimal("0.0025"))

--- a/tests/unit/core/test_realized_outcome_sources.py
+++ b/tests/unit/core/test_realized_outcome_sources.py
@@ -244,6 +244,53 @@ def test_realized_source_missing_ready_value_helper_is_state_specific() -> None:
     )
 
 
+def test_realized_source_state_helpers_classify_source_posture() -> None:
+    not_supported = _source(
+        dimension="RISK_REDUCTION",
+        source_state="READY",
+        quality="NOT_SUPPORTED",
+    )
+    blocked = _source(
+        dimension="DRIFT_REDUCTION",
+        source_state="READY",
+        quality="MALFORMED",
+    )
+    degraded = _source(
+        dimension="CASH_RESIDUAL",
+        source_state="READY",
+        quality="PARTIAL",
+    )
+    ready = _source(dimension="COST")
+
+    assert realized_source_helpers._source_reports_not_supported(not_supported)
+    assert realized_source_helpers._source_reports_blocked(blocked)
+    assert realized_source_helpers._source_reports_degraded(degraded)
+    assert realized_source_helpers._state_from_source(not_supported) == "NOT_SUPPORTED"
+    assert realized_source_helpers._state_from_source(blocked) == "BLOCKED"
+    assert realized_source_helpers._state_from_source(degraded) == "DEGRADED"
+    assert realized_source_helpers._state_from_source(ready) == "READY"
+
+
+def test_realized_source_rollup_helpers_preserve_source_state_precedence() -> None:
+    states = ["READY", "NOT_SUPPORTED", "DEGRADED", "BLOCKED"]
+
+    assert realized_source_helpers._all_realized_states_not_supported(["NOT_SUPPORTED"])
+    assert (
+        realized_source_helpers._all_realized_states_not_supported(["NOT_SUPPORTED", "READY"])
+        is False
+    )
+    assert realized_source_helpers._first_realized_state_by_precedence(states) == "BLOCKED"
+    assert (
+        realized_source_helpers._first_realized_state_by_precedence(["READY", "NOT_SUPPORTED"])
+        == "NOT_SUPPORTED"
+    )
+    assert realized_source_helpers._first_realized_state_by_precedence(["READY"]) is None
+    assert realized_source_helpers._realized_rollup_state_for_precedent("NOT_SUPPORTED") == (
+        "DEGRADED"
+    )
+    assert realized_source_helpers._realized_rollup_state_for_precedent("BLOCKED") == "BLOCKED"
+
+
 def test_source_owner_not_supported_degrades_mixed_snapshot_without_value() -> None:
     snapshot = assemble_realized_outcome_snapshot(
         portfolio_id="PB_SG_GLOBAL_BAL_001",


### PR DESCRIPTION
## Summary
- extracted outcome comparison rollup predicates and direct helper tests
- extracted PM operating-quality policy selection predicates and direct helper tests
- extracted realized outcome source posture and rollup predicates and direct helper tests
- refreshed the codebase review ledger and generated quality reports through the latest branch snapshot

## Evidence
- `python -m ruff check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py src/api/routers/pm_operating_quality_models.py tests/unit/api/test_pm_operating_quality_api.py src/core/outcomes/realized_sources.py tests/unit/core/test_realized_outcome_sources.py`
- `python -m ruff format --check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py src/api/routers/pm_operating_quality_models.py tests/unit/api/test_pm_operating_quality_api.py src/core/outcomes/realized_sources.py tests/unit/core/test_realized_outcome_sources.py`
- `python -m mypy --config-file mypy.ini src/core/outcomes/comparison.py src/api/routers/pm_operating_quality_models.py src/core/outcomes/realized_sources.py`
- `python -m pytest tests/unit/core/test_outcome_comparison.py tests/unit/api/test_pm_operating_quality_api.py tests/unit/core/test_realized_outcome_sources.py -q` - 68 passed
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- service leakage scan for router/FastAPI/Starlette imports in `src/api/services` - no matches
- `git diff --check origin/main...HEAD`
- `make check` - 2738 passed
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` - DiffCount 0

## Governance
- Ledger entries: `BACKEND-REVIEW-20260614-915`, `BACKEND-REVIEW-20260614-916`, `BACKEND-REVIEW-20260614-917`
- No README/wiki/operator truth changed; wiki publication is not required for this PR.
- This is a maintainability and evidence slice only. It does not claim full bank-buyable readiness; remaining hotspots and broader readiness gaps stay visible in the quality reports.