### PR TITLE
Refactor core sourcing helper boundaries

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23577,3 +23577,32 @@ and improves internal transaction-cost source posture maintainability only.
   request shape, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal source-data resilience
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-939: Core snapshot mapping helpers
+
+- Date: 2026-06-17
+- Scope: `src/infrastructure/core_sourcing/client.py` and
+  `tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`.
+- Bank-buyable control area: architecture, source-data mapping supportability, and testing.
+- Finding: core snapshot row mapping helpers combined identifier checks, quantity parsing,
+  currency normalization, cash-row classification, position market-value construction, cash
+  aggregation, and required FX-pair derivation inline. These are source-product mapping
+  boundaries that should be named and tested independently.
+- Action: extracted helpers for row quantity, row currency, market value, cash/position row
+  construction, mapped-row merging, position/cash currency extraction, and non-base currency
+  derivation; added direct tests for row currency fallback and uppercase non-base currency family
+  extraction while preserving the existing snapshot transformation behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `python -m ruff format --check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/core_sourcing/client.py`,
+  `python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py -q`, and
+  `python -m radon cc src/infrastructure/core_sourcing/client.py -s`; the focused core sourcing
+  suite reported 73 passed, and radon reports `_map_core_snapshot_row`,
+  `_portfolio_positions_and_cash_from_core_rows`, and `_required_currency_pairs` at A-grade.
+- Residual risk: this slice improves internal Core snapshot mapping maintainability only. It does
+  not change Core source-product payload semantics, cash classification rules, valuation
+  methodology, FX requirements, stateful sourcing feature flags, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal source-data mapping
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23606,3 +23606,21 @@ and improves internal transaction-cost source posture maintainability only.
   methodology, FX requirements, stateful sourcing feature flags, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal source-data mapping
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-940: Core sourcing hotspot reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the core sourcing helper extractions, the checked-in quality reports needed to
+  reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `83ff760f`, record 2581 test functions, and the current top-ten source hotspot list no longer
+  includes `resolve_execution_context`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23550,3 +23550,30 @@ and improves internal transaction-cost source posture maintainability only.
   bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal source-data resolver
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-938: Core sourcing retry decision helpers
+
+- Date: 2026-06-17
+- Scope: `src/infrastructure/core_sourcing/client.py` and
+  `tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`.
+- Bank-buyable control area: resilience, source-data supportability, and testing.
+- Finding: `_source_product_payload_with_retries` embedded final-attempt detection and transient
+  source-status retry decisions inside the transport retry loop. The behavior was covered by
+  higher-level retry tests, but the retry boundary itself was not directly auditable.
+- Action: extracted helpers for final-attempt detection and transient-status retry eligibility;
+  added direct tests for retryable `502`/`503`/`504` status handling, final-attempt suppression,
+  and non-transient status handling while preserving the existing bounded retry behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `python -m ruff format --check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/core_sourcing/client.py`,
+  `python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py -q`, and
+  `python -m radon cc src/infrastructure/core_sourcing/client.py -s`; the focused core sourcing
+  suite reported 71 passed, and radon reports `_source_product_payload_with_retries` at A(5).
+- Residual risk: this slice improves internal retry-decision maintainability only. Core-snapshot
+  row mapping helpers remain visible B-grade candidates for future slices; this slice does not
+  change timeout policy, max-attempt configuration, downstream status mapping, Core source-product
+  request shape, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal source-data resilience
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23519,3 +23519,34 @@ and improves internal transaction-cost source posture maintainability only.
   baselines into stricter thresholds or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-937: Core sourcing execution-context helpers
