### PR TITLE
Harden source hotspots and local quality gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ install-ci:
 pre-commit:
 	pre-commit run --all-files
 
-check: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate service-boundary-gate mesh-contract-validate test
+check: lint no-alias-gate typecheck typecheck-tests-critical openapi-gate api-vocabulary-gate \
+	service-boundary-gate mesh-contract-validate architecture-gate complexity-gate \
+	dependency-hygiene-gate dead-code-gate test
 
 ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate service-boundary-gate migration-smoke test-all security-audit
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COVERAGE_FAIL_UNDER ?= 99
 
 install:
 	python -m pip install --upgrade pip
-	pip install -e ".[dev]"
+	pip install -e ".[dev,quality]"
 	pre-commit install
 
 install-ci:

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23276,12 +23276,15 @@ and improves internal transaction-cost source posture maintainability only.
   than the documented bank-buyable engineering posture.
 - Action: aligned `make check` with the documented active gate set by adding
   `typecheck-tests-critical`, `architecture-gate`, `complexity-gate`, `dependency-hygiene-gate`,
-  and `dead-code-gate`; refreshed the gate documentation to include the critical-test typecheck.
+  and `dead-code-gate`; aligned `make install` with the expanded local check dependencies by
+  installing the `quality` extra; refreshed the gate documentation to include the critical-test
+  typecheck.
 - Status: hardened.
 - Evidence: `make architecture-gate`, `make complexity-gate`, `make dependency-hygiene-gate`,
-  `make dead-code-gate`, and the expanded `make check`; the expanded local gate completed with
-  ruff, mypy, critical-test mypy, OpenAPI, vocabulary, service-boundary, mesh-contract,
-  import-linter, complexity, deptry, vulture, and 2743 unit tests passing.
+  `make dead-code-gate`, `make -n install`, `make -n check`, and the expanded `make check`; the
+  expanded local gate completed with ruff, mypy, critical-test mypy, OpenAPI, vocabulary,
+  service-boundary, mesh-contract, import-linter, complexity, deptry, vulture, and 2743 unit tests
+  passing.
 - Residual risk: this slice improves local pre-PR enforcement parity only. It does not introduce
   stricter xenon thresholds because current module-level complexity still has known C-ranked
   residuals; those remain visible in reports and should be reduced before threshold promotion.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23210,3 +23210,31 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal wave source-readiness
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-925: Outcome comparison result helpers
+
+- Date: 2026-06-14
+- Scope: `src/core/outcomes/comparison.py` and
+  `tests/unit/core/test_outcome_comparison.py`.
+- Bank-buyable control area: architecture, outcome review supportability, and testing.
+- Finding: `compare_outcome_dimension` mixed source supportability short-circuiting, missing-value
+  blocking, variance classification, and result construction in one path. The behavior was covered,
+  but outcome review supportability is easier to audit when terminal source states, missing
+  mandatory values, and deterministic variance comparison each have named helpers and direct tests.
+- Action: extracted `_source_supportability_result`, `_missing_value_result`, and
+  `_compared_dimension_result`; simplified `_source_supportability_state` with set-based precedence
+  checks; and added direct helper tests while preserving the public comparison behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py`,
+  `python -m ruff format --check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/comparison.py`,
+  `python -m pytest tests/unit/core/test_outcome_comparison.py -q`, and
+  `python -m radon cc src/core/outcomes/comparison.py -s`; the focused outcome comparison suite
+  reported 18 passed, and radon reports every function in `comparison.py` at A-grade after this
+  extraction.
+- Residual risk: this slice improves outcome comparison maintainability only. It does not change
+  outcome review semantics, certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal outcome comparison
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23238,3 +23238,29 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal outcome comparison
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-926: Solver target failure diagnostics helper
+
+- Date: 2026-06-14
+- Scope: `src/core/target_generation.py` and
+  `tests/unit/core/test_target_generation_solver_fallbacks.py`.
+- Bank-buyable control area: architecture, solver target-generation supportability, and testing.
+- Finding: `generate_targets_solver` still owned solver orchestration and infeasible diagnostic
+  enrichment in the same control path. The behavior was covered, but solver failure recording is a
+  distinct supportability concern and should be directly auditable.
+- Action: extracted `_record_solver_failure` to append solver failure reasons and infeasibility
+  hints, and added direct tests for infeasible warning order while preserving existing solver
+  fallback and target-generation behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`,
+  `python -m mypy --config-file mypy.ini src/core/target_generation.py`,
+  `python -m pytest tests/unit/core/test_target_generation_solver_fallbacks.py -q`, and
+  `python -m radon cc src/core/target_generation.py -s`; the focused solver fallback suite
+  reported 16 passed, and radon reports `generate_targets_solver` at A(5) after this extraction.
+- Residual risk: this slice improves solver target-generation maintainability only. It does not
+  change solver semantics, certify global bank-buyable readiness, runtime evidence, or downstream
+  Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal solver target-generation
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23264,3 +23264,26 @@ and improves internal transaction-cost source posture maintainability only.
   Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal solver target-generation
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260614-927: Local check gate alignment
+
+- Date: 2026-06-14
+- Scope: `Makefile`, `quality/ci_quality_gates.md`, and this ledger.
+- Bank-buyable control area: CI measurement, local gate parity, and operational evidence.
+- Finding: `quality/ci_quality_gates.md` documented architecture, complexity, dependency-hygiene,
+  and dead-code scans as active `make check` gates, and Feature Lane already ran those checks, but
+  the local `make check` target did not include them. The local pre-PR gate was therefore narrower
+  than the documented bank-buyable engineering posture.
+- Action: aligned `make check` with the documented active gate set by adding
+  `typecheck-tests-critical`, `architecture-gate`, `complexity-gate`, `dependency-hygiene-gate`,
+  and `dead-code-gate`; refreshed the gate documentation to include the critical-test typecheck.
+- Status: hardened.
+- Evidence: `make architecture-gate`, `make complexity-gate`, `make dependency-hygiene-gate`,
+  `make dead-code-gate`, and the expanded `make check`; the expanded local gate completed with
+  ruff, mypy, critical-test mypy, OpenAPI, vocabulary, service-boundary, mesh-contract,
+  import-linter, complexity, deptry, vulture, and 2743 unit tests passing.
+- Residual risk: this slice improves local pre-PR enforcement parity only. It does not introduce
+  stricter xenon thresholds because current module-level complexity still has known C-ranked
+  residuals; those remain visible in reports and should be reduced before threshold promotion.
+- Wiki decision: no wiki source change required; this is repository-local CI command and quality
+  documentation alignment with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T17:55:07+00:00`
+- Generated at: `2026-06-13T18:20:09+00:00`
 
-- Report source snapshot: `ad40bb38`
+- Report source snapshot: `3e4fe1b3`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 174999 |
-| Test functions | 2554 |
+| Total Python LOC | 175168 |
+| Test functions | 2558 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -20,6 +20,7 @@ The following commands are active repository gates:
   - `python scripts/check_monetary_float_usage.py`
   - `make no-alias-gate`
   - `make typecheck` (`python -m mypy --config-file mypy.ini`)
+  - `make typecheck-tests-critical`
   - `python scripts/openapi_quality_gate.py`
   - `python scripts/api_vocabulary_inventory.py --validate-only`
   - `make mesh-contract-validate`

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T17:55:07+00:00`
+- Generated at: `2026-06-13T18:20:09+00:00`
 
