### PR TITLE
Harden manage source hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23346,3 +23346,23 @@ and improves internal transaction-cost source posture maintainability only.
   downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal outcome-source maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-930: Refactor evidence refresh
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement, maintainability evidence, and operational evidence.
+- Finding: after the wave simulation and RiskMetricsReport helper extractions, the checked-in
+  quality reports still reflected an older source snapshot and listed the now-remediated functions
+  as current source hotspots.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`
+  so the source snapshot, LOC/test counts, and source-hotspot table reflect the current branch.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed complexity report is now
+  sourced from `1c1955c2` and no longer lists `simulate_item` or
+  `realized_risk_source_from_risk_metrics_report` in the top-ten current source hotspots.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23318,3 +23318,31 @@ and improves internal transaction-cost source posture maintainability only.
   evidence, or downstream Gateway/Workbench product behavior.
 - Wiki decision: no wiki source change required; this is internal service maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-929: Risk metrics source snapshot helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/outcomes/risk_sources.py` and
+  `tests/unit/core/test_risk_realized_outcome_sources.py`.
+- Bank-buyable control area: architecture, source-owned risk evidence supportability, and testing.
+- Finding: `realized_risk_source_from_risk_metrics_report` mixed lotus-risk response adaptation,
+  ready-value validation, and realized-source snapshot construction in one function. The behavior
+  was covered, but ready-value enforcement and source snapshot construction are reusable evidence
+  boundaries that should be independently auditable.
+- Action: extracted `_ensure_ready_risk_metric_value` and `_risk_metrics_source_snapshot`, added
+  direct helper tests, and kept the public RiskMetricsReport adapter behavior unchanged.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m ruff format --check src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/risk_sources.py`,
+  `python -m pytest tests/unit/core/test_risk_realized_outcome_sources.py -q`, and
+  `python -m radon cc src/core/outcomes/risk_sources.py -s`; the focused risk realized outcome
+  source suite reported 55 passed, radon reports `realized_risk_source_from_risk_metrics_report`
+  at A(4), and the new risk metrics snapshot helper at A(1).
+- Residual risk: this slice improves internal risk-source maintainability only. Existing unrelated
+  B-grade helpers in `risk_sources.py` remain visible as future source hotspots; this slice does not
+  change source-owned risk semantics, certify global bank-buyable readiness, runtime evidence, or
+  downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal outcome-source maintainability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23290,3 +23290,31 @@ and improves internal transaction-cost source posture maintainability only.
   residuals; those remain visible in reports and should be reduced before threshold promotion.
 - Wiki decision: no wiki source change required; this is repository-local CI command and quality
   documentation alignment with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-928: Wave simulation item result helpers
+
+- Date: 2026-06-17
+- Scope: `src/api/services/wave_simulation_item.py` and
+  `tests/unit/dpm/waves/test_wave_simulation_item.py`.
+- Bank-buyable control area: architecture, wave simulation supportability, and testing.
+- Finding: `simulate_item` mixed simulation-input lookup, request/context normalization,
+  missing-input projection, construction-generation failure projection, and simulated-item
+  diagnostic construction in one service path. The behavior was covered, but these are distinct
+  supportability decisions that are easier to audit when each has a named helper and direct tests.
+- Action: extracted helpers for simulation-input lookup, request/context normalization, missing
+  construction input blocking, construction-generation failure blocking, and simulated-item
+  construction while preserving public wave simulation behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/services/wave_simulation_item.py tests/unit/dpm/waves/test_wave_simulation_item.py`,
+  `python -m ruff format --check src/api/services/wave_simulation_item.py tests/unit/dpm/waves/test_wave_simulation_item.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/wave_simulation_item.py`,
+  `python -m pytest tests/unit/dpm/waves/test_wave_simulation_item.py -q`, and
+  `python -m radon cc src/api/services/wave_simulation_item.py -s`; the focused wave simulation
+  item suite reported 11 passed, and radon reports every function in `wave_simulation_item.py` at
+  A-grade with `simulate_item` reduced to A(4).
+- Residual risk: this slice improves internal wave simulation maintainability only. It does not
+  change API contracts, construction semantics, certify global bank-buyable readiness, runtime
+  evidence, or downstream Gateway/Workbench product behavior.
+- Wiki decision: no wiki source change required; this is internal service maintainability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23393,3 +23393,21 @@ and improves internal transaction-cost source posture maintainability only.
   bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal observability and CI reliability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-932: Post-CI-fix evidence refresh
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the access-log route-template hardening commit, the checked-in quality reports
+  needed to reflect the updated branch head, LOC count, and test-function count.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `c36b80f0` and record 819 Python files, 175422 total Python LOC, 2566 test functions, zero
+  service-boundary findings, and zero router infrastructure imports.
+- Residual risk: this slice updates report truth only. It does not promote report-only baselines
+  into stricter thresholds or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23366,3 +23366,30 @@ and improves internal transaction-cost source posture maintainability only.
   baselines into stricter thresholds or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-931: HTTP access route-template CI hardening
