### PR TITLE
Harden source evidence helper boundaries

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23122,3 +23122,34 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal proof-pack helper
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-922: Historical attribution source adapter helpers
+
+- Date: 2026-06-14
+- Scope: `src/core/outcomes/risk_sources.py` and
+  `tests/unit/core/test_risk_realized_outcome_sources.py`.
+- Bank-buyable control area: architecture, source-owned risk evidence mapping, and testing.
+- Finding: `realized_historical_attribution_source_from_attribution_response` mixed response
+  extraction, fail-closed ready-value validation, source snapshot assembly, source-id creation, and
+  reason-code projection. The behavior was correct, but historical attribution evidence is easier
+  to audit when fail-closed validation, reason codes, and snapshot assembly are named and tested
+  directly.
+- Action: extracted `_ensure_ready_historical_attribution_value`,
+  `_historical_attribution_reason_codes`, and `_historical_attribution_source_snapshot`, then kept
+  `realized_historical_attribution_source_from_attribution_response` as the adapter orchestration
+  boundary. Added direct assertions for ready-value fail-closed behavior, historical attribution
+  reason-code projection, and snapshot identity/date projection.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`,
+  `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py -q`, and
+  `python -m radon cc src/core/outcomes/risk_sources.py -s`; the focused risk realized outcome
+  source suite reported 53 passed, and radon reports
+  `realized_historical_attribution_source_from_attribution_response` at A(3) after this extraction.
+- Residual risk: this slice improves risk source-owned historical attribution adapter
+  maintainability only. It does not change source evidence semantics, certify global bank-buyable
+  readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal source adapter maintainability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23182,3 +23182,31 @@ and improves internal transaction-cost source posture maintainability only.
   runtime evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal source adapter maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-924: Wave source-readiness classification helpers
+
+- Date: 2026-06-14
+- Scope: `src/core/waves/source_readiness.py` and
+  `tests/unit/dpm/waves/test_source_readiness.py`.
+- Bank-buyable control area: architecture, wave source-readiness supportability, and testing.
+- Finding: `_state_from_health` encoded stale, blocked, degraded, review-required, and ready
+  classification branches inline. The behavior was correct, but wave source-readiness posture is
+  easier to audit when each branch has a named predicate or classification builder and direct
+  tests for diagnostic projection.
+- Action: extracted `_health_is_stale`, `_health_blocks_source_readiness`,
+  `_health_degrades_source_readiness`, and the five named classification builders for stale,
+  blocked, degraded, review-required, and ready health. Added direct helper assertions for each
+  branch while preserving existing end-to-end wave item classification tests.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/source_readiness.py tests/unit/dpm/waves/test_source_readiness.py`,
+  `python -m ruff format --check src/core/waves/source_readiness.py tests/unit/dpm/waves/test_source_readiness.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/source_readiness.py`,
+  `python -m pytest tests/unit/dpm/waves/test_source_readiness.py -q`, and
+  `python -m radon cc src/core/waves/source_readiness.py -s`; the focused source-readiness suite
+  reported 4 passed, and radon reports `_state_from_health` at A(5) after this extraction.
+- Residual risk: this slice improves wave source-readiness classification maintainability only. It
+  does not change wave semantics, certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal wave source-readiness
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23153,3 +23153,32 @@ and improves internal transaction-cost source posture maintainability only.
   readiness, runtime evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal source adapter maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-923: Performance attribution selector helpers
+
+- Date: 2026-06-14
+- Scope: `src/core/outcomes/performance_sources.py` and
+  `tests/unit/core/test_performance_realized_outcome_sources.py`.
+- Bank-buyable control area: architecture, source-owned performance evidence mapping, and testing.
+- Finding: `_attribution_value` handled reconciliation, attribution-level, and currency-selector
+  branches inline. The behavior was correct, but performance attribution source evidence is easier
+  to maintain when each selector family has a named helper and direct tests for value conversion,
+  selector reason, and selector token projection.
+- Action: extracted `_reconciliation_attribution_value`, `_level_attribution_value`, and
+  `_currency_attribution_value`, then kept `_attribution_value` as the selector dispatcher. Added
+  direct helper assertions for reconciliation active return, asset-class level total effect, and
+  USD currency total effect.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/performance_sources.py tests/unit/core/test_performance_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/performance_sources.py tests/unit/core/test_performance_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/performance_sources.py`,
+  `python -m pytest tests/unit/core/test_performance_realized_outcome_sources.py -q`, and
+  `python -m radon cc src/core/outcomes/performance_sources.py -s`; the focused performance
+  realized outcome source suite reported 29 passed, and radon reports `_attribution_value` at A(3)
+  after this extraction.
+- Residual risk: this slice improves performance source-owned attribution adapter maintainability
+  only. It does not change source evidence semantics, certify global bank-buyable readiness,
+  runtime evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal source adapter maintainability
+  hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T17:25:52+00:00`
+- Generated at: `2026-06-13T17:55:07+00:00`
 
