### PR TITLE
Harden proof pack builder helper boundaries

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23090,3 +23090,35 @@ and improves internal transaction-cost source posture maintainability only.
   or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal proof-pack helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-921: Proof-pack eligibility payload helpers
+
+- Date: 2026-06-14
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, proof-pack eligibility evidence, and testing.
+- Finding: `_eligibility_and_restrictions_section_payload` combined client-restriction source
+  context handling, Manage-local universe exclusion fallback, exclusion fact serialization,
+  exclusion-state mapping, and reason-code de-duplication in one helper. The behavior was correct,
+  but eligibility proof-pack posture is easier to maintain when source-context and local-exclusion
+  branches are named separately.
+- Action: extracted `_eligibility_payload_with_restriction_context`,
+  `_eligibility_payload_from_universe_exclusions`, `_eligibility_state_from_universe_exclusions`,
+  `_excluded_instrument_facts`, and `_eligibility_reason_codes`, then kept
+  `_eligibility_and_restrictions_section_payload` as the dispatcher. Added direct assertions for
+  exclusion state, exclusion fact serialization, reason-code generation, and source-context payload
+  projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`, and
+  `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder suite
+  reported 96 passed, and radon reports `_eligibility_and_restrictions_section_payload` at A(2)
+  after this extraction.
+- Residual risk: this slice improves proof-pack eligibility evidence maintainability only. It does
+  not change proof-pack semantics, certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal proof-pack helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23061,3 +23061,32 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal proof-pack helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-920: Proof-pack selected-alternative payload helpers
+
+- Date: 2026-06-14
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, proof-pack construction evidence, and testing.
+- Finding: `_selected_alternative_section_payload` combined missing-selection fallback, method
+  state mapping, method reason-code mapping, identity facts, method trace facts, and metrics
+  projection in one helper. The behavior was correct, but selected-alternative proof-pack evidence
+  is easier to audit when the state, reason-code, and fact mappers are named.
+- Action: extracted `_selected_alternative_method_state`,
+  `_selected_alternative_reason_codes`, and `_selected_alternative_facts`, then kept
+  `_selected_alternative_section_payload` as the section assembler. Added direct assertions for
+  ready and degraded method status plus selected-alternative identity fact projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`, and
+  `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder suite
+  reported 96 passed, and radon reports `_selected_alternative_section_payload` at A(2) after this
+  extraction.
+- Residual risk: this slice improves selected-alternative proof-pack evidence maintainability only.
+  It does not change proof-pack semantics, certify global bank-buyable readiness, runtime evidence,
+  or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal proof-pack helper
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23033,3 +23033,31 @@ and improves internal transaction-cost source posture maintainability only.
   readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal PM operating-quality API
   validation hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-919: Proof-pack approval-state predicates
+
+- Date: 2026-06-14
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, proof-pack governance evidence, and testing.
+- Finding: `_approval_section_state` encoded run-blocked, gate-blocked, run-review, and
+  gate-review classification directly inside one conditional rollup. The behavior was correct, but
+  approval proof-pack posture is easier to review when the blocked and pending-review predicates
+  are named and directly tested.
+- Action: extracted `_run_blocks_approval`, `_gate_blocks_approval`,
+  `_run_requires_approval_review`, and `_gate_requires_approval_review`, then kept
+  `_approval_section_state` as the precedence mapper. Added direct assertions for each predicate
+  alongside the existing blocked-before-review precedence proof.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`, and
+  `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder suite
+  reported 96 passed, and radon reports `_approval_section_state` at A(5) after this extraction.
+- Residual risk: this slice improves proof-pack approval posture maintainability only. It does not
+  change proof-pack semantics, certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal proof-pack helper
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T16:52:07+00:00`
+- Generated at: `2026-06-13T17:25:52+00:00`
 
-- Report source snapshot: `fddf0daf`
+- Report source snapshot: `fb9eaa03`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,7 +11,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174467 |
+| Total Python LOC | 174600 |
 | Test functions | 2553 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T16:52:07+00:00`