-- Report source snapshot: `ad40bb38`
+- Report source snapshot: `3e4fe1b3`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -36,12 +36,12 @@
 | 2 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
 | 3 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
 | 4 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
-| 5 | generate_targets_solver | src/core/target_generation.py | 6 | 68 |
-| 6 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
-| 7 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
-| 8 | compare_outcome_dimension | src/core/outcomes/comparison.py | 6 | 59 |
-| 9 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
-| 10 | open_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 57 |
+| 5 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 6 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
+| 7 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
+| 8 | open_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 57 |
+| 9 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
+| 10 | realized_risk_source_from_risk_metrics_report | src/core/outcomes/risk_sources.py | 6 | 53 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T17:55:07+00:00`
+- Generated at: `2026-06-13T18:20:09+00:00`
 
-- Report source snapshot: `ad40bb38`
+- Report source snapshot: `3e4fe1b3`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T17:55:07+00:00`
+- Generated at: `2026-06-13T18:20:09+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `ad40bb38`
+- Report source snapshot: `3e4fe1b3`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174600 | 174999 | +399 |
-| Test functions | 2553 | 2554 | +1 |
+| Total Python LOC | 174999 | 175168 | +169 |
+| Test functions | 2554 | 2558 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/outcomes/comparison.py
+++ b/src/core/outcomes/comparison.py
@@ -74,6 +74,35 @@ def compare_outcome_dimension(
 
     source_refs = _dimension_source_refs(dimension_input)
     supportability_state = _source_supportability_state(dimension_input)
+    if source_result := _source_supportability_result(
+        dimension_input=dimension_input,
+        source_refs=source_refs,
+        supportability_state=supportability_state,
+    ):
+        return source_result
+
+    expected = dimension_input.expected.value
+    realized = dimension_input.realized.value
+    if _dimension_values_missing(dimension_input):
+        return _missing_value_result(dimension_input, source_refs=source_refs)
+    assert expected is not None
+    assert realized is not None
+
+    return _compared_dimension_result(
+        dimension_input=dimension_input,
+        source_refs=source_refs,
+        supportability_state=supportability_state,
+        expected=expected,
+        realized=realized,
+    )
+
+
+def _source_supportability_result(
+    *,
+    dimension_input: DpmOutcomeDimensionInput,
+    source_refs: list[DpmOutcomeSourceRef],
+    supportability_state: OutcomeDimensionState,
+) -> DpmOutcomeDimensionResult | None:
     if supportability_state == "NOT_SUPPORTED":
         return _result(
             dimension_input,
@@ -90,20 +119,31 @@ def compare_outcome_dimension(
             source_refs=source_refs,
             explanation="Mandatory source evidence is missing, conflicting, or invalid.",
         )
+    return None
 
-    expected = dimension_input.expected.value
-    realized = dimension_input.realized.value
-    if _dimension_values_missing(dimension_input):
-        return _result(
-            dimension_input,
-            state="BLOCKED",
-            reason_code=_blocked_reason(dimension_input.dimension),
-            source_refs=source_refs,
-            explanation="Expected and realized values are mandatory for deterministic comparison.",
-        )
-    assert expected is not None
-    assert realized is not None
 
+def _missing_value_result(
+    dimension_input: DpmOutcomeDimensionInput,
+    *,
+    source_refs: list[DpmOutcomeSourceRef],
+) -> DpmOutcomeDimensionResult:
+    return _result(
+        dimension_input,
+        state="BLOCKED",
+        reason_code=_blocked_reason(dimension_input.dimension),
+        source_refs=source_refs,
+        explanation="Expected and realized values are mandatory for deterministic comparison.",
+    )
+
+
+def _compared_dimension_result(
+    *,
+    dimension_input: DpmOutcomeDimensionInput,
+    source_refs: list[DpmOutcomeSourceRef],
+    supportability_state: OutcomeDimensionState,
+    expected: Decimal,
+    realized: Decimal,
+) -> DpmOutcomeDimensionResult:
     variance = realized - expected
     pressure = _variance_pressure(
         expected=expected,
@@ -173,15 +213,15 @@ def _variance_pressure(
 def _source_supportability_state(
     dimension_input: DpmOutcomeDimensionInput,
 ) -> OutcomeDimensionState:
-    source_states = [
+    source_states = {
         dimension_input.expected.supportability.state,
         dimension_input.realized.supportability.state,
-    ]
-    if any(state in _NOT_SUPPORTED_STATES for state in source_states):
+    }
+    if source_states & _NOT_SUPPORTED_STATES:
         return "NOT_SUPPORTED"
-    if any(state in _BLOCKING_STATES for state in source_states):
+    if source_states & _BLOCKING_STATES:
         return "BLOCKED"
-    if any(state in _DEGRADED_STATES for state in source_states):
+    if source_states & _DEGRADED_STATES:
         return "DEGRADED"
     return "READY"
 

--- a/src/core/target_generation.py
+++ b/src/core/target_generation.py
@@ -525,18 +525,15 @@ def generate_targets_solver(
     solved, latest_status = _solve_with_fallbacks(solver_problem.problem, cp)
 
     if not solved:
-        reason = _solver_failure_reason(latest_status)
-        diagnostics.warnings.append(reason)
-        if reason.startswith("INFEASIBLE_"):
-            diagnostics.warnings.extend(
-                _collect_infeasibility_hints(
-                    tradeable_ids=tradeable_ids,
-                    locked_weight=locked_weight,
-                    options=options,
-                    eligible_targets=eligible_targets,
-                    shelf=shelf,
-                )
-            )
+        _record_solver_failure(
+            latest_status=latest_status,
+            tradeable_ids=tradeable_ids,
+            locked_weight=locked_weight,
+            options=options,
+            eligible_targets=eligible_targets,
+            shelf=shelf,
+            diagnostics=diagnostics,
+        )
         return [], "BLOCKED"
 
     if not _apply_solver_values(
@@ -547,3 +544,27 @@ def generate_targets_solver(
     ):
         return [], "BLOCKED"
     return build_target_trace(model, eligible_targets, buy_list, total_val, base_ccy), status
+
+
+def _record_solver_failure(
+    *,
+    latest_status: str | None,
+    tradeable_ids: list[str],
+    locked_weight: Decimal,
+    options: EngineOptions,
+    eligible_targets: dict[str, Decimal],
+    shelf: list[ShelfEntry],
+    diagnostics: DiagnosticsData,
+) -> None:
+    reason = _solver_failure_reason(latest_status)
+    diagnostics.warnings.append(reason)
+    if reason.startswith("INFEASIBLE_"):
+        diagnostics.warnings.extend(
+            _collect_infeasibility_hints(
+                tradeable_ids=tradeable_ids,
+                locked_weight=locked_weight,
+                options=options,
+                eligible_targets=eligible_targets,
+                shelf=shelf,
+            )
+        )

--- a/tests/unit/core/test_outcome_comparison.py
+++ b/tests/unit/core/test_outcome_comparison.py
@@ -171,6 +171,77 @@ def test_dimension_values_missing_detects_expected_or_realized_gaps() -> None:
     )
 
 
+def test_source_supportability_result_short_circuits_terminal_source_states() -> None:
+    not_supported_input = _dimension(
+        dimension="PERFORMANCE",
+        expected="0.0150",
+        realized="0.0160",
+        realized_state="NOT_SUPPORTED",
+        direction="HIGHER_IS_BETTER",
+    )
+    blocked_input = _dimension(
+        dimension="EXECUTION_QUALITY",
+        expected="0.0005",
+        realized="0.0007",
+        realized_state="BLOCKED",
+    )
+    source_refs = outcome_comparison._dimension_source_refs(not_supported_input)
+
+    not_supported_result = outcome_comparison._source_supportability_result(
+        dimension_input=not_supported_input,
+        source_refs=source_refs,
+        supportability_state="NOT_SUPPORTED",
+    )
+    blocked_result = outcome_comparison._source_supportability_result(
+        dimension_input=blocked_input,
+        source_refs=outcome_comparison._dimension_source_refs(blocked_input),
+        supportability_state="BLOCKED",
+    )
+    ready_result = outcome_comparison._source_supportability_result(
+        dimension_input=_dimension(),
+        source_refs=outcome_comparison._dimension_source_refs(_dimension()),
+        supportability_state="READY",
+    )
+
+    assert not_supported_result is not None
+    assert not_supported_result.state == "NOT_SUPPORTED"
+    assert not_supported_result.reason_code == "PERFORMANCE_OUTCOME_NOT_SUPPORTED"
+    assert blocked_result is not None
+    assert blocked_result.state == "BLOCKED"
+    assert blocked_result.reason_code == "EXECUTION_EVIDENCE_BLOCKED"
+    assert ready_result is None
+
+
+def test_missing_value_result_preserves_blocked_source_evidence_shape() -> None:
+    dimension_input = _dimension(expected="0.1200", realized=None)
+    result = outcome_comparison._missing_value_result(
+        dimension_input,
+        source_refs=outcome_comparison._dimension_source_refs(dimension_input),
+    )
+
+    assert result.state == "BLOCKED"
+    assert result.reason_code == "SOURCE_EVIDENCE_INCOMPLETE"
+    assert result.expected == Decimal("0.1200")
+    assert result.realized is None
+    assert result.calculation_trace["variance_pressure"] is None
+
+
+def test_compared_dimension_result_preserves_variance_classification() -> None:
+    dimension_input = _dimension(dimension="COST", expected="100.00", realized="111.00")
+    result = outcome_comparison._compared_dimension_result(
+        dimension_input=dimension_input,
+        source_refs=outcome_comparison._dimension_source_refs(dimension_input),
+        supportability_state="READY",
+        expected=Decimal("100.00"),
+        realized=Decimal("111.00"),
+    )
+
+    assert result.state == "BREACHED"
+    assert result.reason_code == "COST_ABOVE_ESTIMATE"
+    assert result.variance == Decimal("11.00")
+    assert result.calculation_trace["variance_pressure"] == Decimal("11.00")
+
+
 def test_dimension_state_and_reason_classifies_pressure_and_degraded_sources() -> None:
     breached_state, breached_reason = outcome_comparison._dimension_state_and_reason(
         dimension_input=_dimension(dimension="COST", expected="100.00", realized="111.00"),

--- a/tests/unit/core/test_target_generation_solver_fallbacks.py
+++ b/tests/unit/core/test_target_generation_solver_fallbacks.py
@@ -7,6 +7,7 @@ from src.core.models import DiagnosticsData, EngineOptions, ModelPortfolio, Mode
 from src.core.target_generation import (
     _installed_solver_names,
     _load_solver_modules,
+    _record_solver_failure,
     _solve_attempt_status,
     _solve_with_fallbacks,
     _solver_is_available,
@@ -236,6 +237,42 @@ def test_load_solver_modules_does_not_hide_non_import_failures(monkeypatch) -> N
     with pytest.raises(RuntimeError, match="solver import side effect failed"):
         _load_solver_modules(diagnostics)
     assert diagnostics.warnings == []
+
+
+def test_record_solver_failure_adds_infeasibility_hints() -> None:
+    diagnostics = DiagnosticsData(data_quality={}, suppressed_intents=[], warnings=[])
+
+    _record_solver_failure(
+        latest_status="infeasible",
+        tradeable_ids=["BUY_1", "BUY_2"],
+        locked_weight=Decimal("0.4"),
+        options=EngineOptions(
+            cash_band_max_weight=Decimal("0.20"),
+            single_position_max_weight=Decimal("0.10"),
+            group_constraints={"sector:TECH": {"max_weight": Decimal("0.3")}},
+        ),
+        eligible_targets={
+            "BUY_1": Decimal("0.3"),
+            "BUY_2": Decimal("0.3"),
+            "LOCKED_TECH": Decimal("0.4"),
+        },
+        shelf=[
+            ShelfEntry(instrument_id="BUY_1", status="APPROVED", attributes={"sector": "FIN"}),
+            ShelfEntry(instrument_id="BUY_2", status="APPROVED", attributes={"sector": "FIN"}),
+            ShelfEntry(
+                instrument_id="LOCKED_TECH",
+                status="SELL_ONLY",
+                attributes={"sector": "TECH"},
+            ),
+        ],
+        diagnostics=diagnostics,
+    )
+
+    assert diagnostics.warnings == [
+        "INFEASIBLE_INFEASIBLE",
+        "INFEASIBILITY_HINT_SINGLE_POSITION_CAPACITY",
+        "INFEASIBILITY_HINT_LOCKED_GROUP_WEIGHT_sector:TECH",
+    ]
 
 
 def test_generate_targets_solver_reports_pending_review_when_sell_excess_has_no_recipient(


### PR DESCRIPTION
## Summary
- Refactor outcome comparison result construction into explicit supportability, missing-value, and variance-result helpers with direct tests.
- Extract solver target-generation failure diagnostics into a named helper with direct infeasibility warning tests.
- Align `make check` with documented local/CI gate coverage by adding critical-test mypy, architecture, complexity, dependency-hygiene, and dead-code gates.
- Refresh quality reports and review ledger entries through `BACKEND-REVIEW-20260614-927`.

## Evidence
- `python -m ruff check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py`
- `python -m ruff format --check src/core/outcomes/comparison.py tests/unit/core/test_outcome_comparison.py`
- `python -m mypy --config-file mypy.ini src/core/outcomes/comparison.py`
- `python -m pytest tests/unit/core/test_outcome_comparison.py -q` (18 passed)
- `python -m radon cc src/core/outcomes/comparison.py -s` (all functions A-grade)
- `python -m ruff check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`
- `python -m ruff format --check src/core/target_generation.py tests/unit/core/test_target_generation_solver_fallbacks.py`
- `python -m mypy --config-file mypy.ini src/core/target_generation.py`
- `python -m pytest tests/unit/core/test_target_generation_solver_fallbacks.py -q` (16 passed)
- `python -m radon cc src/core/target_generation.py -s` (`generate_targets_solver` A(5))
- `make architecture-gate`
- `make complexity-gate`
- `make dependency-hygiene-gate`
- `make dead-code-gate`
- `make -n check`
- `make check` (expanded gate set, 2743 passed)
- `python scripts/engineering_health_report.py`
- `git diff --check`
- service leakage scan: no matches
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (only this active feature branch)
- `gh pr list --state open --json number,title,headRefName,baseRefName,url` (`[]` before this PR)
- wiki drift check: DiffCount 0

## Residual Risk
- This does not claim full bank-buyable readiness.
- Xenon module-level complexity thresholds were not promoted because known C-ranked module residuals remain; the active change keeps those visible in reports and gates without pretending the threshold is remediated.
- Remaining source hotspots are recorded in `quality/complexity_report.md` for future slices.

## Wiki
- No wiki publication required; repo-local wiki DiffCount is 0 and changes are internal architecture/CI quality posture plus generated quality reports.