-- Report source snapshot: `fb9eaa03`
+- Report source snapshot: `ad40bb38`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174600 |
-| Test functions | 2553 |
+| Total Python LOC | 174999 |
+| Test functions | 2554 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T17:25:52+00:00`
+- Generated at: `2026-06-13T17:55:07+00:00`
 
-- Report source snapshot: `fb9eaa03`
+- Report source snapshot: `ad40bb38`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -34,14 +34,14 @@
 | --- | --- | --- | --- | --- |
 | 1 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
 | 2 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 3 | realized_historical_attribution_source_from_attribution_response | src/core/outcomes/risk_sources.py | 6 | 85 |
-| 4 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
-| 5 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
-| 6 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
-| 7 | _attribution_value | src/core/outcomes/performance_sources.py | 6 | 65 |
-| 8 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
-| 9 | _state_from_health | src/core/waves/source_readiness.py | 6 | 64 |
-| 10 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
+| 3 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
+| 4 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
+| 5 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
+| 6 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 7 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
+| 8 | compare_outcome_dimension | src/core/outcomes/comparison.py | 6 | 59 |
+| 9 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
+| 10 | open_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 57 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T17:25:52+00:00`
+- Generated at: `2026-06-13T17:55:07+00:00`
 
-- Report source snapshot: `fb9eaa03`
+- Report source snapshot: `ad40bb38`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T17:25:52+00:00`
+- Generated at: `2026-06-13T17:55:07+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `fb9eaa03`
+- Report source snapshot: `ad40bb38`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174481 | 174600 | +119 |
-| Test functions | 2553 | 2553 | +0 |
+| Total Python LOC | 174600 | 174999 | +399 |
+| Test functions | 2553 | 2554 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,14 +37,14 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2866 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2908 |
 | 4 | tests/unit/test_documentation_current_state.py | 2721 |
 | 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2512 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/core/proof_packs/builder.py | 1823 |
+| 10 | src/core/proof_packs/builder.py | 1900 |
 
 ### current branch
 

--- a/src/core/outcomes/performance_sources.py
+++ b/src/core/outcomes/performance_sources.py
@@ -503,42 +503,77 @@ def _attribution_value(
     currency: str | None,
 ) -> tuple[Decimal | None, str, str]:
     if measure.startswith("reconciliation_"):
