### PR TITLE
Refactor campaign assignment task helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23441,3 +23441,32 @@ and improves internal transaction-cost source posture maintainability only.
   ownership, OMS posture, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal workflow maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-934: Campaign assignment task open helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/waves/campaign_assignment_tasks.py` and
+  `tests/unit/dpm/waves/test_campaign_discovery.py`.
+- Bank-buyable control area: architecture, campaign workflow supportability, and testing.
+- Finding: `open_bulk_review_campaign_definition_assignment_task` still combined active-definition
+  validation, open-task request normalization, assignment-task construction, idempotent replay
+  detection, duplicate-ref conflict detection, append mutation, and definition revalidation in one
+  path. That kept the open-task lifecycle harder to review than the surrounding transition helpers.
+- Action: extracted helpers for open-task request normalization, idempotent open-task replay,
+  duplicate-ref conflict detection, and assignment-task append/revalidation; added direct tests for
+  normalization, required-field failures, replay/conflict behavior, and content-hash revalidation.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_tasks.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q`, and
+  `python -m radon cc src/core/waves/campaign_assignment_tasks.py -s`; the focused campaign
+  discovery suite reported 103 passed, and radon reports
+  `open_bulk_review_campaign_definition_assignment_task` at A(3).
+- Residual risk: this slice improves internal campaign assignment-task maintainability only. The
+  assignment-task page builder remains a visible B-grade helper for a future focused slice; this
+  slice does not change API contracts, assignment-task semantics, external workflow ownership, OMS
+  posture, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal workflow maintainability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23499,3 +23499,23 @@ and improves internal transaction-cost source posture maintainability only.
   external workflow ownership, OMS posture, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal read-model maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-936: Campaign assignment hotspot reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the campaign assignment task helper extractions, the checked-in quality reports
+  needed to reflect the updated branch head and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `669949b7` and the current top-ten source hotspot list no longer includes
+  `transition_bulk_review_campaign_definition_assignment_task`,
+  `open_bulk_review_campaign_definition_assignment_task`, or
+  `build_bulk_review_campaign_definition_assignment_task_page`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23411,3 +23411,33 @@ and improves internal transaction-cost source posture maintainability only.
   into stricter thresholds or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-933: Campaign assignment task transition helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/waves/campaign_assignment_tasks.py` and
+  `tests/unit/dpm/waves/test_campaign_discovery.py`.
+- Bank-buyable control area: architecture, campaign workflow supportability, and testing.
+- Finding: `transition_bulk_review_campaign_definition_assignment_task` mixed active-definition
+  validation, transition request normalization, assignment-task lookup, replay detection,
+  transition mutation, and definition replacement in one orchestration path. The behavior was
+  covered through public workflow tests, but these boundaries are distinct supportability decisions
+  that should be independently auditable.
+- Action: extracted helpers for active-definition validation, transition request normalization,
+  assignment-task lookup, and assignment-task replacement; added direct helper tests while
+  preserving the public transition behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_tasks.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q`, and
+  `python -m radon cc src/core/waves/campaign_assignment_tasks.py -s`; the focused campaign
+  discovery suite reported 95 passed, and radon reports
+  `transition_bulk_review_campaign_definition_assignment_task` at A(4).
+- Residual risk: this slice improves internal campaign assignment-task maintainability only.
+  Existing adjacent B-grade helpers in `campaign_assignment_tasks.py` remain visible for future
+  slices; this slice does not change API contracts, assignment-task semantics, external workflow
+  ownership, OMS posture, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal workflow maintainability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23470,3 +23470,32 @@ and improves internal transaction-cost source posture maintainability only.
   posture, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal workflow maintainability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-935: Campaign assignment task page helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/waves/campaign_assignment_tasks.py` and
+  `tests/unit/dpm/waves/test_campaign_discovery.py`.
+- Bank-buyable control area: architecture, campaign workflow supportability, and testing.
+- Finding: `build_bulk_review_campaign_definition_assignment_task_page` still owned sorting,
+  status filtering, pagination, open-count calculation, and response assembly inline. That made the
+  assignment-task read-model page harder to review and kept list behavior coupled to response
+  construction.
+- Action: extracted helpers for latest-first sorting, status filtering, page slicing, and open-task
+  counting; added direct helper tests with deterministic timestamps and closed/open statuses while
+  preserving the public page contract.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_tasks.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q`, and
+  `python -m radon cc src/core/waves/campaign_assignment_tasks.py -s`; the focused campaign
+  discovery suite reported 104 passed, and radon reports
+  `build_bulk_review_campaign_definition_assignment_task_page` at A(1).
+- Residual risk: this slice improves internal assignment-task read-model maintainability only. The
+  `DpmBulkReviewCampaignDefinitionAssignmentTaskPage` validator remains B-grade because it
+  centralizes response invariants; this slice does not change API contracts, pagination semantics,
+  external workflow ownership, OMS posture, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal read-model maintainability
+  hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-16T23:04:44+00:00`
+- Generated at: `2026-06-16T23:26:52+00:00`
 
-- Report source snapshot: `c36b80f0`
+- Report source snapshot: `669949b7`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 175422 |
-| Test functions | 2566 |
+| Total Python LOC | 175839 |
+| Test functions | 2576 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-16T23:04:44+00:00`
+- Generated at: `2026-06-16T23:26:52+00:00`
 