+
+- Date: 2026-06-17
+- Scope: `src/infrastructure/core_sourcing/client.py` and
+  `tests/unit/dpm/infrastructure/test_core_sourcing_client.py`.
+- Bank-buyable control area: architecture, source-data supportability, and testing.
+- Finding: `DpmCoreResolverClient.resolve_execution_context` mixed source-product orchestration
+  with requested-instrument identity derivation, FX exposure currency derivation, policy-pack
+  override assembly, source-lineage assembly, and ready supportability construction. These are
+  stable source-data supportability contracts that should be independently auditable.
+- Action: extracted pure helpers for requested execution instruments, required currency pairs,
+  exposure currencies, policy context override, source-lineage construction, and ready
+  supportability; added direct helper tests using the existing synthetic Core source-product
+  payloads while preserving the composed resolver behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py`,
+  `python -m ruff format --check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py`,
+  `python -m mypy --config-file mypy.ini src/infrastructure/core_sourcing/client.py`,
+  `python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py -q`, and
+  `python -m radon cc src/infrastructure/core_sourcing/client.py -s`; the focused core sourcing
+  suite reported 63 passed, and radon reports
+  `DpmCoreResolverClient.resolve_execution_context` at A(4).
+- Residual risk: this slice improves internal core-sourcing resolver maintainability only. The
+  source-product retry helper and core-snapshot row mapping helpers remain visible B-grade
+  candidates for future slices; this slice does not change Core API contracts, source-product
+  ordering, retry behavior, stateful sourcing feature flags, external execution posture, or global
+  bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal source-data resolver
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-16T23:26:52+00:00`
+- Generated at: `2026-06-16T23:48:48+00:00`
 
-- Report source snapshot: `669949b7`
+- Report source snapshot: `83ff760f`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 175839 |
-| Test functions | 2576 |
+| Total Python LOC | 176142 |
+| Test functions | 2581 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-16T23:26:52+00:00`
+- Generated at: `2026-06-16T23:48:48+00:00`
 
-- Report source snapshot: `669949b7`
+- Report source snapshot: `83ff760f`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | resolve_execution_context | src/infrastructure/core_sourcing/client.py | 6 | 233 |
-| 2 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 3 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
-| 4 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
-| 5 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
-| 6 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
-| 7 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
-| 8 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
-| 9 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
-| 10 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
+| 1 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
+| 2 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 3 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
+| 4 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
+| 5 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
+| 6 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
+| 7 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
+| 8 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
+| 9 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
+| 10 | resolve_cio_model_change_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 47 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-16T23:26:52+00:00`
+- Generated at: `2026-06-16T23:48:48+00:00`
 
-- Report source snapshot: `669949b7`
+- Report source snapshot: `83ff760f`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-16T23:26:52+00:00`
+- Generated at: `2026-06-16T23:48:48+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `669949b7`
+- Report source snapshot: `83ff760f`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 175422 | 175839 | +417 |
-| Test functions | 2566 | 2576 | +10 |
+| Total Python LOC | 175839 | 176142 | +303 |
+| Test functions | 2576 | 2581 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -38,9 +38,9 @@
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2908 |
-| 4 | tests/unit/test_documentation_current_state.py | 2721 |
-| 5 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 2512 |
+| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
+| 5 | tests/unit/test_documentation_current_state.py | 2721 |
+| 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |
@@ -56,7 +56,7 @@
 | 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
+| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/core/proof_packs/builder.py | 1900 |

--- a/src/infrastructure/core_sourcing/client.py
+++ b/src/infrastructure/core_sourcing/client.py
@@ -1660,6 +1660,51 @@ def _core_snapshot_row_instrument_id(row: Mapping[str, Any]) -> str:
     return str(row.get("security_id") or row.get("instrument_id") or "").strip()
 
 
+def _core_snapshot_row_quantity(row: Mapping[str, Any]) -> Decimal:
+    return Decimal(str(row.get("quantity") or "0"))
+
+
+def _core_snapshot_row_currency(row: Mapping[str, Any], *, base_currency: str) -> str:
+    return str(row.get("currency") or base_currency).upper()
+
+
+def _core_snapshot_row_market_value(row: Mapping[str, Any]) -> Decimal | None:
+    market_value = row.get("market_value_local")
+    if market_value is None:
+        return None
+    return Decimal(str(market_value))
+
+
+def _core_snapshot_row_is_cash(instrument_id: str) -> bool:
+    return instrument_id.startswith("CASH_")
+
+
+def _cash_core_snapshot_row(
+    *,
+    currency: str,
+    quantity: Decimal,
+) -> _CoreSnapshotMappedRow:
+    return _CoreSnapshotMappedRow(cash_currency=currency, cash_amount=quantity)
+
+
+def _position_core_snapshot_row(
+    *,
+    instrument_id: str,
+    quantity: Decimal,
+    currency: str,
+    market_value: Decimal | None,
+) -> _CoreSnapshotMappedRow:
+    return _CoreSnapshotMappedRow(
+        position=Position(
+            instrument_id=instrument_id,
+            quantity=quantity,
+            market_value=(
+                Money(amount=market_value, currency=currency) if market_value is not None else None
+            ),
+        )
+    )
+
+
 def _held_instrument_ids(portfolio_snapshot: PortfolioSnapshot) -> list[str]:
     return [position.instrument_id for position in portfolio_snapshot.positions]
 