+
+- Date: 2026-06-17
+- Scope: `src/api/observability.py`, `tests/unit/dpm/api/test_observability_api.py`, and this
+  ledger.
+- Bank-buyable control area: observability, CI reliability, and sensitive-data logging controls.
+- Finding: GitHub Feature Lane on Python 3.12 exposed an environment-sensitive route-template
+  shape where `request.scope["route"].path` omitted the `/api/v1` include-router prefix while
+  `request.scope["path"]` retained it. The access log still avoided sensitive path values, but the
+  endpoint template contract differed between local and CI runs.
+- Action: added `_route_template_with_request_prefix` so API request paths restore the stable
+  `/api/v1` prefix without using raw path parameter values, and added a direct regression test for
+  the CI shape plus the already-prefixed and non-API cases.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/observability.py tests/unit/dpm/api/test_observability_api.py`,
+  `python -m ruff format --check src/api/observability.py tests/unit/dpm/api/test_observability_api.py`,
+  `python -m mypy --config-file mypy.ini src/api/observability.py`,
+  `python -m pytest tests/unit/dpm/api/test_observability_api.py::test_http_access_log_uses_route_template_not_sensitive_path_values tests/unit/dpm/api/test_observability_api.py::test_route_template_restores_api_prefix_without_path_values -q`,
+  and `python -m radon cc src/api/observability.py -s`; focused observability tests reported
+  2 passed, `_route_template` remains A(4), and the new prefix helper is A(3).
+- Residual risk: this slice hardens the HTTP access-log route-template contract only. It does not
+  change API behavior, logging payload fields beyond endpoint template normalization, or global
+  bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal observability and CI reliability
+  hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-16T22:58:51+00:00`
+- Generated at: `2026-06-16T23:04:44+00:00`
 
-- Report source snapshot: `1c1955c2`
+- Report source snapshot: `c36b80f0`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 175383 |
-| Test functions | 2565 |
+| Total Python LOC | 175422 |
+| Test functions | 2566 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-13T18:20:09+00:00`
+- Generated at: `2026-06-16T22:58:51+00:00`
 
-- Report source snapshot: `3e4fe1b3`
+- Report source snapshot: `1c1955c2`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 175168 |
-| Test functions | 2558 |
+| Total Python LOC | 175383 |
+| Test functions | 2565 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-13T18:20:09+00:00`
+- Generated at: `2026-06-16T22:58:51+00:00`
 
-- Report source snapshot: `3e4fe1b3`
+- Report source snapshot: `1c1955c2`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -34,14 +34,14 @@
 | --- | --- | --- | --- | --- |
 | 1 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
 | 2 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 3 | simulate_item | src/api/services/wave_simulation_item.py | 6 | 72 |
-| 4 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
-| 5 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
-| 6 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
-| 7 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
-| 8 | open_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 57 |
-| 9 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
-| 10 | realized_risk_source_from_risk_metrics_report | src/core/outcomes/risk_sources.py | 6 | 53 |
+| 3 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
+| 4 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 5 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
+| 6 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
+| 7 | open_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 57 |
+| 8 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
+| 9 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
+| 10 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-16T22:58:51+00:00`
+- Generated at: `2026-06-16T23:04:44+00:00`
 
-- Report source snapshot: `1c1955c2`
+- Report source snapshot: `c36b80f0`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-13T18:20:09+00:00`
+- Generated at: `2026-06-16T22:58:51+00:00`
 