-        reconciliation = _read_mapping(period_result.get("reconciliation"))
-        source_field = {
-            "reconciliation_total_active_return": "total_active_return",
-            "reconciliation_sum_of_effects": "sum_of_effects",
-            "reconciliation_residual": "residual",
-        }[measure]
-        value = reconciliation.get(source_field)
-        return (
-            _decimal_from_percentage_points(value, context=f"attribution {measure}")
-            if value is not None
-            else None,
-            "PERFORMANCE_ATTRIBUTION_SELECTOR_RECONCILIATION",
-            "reconciliation",
-        )
-
-    if measure.startswith("level_"):
-        level, dimension = _attribution_level(
+        return _reconciliation_attribution_value(
             period_result=period_result,
+            measure=measure,
+        )
+    if measure.startswith("level_"):
+        return _level_attribution_value(
+            period_result=period_result,
+            measure=measure,
             level_dimension=level_dimension,
         )
-        source_field = {
-            "level_allocation_total": "allocation_total_pct",
-            "level_selection_total": "selection_total_pct",
-            "level_interaction_total": "interaction_total_pct",
-            "level_total_effect": "total_effect_pct",
-        }[measure]
-        value = level.get(source_field)
-        selector = _reason_token(dimension)
-        return (
-            _decimal_from_percentage_points(value, context=f"attribution {measure}")
-            if value is not None
-            else None,
-            f"PERFORMANCE_ATTRIBUTION_LEVEL_{selector}",
-            f"level:{selector.lower()}",
-        )
+    return _currency_attribution_value(
+        period_result=period_result,
+        measure=measure,
+        currency=currency,
+    )
 
+
+def _reconciliation_attribution_value(
+    *,
+    period_result: dict[str, Any],
+    measure: AttributionOutcomeMeasure,
+) -> tuple[Decimal | None, str, str]:
+    reconciliation = _read_mapping(period_result.get("reconciliation"))
+    source_field = {
+        "reconciliation_total_active_return": "total_active_return",
+        "reconciliation_sum_of_effects": "sum_of_effects",
+        "reconciliation_residual": "residual",
+    }[measure]
+    value = reconciliation.get(source_field)
+    return (
+        _decimal_from_percentage_points(value, context=f"attribution {measure}")
+        if value is not None
+        else None,
+        "PERFORMANCE_ATTRIBUTION_SELECTOR_RECONCILIATION",
+        "reconciliation",
+    )
+
+
+def _level_attribution_value(
+    *,
+    period_result: dict[str, Any],
+    measure: AttributionOutcomeMeasure,
+    level_dimension: str | None,
+) -> tuple[Decimal | None, str, str]:
+    level, dimension = _attribution_level(
+        period_result=period_result,
+        level_dimension=level_dimension,
+    )
+    source_field = {
+        "level_allocation_total": "allocation_total_pct",
+        "level_selection_total": "selection_total_pct",
+        "level_interaction_total": "interaction_total_pct",
+        "level_total_effect": "total_effect_pct",
+    }[measure]
+    value = level.get(source_field)
+    selector = _reason_token(dimension)
+    return (
+        _decimal_from_percentage_points(value, context=f"attribution {measure}")
+        if value is not None
+        else None,
+        f"PERFORMANCE_ATTRIBUTION_LEVEL_{selector}",
+        f"level:{selector.lower()}",
+    )
+
+
+def _currency_attribution_value(
+    *,
+    period_result: dict[str, Any],
+    measure: AttributionOutcomeMeasure,
+    currency: str | None,
+) -> tuple[Decimal | None, str, str]:
     currency_result, currency_code = _attribution_currency(
         period_result=period_result,
         currency=currency,

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -351,49 +351,38 @@ def realized_historical_attribution_source_from_attribution_response(
         period_error=period_error,
         quality_flags=quality_flags,
     )
-    if source_state == "READY" and value is None:
-        raise RiskOutcomeSourceError(
-            "lotus-risk historical attribution response is missing a numeric "
-            f"{measure} value for {period} {attribution_type} {metric} {grouping_dimension}"
-        )
+    _ensure_ready_historical_attribution_value(
+        source_state=source_state,
+        value=value,
+        measure=measure,
+        period=period,
+        attribution_type=attribution_type,
+        metric=metric,
+        grouping_dimension=grouping_dimension,
+    )
 
     input_mode = _read_text(response.get("input_mode")) or "unknown"
 
-    return DpmRealizedSourceSnapshot(
-        dimension="RISK_REDUCTION",
-        source_system="lotus-risk",
-        source_type="HISTORICAL_RISK_ATTRIBUTION",
-        source_id=_historical_attribution_source_id(
-            request_fingerprint=request_fingerprint,
-            period=period,
-            attribution_type=attribution_type,
-            metric=metric,
-            grouping_dimension=grouping_dimension,
-            measure=measure,
-            contributor_group_key=contributor_group_key,
-        ),
-        value=value if source_state != "NOT_SUPPORTED" else None,
-        unit="ratio",
+    return _historical_attribution_source_snapshot(
+        request_fingerprint=request_fingerprint,
+        period=period,
+        attribution_type=attribution_type,
+        metric=metric,
+        grouping_dimension=grouping_dimension,
+        measure=measure,
+        contributor_group_key=contributor_group_key,
+        value=value,
         source_state=source_state,
         quality=quality,
         observed_at=_read_text(period_result.get("end_date")),
         as_of_date=_read_text(scope.get("as_of_date")),
-        content_hash=request_fingerprint,
-        reason_codes=[
-            _primary_reason(source_state),
-            f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
-            f"RISK_REASON_{supportability_reason.upper()}",
-            f"RISK_PERIOD_{period}",
-            f"RISK_ATTRIBUTION_TYPE_{attribution_type}",
-            f"RISK_ATTRIBUTION_METRIC_{metric}",
-            f"RISK_ATTRIBUTION_GROUPING_{grouping_dimension}",
-            f"RISK_ATTRIBUTION_MEASURE_{measure.upper()}",
-            f"RISK_ATTRIBUTION_INPUT_MODE_{input_mode.upper()}",
-            _historical_attribution_support_reason(metadata),
-            measure_reason,
-            _quality_flags_reason(quality_flags),
-            _period_error_reason(period_error),
-        ],
+        supportability_state=supportability_state,
+        supportability_reason=supportability_reason,
+        input_mode=input_mode,
+        metadata=metadata,
+        measure_reason=measure_reason,
+        quality_flags=quality_flags,
+        period_error=period_error,
     )
 
 
@@ -680,6 +669,117 @@ def _historical_attribution_source_id(
     if contributor_group_key is not None:
         source_id_parts.append(contributor_group_key)
     return ":".join(source_id_parts)
+
+
+def _historical_attribution_source_snapshot(
+    *,
+    request_fingerprint: str,
+    period: str,
+    attribution_type: str,
+    metric: str,
+    grouping_dimension: str,
+    measure: HistoricalAttributionOutcomeMeasure,
+    contributor_group_key: str | None,
+    value: Decimal | None,
+    source_state: _RiskSourceState,
+    quality: _RiskSourceQuality,
+    observed_at: str | None,
+    as_of_date: str | None,
+    supportability_state: str,
+    supportability_reason: str,
+    input_mode: str,
+    metadata: dict[str, Any],
+    measure_reason: str,
+    quality_flags: list[Any],
+    period_error: str | None,
+) -> DpmRealizedSourceSnapshot:
+    return DpmRealizedSourceSnapshot(
+        dimension="RISK_REDUCTION",
+        source_system="lotus-risk",
+        source_type="HISTORICAL_RISK_ATTRIBUTION",
+        source_id=_historical_attribution_source_id(
+            request_fingerprint=request_fingerprint,
+            period=period,
+            attribution_type=attribution_type,
+            metric=metric,
+            grouping_dimension=grouping_dimension,
+            measure=measure,
+            contributor_group_key=contributor_group_key,
+        ),
+        value=value if source_state != "NOT_SUPPORTED" else None,
+        unit="ratio",
+        source_state=source_state,
+        quality=quality,
+        observed_at=observed_at,
+        as_of_date=as_of_date,
+        content_hash=request_fingerprint,
+        reason_codes=_historical_attribution_reason_codes(
+            source_state=source_state,
+            supportability_state=supportability_state,
+            supportability_reason=supportability_reason,
+            period=period,
+            attribution_type=attribution_type,
+            metric=metric,
+            grouping_dimension=grouping_dimension,
+            measure=measure,
+            input_mode=input_mode,
+            metadata=metadata,
+            measure_reason=measure_reason,
+            quality_flags=quality_flags,
+            period_error=period_error,
+        ),
+    )
+
+
+def _historical_attribution_reason_codes(
+    *,
+    source_state: _RiskSourceState,
+    supportability_state: str,
+    supportability_reason: str,
+    period: str,
+    attribution_type: str,
+    metric: str,
+    grouping_dimension: str,
+    measure: HistoricalAttributionOutcomeMeasure,
+    input_mode: str,
+    metadata: dict[str, Any],
+    measure_reason: str,
+    quality_flags: list[Any],
+    period_error: str | None,
+) -> list[str]:
+    return [
+        _primary_reason(source_state),
+        f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
+        f"RISK_REASON_{supportability_reason.upper()}",
+        f"RISK_PERIOD_{period}",
+        f"RISK_ATTRIBUTION_TYPE_{attribution_type}",
+        f"RISK_ATTRIBUTION_METRIC_{metric}",
+        f"RISK_ATTRIBUTION_GROUPING_{grouping_dimension}",
+        f"RISK_ATTRIBUTION_MEASURE_{measure.upper()}",
+        f"RISK_ATTRIBUTION_INPUT_MODE_{input_mode.upper()}",
+        _historical_attribution_support_reason(metadata),
+        measure_reason,
+        _quality_flags_reason(quality_flags),
+        _period_error_reason(period_error),
+    ]
+
+
+def _ensure_ready_historical_attribution_value(
+    *,
+    source_state: _RiskSourceState,
+    value: Decimal | None,
+    measure: HistoricalAttributionOutcomeMeasure,
+    period: str,
+    attribution_type: str,
+    metric: str,
+    grouping_dimension: str,
+) -> None:
+    if source_state != "READY" or value is not None:
+        return
+    raise RiskOutcomeSourceError(
+        "lotus-risk historical attribution response is missing a numeric "
+        f"{measure} value for {period} {attribution_type} {metric} {grouping_dimension}"
+    )
 
 
 def _rolling_window_matches_request(

--- a/src/core/waves/source_readiness.py
+++ b/src/core/waves/source_readiness.py
@@ -3,6 +3,8 @@
 from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthSnapshot
 from src.core.waves.models import DpmRebalanceWaveItem, DpmWaveSourceRef, WaveItemState
 
+_SourceReadinessClassification = tuple[WaveItemState, list[str], dict[str, object]]
+
 
 def classify_wave_item_source_readiness(
     *,
@@ -73,57 +75,117 @@ def _state_from_health(
     *,
     health: DpmMandateHealthSnapshot,
     wave_as_of_date: str,
-) -> tuple[WaveItemState, list[str], dict[str, object]]:
-    if health.as_of_date.isoformat() < wave_as_of_date:
-        return (
-            "SOURCE_DEGRADED",
-            ["MANDATE_HEALTH_STALE"],
-            {
-                "source_owner": "lotus-manage",
-                "required_action": "REFRESH_MANDATE_HEALTH",
-                "health_as_of_date": health.as_of_date.isoformat(),
-                "wave_as_of_date": wave_as_of_date,
-            },
-        )
+) -> _SourceReadinessClassification:
+    if _health_is_stale(health=health, wave_as_of_date=wave_as_of_date):
+        return _stale_health_classification(health=health, wave_as_of_date=wave_as_of_date)
     health_state = health.health_state.value
-    if health_state == "BLOCKED" or health.source_readiness_state in {
+    if _health_blocks_source_readiness(health=health, health_state=health_state):
+        return _blocked_health_classification(health=health, health_state=health_state)
+    if _health_degrades_source_readiness(health=health):
+        return _degraded_health_classification(health=health, health_state=health_state)
+    if health_state == "PENDING_REVIEW":
+        return _review_required_health_classification(health=health, health_state=health_state)
+    return _ready_health_classification(health=health, health_state=health_state)
+
+
+def _health_is_stale(
+    *,
+    health: DpmMandateHealthSnapshot,
+    wave_as_of_date: str,
+) -> bool:
+    return health.as_of_date.isoformat() < wave_as_of_date
+
+
+def _health_blocks_source_readiness(
+    *,
+    health: DpmMandateHealthSnapshot,
+    health_state: str,
+) -> bool:
+    return health_state == "BLOCKED" or health.source_readiness_state in {
         "INCOMPLETE",
         "UNAVAILABLE",
-    }:
-        return (
-            "SOURCE_BLOCKED",
-            ["MANDATE_HEALTH_BLOCKED", f"SOURCE_READINESS_{health.source_readiness_state}"],
-            {
-                "source_owner": "lotus-manage",
-                "source_owner_upstream": "lotus-core",
-                "required_action": "FIX_SOURCE_DATA",
-                "health_state": health_state,
-                "source_readiness_state": health.source_readiness_state,
-            },
-        )
-    if health.source_readiness_state == "DEGRADED":
-        return (
-            "SOURCE_DEGRADED",
-            ["SOURCE_READINESS_DEGRADED"],
-            {
-                "source_owner": "lotus-manage",
-                "source_owner_upstream": "lotus-core",
-                "required_action": "REVIEW_SOURCE_DEGRADATION",
-                "health_state": health_state,
-                "source_readiness_state": health.source_readiness_state,
-            },
-        )
-    if health_state == "PENDING_REVIEW":
-        return (
-            "REVIEW_REQUIRED",
-            ["MANDATE_HEALTH_PENDING_REVIEW"],
-            {
-                "source_owner": "lotus-manage",
-                "required_action": health.recommended_action.value,
-                "health_state": health_state,
-                "source_readiness_state": health.source_readiness_state,
-            },
-        )
+    }
+
+
+def _health_degrades_source_readiness(*, health: DpmMandateHealthSnapshot) -> bool:
+    return health.source_readiness_state == "DEGRADED"
+
+
+def _stale_health_classification(
+    *,
+    health: DpmMandateHealthSnapshot,
+    wave_as_of_date: str,
+) -> _SourceReadinessClassification:
+    return (
+        "SOURCE_DEGRADED",
+        ["MANDATE_HEALTH_STALE"],
+        {
+            "source_owner": "lotus-manage",
+            "required_action": "REFRESH_MANDATE_HEALTH",
+            "health_as_of_date": health.as_of_date.isoformat(),
+            "wave_as_of_date": wave_as_of_date,
+        },
+    )
+
+
+def _blocked_health_classification(
+    *,
+    health: DpmMandateHealthSnapshot,
+    health_state: str,
+) -> _SourceReadinessClassification:
+    return (
+        "SOURCE_BLOCKED",
+        ["MANDATE_HEALTH_BLOCKED", f"SOURCE_READINESS_{health.source_readiness_state}"],
+        {
+            "source_owner": "lotus-manage",
+            "source_owner_upstream": "lotus-core",
+            "required_action": "FIX_SOURCE_DATA",
+            "health_state": health_state,
+            "source_readiness_state": health.source_readiness_state,
+        },
+    )
+
+
+def _degraded_health_classification(
+    *,
+    health: DpmMandateHealthSnapshot,
+    health_state: str,
+) -> _SourceReadinessClassification:
+    return (
+        "SOURCE_DEGRADED",
+        ["SOURCE_READINESS_DEGRADED"],
+        {
+            "source_owner": "lotus-manage",
+            "source_owner_upstream": "lotus-core",
+            "required_action": "REVIEW_SOURCE_DEGRADATION",
+            "health_state": health_state,
+            "source_readiness_state": health.source_readiness_state,
+        },
+    )
+
+
+def _review_required_health_classification(
+    *,
+    health: DpmMandateHealthSnapshot,
+    health_state: str,
+) -> _SourceReadinessClassification:
+    return (
+        "REVIEW_REQUIRED",
+        ["MANDATE_HEALTH_PENDING_REVIEW"],
+        {
+            "source_owner": "lotus-manage",
+            "required_action": health.recommended_action.value,
+            "health_state": health_state,
+            "source_readiness_state": health.source_readiness_state,
+        },
+    )
+
+
+def _ready_health_classification(
+    *,
+    health: DpmMandateHealthSnapshot,
+    health_state: str,
+) -> _SourceReadinessClassification:
     return (
         "SOURCE_READY",
         ["SOURCE_READINESS_READY"],

--- a/tests/unit/core/test_performance_realized_outcome_sources.py
+++ b/tests/unit/core/test_performance_realized_outcome_sources.py
@@ -290,6 +290,35 @@ def test_attribution_adapter_wraps_source_owned_active_return_reconciliation() -
 
 
 def test_attribution_source_helper_builds_source_id_and_reason_codes() -> None:
+    period_result = perf_sources._attribution_period(_attribution_response(), period="YTD")
+    reconciliation_value, reconciliation_reason, reconciliation_token = (
+        perf_sources._reconciliation_attribution_value(
+            period_result=period_result,
+            measure="reconciliation_total_active_return",
+        )
+    )
+    assert str(reconciliation_value) == "0.0049"
+    assert reconciliation_reason == "PERFORMANCE_ATTRIBUTION_SELECTOR_RECONCILIATION"
+    assert reconciliation_token == "reconciliation"
+
+    level_value, level_reason, level_token = perf_sources._level_attribution_value(
+        period_result=period_result,
+        measure="level_total_effect",
+        level_dimension="asset_class",
+    )
+    assert str(level_value) == "0.0047"
+    assert level_reason == "PERFORMANCE_ATTRIBUTION_LEVEL_ASSET_CLASS"
+    assert level_token == "level:asset_class"
+
+    currency_value, currency_reason, currency_token = perf_sources._currency_attribution_value(
+        period_result=period_result,
+        measure="currency_total_effect",
+        currency="USD",
+    )
+    assert str(currency_value) == "0.0011"
+    assert currency_reason == "PERFORMANCE_ATTRIBUTION_CURRENCY_USD"
+    assert currency_token == "currency:usd"
+
     perf_sources._ensure_ready_attribution_value(
         source_state="DEGRADED",
         value=None,

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -18,11 +18,14 @@ from src.core.outcomes.risk_sources import (
     _concentration_source_posture,
     _drawdown_measure_unavailable,
     _drawdown_source_posture,
+    _ensure_ready_historical_attribution_value,
     _ensure_ready_rolling_metric_value,
     _historical_attribution_contributor,
+    _historical_attribution_reason_codes,
     _historical_attribution_set,
     _historical_attribution_source_id,
     _historical_attribution_source_posture,
+    _historical_attribution_source_snapshot,
     _historical_attribution_value,
     _metric_unit,
     _primary_reason,
@@ -1561,6 +1564,87 @@ def test_rolling_and_historical_attribution_helper_edges_are_explicit() -> None:
         measure="contributor_component_contribution",
         contributor_group_key="TECH",
     ) == (Decimal("0.07"), "RISK_ATTRIBUTION_CONTRIBUTOR_TECH")
+    _ensure_ready_historical_attribution_value(
+        source_state="DEGRADED",
+        value=None,
+        measure="total_value",
+        period="YTD",
+        attribution_type="ACTIVE_RISK",
+        metric="TRACKING_ERROR",
+        grouping_dimension="SECTOR",
+    )
+    with pytest.raises(RiskOutcomeSourceError, match="missing a numeric total_value"):
+        _ensure_ready_historical_attribution_value(
+            source_state="READY",
+            value=None,
+            measure="total_value",
+            period="YTD",
+            attribution_type="ACTIVE_RISK",
+            metric="TRACKING_ERROR",
+            grouping_dimension="SECTOR",
+        )
+    metadata = {
+        "stateful_active_risk_supported_grouping_dimensions": ["SECTOR", "ISSUER"],
+        "stateful_active_risk_gated_grouping_dimensions": ["ISSUER"],
+        "stateful_active_risk_gate_reason": "issuer unavailable",
+    }
+    assert _historical_attribution_reason_codes(
+        source_state="DEGRADED",
+        supportability_state="stale",
+        supportability_reason="calculation_stale",
+        period="YTD",
+        attribution_type="ACTIVE_RISK",
+        metric="TRACKING_ERROR",
+        grouping_dimension="SECTOR",
+        measure="contributor_percent_contribution",
+        input_mode="stateful",
+        metadata=metadata,
+        measure_reason="RISK_ATTRIBUTION_CONTRIBUTOR_TECH",
+        quality_flags=["ESTIMATED"],
+        period_error="period missing",
+    ) == [
+        "RISK_SOURCE_DEGRADED",
+        "RISK_SUPPORTABILITY_STALE",
+        "RISK_REASON_CALCULATION_STALE",
+        "RISK_PERIOD_YTD",
+        "RISK_ATTRIBUTION_TYPE_ACTIVE_RISK",
+        "RISK_ATTRIBUTION_METRIC_TRACKING_ERROR",
+        "RISK_ATTRIBUTION_GROUPING_SECTOR",
+        "RISK_ATTRIBUTION_MEASURE_CONTRIBUTOR_PERCENT_CONTRIBUTION",
+        "RISK_ATTRIBUTION_INPUT_MODE_STATEFUL",
+        "RISK_ATTRIBUTION_STATEFUL_ACTIVE_RISK_SUPPORT_SUPPORTED_2_GATED_1_REASON_ISSUER_UNAVAILABLE",
+        "RISK_ATTRIBUTION_CONTRIBUTOR_TECH",
+        "RISK_ATTRIBUTION_QUALITY_FLAGS_1",
+        "RISK_ATTRIBUTION_PERIOD_ERROR_PERIOD_MISSING",
+    ]
+    snapshot = _historical_attribution_source_snapshot(
+        request_fingerprint="sha256:hist-attr",
+        period="YTD",
+        attribution_type="ACTIVE_RISK",
+        metric="TRACKING_ERROR",
+        grouping_dimension="SECTOR",
+        measure="total_value",
+        contributor_group_key=None,
+        value=Decimal("0.15"),
+        source_state="READY",
+        quality="COMPLETE",
+        observed_at="2026-05-06",
+        as_of_date="2026-05-07",
+        supportability_state="ready",
+        supportability_reason="calculation_complete",
+        input_mode="stateless",
+        metadata={},
+        measure_reason="RISK_ATTRIBUTION_SET_LEVEL",
+        quality_flags=[],
+        period_error=None,
+    )
+    assert snapshot.source_id == (
+        "sha256:hist-attr:YTD:historical-attribution:ACTIVE_RISK:TRACKING_ERROR:SECTOR:total_value"
+    )
+    assert snapshot.value == Decimal("0.15")
+    assert snapshot.observed_at == "2026-05-06"
+    assert snapshot.as_of_date == "2026-05-07"
+    assert "RISK_ATTRIBUTION_PERIOD_OK" in snapshot.reason_codes
 
 
 def test_historical_attribution_posture_and_decimal_errors_are_fail_closed() -> None:

--- a/tests/unit/dpm/waves/test_source_readiness.py
+++ b/tests/unit/dpm/waves/test_source_readiness.py
@@ -10,7 +10,17 @@ from src.core.mandates import (
     calculate_mandate_health,
 )
 from src.core.waves.models import DpmRebalanceWaveItem
-from src.core.waves.source_readiness import classify_wave_item_source_readiness
+from src.core.waves.source_readiness import (
+    _blocked_health_classification,
+    _degraded_health_classification,
+    _health_blocks_source_readiness,
+    _health_degrades_source_readiness,
+    _health_is_stale,
+    _ready_health_classification,
+    _review_required_health_classification,
+    _stale_health_classification,
+    classify_wave_item_source_readiness,
+)
 
 
 def _twin(*, lineage_record_id: str | None = "core-binding-001") -> DpmMandateDigitalTwin:
@@ -47,6 +57,85 @@ def _item() -> DpmRebalanceWaveItem:
         portfolio_id="PB_SG_GLOBAL_BAL_001",
         state="CANDIDATE",
     )
+
+
+def test_source_readiness_health_classification_helpers_preserve_posture() -> None:
+    twin = _twin(lineage_record_id=None)
+    ready_health = calculate_mandate_health(
+        DpmMandateHealthInput(
+            twin=twin,
+            current_weights={"CASH": Decimal("0.05")},
+            target_weights={"CASH": Decimal("0.05")},
+            cash_weight=Decimal("0.05"),
+        )
+    )
+    stale_health = ready_health.model_copy(update={"as_of_date": date(2026, 5, 2)})
+    blocked_health = calculate_mandate_health(
+        DpmMandateHealthInput(
+            twin=twin,
+            current_weights={"CASH": Decimal("0.05")},
+            target_weights={"CASH": Decimal("0.05")},
+            cash_weight=Decimal("0.05"),
+            source_readiness_state="UNAVAILABLE",
+        )
+    )
+    degraded_health = calculate_mandate_health(
+        DpmMandateHealthInput(
+            twin=twin,
+            current_weights={"CASH": Decimal("0.05")},
+            target_weights={"CASH": Decimal("0.05")},
+            cash_weight=Decimal("0.05"),
+            source_readiness_state="DEGRADED",
+        )
+    )
+    review_health = calculate_mandate_health(
+        DpmMandateHealthInput(
+            twin=twin,
+            current_weights={"CASH": Decimal("0.05")},
+            target_weights={"CASH": Decimal("0.05")},
+            cash_weight=Decimal("0.05"),
+            approval_required=True,
+        )
+    )
+
+    assert _health_is_stale(health=stale_health, wave_as_of_date="2026-05-03")
+    assert _stale_health_classification(
+        health=stale_health,
+        wave_as_of_date="2026-05-03",
+    ) == (
+        "SOURCE_DEGRADED",
+        ["MANDATE_HEALTH_STALE"],
+        {
+            "source_owner": "lotus-manage",
+            "required_action": "REFRESH_MANDATE_HEALTH",
+            "health_as_of_date": "2026-05-02",
+            "wave_as_of_date": "2026-05-03",
+        },
+    )
+    assert _health_blocks_source_readiness(
+        health=blocked_health,
+        health_state=blocked_health.health_state.value,
+    )
+    assert _blocked_health_classification(
+        health=blocked_health,
+        health_state=blocked_health.health_state.value,
+    )[0:2] == (
+        "SOURCE_BLOCKED",
+        ["MANDATE_HEALTH_BLOCKED", "SOURCE_READINESS_UNAVAILABLE"],
+    )
+    assert _health_degrades_source_readiness(health=degraded_health)
+    assert _degraded_health_classification(
+        health=degraded_health,
+        health_state=degraded_health.health_state.value,
+    )[0:2] == ("SOURCE_DEGRADED", ["SOURCE_READINESS_DEGRADED"])
+    assert _review_required_health_classification(
+        health=review_health,
+        health_state=review_health.health_state.value,
+    )[0:2] == ("REVIEW_REQUIRED", ["MANDATE_HEALTH_PENDING_REVIEW"])
+    assert _ready_health_classification(
+        health=ready_health,
+        health_state=ready_health.health_state.value,
+    )[0:2] == ("SOURCE_READY", ["SOURCE_READINESS_READY"])
 
 
 def test_source_readiness_blocks_missing_twin_without_synthetic_readiness() -> None:


### PR DESCRIPTION
## Summary
- Extract historical attribution source adapter helpers for fail-closed ready-value validation, reason-code projection, and source snapshot assembly.
- Extract performance attribution selector helpers for reconciliation, attribution-level, and currency selector value projection.
- Extract wave source-readiness classification predicates/builders for stale, blocked, degraded, review-required, and ready health posture.
- Refresh quality reports and add ledger entries BACKEND-REVIEW-20260614-922 through 924.

## Quality movement
- `realized_historical_attribution_source_from_attribution_response` now reports A(3) in radon and dropped out of the generated top source hotspot list.
- `_attribution_value` now reports A(3) in radon and dropped out of the generated top source hotspot list.
- `_state_from_health` now reports A(5) in radon and dropped out of the generated top source hotspot list.
- `quality/complexity_report.md`, `quality/refactor_health_report.md`, `quality/quality_scorecard.md`, and `quality/baseline_report.md` were regenerated at `ad40bb38`.

## Evidence
- `python -m ruff check src/core/outcomes/risk_sources.py src/core/outcomes/performance_sources.py src/core/waves/source_readiness.py tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/core/test_performance_realized_outcome_sources.py tests/unit/dpm/waves/test_source_readiness.py`
- `python -m ruff format --check src/core/outcomes/risk_sources.py src/core/outcomes/performance_sources.py src/core/waves/source_readiness.py tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/core/test_performance_realized_outcome_sources.py tests/unit/dpm/waves/test_source_readiness.py`
- `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py src/core/outcomes/performance_sources.py src/core/waves/source_readiness.py`
- `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py tests/unit/core/test_performance_realized_outcome_sources.py tests/unit/dpm/waves/test_source_readiness.py -q` -> 86 passed
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- service leakage scan returned no matches
- `git diff --check origin/main...HEAD`
- `make check` -> 2739 passed
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged remote branches
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0

## Wiki / docs
- Repo-local codebase review ledger updated for all three slices.
- No wiki source change required; these are internal helper-boundary and test-hardening changes with no operator-facing contract change.

## Residual risk
- This PR improves maintainability, source evidence adapter clarity, test coverage, and generated quality evidence only.
- It does not claim full bank-buyable readiness, runtime certification, or downstream Gateway/Workbench product behavior changes.