@@ -1744,23 +1789,32 @@ def _map_core_snapshot_row(
     if not instrument_id:
         return None
 
-    quantity = Decimal(str(row.get("quantity") or "0"))
-    currency = str(row.get("currency") or base_currency).upper()
-    if instrument_id.startswith("CASH_"):
-        return _CoreSnapshotMappedRow(cash_currency=currency, cash_amount=quantity)
+    quantity = _core_snapshot_row_quantity(row)
+    currency = _core_snapshot_row_currency(row, base_currency=base_currency)
+    if _core_snapshot_row_is_cash(instrument_id):
+        return _cash_core_snapshot_row(currency=currency, quantity=quantity)
 
-    market_value = row.get("market_value_local")
-    return _CoreSnapshotMappedRow(
-        position=Position(
-            instrument_id=instrument_id,
-            quantity=quantity,
-            market_value=(
-                Money(amount=Decimal(str(market_value)), currency=currency)
-                if market_value is not None
-                else None
-            ),
-        )
+    return _position_core_snapshot_row(
+        instrument_id=instrument_id,
+        quantity=quantity,
+        currency=currency,
+        market_value=_core_snapshot_row_market_value(row),
     )
+
+
+def _merge_core_snapshot_mapped_row(
+    *,
+    positions: list[Position],
+    cash_by_currency: dict[str, Decimal],
+    mapped_row: _CoreSnapshotMappedRow,
+) -> None:
+    if mapped_row.position is not None:
+        positions.append(mapped_row.position)
+        return
+    if mapped_row.cash_currency is not None and mapped_row.cash_amount is not None:
+        cash_by_currency[mapped_row.cash_currency] = (
+            cash_by_currency.get(mapped_row.cash_currency, Decimal("0")) + mapped_row.cash_amount
+        )
 
 
 def _portfolio_positions_and_cash_from_core_rows(
@@ -1774,13 +1828,11 @@ def _portfolio_positions_and_cash_from_core_rows(
         mapped_row = _map_core_snapshot_row(row, base_currency=base_currency)
         if mapped_row is None:
             continue
-        if mapped_row.position is not None:
-            positions.append(mapped_row.position)
-        elif mapped_row.cash_currency is not None and mapped_row.cash_amount is not None:
-            cash_by_currency[mapped_row.cash_currency] = (
-                cash_by_currency.get(mapped_row.cash_currency, Decimal("0"))
-                + mapped_row.cash_amount
-            )
+        _merge_core_snapshot_mapped_row(
+            positions=positions,
+            cash_by_currency=cash_by_currency,
+            mapped_row=mapped_row,
+        )
 
     return positions, cash_by_currency
 
@@ -1813,10 +1865,34 @@ def _required_currency_pairs(
     base_currency: str,
 ) -> list[tuple[str, str]]:
     base = base_currency.upper()
-    currencies = {
+    return sorted(
+        (currency, base)
+        for currency in _required_non_base_currencies(
+            portfolio_snapshot=portfolio_snapshot,
+            base_currency=base,
+        )
+    )
+
+
+def _position_market_value_currencies(
+    positions: list[Position],
+) -> set[str]:
+    return {
         position.market_value.currency.upper()
-        for position in portfolio_snapshot.positions
+        for position in positions
         if position.market_value is not None
     }
-    currencies.update(cash.currency.upper() for cash in portfolio_snapshot.cash_balances)
-    return sorted((currency, base) for currency in currencies if currency != base)
+
+
+def _cash_balance_currencies(cash_balances: list[CashBalance]) -> set[str]:
+    return {cash.currency.upper() for cash in cash_balances}
+
+
+def _required_non_base_currencies(
+    *,
+    portfolio_snapshot: PortfolioSnapshot,
+    base_currency: str,
+) -> set[str]:
+    currencies = _position_market_value_currencies(portfolio_snapshot.positions)
+    currencies.update(_cash_balance_currencies(portfolio_snapshot.cash_balances))
+    return {currency for currency in currencies if currency != base_currency}

--- a/src/infrastructure/core_sourcing/client.py
+++ b/src/infrastructure/core_sourcing/client.py
@@ -515,9 +515,11 @@ class DpmCoreResolverClient:
             consumer_system="lotus-manage",
             correlation_id=correlation_id,
         )
-        held_instrument_ids = [position.instrument_id for position in portfolio_snapshot.positions]
-        target_instrument_ids = [target.instrument_id for target in model_targets.targets]
-        requested_instrument_ids = sorted(set(held_instrument_ids + target_instrument_ids))
+        held_instrument_ids = _held_instrument_ids(portfolio_snapshot)
+        requested_instrument_ids = _requested_execution_instrument_ids(
+            portfolio_snapshot=portfolio_snapshot,
+            model_targets=model_targets,
+        )
 
         eligibility = self.resolve_instrument_eligibility(
             security_ids=requested_instrument_ids,
@@ -540,12 +542,10 @@ class DpmCoreResolverClient:
                 portfolio_snapshot=portfolio_snapshot,
                 response=tax_lots,
             )
+        currency_pairs = _execution_context_currency_pairs(portfolio_snapshot)
         market_data = self.resolve_market_data_coverage(
             instrument_ids=requested_instrument_ids,
-            currency_pairs=_required_currency_pairs(
-                portfolio_snapshot=portfolio_snapshot,
-                base_currency=portfolio_snapshot.base_currency,
-            ),
+            currency_pairs=currency_pairs,
             as_of_date=stateful_input.as_of,
             valuation_currency=portfolio_snapshot.base_currency,
             tenant_id=stateful_input.tenant_id,
@@ -587,15 +587,7 @@ class DpmCoreResolverClient:
             horizon_days=365,
             correlation_id=correlation_id,
         )
-        exposure_currencies = sorted(
-            {
-                source_currency
-                for source_currency, _ in _required_currency_pairs(
-                    portfolio_snapshot=portfolio_snapshot,
-                    base_currency=portfolio_snapshot.base_currency,
-                )
-            }
-        )
+        exposure_currencies = _execution_context_exposure_currencies(currency_pairs)
         external_hedge_execution_readiness = self._try_resolve_external_hedge_execution_readiness(
             portfolio_id=stateful_input.portfolio_id,
             as_of_date=stateful_input.as_of,
@@ -674,35 +666,18 @@ class DpmCoreResolverClient:
             market_data_snapshot=build_market_data_snapshot_from_core_coverage(market_data),
             model_portfolio=build_model_portfolio_from_core_targets(model_targets),
             shelf_entries=build_shelf_entries_from_core_eligibility(eligibility),
-            policy_context=DpmCorePolicyContext(
-                recommended_policy_pack_id=(
-                    stateful_input.policy_pack_id or policy_context.recommended_policy_pack_id
-                ),
-                tenant_id=policy_context.tenant_id,
-                booking_center_code=policy_context.booking_center_code,
-                mandate_id=policy_context.mandate_id,
+            policy_context=_execution_context_policy(
+                stateful_input=stateful_input,
+                policy_context=policy_context,
             ),
-            source_lineage=DpmCoreSourceLineage(
-                portfolio_snapshot_id=portfolio_snapshot.snapshot_id
-                or f"core-snapshot:{stateful_input.portfolio_id}:{stateful_input.as_of.isoformat()}",
-                market_data_snapshot_id=(
-                    f"market-data-coverage:{stateful_input.as_of.isoformat()}"
-                ),
-                model_portfolio_id=model_targets.model_portfolio_id,
-                model_portfolio_version=model_targets.model_portfolio_version,
-                shelf_version=eligibility.lineage.get("contract_version"),
-                integration_policy_version=mandate.lineage.get("contract_version"),
-                source_lineage_bundle_id=(
-                    f"rfc-087:{stateful_input.portfolio_id}:{stateful_input.as_of.isoformat()}"
-                ),
+            source_lineage=_execution_context_lineage(
+                stateful_input=stateful_input,
+                portfolio_snapshot=portfolio_snapshot,
+                model_targets=model_targets,
+                eligibility=eligibility,
+                mandate=mandate,
             ),
-            supportability=DpmCoreSupportability(
-                state="READY",
-                reason="DPM_CORE_CONTEXT_READY",
-                freshness_bucket="current",
-                missing_source_families=[],
-                degraded_source_families=[],
-            ),
+            supportability=_ready_execution_context_supportability(),
             transaction_cost_curve=transaction_cost_curve,
             portfolio_cashflow_projection=portfolio_cashflow_projection,
             client_income_needs_schedule=client_income_needs_schedule,
@@ -1663,6 +1638,81 @@ def _core_snapshot_base_currency(payload: Mapping[str, Any]) -> str:
 
 def _core_snapshot_row_instrument_id(row: Mapping[str, Any]) -> str:
     return str(row.get("security_id") or row.get("instrument_id") or "").strip()
+
+
+def _held_instrument_ids(portfolio_snapshot: PortfolioSnapshot) -> list[str]:
+    return [position.instrument_id for position in portfolio_snapshot.positions]
+
+
+def _requested_execution_instrument_ids(
+    *,
+    portfolio_snapshot: PortfolioSnapshot,
+    model_targets: DpmCoreModelPortfolioTargetResponse,
+) -> list[str]:
+    held_instrument_ids = _held_instrument_ids(portfolio_snapshot)
+    target_instrument_ids = [target.instrument_id for target in model_targets.targets]
+    return sorted(set(held_instrument_ids + target_instrument_ids))
+
+
+def _execution_context_currency_pairs(
+    portfolio_snapshot: PortfolioSnapshot,
+) -> list[tuple[str, str]]:
+    return _required_currency_pairs(
+        portfolio_snapshot=portfolio_snapshot,
+        base_currency=portfolio_snapshot.base_currency,
+    )
+
+
+def _execution_context_exposure_currencies(
+    currency_pairs: list[tuple[str, str]],
+) -> list[str]:
+    return sorted({source_currency for source_currency, _ in currency_pairs})
+
+
+def _execution_context_policy(
+    *,
+    stateful_input: DpmStatefulInput,
+    policy_context: DpmCorePolicyContext,
+) -> DpmCorePolicyContext:
+    return DpmCorePolicyContext(
+        recommended_policy_pack_id=(
+            stateful_input.policy_pack_id or policy_context.recommended_policy_pack_id
+        ),
+        tenant_id=policy_context.tenant_id,
+        booking_center_code=policy_context.booking_center_code,
+        mandate_id=policy_context.mandate_id,
+    )
+
+
+def _execution_context_lineage(
+    *,
+    stateful_input: DpmStatefulInput,
+    portfolio_snapshot: PortfolioSnapshot,
+    model_targets: DpmCoreModelPortfolioTargetResponse,
+    eligibility: DpmCoreInstrumentEligibilityBulkResponse,
+    mandate: DpmCoreMandateBindingResponse,
+) -> DpmCoreSourceLineage:
+    as_of_date = stateful_input.as_of.isoformat()
+    return DpmCoreSourceLineage(
+        portfolio_snapshot_id=portfolio_snapshot.snapshot_id
+        or f"core-snapshot:{stateful_input.portfolio_id}:{as_of_date}",
+        market_data_snapshot_id=f"market-data-coverage:{as_of_date}",
+        model_portfolio_id=model_targets.model_portfolio_id,
+        model_portfolio_version=model_targets.model_portfolio_version,
+        shelf_version=eligibility.lineage.get("contract_version"),
+        integration_policy_version=mandate.lineage.get("contract_version"),
+        source_lineage_bundle_id=f"rfc-087:{stateful_input.portfolio_id}:{as_of_date}",
+    )
+
+
+def _ready_execution_context_supportability() -> DpmCoreSupportability:
+    return DpmCoreSupportability(
+        state="READY",
+        reason="DPM_CORE_CONTEXT_READY",
+        freshness_bucket="current",
+        missing_source_families=[],
+        degraded_source_families=[],
+    )
 
 
 def _map_core_snapshot_row(

--- a/src/infrastructure/core_sourcing/client.py
+++ b/src/infrastructure/core_sourcing/client.py
@@ -95,6 +95,22 @@ def _source_product_request(
     return cast(httpx.Response, client.get(url, params=selector, headers=headers))
 
 
+def _final_source_product_attempt(*, attempt_index: int, attempts: int) -> bool:
+    return attempt_index + 1 >= attempts
+
+
+def _should_retry_transient_source_status(
+    response: httpx.Response,
+    *,
+    attempt_index: int,
+    attempts: int,
+) -> bool:
+    return (
+        response.status_code in _TRANSIENT_SOURCE_STATUS_CODES
+        and not _final_source_product_attempt(attempt_index=attempt_index, attempts=attempts)
+    )
+
+
 def _source_product_payload_with_retries(
     client: Any,
     *,
@@ -118,10 +134,14 @@ def _source_product_payload_with_retries(
             )
         except (httpx.TimeoutException, httpx.TransportError) as exc:
             last_error = exc
-            if attempt + 1 >= attempts:
+            if _final_source_product_attempt(attempt_index=attempt, attempts=attempts):
                 raise DpmCoreResolverUnavailableError(unavailable_code) from exc
             continue
-        if response.status_code in _TRANSIENT_SOURCE_STATUS_CODES and attempt + 1 < attempts:
+        if _should_retry_transient_source_status(
+            response,
+            attempt_index=attempt,
+            attempts=attempts,
+        ):
             continue
         _raise_for_source_product_status(
             response,

--- a/tests/unit/dpm/infrastructure/test_core_sourcing_client.py
+++ b/tests/unit/dpm/infrastructure/test_core_sourcing_client.py
@@ -4,12 +4,28 @@ from decimal import Decimal
 import httpx
 import pytest
 
-from src.core.dpm_source_context import DpmCoreExternalFXForwardCurveResponse, DpmStatefulInput
+from src.core.dpm_source_context import (
+    DpmCoreExternalFXForwardCurveResponse,
+    DpmCoreInstrumentEligibilityBulkResponse,
+    DpmCoreMandateBindingResponse,
+    DpmCoreModelPortfolioTargetResponse,
+    DpmCorePolicyContext,
+    DpmStatefulInput,
+)
 from src.infrastructure.core_sourcing import (
     DpmCoreResolverClient,
     DpmCoreResolverConfig,
     DpmCoreResolverError,
     DpmCoreResolverUnavailableError,
+)
+from src.infrastructure.core_sourcing.client import (
+    _execution_context_currency_pairs,
+    _execution_context_exposure_currencies,
+    _execution_context_lineage,
+    _execution_context_policy,
+    _portfolio_snapshot_from_core_snapshot,
+    _ready_execution_context_supportability,
+    _requested_execution_instrument_ids,
 )
 
 
@@ -1044,6 +1060,60 @@ def _composed_context_response_for(request: httpx.Request) -> httpx.Response:
     if path.endswith("/sustainability-preference-profile"):
         return httpx.Response(200, json=_sustainability_preference_profile_payload())
     return httpx.Response(404, json={"detail": "unexpected path"})
+
+
+def test_core_execution_context_helpers_build_source_ids_policy_and_supportability():
+    stateful_input = _stateful_input().model_copy(update={"policy_pack_id": "POLICY_OVERRIDE"})
+    portfolio_snapshot = _portfolio_snapshot_from_core_snapshot(
+        _core_snapshot_payload()
+    ).model_copy(update={"snapshot_id": None})
+    model_targets = DpmCoreModelPortfolioTargetResponse.model_validate(
+        _model_portfolio_target_payload()
+    )
+    eligibility = DpmCoreInstrumentEligibilityBulkResponse.model_validate(
+        _instrument_eligibility_payload()
+    )
+    mandate = DpmCoreMandateBindingResponse.model_validate(_mandate_binding_payload())
+    policy_context = DpmCorePolicyContext(
+        recommended_policy_pack_id="POLICY_FROM_MANDATE",
+        tenant_id="tenant_001",
+        booking_center_code="SG",
+        mandate_id="mandate_balanced_discretionary",
+    )
+
+    requested_instrument_ids = _requested_execution_instrument_ids(
+        portfolio_snapshot=portfolio_snapshot,
+        model_targets=model_targets,
+    )
+    currency_pairs = _execution_context_currency_pairs(portfolio_snapshot)
+    lineage = _execution_context_lineage(
+        stateful_input=stateful_input,
+        portfolio_snapshot=portfolio_snapshot,
+        model_targets=model_targets,
+        eligibility=eligibility,
+        mandate=mandate,
+    )
+    resolved_policy = _execution_context_policy(
+        stateful_input=stateful_input,
+        policy_context=policy_context,
+    )
+    supportability = _ready_execution_context_supportability()
+
+    assert requested_instrument_ids == ["EQ_US_AAPL", "FI_US_TREASURY_10Y"]
+    assert currency_pairs == [("USD", "SGD")]
+    assert _execution_context_exposure_currencies(currency_pairs) == ["USD"]
+    assert resolved_policy.recommended_policy_pack_id == "POLICY_OVERRIDE"
+    assert resolved_policy.tenant_id == "tenant_001"
+    assert lineage.portfolio_snapshot_id == "core-snapshot:PB_SG_GLOBAL_BAL_001:2026-03-25"
+    assert lineage.market_data_snapshot_id == "market-data-coverage:2026-03-25"
+    assert lineage.model_portfolio_id == "MODEL_PB_SG_GLOBAL_BAL_DPM"
+    assert lineage.shelf_version == "rfc_087_v1"
+    assert lineage.integration_policy_version == "rfc_087_v1"
+    assert lineage.source_lineage_bundle_id == "rfc-087:PB_SG_GLOBAL_BAL_001:2026-03-25"
+    assert supportability.state == "READY"
+    assert supportability.reason == "DPM_CORE_CONTEXT_READY"
+    assert supportability.missing_source_families == []
+    assert supportability.degraded_source_families == []
 
 
 def test_core_resolver_posts_selector_payload_and_correlation_header():

--- a/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
+++ b/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
@@ -9,10 +9,12 @@ from src.infrastructure.core_sourcing.client import (
     DpmCoreResolverConfig,
     DpmCoreResolverError,
     DpmCoreResolverUnavailableError,
+    _final_source_product_attempt,
     _map_core_snapshot_row,
     _portfolio_snapshot_from_core_snapshot,
     _portfolio_positions_and_cash_from_core_rows,
     _required_currency_pairs,
+    _should_retry_transient_source_status,
     _source_product_payload_with_retries,
 )
 
@@ -181,6 +183,48 @@ def test_source_product_retry_helper_exhausts_transient_status_safely() -> None:
         )
 
     assert calls["count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("attempt_index", "attempts", "expected"),
+    [
+        (0, 2, False),
+        (1, 2, True),
+        (0, 1, True),
+    ],
+)
+def test_final_source_product_attempt_identifies_retry_boundary(
+    attempt_index: int,
+    attempts: int,
+    expected: bool,
+) -> None:
+    assert _final_source_product_attempt(attempt_index=attempt_index, attempts=attempts) is expected
+
+
+@pytest.mark.parametrize(
+    ("status_code", "attempt_index", "attempts", "expected"),
+    [
+        (503, 0, 2, True),
+        (502, 1, 2, False),
+        (504, 0, 1, False),
+        (500, 0, 2, False),
+        (429, 0, 2, False),
+    ],
+)
+def test_should_retry_transient_source_status_only_before_final_attempt(
+    status_code: int,
+    attempt_index: int,
+    attempts: int,
+    expected: bool,
+) -> None:
+    assert (
+        _should_retry_transient_source_status(
+            httpx.Response(status_code, json={"detail": "source posture"}),
+            attempt_index=attempt_index,
+            attempts=attempts,
+        )
+        is expected
+    )
 
 
 def test_core_resolver_source_product_helpers_preserve_selector_transport_shape() -> None:

--- a/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
+++ b/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
@@ -9,11 +9,15 @@ from src.infrastructure.core_sourcing.client import (
     DpmCoreResolverConfig,
     DpmCoreResolverError,
     DpmCoreResolverUnavailableError,
+    _cash_balance_currencies,
+    _core_snapshot_row_currency,
     _final_source_product_attempt,
     _map_core_snapshot_row,
     _portfolio_snapshot_from_core_snapshot,
     _portfolio_positions_and_cash_from_core_rows,
+    _position_market_value_currencies,
     _required_currency_pairs,
+    _required_non_base_currencies,
     _should_retry_transient_source_status,
     _source_product_payload_with_retries,
 )
@@ -401,6 +405,11 @@ def test_core_snapshot_row_mapper_preserves_position_market_value_currency() -> 
     assert mapped_row.position.market_value.currency == "USD"
 
 
+def test_core_snapshot_row_currency_normalizes_or_falls_back_to_base_currency() -> None:
+    assert _core_snapshot_row_currency({"currency": "sgd"}, base_currency="USD") == "SGD"
+    assert _core_snapshot_row_currency({}, base_currency="eur") == "EUR"
+
+
 def test_core_snapshot_rows_aggregate_cash_by_currency() -> None:
     positions, cash_by_currency = _portfolio_positions_and_cash_from_core_rows(
         [
@@ -413,6 +422,40 @@ def test_core_snapshot_rows_aggregate_cash_by_currency() -> None:
 
     assert [position.instrument_id for position in positions] == ["EQ_EU"]
     assert cash_by_currency == {"USD": Decimal("25")}
+
+
+def test_core_snapshot_currency_helpers_return_uppercase_non_base_families() -> None:
+    snapshot = _portfolio_snapshot_from_core_snapshot(
+        {
+            "portfolio_id": "PF_TEST",
+            "as_of_date": "2026-04-10",
+            "valuation_context": {"portfolio_currency": "USD"},
+            "sections": {
+                "positions_baseline": [
+                    {
+                        "instrument_id": "EQ_US",
+                        "quantity": "10",
+                        "currency": "usd",
+                        "market_value_local": "100",
+                    },
+                    {
+                        "instrument_id": "EQ_EU",
+                        "quantity": "5",
+                        "currency": "eur",
+                        "market_value_local": "50",
+                    },
+                    {"instrument_id": "CASH_GBP", "quantity": "100", "currency": "gbp"},
+                ]
+            },
+        }
+    )
+
+    assert _position_market_value_currencies(snapshot.positions) == {"EUR", "USD"}
+    assert _cash_balance_currencies(snapshot.cash_balances) == {"GBP"}
+    assert _required_non_base_currencies(
+        portfolio_snapshot=snapshot,
+        base_currency="USD",
+    ) == {"EUR", "GBP"}
 
 
 def test_required_currency_pairs_ignores_base_currency_and_missing_market_values() -> None:


### PR DESCRIPTION
## Summary
- Extract core sourcing execution-context helper boundaries for requested instruments, currency pairs, policy overrides, lineage, and ready supportability.
- Extract source-product retry decision helpers and core snapshot mapping/currency helpers.
- Add direct helper tests and refresh quality reports and ledger through BACKEND-REVIEW-20260617-940.

## Validation
- python -m ruff check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
- python -m ruff format --check src/infrastructure/core_sourcing/client.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
- python -m mypy --config-file mypy.ini src/infrastructure/core_sourcing/client.py
- python -m pytest tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py -q (73 passed)
- python -m radon cc src/infrastructure/core_sourcing/client.py -s
- python scripts/engineering_health_report.py
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- rg service leakage scan in src/api/services (no matches)
- git diff --check
- make check (2780 passed)
- git fetch origin --prune
- git branch -r --no-merged origin/main (only this branch)
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage (DiffCount 0)

## Residual risk
- This improves internal core sourcing maintainability and source-data mapping auditability only; it does not claim global bank-buyable readiness.
- Remaining current source hotspots include rebalance intent generation, proof-pack builders, wave portfolio/source resolution, PM-quality scoring, rebalance target heuristics, and campaign read-model pages.