+- Generated at: `2026-06-13T17:25:52+00:00`
 
-- Report source snapshot: `fddf0daf`
+- Report source snapshot: `fb9eaa03`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _approval_section_state | src/core/proof_packs/builder.py | 7 | 8 |
-| 2 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 3 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 4 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
-| 5 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
-| 6 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
-| 7 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
-| 8 | _attribution_value | src/core/outcomes/performance_sources.py | 6 | 65 |
-| 9 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
-| 10 | _state_from_health | src/core/waves/source_readiness.py | 6 | 64 |
+| 1 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
+| 2 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 3 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
+| 4 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
+| 5 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
+| 6 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
+| 7 | _attribution_value | src/core/outcomes/performance_sources.py | 6 | 65 |
+| 8 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 9 | _state_from_health | src/core/waves/source_readiness.py | 6 | 64 |
+| 10 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T16:52:07+00:00`
+- Generated at: `2026-06-13T17:25:52+00:00`
 
-- Report source snapshot: `fddf0daf`
+- Report source snapshot: `fb9eaa03`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T16:52:07+00:00`
+- Generated at: `2026-06-13T17:25:52+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `fddf0daf`
+- Report source snapshot: `fb9eaa03`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174283 | 174467 | +184 |
-| Test functions | 2548 | 2553 | +5 |
+| Total Python LOC | 174481 | 174600 | +119 |
+| Test functions | 2553 | 2553 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -52,14 +52,14 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2866 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2908 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2512 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/core/proof_packs/builder.py | 1823 |
+| 10 | src/core/proof_packs/builder.py | 1900 |
 
 ## Largest Functions
 

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -877,11 +877,27 @@ def _approval_workflow_decision_facts(
 def _approval_section_state(
     *, result: RebalanceResult, gate: GateDecision | None
 ) -> ProofPackSectionState:
-    if result.status == "BLOCKED" or (gate is not None and gate.gate == "BLOCKED"):
+    if _run_blocks_approval(result) or _gate_blocks_approval(gate):
         return "BLOCKED"
-    if result.status == "PENDING_REVIEW" or (gate is not None and gate.gate.endswith("REQUIRED")):
+    if _run_requires_approval_review(result) or _gate_requires_approval_review(gate):
         return "PENDING_REVIEW"
     return "READY"
+
+
+def _run_blocks_approval(result: RebalanceResult) -> bool:
+    return result.status == "BLOCKED"
+
+
+def _gate_blocks_approval(gate: GateDecision | None) -> bool:
+    return gate is not None and gate.gate == "BLOCKED"
+
+
+def _run_requires_approval_review(result: RebalanceResult) -> bool:
+    return result.status == "PENDING_REVIEW"
+
+
+def _gate_requires_approval_review(gate: GateDecision | None) -> bool:
+    return gate is not None and gate.gate.endswith("REQUIRED")
 
 
 def _approval_gate_fact(gate: GateDecision | None) -> dict[str, Any] | None:

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -993,31 +993,55 @@ def _selected_alternative_section_payload(
             {},
             ["DPM_DIRECT_RUN_NO_SELECTED_ALTERNATIVE"],
         )
-    selected_state = (
-        "READY"
-        if selected_alternative.method_status == "READY"
-        else cast(ProofPackSectionState, str(selected_alternative.method_status))
-    )
     return (
-        selected_state,
+        _selected_alternative_method_state(selected_alternative),
         "Selected construction alternative captured with method and trace evidence.",
-        {
-            "alternative_set_id": alternative_set.alternative_set_id if alternative_set else None,
-            "selected_alternative_id": selected_alternative.alternative_id,
-            "selection_id": selection.selection_id if selection else None,
-            "method": selected_alternative.method,
-            "method_status": selected_alternative.method_status,
-            "summary": selected_alternative.summary,
-            "objective_trace": [
-                item.model_dump(mode="json") for item in selected_alternative.objective_trace
-            ],
-            "constraint_trace": [
-                item.model_dump(mode="json") for item in selected_alternative.constraint_trace
-            ],
-        },
+        _selected_alternative_facts(
+            alternative_set=alternative_set,
+            selected_alternative=selected_alternative,
+            selection=selection,
+        ),
         selected_alternative.comparison_metrics.model_dump(mode="json"),
-        [] if selected_alternative.method_status == "READY" else ["DPM_SELECTED_METHOD_NOT_READY"],
+        _selected_alternative_reason_codes(selected_alternative),
     )
+
+
+def _selected_alternative_method_state(
+    selected_alternative: ConstructionAlternative,
+) -> ProofPackSectionState:
+    if selected_alternative.method_status == "READY":
+        return "READY"
+    return cast(ProofPackSectionState, str(selected_alternative.method_status))
+
+
+def _selected_alternative_reason_codes(
+    selected_alternative: ConstructionAlternative,
+) -> list[str]:
+    if selected_alternative.method_status == "READY":
+        return []
+    return ["DPM_SELECTED_METHOD_NOT_READY"]
+
+
+def _selected_alternative_facts(
+    *,
+    alternative_set: ConstructionAlternativeSet | None,
+    selected_alternative: ConstructionAlternative,
+    selection: ConstructionAlternativeSelection | None,
+) -> dict[str, Any]:
+    return {
+        "alternative_set_id": alternative_set.alternative_set_id if alternative_set else None,
+        "selected_alternative_id": selected_alternative.alternative_id,
+        "selection_id": selection.selection_id if selection else None,
+        "method": selected_alternative.method,
+        "method_status": selected_alternative.method_status,
+        "summary": selected_alternative.summary,
+        "objective_trace": [
+            item.model_dump(mode="json") for item in selected_alternative.objective_trace
+        ],
+        "constraint_trace": [
+            item.model_dump(mode="json") for item in selected_alternative.constraint_trace
+        ],
+    }
 
 
 def _source_readiness_section_payload(

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -34,7 +34,7 @@ from src.core.proof_packs.source_analytics import (
 from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthSnapshot
 from src.core.rebalance_runs.artifact import build_dpm_run_artifact
 from src.core.rebalance_runs.models import DpmRunRecord, DpmRunWorkflowDecisionRecord
-from src.core.models import GateDecision, RebalanceResult
+from src.core.models import ExcludedInstrument, GateDecision, RebalanceResult
 
 PROOF_PACK_VERSION = "1.0"
 
@@ -1113,32 +1113,69 @@ def _eligibility_and_restrictions_section_payload(
     restriction_context = source_analytics.get("client_restriction")
     excluded = result.universe.excluded
     if restriction_context is not None:
-        reason_codes = list(restriction_context.reason_codes)
-        if excluded:
-            reason_codes.append("DPM_UNIVERSE_EXCLUSIONS_PRESENT")
-        return (
-            _lowest_section_state(
-                [
-                    restriction_context.state,
-                    "PENDING_REVIEW" if excluded else "READY",
-                ]
-            ),
-            "Eligibility evidence and source-owned client restriction profile are attached.",
-            {
-                **restriction_context.facts,
-                "excluded": [item.model_dump(mode="json") for item in excluded],
-            },
-            {**restriction_context.metrics, "excluded_count": len(excluded)},
-            sorted(set(reason_codes)),
+        return _eligibility_payload_with_restriction_context(
+            restriction_context=restriction_context,
+            excluded=excluded,
         )
 
+    return _eligibility_payload_from_universe_exclusions(excluded)
+
+
+def _eligibility_payload_with_restriction_context(
+    *,
+    restriction_context: ProofPackSourceAnalytics,
+    excluded: list[ExcludedInstrument],
+) -> _SectionPayload:
     return (
-        "READY" if not excluded else "PENDING_REVIEW",
-        "Eligibility and restriction evidence captured from source run universe.",
-        {"excluded": [item.model_dump(mode="json") for item in excluded]},
-        {"excluded_count": len(excluded)},
-        ["DPM_UNIVERSE_EXCLUSIONS_PRESENT"] if excluded else [],
+        _lowest_section_state(
+            [
+                restriction_context.state,
+                _eligibility_state_from_universe_exclusions(excluded),
+            ]
+        ),
+        "Eligibility evidence and source-owned client restriction profile are attached.",
+        {**restriction_context.facts, "excluded": _excluded_instrument_facts(excluded)},
+        {**restriction_context.metrics, "excluded_count": len(excluded)},
+        _eligibility_reason_codes(
+            base_reason_codes=restriction_context.reason_codes,
+            excluded=excluded,
+        ),
     )
+
+
+def _eligibility_payload_from_universe_exclusions(
+    excluded: list[ExcludedInstrument],
+) -> _SectionPayload:
+    return (
+        _eligibility_state_from_universe_exclusions(excluded),
+        "Eligibility and restriction evidence captured from source run universe.",
+        {"excluded": _excluded_instrument_facts(excluded)},
+        {"excluded_count": len(excluded)},
+        _eligibility_reason_codes(base_reason_codes=[], excluded=excluded),
+    )
+
+
+def _eligibility_state_from_universe_exclusions(
+    excluded: list[ExcludedInstrument],
+) -> ProofPackSectionState:
+    return "PENDING_REVIEW" if excluded else "READY"
+
+
+def _excluded_instrument_facts(
+    excluded: list[ExcludedInstrument],
+) -> list[dict[str, Any]]:
+    return [item.model_dump(mode="json") for item in excluded]
+
+
+def _eligibility_reason_codes(
+    *,
+    base_reason_codes: list[str],
+    excluded: list[ExcludedInstrument],
+) -> list[str]:
+    reason_codes = list(base_reason_codes)
+    if excluded:
+        reason_codes.append("DPM_UNIVERSE_EXCLUSIONS_PRESENT")
+    return sorted(set(reason_codes))
 
 
 def _decision_summary_section_payload(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -983,6 +983,21 @@ def test_selected_alternative_section_payload_projects_method_trace() -> None:
     assert facts["constraint_trace"]
     assert metrics == alternative.comparison_metrics.model_dump(mode="json")
     assert reason_codes == []
+    assert builder_module._selected_alternative_method_state(alternative) == "READY"
+    assert builder_module._selected_alternative_reason_codes(alternative) == []
+    degraded_alternative = alternative.model_copy(update={"method_status": "DEGRADED"})
+    assert builder_module._selected_alternative_method_state(degraded_alternative) == "DEGRADED"
+    assert builder_module._selected_alternative_reason_codes(degraded_alternative) == [
+        "DPM_SELECTED_METHOD_NOT_READY"
+    ]
+    assert (
+        builder_module._selected_alternative_facts(
+            alternative_set=alternative_set,
+            selected_alternative=alternative,
+            selection=selection,
+        )["selected_alternative_id"]
+        == alternative.alternative_id
+    )
 
 
 def test_decision_timeline_orders_source_workflow_and_generated_events() -> None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -1232,6 +1232,15 @@ def test_eligibility_and_restrictions_section_payload_reports_universe_exclusion
     assert facts["excluded"][0]["instrument_id"] == "PRIVATE_CREDIT_FUND"
     assert metrics == {"excluded_count": 1}
     assert reason_codes == ["DPM_UNIVERSE_EXCLUSIONS_PRESENT"]
+    excluded = result.universe.excluded
+    assert builder_module._eligibility_state_from_universe_exclusions(excluded) == "PENDING_REVIEW"
+    assert builder_module._excluded_instrument_facts(excluded)[0]["instrument_id"] == (
+        "PRIVATE_CREDIT_FUND"
+    )
+    assert builder_module._eligibility_reason_codes(
+        base_reason_codes=[],
+        excluded=excluded,
+    ) == ["DPM_UNIVERSE_EXCLUSIONS_PRESENT"]
 
 
 def test_eligibility_and_restrictions_section_payload_merges_restriction_context() -> None:
@@ -1301,6 +1310,12 @@ def test_eligibility_and_restrictions_section_payload_merges_restriction_context
         "CLIENT_RESTRICTION_PROFILE_READY",
         "DPM_UNIVERSE_EXCLUSIONS_PRESENT",
     ]
+    restriction_payload = builder_module._eligibility_payload_with_restriction_context(
+        restriction_context=restriction,
+        excluded=result.universe.excluded,
+    )
+    assert restriction_payload[0] == "PENDING_REVIEW"
+    assert restriction_payload[2]["source_product_name"] == "ClientRestrictionProfile"
 
 
 def test_run_source_context_section_payload_dispatches_source_context_sections() -> None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -703,6 +703,8 @@ def test_approval_requirements_section_payload_blocks_for_blocked_run() -> None:
 
 def test_approval_section_state_uses_gate_required_review_and_blocked_precedence() -> None:
     result = _ready_rebalance_result()
+    review_result = result.model_copy(update={"status": "PENDING_REVIEW"})
+    blocked_result = result.model_copy(update={"status": "BLOCKED"})
     review_gate = GateDecision(
         gate="MANDATE_APPROVAL_REQUIRED",
         recommended_next_step="REQUEST_MANDATE_APPROVAL",
@@ -724,11 +726,21 @@ def test_approval_section_state_uses_gate_required_review_and_blocked_precedence
     assert builder_module._approval_section_state(result=result, gate=blocked_gate) == "BLOCKED"
     assert (
         builder_module._approval_section_state(
-            result=result.model_copy(update={"status": "BLOCKED"}),
+            result=blocked_result,
             gate=review_gate,
         )
         == "BLOCKED"
     )
+    assert builder_module._run_blocks_approval(blocked_result)
+    assert builder_module._run_blocks_approval(result) is False
+    assert builder_module._gate_blocks_approval(blocked_gate)
+    assert builder_module._gate_blocks_approval(review_gate) is False
+    assert builder_module._gate_blocks_approval(None) is False
+    assert builder_module._run_requires_approval_review(review_result)
+    assert builder_module._run_requires_approval_review(result) is False
+    assert builder_module._gate_requires_approval_review(review_gate)
+    assert builder_module._gate_requires_approval_review(blocked_gate) is False
+    assert builder_module._gate_requires_approval_review(None) is False
 
 
 def test_approval_support_helpers_serialize_ordered_facts_and_reason_codes() -> None:


### PR DESCRIPTION
## Summary
- extracted proof-pack approval-state predicates for blocked and pending-review precedence
- extracted selected-alternative proof-pack state, reason-code, and fact helpers
- extracted eligibility/restriction proof-pack payload helpers for source-owned restriction context and local universe exclusions
- refreshed codebase review ledger and quality reports after hotspot movement

## Evidence
- `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` - 96 passed
- `python -m radon cc src/core/proof_packs/builder.py -s`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- `python scripts/service_boundary_gate.py`
- service leakage scan for router/FastAPI/Starlette imports in `src/api/services` - no matches
- `git diff --check origin/main...HEAD`
- `make check` - 2738 passed
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` - DiffCount 0

## Quality Movement
- `_approval_section_state`: B(7) removed from top source hotspot list; radon now reports A(5)
- `_selected_alternative_section_payload`: radon now reports A(2)
- `_eligibility_and_restrictions_section_payload`: radon now reports A(2)
- current generated complexity report no longer lists `_approval_section_state` in the top source hotspots

## Governance
- Ledger entries: `BACKEND-REVIEW-20260614-919`, `BACKEND-REVIEW-20260614-920`, `BACKEND-REVIEW-20260614-921`
- No README/wiki/operator truth changed; wiki publication is not required for this PR.
- This is an internal maintainability and evidence slice only. It does not claim full bank-buyable readiness; remaining hotspots and broader readiness gaps stay visible in the generated quality reports.