-- Report source snapshot: `c36b80f0`
+- Report source snapshot: `669949b7`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -34,14 +34,14 @@
 | --- | --- | --- | --- | --- |
 | 1 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
 | 2 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 3 | transition_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 70 |
-| 4 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
-| 5 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
-| 6 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
-| 7 | open_bulk_review_campaign_definition_assignment_task | src/core/waves/campaign_assignment_tasks.py | 6 | 57 |
-| 8 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
-| 9 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
-| 10 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
+| 3 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 4 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
+| 5 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
+| 6 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
+| 7 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
+| 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
+| 9 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
+| 10 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-16T23:04:44+00:00`
+- Generated at: `2026-06-16T23:26:52+00:00`
 
-- Report source snapshot: `c36b80f0`
+- Report source snapshot: `669949b7`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-16T23:04:44+00:00`
+- Generated at: `2026-06-16T23:26:52+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `c36b80f0`
+- Report source snapshot: `669949b7`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 175168 | 175422 | +254 |
-| Test functions | 2558 | 2566 | +8 |
+| Total Python LOC | 175422 | 175839 | +417 |
+| Test functions | 2566 | 2576 | +10 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -53,9 +53,9 @@
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2908 |
-| 4 | tests/unit/test_documentation_current_state.py | 2721 |
-| 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2512 |
+| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
+| 5 | tests/unit/test_documentation_current_state.py | 2721 |
+| 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |

--- a/src/core/waves/campaign_assignment_tasks.py
+++ b/src/core/waves/campaign_assignment_tasks.py
@@ -57,6 +57,14 @@ class _TransitionTaskFields(BaseModel):
     next_due_at: datetime | None
 
 
+class _TransitionRequestFields(BaseModel):
+    task_ref: str
+    transition_ref: str
+    transitioned_by: str
+    transition_reason: str
+    correlation_id: str
+
+
 _CLOSED_STATUSES = {"RESOLVED", "CANCELLED"}
 _STATUS_TRANSITIONS: dict[
     CampaignAssignmentTaskTransitionType, tuple[set[str], CampaignAssignmentTaskStatus]
@@ -126,8 +134,7 @@ def open_bulk_review_campaign_definition_assignment_task(
     due_at: datetime | None = None,
     source_refs: list[DpmWaveSourceRef] | None = None,
 ) -> DpmBulkReviewCampaignDefinition:
-    if definition.status != "ACTIVE":
-        raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ACTIVE_REQUIRED")
+    _validate_active_assignment_task_definition(definition)
     normalized_ref = _required_text(task_ref, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_REQUIRED")
     normalized_opened_by = _required_text(
         opened_by, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ACTOR_REQUIRED"
@@ -186,34 +193,27 @@ def transition_bulk_review_campaign_definition_assignment_task(
     due_at: datetime | None = None,
     source_refs: list[DpmWaveSourceRef] | None = None,
 ) -> DpmBulkReviewCampaignDefinition:
-    if definition.status != "ACTIVE":
-        raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ACTIVE_REQUIRED")
-    normalized_ref = _required_text(task_ref, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_REQUIRED")
-    normalized_transition_ref = _required_text(
-        transition_ref, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_REF_REQUIRED"
-    )
-    normalized_transitioned_by = _required_text(
-        transitioned_by, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_ACTOR_REQUIRED"
-    )
-    normalized_reason = _required_text(
-        transition_reason, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_REASON_REQUIRED"
-    )
-    normalized_correlation = _required_text(
-        correlation_id, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_CORRELATION_REQUIRED"
+    _validate_active_assignment_task_definition(definition)
+    normalized = _transition_request_fields(
+        task_ref=task_ref,
+        transition_ref=transition_ref,
+        transitioned_by=transitioned_by,
+        transition_reason=transition_reason,
+        correlation_id=correlation_id,
     )
 
-    task_index = _assignment_task_index(definition=definition, task_ref=normalized_ref)
-    if task_index is None:
-        raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_NOT_FOUND")
-    task = definition.assignment_tasks[task_index]
+    task_index, task = _assignment_task_for_ref(
+        definition=definition,
+        task_ref=normalized.task_ref,
+    )
     replayed_definition = _replayed_transition_definition(
         definition=definition,
         task=task,
-        transition_ref=normalized_transition_ref,
+        transition_ref=normalized.transition_ref,
         transition_type=transition_type,
-        transitioned_by=normalized_transitioned_by,
-        transition_reason=normalized_reason,
-        correlation_id=normalized_correlation,
+        transitioned_by=normalized.transitioned_by,
+        transition_reason=normalized.transition_reason,
+        correlation_id=normalized.correlation_id,
         assigned_actor_ids=assigned_actor_ids,
         escalation_tier=escalation_tier,
         sla_posture=sla_posture,
@@ -226,10 +226,10 @@ def transition_bulk_review_campaign_definition_assignment_task(
     replacement = _transitioned_task(
         task=task,
         transition_type=transition_type,
-        transition_ref=normalized_transition_ref,
-        transitioned_by=normalized_transitioned_by,
-        transition_reason=normalized_reason,
-        correlation_id=normalized_correlation,
+        transition_ref=normalized.transition_ref,
+        transitioned_by=normalized.transitioned_by,
+        transition_reason=normalized.transition_reason,
+        correlation_id=normalized.correlation_id,
         assigned_actor_ids=assigned_actor_ids,
         escalation_tier=escalation_tier,
         sla_posture=sla_posture,
@@ -237,10 +237,59 @@ def transition_bulk_review_campaign_definition_assignment_task(
         source_refs=source_refs or [],
     )
 
+    return _definition_with_replaced_assignment_task(
+        definition=definition,
+        task_index=task_index,
+        task=replacement,
+    )
+
+
+def _transition_request_fields(
+    *,
+    task_ref: str,
+    transition_ref: str,
+    transitioned_by: str,
+    transition_reason: str,
+    correlation_id: str,
+) -> _TransitionRequestFields:
+    return _TransitionRequestFields(
+        task_ref=_required_text(task_ref, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_REQUIRED"),
+        transition_ref=_required_text(
+            transition_ref,
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_REF_REQUIRED",
+        ),
+        transitioned_by=_required_text(
+            transitioned_by,
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_ACTOR_REQUIRED",
+        ),
+        transition_reason=_required_text(
+            transition_reason,
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_REASON_REQUIRED",
+        ),
+        correlation_id=_required_text(
+            correlation_id,
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_CORRELATION_REQUIRED",
+        ),
+    )
+
+
+def _definition_with_replaced_assignment_task(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+    task_index: int,
+    task: DpmBulkReviewCampaignDefinitionAssignmentTask,
+) -> DpmBulkReviewCampaignDefinition:
     tasks = list(definition.assignment_tasks)
-    tasks[task_index] = replacement
+    tasks[task_index] = task
     updated = definition.model_copy(update={"assignment_tasks": tasks, "content_hash": ""})
     return DpmBulkReviewCampaignDefinition.model_validate(updated.model_dump(mode="python"))
+
+
+def _validate_active_assignment_task_definition(
+    definition: DpmBulkReviewCampaignDefinition,
+) -> None:
+    if definition.status != "ACTIVE":
+        raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ACTIVE_REQUIRED")
 
 
 def build_bulk_review_campaign_definition_assignment_task_page(
@@ -392,6 +441,17 @@ def _assignment_task_index(
         ),
         None,
     )
+
+
+def _assignment_task_for_ref(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+    task_ref: str,
+) -> tuple[int, DpmBulkReviewCampaignDefinitionAssignmentTask]:
+    task_index = _assignment_task_index(definition=definition, task_ref=task_ref)
+    if task_index is None:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_NOT_FOUND")
+    return task_index, definition.assignment_tasks[task_index]
 
 
 def _assignment_task_transition(

--- a/src/core/waves/campaign_assignment_tasks.py
+++ b/src/core/waves/campaign_assignment_tasks.py
@@ -345,14 +345,14 @@ def build_bulk_review_campaign_definition_assignment_task_page(
     limit: int = 50,
     offset: int = 0,
 ) -> DpmBulkReviewCampaignDefinitionAssignmentTaskPage:
-    tasks = sorted(
-        definition.assignment_tasks,
-        key=lambda task: task.opened_at,
-        reverse=True,
+    page = _assignment_task_page_slice(
+        tasks=_filtered_assignment_tasks(
+            tasks=_assignment_tasks_sorted_latest(definition.assignment_tasks),
+            status_filter=status_filter,
+        ),
+        limit=limit,
+        offset=offset,
     )
-    if status_filter is not None:
-        tasks = [task for task in tasks if task.status == status_filter]
-    page = tasks[offset : offset + limit]
     return DpmBulkReviewCampaignDefinitionAssignmentTaskPage(
         campaign_id=definition.campaign_id,
         campaign_version=definition.campaign_version,
@@ -360,13 +360,42 @@ def build_bulk_review_campaign_definition_assignment_task_page(
         status_counts=_count_by(definition.assignment_tasks, "status"),
         escalation_tier_counts=_count_by(definition.assignment_tasks, "escalation_tier"),
         sla_posture_counts=_count_by(definition.assignment_tasks, "sla_posture"),
-        open_task_count=sum(
-            1 for task in definition.assignment_tasks if task.status not in _CLOSED_STATUSES
-        ),
+        open_task_count=_open_assignment_task_count(definition.assignment_tasks),
         count=len(page),
         limit=limit,
         offset=offset,
     )
+
+
+def _assignment_tasks_sorted_latest(
+    tasks: list[DpmBulkReviewCampaignDefinitionAssignmentTask],
+) -> list[DpmBulkReviewCampaignDefinitionAssignmentTask]:
+    return sorted(tasks, key=lambda task: task.opened_at, reverse=True)
+
+
+def _filtered_assignment_tasks(
+    *,
+    tasks: list[DpmBulkReviewCampaignDefinitionAssignmentTask],
+    status_filter: CampaignAssignmentTaskStatus | None,
+) -> list[DpmBulkReviewCampaignDefinitionAssignmentTask]:
+    if status_filter is None:
+        return tasks
+    return [task for task in tasks if task.status == status_filter]
+
+
+def _assignment_task_page_slice(
+    *,
+    tasks: list[DpmBulkReviewCampaignDefinitionAssignmentTask],
+    limit: int,
+    offset: int,
+) -> list[DpmBulkReviewCampaignDefinitionAssignmentTask]:
+    return tasks[offset : offset + limit]
+
+
+def _open_assignment_task_count(
+    tasks: list[DpmBulkReviewCampaignDefinitionAssignmentTask],
+) -> int:
+    return sum(1 for task in tasks if task.status not in _CLOSED_STATUSES)
 
 
 def _build_task(

--- a/src/core/waves/campaign_assignment_tasks.py
+++ b/src/core/waves/campaign_assignment_tasks.py
@@ -65,6 +65,14 @@ class _TransitionRequestFields(BaseModel):
     correlation_id: str
 
 
+class _OpenTaskRequestFields(BaseModel):
+    task_ref: str
+    opened_by: str
+    task_reason: str
+    assigned_actor_ids: list[str]
+    correlation_id: str
+
+
 _CLOSED_STATUSES = {"RESOLVED", "CANCELLED"}
 _STATUS_TRANSITIONS: dict[
     CampaignAssignmentTaskTransitionType, tuple[set[str], CampaignAssignmentTaskStatus]
@@ -135,47 +143,32 @@ def open_bulk_review_campaign_definition_assignment_task(
     source_refs: list[DpmWaveSourceRef] | None = None,
 ) -> DpmBulkReviewCampaignDefinition:
     _validate_active_assignment_task_definition(definition)
-    normalized_ref = _required_text(task_ref, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_REQUIRED")
-    normalized_opened_by = _required_text(
-        opened_by, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ACTOR_REQUIRED"
+    normalized = _open_task_request_fields(
+        task_ref=task_ref,
+        opened_by=opened_by,
+        task_reason=task_reason,
+        assigned_actor_ids=assigned_actor_ids,
+        correlation_id=correlation_id,
     )
-    normalized_reason = _required_text(
-        task_reason, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REASON_REQUIRED"
-    )
-    normalized_correlation = _required_text(
-        correlation_id, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_CORRELATION_REQUIRED"
-    )
-    normalized_actor_ids = _normalize_actor_ids(assigned_actor_ids)
-    if not normalized_actor_ids:
-        raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ASSIGNEES_REQUIRED")
 
     task = _build_task(
         definition=definition,
-        task_ref=normalized_ref,
+        task_ref=normalized.task_ref,
         task_type=task_type,
-        opened_by=normalized_opened_by,
-        task_reason=normalized_reason,
-        assigned_actor_ids=normalized_actor_ids,
+        opened_by=normalized.opened_by,
+        task_reason=normalized.task_reason,
+        assigned_actor_ids=normalized.assigned_actor_ids,
         escalation_tier=escalation_tier,
         sla_posture=sla_posture,
         due_at=due_at,
-        correlation_id=normalized_correlation,
+        correlation_id=normalized.correlation_id,
         source_refs=source_refs or [],
     )
-    existing_by_ref = {existing.task_ref: existing for existing in definition.assignment_tasks}
-    existing = existing_by_ref.get(task.task_ref)
-    if existing is not None:
-        if existing.content_hash == task.content_hash:
-            return definition
-        raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_CONFLICT")
+    replayed_definition = _replayed_open_task_definition(definition=definition, task=task)
+    if replayed_definition is not None:
+        return replayed_definition
 
-    updated = definition.model_copy(
-        update={
-            "assignment_tasks": [*definition.assignment_tasks, task],
-            "content_hash": "",
-        }
-    )
-    return DpmBulkReviewCampaignDefinition.model_validate(updated.model_dump(mode="python"))
+    return _definition_with_appended_assignment_task(definition=definition, task=task)
 
 
 def transition_bulk_review_campaign_definition_assignment_task(
@@ -273,6 +266,32 @@ def _transition_request_fields(
     )
 
 
+def _open_task_request_fields(
+    *,
+    task_ref: str,
+    opened_by: str,
+    task_reason: str,
+    assigned_actor_ids: list[str],
+    correlation_id: str,
+) -> _OpenTaskRequestFields:
+    normalized_actor_ids = _normalize_actor_ids(assigned_actor_ids)
+    if not normalized_actor_ids:
+        raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ASSIGNEES_REQUIRED")
+    return _OpenTaskRequestFields(
+        task_ref=_required_text(task_ref, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_REQUIRED"),
+        opened_by=_required_text(opened_by, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ACTOR_REQUIRED"),
+        task_reason=_required_text(
+            task_reason,
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REASON_REQUIRED",
+        ),
+        assigned_actor_ids=normalized_actor_ids,
+        correlation_id=_required_text(
+            correlation_id,
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_CORRELATION_REQUIRED",
+        ),
+    )
+
+
 def _definition_with_replaced_assignment_task(
     *,
     definition: DpmBulkReviewCampaignDefinition,
@@ -283,6 +302,33 @@ def _definition_with_replaced_assignment_task(
     tasks[task_index] = task
     updated = definition.model_copy(update={"assignment_tasks": tasks, "content_hash": ""})
     return DpmBulkReviewCampaignDefinition.model_validate(updated.model_dump(mode="python"))
+
+
+def _definition_with_appended_assignment_task(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+    task: DpmBulkReviewCampaignDefinitionAssignmentTask,
+) -> DpmBulkReviewCampaignDefinition:
+    updated = definition.model_copy(
+        update={
+            "assignment_tasks": [*definition.assignment_tasks, task],
+            "content_hash": "",
+        }
+    )
+    return DpmBulkReviewCampaignDefinition.model_validate(updated.model_dump(mode="python"))
+
+
+def _replayed_open_task_definition(
+    *,
+    definition: DpmBulkReviewCampaignDefinition,
+    task: DpmBulkReviewCampaignDefinitionAssignmentTask,
+) -> DpmBulkReviewCampaignDefinition | None:
+    task_index = _assignment_task_index(definition=definition, task_ref=task.task_ref)
+    if task_index is None:
+        return None
+    if definition.assignment_tasks[task_index].content_hash == task.content_hash:
+        return definition
+    raise ValueError("BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_CONFLICT")
 
 
 def _validate_active_assignment_task_definition(

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -66,10 +66,14 @@ from src.core.waves.campaign_assignment_tasks import (
     DpmBulkReviewCampaignDefinitionAssignmentTaskPage,
     _assignment_task_for_ref,
     _assignment_task_index,
+    _assignment_task_page_slice,
     _assignment_task_transition,
+    _assignment_tasks_sorted_latest,
     _definition_with_appended_assignment_task,
     _definition_with_replaced_assignment_task,
+    _filtered_assignment_tasks,
     _open_task_request_fields,
+    _open_assignment_task_count,
     _optional_transition_replay_fields_match,
     _replayed_open_task_definition,
     _replayed_transition_definition,
@@ -1086,6 +1090,52 @@ def test_campaign_assignment_tasks_open_transition_and_page_current_state() -> N
     assert page.status_counts == {"ACKNOWLEDGED": 1}
     assert page.escalation_tier_counts == {"OPS": 1}
     assert page.sla_posture_counts == {"ATTENTION": 1}
+
+
+def test_assignment_task_page_helpers_sort_filter_page_and_count_open_tasks() -> None:
+    first_opened = open_bulk_review_campaign_definition_assignment_task(
+        definition=_definition(),
+        task_ref="BRC-TASK-2026-05-001",
+        task_type="ASSIGNMENT",
+        opened_by="ops",
+        task_reason="Campaign requires PM acknowledgement.",
+        assigned_actor_ids=["pm_001"],
+        escalation_tier="PM",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-task-001",
+    )
+    second_opened = open_bulk_review_campaign_definition_assignment_task(
+        definition=first_opened,
+        task_ref="BRC-TASK-2026-05-002",
+        task_type="ESCALATION",
+        opened_by="ops",
+        task_reason="Campaign requires escalation review.",
+        assigned_actor_ids=["ops_001"],
+        escalation_tier="OPS",
+        sla_posture="ATTENTION",
+        correlation_id="corr-campaign-assignment-task-002",
+    )
+    older_open_task = second_opened.assignment_tasks[0].model_copy(
+        update={"opened_at": datetime(2026, 5, 10, tzinfo=timezone.utc)}
+    )
+    newer_closed_task = second_opened.assignment_tasks[1].model_copy(
+        update={
+            "opened_at": datetime(2026, 5, 11, tzinfo=timezone.utc),
+            "status": "RESOLVED",
+        }
+    )
+    tasks = [older_open_task, newer_closed_task]
+
+    sorted_tasks = _assignment_tasks_sorted_latest(tasks)
+
+    assert [task.task_ref for task in sorted_tasks] == [
+        "BRC-TASK-2026-05-002",
+        "BRC-TASK-2026-05-001",
+    ]
+    assert _filtered_assignment_tasks(tasks=sorted_tasks, status_filter="OPEN") == [older_open_task]
+    assert _filtered_assignment_tasks(tasks=sorted_tasks, status_filter=None) == sorted_tasks
+    assert _assignment_task_page_slice(tasks=sorted_tasks, limit=1, offset=1) == [older_open_task]
+    assert _open_assignment_task_count(tasks) == 1
 
 
 def test_campaign_workflow_automation_classifies_candidates_active_tasks_and_blocks() -> None:

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -67,8 +67,11 @@ from src.core.waves.campaign_assignment_tasks import (
     _assignment_task_for_ref,
     _assignment_task_index,
     _assignment_task_transition,
+    _definition_with_appended_assignment_task,
     _definition_with_replaced_assignment_task,
+    _open_task_request_fields,
     _optional_transition_replay_fields_match,
+    _replayed_open_task_definition,
     _replayed_transition_definition,
     _required_transition_replay_fields,
     _source_ref_payloads,
@@ -1678,6 +1681,82 @@ def test_assignment_task_for_ref_returns_index_and_task_or_not_found() -> None:
         _assignment_task_for_ref(definition=opened, task_ref="missing-task")
 
 
+def test_campaign_assignment_task_open_request_fields_are_normalized() -> None:
+    fields = _open_task_request_fields(
+        task_ref=" BRC-TASK-2026-05-001 ",
+        opened_by=" ops ",
+        task_reason=" Campaign requires PM acknowledgement. ",
+        assigned_actor_ids=[" pm_002 ", "pm_001", "pm_001", " "],
+        correlation_id=" corr-campaign-assignment-task-001 ",
+    )
+
+    assert fields.task_ref == "BRC-TASK-2026-05-001"
+    assert fields.opened_by == "ops"
+    assert fields.task_reason == "Campaign requires PM acknowledgement."
+    assert fields.assigned_actor_ids == ["pm_001", "pm_002"]
+    assert fields.correlation_id == "corr-campaign-assignment-task-001"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason_code"),
+    [
+        ({"task_ref": " "}, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_REQUIRED"),
+        ({"opened_by": " "}, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ACTOR_REQUIRED"),
+        ({"task_reason": " "}, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REASON_REQUIRED"),
+        (
+            {"assigned_actor_ids": [" "]},
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ASSIGNEES_REQUIRED",
+        ),
+        (
+            {"correlation_id": " "},
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_CORRELATION_REQUIRED",
+        ),
+    ],
+)
+def test_campaign_assignment_task_open_request_fields_reject_missing_input(
+    overrides: dict[str, object],
+    reason_code: str,
+) -> None:
+    request = {
+        "task_ref": "BRC-TASK-2026-05-001",
+        "opened_by": "ops",
+        "task_reason": "Campaign requires PM acknowledgement.",
+        "assigned_actor_ids": ["pm_001"],
+        "correlation_id": "corr-campaign-assignment-task-001",
+    } | overrides
+
+    with pytest.raises(ValueError, match=reason_code):
+        _open_task_request_fields(**request)
+
+
+def test_replayed_open_task_definition_returns_definition_or_conflicts() -> None:
+    opened = open_bulk_review_campaign_definition_assignment_task(
+        definition=_definition(),
+        task_ref="BRC-TASK-2026-05-001",
+        task_type="ASSIGNMENT",
+        opened_by="ops",
+        task_reason="Campaign requires PM acknowledgement.",
+        assigned_actor_ids=["pm_001"],
+        escalation_tier="PM",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-task-001",
+    )
+    existing_task = opened.assignment_tasks[0]
+
+    assert _replayed_open_task_definition(definition=opened, task=existing_task) is opened
+    assert (
+        _replayed_open_task_definition(
+            definition=_definition(),
+            task=existing_task,
+        )
+        is None
+    )
+
+    conflicting_task = existing_task.model_copy(update={"content_hash": "sha256:conflict"})
+    with pytest.raises(ValueError, match="BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_CONFLICT"):
+        _replayed_open_task_definition(definition=opened, task=conflicting_task)
+
+
 @pytest.mark.parametrize(
     ("overrides", "reason_code"),
     [
@@ -1818,6 +1897,30 @@ def test_definition_with_replaced_assignment_task_preserves_other_tasks() -> Non
     assert updated.assignment_tasks[0].status == "ACKNOWLEDGED"
     assert updated.assignment_tasks[1] == second_opened.assignment_tasks[1]
     assert updated.content_hash
+
+
+def test_definition_with_appended_assignment_task_revalidates_content_hash() -> None:
+    opened = open_bulk_review_campaign_definition_assignment_task(
+        definition=_definition(),
+        task_ref="BRC-TASK-2026-05-001",
+        task_type="ASSIGNMENT",
+        opened_by="ops",
+        task_reason="Campaign requires PM acknowledgement.",
+        assigned_actor_ids=["pm_001"],
+        escalation_tier="PM",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-task-001",
+    )
+    source_definition = _definition()
+
+    updated = _definition_with_appended_assignment_task(
+        definition=source_definition,
+        task=opened.assignment_tasks[0],
+    )
+
+    assert updated.assignment_tasks == opened.assignment_tasks
+    assert updated.content_hash
+    assert updated.content_hash != source_definition.content_hash
 
 
 def test_campaign_assignment_tasks_validate_transition_edges() -> None:

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -64,8 +64,10 @@ from src.core.waves.campaign_assignment_actions import (
 )
 from src.core.waves.campaign_assignment_tasks import (
     DpmBulkReviewCampaignDefinitionAssignmentTaskPage,
+    _assignment_task_for_ref,
     _assignment_task_index,
     _assignment_task_transition,
+    _definition_with_replaced_assignment_task,
     _optional_transition_replay_fields_match,
     _replayed_transition_definition,
     _required_transition_replay_fields,
@@ -77,9 +79,11 @@ from src.core.waves.campaign_assignment_tasks import (
     _transition_requires_actor_ids,
     _transition_requires_due_at,
     _transition_requires_open_assignees,
+    _transition_request_fields,
     _transition_sla_posture_replay_match,
     _transition_task_fields,
     _validate_transition_field_requirements,
+    _validate_active_assignment_task_definition,
     _validate_transition_allowed,
     build_bulk_review_campaign_definition_assignment_task_page,
     open_bulk_review_campaign_definition_assignment_task,
@@ -1542,6 +1546,15 @@ def test_campaign_assignment_tasks_validate_open_request(
         open_bulk_review_campaign_definition_assignment_task(**request)
 
 
+def test_validate_active_assignment_task_definition_rejects_inactive_definition() -> None:
+    _validate_active_assignment_task_definition(_definition())
+
+    with pytest.raises(ValueError, match="BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_ACTIVE_REQUIRED"):
+        _validate_active_assignment_task_definition(
+            _definition().model_copy(update={"status": "DRAFT"})
+        )
+
+
 def test_campaign_assignment_tasks_reject_invalid_transitions_and_closed_mutation() -> None:
     opened = open_bulk_review_campaign_definition_assignment_task(
         definition=_definition(),
@@ -1641,6 +1654,30 @@ def test_campaign_assignment_tasks_replay_and_conflict_on_task_ref() -> None:
         )
 
 
+def test_assignment_task_for_ref_returns_index_and_task_or_not_found() -> None:
+    opened = open_bulk_review_campaign_definition_assignment_task(
+        definition=_definition(),
+        task_ref="BRC-TASK-2026-05-001",
+        task_type="ASSIGNMENT",
+        opened_by="ops",
+        task_reason="Campaign requires PM acknowledgement.",
+        assigned_actor_ids=["pm_001"],
+        escalation_tier="PM",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-task-001",
+    )
+
+    index, task = _assignment_task_for_ref(
+        definition=opened,
+        task_ref="BRC-TASK-2026-05-001",
+    )
+
+    assert index == 0
+    assert task.task_ref == "BRC-TASK-2026-05-001"
+    with pytest.raises(ValueError, match="BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_NOT_FOUND"):
+        _assignment_task_for_ref(definition=opened, task_ref="missing-task")
+
+
 @pytest.mark.parametrize(
     ("overrides", "reason_code"),
     [
@@ -1689,6 +1726,98 @@ def test_campaign_assignment_tasks_validate_transition_required_fields(
 
     with pytest.raises(ValueError, match=reason_code):
         transition_bulk_review_campaign_definition_assignment_task(**request)
+
+
+def test_campaign_assignment_task_transition_request_fields_are_normalized() -> None:
+    fields = _transition_request_fields(
+        task_ref=" BRC-TASK-2026-05-001 ",
+        transition_ref=" BRC-TASK-2026-05-001:ack ",
+        transitioned_by=" pm_001 ",
+        transition_reason=" Assigned PM acknowledged the task. ",
+        correlation_id=" corr-campaign-assignment-task-transition-001 ",
+    )
+
+    assert fields.task_ref == "BRC-TASK-2026-05-001"
+    assert fields.transition_ref == "BRC-TASK-2026-05-001:ack"
+    assert fields.transitioned_by == "pm_001"
+    assert fields.transition_reason == "Assigned PM acknowledged the task."
+    assert fields.correlation_id == "corr-campaign-assignment-task-transition-001"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason_code"),
+    [
+        ({"task_ref": " "}, "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_REF_REQUIRED"),
+        (
+            {"transition_ref": " "},
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_REF_REQUIRED",
+        ),
+        (
+            {"transitioned_by": " "},
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_ACTOR_REQUIRED",
+        ),
+        (
+            {"transition_reason": " "},
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_REASON_REQUIRED",
+        ),
+        (
+            {"correlation_id": " "},
+            "BULK_REVIEW_CAMPAIGN_ASSIGNMENT_TASK_TRANSITION_CORRELATION_REQUIRED",
+        ),
+    ],
+)
+def test_campaign_assignment_task_transition_request_fields_reject_missing_text(
+    overrides: dict[str, str],
+    reason_code: str,
+) -> None:
+    request = {
+        "task_ref": "BRC-TASK-2026-05-001",
+        "transition_ref": "BRC-TASK-2026-05-001:ack",
+        "transitioned_by": "pm_001",
+        "transition_reason": "Assigned PM acknowledged the task.",
+        "correlation_id": "corr-campaign-assignment-task-transition-001",
+    } | overrides
+
+    with pytest.raises(ValueError, match=reason_code):
+        _transition_request_fields(**request)
+
+
+def test_definition_with_replaced_assignment_task_preserves_other_tasks() -> None:
+    first_opened = open_bulk_review_campaign_definition_assignment_task(
+        definition=_definition(),
+        task_ref="BRC-TASK-2026-05-001",
+        task_type="ASSIGNMENT",
+        opened_by="ops",
+        task_reason="Campaign requires PM acknowledgement.",
+        assigned_actor_ids=["pm_001"],
+        escalation_tier="PM",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-task-001",
+    )
+    second_opened = open_bulk_review_campaign_definition_assignment_task(
+        definition=first_opened,
+        task_ref="BRC-TASK-2026-05-002",
+        task_type="ESCALATION",
+        opened_by="ops",
+        task_reason="Campaign requires escalation review.",
+        assigned_actor_ids=["ops_001"],
+        escalation_tier="OPS",
+        sla_posture="ATTENTION",
+        correlation_id="corr-campaign-assignment-task-002",
+    )
+    replacement = second_opened.assignment_tasks[0].model_copy(
+        update={"status": "ACKNOWLEDGED", "content_hash": "sha256:replacement"}
+    )
+
+    updated = _definition_with_replaced_assignment_task(
+        definition=second_opened,
+        task_index=0,
+        task=replacement,
+    )
+
+    assert updated.assignment_tasks[0].status == "ACKNOWLEDGED"
+    assert updated.assignment_tasks[1] == second_opened.assignment_tasks[1]
+    assert updated.content_hash
 
 
 def test_campaign_assignment_tasks_validate_transition_edges() -> None:


### PR DESCRIPTION
## Summary
- Extract campaign assignment task transition, open-task, and page helper boundaries.
- Add direct helper tests for normalization, replay/conflict handling, replacement/append revalidation, and page sort/filter/count behavior.
- Refresh quality reports and ledger through BACKEND-REVIEW-20260617-936.

## Validation
- python -m ruff check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py
- python -m ruff format --check src/core/waves/campaign_assignment_tasks.py tests/unit/dpm/waves/test_campaign_discovery.py
- python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_tasks.py
- python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py -q (104 passed)
- python -m radon cc src/core/waves/campaign_assignment_tasks.py -s
- python scripts/engineering_health_report.py
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- rg service leakage scan in src/api/services (no matches)
- git diff --check
- make check (2769 passed)
- git fetch origin --prune
- git branch -r --no-merged origin/main (only this branch)
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Residual risk
- This improves internal campaign assignment workflow maintainability only; it does not claim global bank-buyable readiness.
- Remaining current source hotspots include core sourcing, rebalance intents, proof-pack builders, wave portfolio resolution, and adjacent campaign read-model pages.