-- Report source snapshot: `3e4fe1b3`
+- Report source snapshot: `1c1955c2`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-16T22:58:51+00:00`
+- Generated at: `2026-06-16T23:04:44+00:00`
 
-- Report source snapshot: `1c1955c2`
+- Report source snapshot: `c36b80f0`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-16T22:58:51+00:00`
+- Generated at: `2026-06-16T23:04:44+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `1c1955c2`
+- Report source snapshot: `c36b80f0`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 175168 | 175383 | +215 |
-| Test functions | 2558 | 2565 | +7 |
+| Total Python LOC | 175168 | 175422 | +254 |
+| Test functions | 2558 | 2566 | +8 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-13T18:20:09+00:00`
+- Generated at: `2026-06-16T22:58:51+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `3e4fe1b3`
+- Report source snapshot: `1c1955c2`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 174999 | 175168 | +169 |
-| Test functions | 2554 | 2558 | +4 |
+| Total Python LOC | 175168 | 175383 | +215 |
+| Test functions | 2558 | 2565 | +7 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/observability.py
+++ b/src/api/observability.py
@@ -184,6 +184,7 @@ _SENSITIVE_LOG_FIELD_NAMES = frozenset(
     }
 )
 _LATENCY_BUCKETS_MS = (10, 50, 100, 250, 500, 1000)
+_API_ROUTE_PREFIX = "/api/v1"
 
 
 def _safe_metric_label(value: str, *, allowed_values: frozenset[str], fallback: str) -> str:
@@ -209,7 +210,21 @@ def _status_family(status_code: int) -> str:
 def _route_template(request: Request) -> str:
     route = request.scope.get("route")
     route_path = getattr(route, "path", None)
-    return route_path if isinstance(route_path, str) and route_path else "unmatched"
+    if not isinstance(route_path, str) or not route_path:
+        return "unmatched"
+    request_path = request.scope.get("path")
+    return _route_template_with_request_prefix(
+        route_path=route_path,
+        request_path=request_path if isinstance(request_path, str) else "",
+    )
+
+
+def _route_template_with_request_prefix(*, route_path: str, request_path: str) -> str:
+    if route_path.startswith(_API_ROUTE_PREFIX):
+        return route_path
+    if request_path.startswith(f"{_API_ROUTE_PREFIX}/"):
+        return f"{_API_ROUTE_PREFIX}{route_path}"
+    return route_path
 
 
 def _safe_log_extra_fields(extra_fields: dict[str, Any]) -> dict[str, Any]:

--- a/src/api/services/wave_simulation_item.py
+++ b/src/api/services/wave_simulation_item.py
@@ -12,7 +12,7 @@ from src.core.construction.vocabulary import ConstructionMethod
 from src.core.rebalance_runs.service import DpmAsyncOperationConflictError, DpmRunSupportService
 from src.core.waves import DpmRebalanceWaveItem
 from src.core.waves.source_analytics import build_source_analytics_from_alternative_set
-from src.core.construction.models import ConstructionAuthorityContext
+from src.core.construction.models import ConstructionAlternativeSet, ConstructionAuthorityContext
 
 _CONSTRUCTION_SIMULATION_BLOCKING_ERRORS = (
     ConstructionIdempotencyConflictError,
@@ -27,6 +27,22 @@ class DpmWaveSimulationInput:
     authority_context: ConstructionAuthorityContext | None = None
 
 
+def _simulation_input_for_item(
+    *,
+    item: DpmRebalanceWaveItem,
+    item_inputs: dict[str, RebalanceRequest | DpmWaveSimulationInput],
+) -> RebalanceRequest | DpmWaveSimulationInput | None:
+    return item_inputs.get(item.wave_item_id) or item_inputs.get(item.portfolio_id)
+
+
+def _simulation_request_and_authority_context(
+    simulation_input: RebalanceRequest | DpmWaveSimulationInput,
+) -> tuple[RebalanceRequest, ConstructionAuthorityContext | None]:
+    if isinstance(simulation_input, DpmWaveSimulationInput):
+        return simulation_input.stateless_input, simulation_input.authority_context
+    return simulation_input, None
+
+
 def simulate_item(
     *,
     item: DpmRebalanceWaveItem,
@@ -39,26 +55,12 @@ def simulate_item(
 ) -> DpmRebalanceWaveItem:
     if item.state != "SOURCE_READY":
         return item
-    simulation_input = item_inputs.get(item.wave_item_id) or item_inputs.get(item.portfolio_id)
+    simulation_input = _simulation_input_for_item(item=item, item_inputs=item_inputs)
     if simulation_input is None:
-        return item.model_copy(
-            update={
-                "state": "SIMULATION_BLOCKED",
-                "reason_codes": ["CONSTRUCTION_INPUT_MISSING"],
-                "diagnostics": {
-                    **item.diagnostics,
-                    "source_owner": "wave-simulation-request",
-                    "required_action": "SUPPLY_RFC0039_REBALANCE_REQUEST",
-                },
-            },
-            deep=True,
-        )
-    if isinstance(simulation_input, DpmWaveSimulationInput):
-        rebalance_request = simulation_input.stateless_input
-        authority_context = simulation_input.authority_context
-    else:
-        rebalance_request = simulation_input
-        authority_context = None
+        return _missing_construction_input_item(item)
+    rebalance_request, authority_context = _simulation_request_and_authority_context(
+        simulation_input
+    )
     try:
         alternative_set = construction_service.generate_construction_alternative_set(
             request=rebalance_request,
@@ -71,19 +73,52 @@ def simulate_item(
             run_service=run_service,
         )
     except _CONSTRUCTION_SIMULATION_BLOCKING_ERRORS as exc:
-        return item.model_copy(
-            update={
-                "state": "SIMULATION_BLOCKED",
-                "reason_codes": ["CONSTRUCTION_ALTERNATIVE_GENERATION_FAILED"],
-                "diagnostics": {
-                    **item.diagnostics,
-                    "source_owner": "lotus-manage-construction",
-                    "required_action": "REVIEW_CONSTRUCTION_INPUTS",
-                    "construction_error": type(exc).__name__,
-                },
+        return _construction_generation_failed_item(item=item, exc=exc)
+    return _simulated_item(item=item, alternative_set=alternative_set)
+
+
+def _missing_construction_input_item(
+    item: DpmRebalanceWaveItem,
+) -> DpmRebalanceWaveItem:
+    return item.model_copy(
+        update={
+            "state": "SIMULATION_BLOCKED",
+            "reason_codes": ["CONSTRUCTION_INPUT_MISSING"],
+            "diagnostics": {
+                **item.diagnostics,
+                "source_owner": "wave-simulation-request",
+                "required_action": "SUPPLY_RFC0039_REBALANCE_REQUEST",
             },
-            deep=True,
-        )
+        },
+        deep=True,
+    )
+
+
+def _construction_generation_failed_item(
+    *,
+    item: DpmRebalanceWaveItem,
+    exc: BaseException,
+) -> DpmRebalanceWaveItem:
+    return item.model_copy(
+        update={
+            "state": "SIMULATION_BLOCKED",
+            "reason_codes": ["CONSTRUCTION_ALTERNATIVE_GENERATION_FAILED"],
+            "diagnostics": {
+                **item.diagnostics,
+                "source_owner": "lotus-manage-construction",
+                "required_action": "REVIEW_CONSTRUCTION_INPUTS",
+                "construction_error": type(exc).__name__,
+            },
+        },
+        deep=True,
+    )
+
+
+def _simulated_item(
+    *,
+    item: DpmRebalanceWaveItem,
+    alternative_set: ConstructionAlternativeSet,
+) -> DpmRebalanceWaveItem:
     return item.model_copy(
         update={
             "state": "SIMULATED",

--- a/src/core/outcomes/risk_sources.py
+++ b/src/core/outcomes/risk_sources.py
@@ -113,30 +113,23 @@ def realized_risk_source_from_risk_metrics_report(
         supportability_state=supportability_state,
         value=value,
     )
-    if source_state == "READY" and value is None:
-        raise RiskOutcomeSourceError(
-            f"lotus-risk metrics report is missing a numeric {metric} value for {period}"
-        )
+    _ensure_ready_risk_metric_value(
+        source_state=source_state,
+        value=value,
+        metric=metric,
+        period=period,
+    )
 
-    return DpmRealizedSourceSnapshot(
-        dimension="RISK_REDUCTION",
-        source_system="lotus-risk",
-        source_type="RISK_METRICS_REPORT",
-        source_id=f"{request_fingerprint}:{period}:{metric}",
+    return _risk_metrics_source_snapshot(
+        request_fingerprint=request_fingerprint,
+        period=period,
+        metric=metric,
         value=value if source_state != "NOT_SUPPORTED" else None,
-        unit=_metric_unit(metric),
         source_state=source_state,
         quality=quality,
-        observed_at=None,
         as_of_date=_read_text(scope.get("as_of_date")),
-        content_hash=request_fingerprint,
-        reason_codes=[
-            _primary_reason(source_state),
-            f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
-            f"RISK_REASON_{supportability_reason.upper()}",
-            f"RISK_PERIOD_{period}",
-            f"RISK_METRIC_{metric}",
-        ],
+        supportability_state=supportability_state,
+        supportability_reason=supportability_reason,
     )
 
 
@@ -428,6 +421,54 @@ def _drawdown_value(
     if absolute_drawdown is not None:
         return absolute_drawdown
     return _relative_drawdown_value(result=result)
+
+
+def _ensure_ready_risk_metric_value(
+    *,
+    source_state: _RiskSourceState,
+    value: Decimal | None,
+    metric: RiskOutcomeMeasure,
+    period: str,
+) -> None:
+    if source_state != "READY" or value is not None:
+        return
+    raise RiskOutcomeSourceError(
+        f"lotus-risk metrics report is missing a numeric {metric} value for {period}"
+    )
+
+
+def _risk_metrics_source_snapshot(
+    *,
+    request_fingerprint: str,
+    period: str,
+    metric: RiskOutcomeMeasure,
+    value: Decimal | None,
+    source_state: _RiskSourceState,
+    quality: _RiskSourceQuality,
+    as_of_date: str | None,
+    supportability_state: str,
+    supportability_reason: str,
+) -> DpmRealizedSourceSnapshot:
+    return DpmRealizedSourceSnapshot(
+        dimension="RISK_REDUCTION",
+        source_system="lotus-risk",
+        source_type="RISK_METRICS_REPORT",
+        source_id=f"{request_fingerprint}:{period}:{metric}",
+        value=value,
+        unit=_metric_unit(metric),
+        source_state=source_state,
+        quality=quality,
+        observed_at=None,
+        as_of_date=as_of_date,
+        content_hash=request_fingerprint,
+        reason_codes=[
+            _primary_reason(source_state),
+            f"RISK_SUPPORTABILITY_{supportability_state.upper()}",
+            f"RISK_REASON_{supportability_reason.upper()}",
+            f"RISK_PERIOD_{period}",
+            f"RISK_METRIC_{metric}",
+        ],
+    )
 
 
 def _absolute_drawdown_value(

--- a/tests/unit/core/test_risk_realized_outcome_sources.py
+++ b/tests/unit/core/test_risk_realized_outcome_sources.py
@@ -18,6 +18,7 @@ from src.core.outcomes.risk_sources import (
     _concentration_source_posture,
     _drawdown_measure_unavailable,
     _drawdown_source_posture,
+    _ensure_ready_risk_metric_value,
     _ensure_ready_historical_attribution_value,
     _ensure_ready_rolling_metric_value,
     _historical_attribution_contributor,
@@ -31,6 +32,7 @@ from src.core.outcomes.risk_sources import (
     _primary_reason,
     _quality_for_degraded_value,
     _relative_drawdown_value,
+    _risk_metrics_source_snapshot,
     _risk_source_posture,
     _rolling_context_unavailable,
     _rolling_context_reason,
@@ -488,6 +490,49 @@ def test_risk_metrics_report_adapter_wraps_source_truth_without_recalculation() 
         "RISK_PERIOD_YTD",
         "RISK_METRIC_VOLATILITY",
     ]
+
+
+def test_risk_metrics_source_snapshot_records_source_posture() -> None:
+    source = _risk_metrics_source_snapshot(
+        request_fingerprint="sha256:risk-metrics-request",
+        period="YTD",
+        metric="VAR",
+        value=Decimal("-1.775"),
+        source_state="READY",
+        quality="COMPLETE",
+        as_of_date="2026-05-06",
+        supportability_state="ready",
+        supportability_reason="calculation_complete",
+    )
+
+    assert source.source_id == "sha256:risk-metrics-request:YTD:VAR"
+    assert source.value == Decimal("-1.775")
+    assert source.unit == "percentage_point"
+    assert source.as_of_date == "2026-05-06"
+    assert source.reason_codes == [
+        "RISK_SOURCE_READY",
+        "RISK_SUPPORTABILITY_READY",
+        "RISK_REASON_CALCULATION_COMPLETE",
+        "RISK_PERIOD_YTD",
+        "RISK_METRIC_VAR",
+    ]
+
+
+def test_ensure_ready_risk_metric_value_rejects_missing_ready_value() -> None:
+    with pytest.raises(RiskOutcomeSourceError, match="numeric VOLATILITY value"):
+        _ensure_ready_risk_metric_value(
+            source_state="READY",
+            value=None,
+            metric="VOLATILITY",
+            period="YTD",
+        )
+
+    _ensure_ready_risk_metric_value(
+        source_state="DEGRADED",
+        value=None,
+        metric="VOLATILITY",
+        period="YTD",
+    )
 
 
 def test_concentration_adapter_wraps_source_owned_hhi_without_recalculation() -> None:

--- a/tests/unit/dpm/api/test_observability_api.py
+++ b/tests/unit/dpm/api/test_observability_api.py
@@ -333,6 +333,30 @@ def test_http_access_log_uses_route_template_not_sensitive_path_values():
     assert "sha256:sensitive-request-hash" not in json.dumps(extra_fields)
 
 
+def test_route_template_restores_api_prefix_without_path_values():
+    assert (
+        observability_module._route_template_with_request_prefix(
+            route_path="/rebalance/runs/by-request-hash/{request_hash}",
+            request_path="/api/v1/rebalance/runs/by-request-hash/sha256:sensitive-request-hash",
+        )
+        == "/api/v1/rebalance/runs/by-request-hash/{request_hash}"
+    )
+    assert (
+        observability_module._route_template_with_request_prefix(
+            route_path="/api/v1/rebalance/runs/by-request-hash/{request_hash}",
+            request_path="/api/v1/rebalance/runs/by-request-hash/sha256:sensitive-request-hash",
+        )
+        == "/api/v1/rebalance/runs/by-request-hash/{request_hash}"
+    )
+    assert (
+        observability_module._route_template_with_request_prefix(
+            route_path="/metrics",
+            request_path="/metrics",
+        )
+        == "/metrics"
+    )
+
+
 def test_traceparent_header_propagates_trace_id():
     client = TestClient(app)
     upstream_trace_id = "1234567890abcdef1234567890abcdef"

--- a/tests/unit/dpm/waves/test_wave_simulation_item.py
+++ b/tests/unit/dpm/waves/test_wave_simulation_item.py
@@ -4,7 +4,11 @@ from pytest import MonkeyPatch
 from src.api.request_models import RebalanceRequest
 from src.api.services import wave_simulation_item
 from src.api.services.wave_simulation_item import DpmWaveSimulationInput, simulate_item
-from src.core.construction.models import ConstructionAlternative, ConstructionAlternativeSet
+from src.core.construction.models import (
+    ConstructionAlternative,
+    ConstructionAlternativeSet,
+    ConstructionAuthorityContext,
+)
 from src.core.construction.repository import ConstructionIdempotencyConflictError
 from src.core.construction.vocabulary import ConstructionMethodStatus
 from src.core.waves import DpmRebalanceWaveItem
@@ -81,6 +85,64 @@ def test_simulate_item_blocks_missing_construction_input() -> None:
     }
 
 
+def test_simulation_input_for_item_prefers_wave_item_id_then_portfolio_id() -> None:
+    wave_input = DpmWaveSimulationInput(stateless_input=_request())
+    portfolio_input = _request()
+
+    assert (
+        wave_simulation_item._simulation_input_for_item(
+            item=_item(),
+            item_inputs={
+                "dwi_simulate": wave_input,
+                "PB_SG_SIMULATE": portfolio_input,
+            },
+        )
+        is wave_input
+    )
+    assert (
+        wave_simulation_item._simulation_input_for_item(
+            item=_item(),
+            item_inputs={"PB_SG_SIMULATE": portfolio_input},
+        )
+        is portfolio_input
+    )
+    assert wave_simulation_item._simulation_input_for_item(item=_item(), item_inputs={}) is None
+
+
+def test_simulation_request_and_authority_context_normalizes_input_shapes() -> None:
+    request = _request()
+    authority_context = ConstructionAuthorityContext()
+
+    wrapped_request, wrapped_context = (
+        wave_simulation_item._simulation_request_and_authority_context(
+            DpmWaveSimulationInput(
+                stateless_input=request,
+                authority_context=authority_context,
+            )
+        )
+    )
+    plain_request, plain_context = wave_simulation_item._simulation_request_and_authority_context(
+        request
+    )
+
+    assert wrapped_request is request
+    assert wrapped_context is authority_context
+    assert plain_request is request
+    assert plain_context is None
+
+
+def test_missing_construction_input_item_preserves_existing_diagnostics() -> None:
+    updated = wave_simulation_item._missing_construction_input_item(_item())
+
+    assert updated.state == "SIMULATION_BLOCKED"
+    assert updated.reason_codes == ["CONSTRUCTION_INPUT_MISSING"]
+    assert updated.diagnostics == {
+        "existing": "value",
+        "source_owner": "wave-simulation-request",
+        "required_action": "SUPPLY_RFC0039_REBALANCE_REQUEST",
+    }
+
+
 def test_simulate_item_records_generated_construction_alternative_set(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -120,6 +182,22 @@ def test_simulate_item_records_generated_construction_alternative_set(
     ]
 
 
+def test_simulated_item_records_construction_posture() -> None:
+    updated = wave_simulation_item._simulated_item(
+        item=_item(),
+        alternative_set=_alternative_set(),
+    )
+
+    assert updated.state == "SIMULATED"
+    assert updated.alternative_set_id == "cas_simulate"
+    assert updated.reason_codes == ["CONSTRUCTION_ALTERNATIVES_GENERATED"]
+    assert updated.diagnostics["construction_state"] == "READY"
+    assert updated.diagnostics["alternative_count"] == 1
+    assert updated.diagnostics["proposed_changes"] == [
+        {"security_id": "SEC_A", "target_weight": "0.10"}
+    ]
+
+
 def test_simulate_item_blocks_construction_generation_failure(
     monkeypatch: MonkeyPatch,
 ) -> None:
@@ -149,6 +227,22 @@ def test_simulate_item_blocks_construction_generation_failure(
         "source_owner": "lotus-manage-construction",
         "required_action": "REVIEW_CONSTRUCTION_INPUTS",
         "construction_error": "ConstructionIdempotencyConflictError",
+    }
+
+
+def test_construction_generation_failed_item_records_safe_error_type() -> None:
+    updated = wave_simulation_item._construction_generation_failed_item(
+        item=_item(),
+        exc=ValueError("raw request details stay out of diagnostics"),
+    )
+
+    assert updated.state == "SIMULATION_BLOCKED"
+    assert updated.reason_codes == ["CONSTRUCTION_ALTERNATIVE_GENERATION_FAILED"]
+    assert updated.diagnostics == {
+        "existing": "value",
+        "source_owner": "lotus-manage-construction",
+        "required_action": "REVIEW_CONSTRUCTION_INPUTS",
+        "construction_error": "ValueError",
     }
 
 


### PR DESCRIPTION
## Summary
- Extracted behavior-preserving helpers from wave simulation item orchestration for input lookup, request/context normalization, blocked result construction, and simulated-item diagnostics.
- Extracted RiskMetricsReport source-owned snapshot and ready-value guard helpers from the risk realized evidence adapter.
- Refreshed quality reports and codebase review ledger through BACKEND-REVIEW-20260617-930.

## Bank-buyable progress
- Reduces two current source hotspots from the checked-in complexity report.
- Adds direct helper tests for each extraction instead of relying only on public adapter/service behavior.
- Keeps router/HTTP concerns out of services and does not change API contracts or operator-facing wiki truth.

## Validation
- `python -m ruff check src/api/services/wave_simulation_item.py tests/unit/dpm/waves/test_wave_simulation_item.py src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`
- `python -m ruff format --check src/api/services/wave_simulation_item.py tests/unit/dpm/waves/test_wave_simulation_item.py src/core/outcomes/risk_sources.py tests/unit/core/test_risk_realized_outcome_sources.py`
- `python -m mypy --config-file mypy.ini src/api/services/wave_simulation_item.py src/core/outcomes/risk_sources.py`
- `python -m pytest tests/unit/dpm/waves/test_wave_simulation_item.py tests/unit/core/test_risk_realized_outcome_sources.py -q` (66 passed)
- `python -m radon cc src/api/services/wave_simulation_item.py -s`
- `python -m radon cc src/core/outcomes/risk_sources.py -s`
- `python scripts/engineering_health_report.py`
- `make check` (2737 passed, 13 skipped)
- `git diff --check`
- Service leakage scan: no matches for router/FastAPI/Starlette/HTTPException imports in `src/api/services`
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` (only this feature branch before PR)
- Wiki drift check: `DiffCount 0`

## Residual risk
- This PR improves internal maintainability and evidence only. It does not claim global bank-buyable readiness, change API behavior, or publish wiki/operator truth.
- Existing unrelated complexity hotspots remain visible in `quality/complexity_report.md` for future slices.