### PR TITLE
Refine rebalance and proof-pack source hotspots

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23681,3 +23681,25 @@ and improves internal transaction-cost source posture maintainability only.
   source-ref meaning, external API contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal proof-pack supportability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-943: Rebalance and proof-pack hotspot reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`,
+  `quality/architecture_rules.md`, `quality/api_governance_rules.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the rebalance-intent and proof-pack build-context helper extractions, the checked-in
+  quality reports needed to reflect the updated branch head, test-function count, and current
+  source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `d1a4e33c`, record 2586 test functions, keep service boundary findings and router
+  infrastructure imports at 0, and the current top-ten source hotspot list no longer includes
+  `generate_intents` or `_proof_pack_build_context`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining B-grade proof-pack/router/source
+  hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23652,3 +23652,32 @@ and improves internal transaction-cost source posture maintainability only.
   external API contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal portfolio-construction
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-942: Proof-pack build-context source evidence helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, proof-pack evidence supportability, and testing.
+- Finding: `_proof_pack_build_context` still mixed timestamp resolution, source hash assembly,
+  source analytics enrichment, source-ref assembly, run-result hydration, run-artifact hashing,
+  proof-pack id resolution, portfolio resolution, and correlation resolution. That made the
+  proof-pack evidence context harder to review as an auditable supportability boundary.
+- Action: extracted source-evidence context assembly, run-result hydration, and run-artifact hash
+  helpers; added direct tests for analytics hash/ref enrichment and run evidence hydration while
+  preserving the existing proof-pack build contract.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`, and
+  `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder suite
+  reported 98 passed, and radon reports `_proof_pack_build_context` at A(2) with
+  `_proof_pack_source_context` at A(3).
+- Residual risk: this slice improves internal proof-pack evidence-context maintainability only.
+  Additional B-grade proof-pack section helpers remain visible candidates for future slices; this
+  slice does not change proof-pack schemas, content-hash semantics, source analytics facts,
+  source-ref meaning, external API contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal proof-pack supportability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23624,3 +23624,31 @@ and improves internal transaction-cost source posture maintainability only.
   baselines into stricter thresholds or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-941: Rebalance intent target-context helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/rebalance/intents.py` and
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`.
+- Bank-buyable control area: architecture, portfolio construction supportability, and testing.
+- Finding: `generate_intents` still owned per-target market-context resolution, target/current
+  value comparison, safety-limit application, dust suppression, and intent append mechanics inline.
+  That kept the top-level intent generator harder to audit even though most underlying decisions
+  already had focused helpers.
+- Action: extracted a target intent context helper and a security-trade append helper; added direct
+  tests for supported buy-context assembly, dust suppression, zero-quantity skipping, and stable
+  intent numbering while preserving the existing public generation behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m ruff format --check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py -q`, and
+  `python -m radon cc src/core/rebalance/intents.py -s`; the focused rebalance safety suite
+  reported 36 passed, and radon reports `generate_intents` at A(4) with
+  `_target_intent_context` at A(5).
+- Residual risk: this slice improves internal rebalance intent maintainability only. It does not
+  change target-weight methodology, tax-budget behavior, turnover controls, execution posture,
+  external API contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal portfolio-construction
+  maintainability hardening with no operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-16T23:48:48+00:00`
+- Generated at: `2026-06-17T00:09:55+00:00`
 
-- Report source snapshot: `83ff760f`
+- Report source snapshot: `d1a4e33c`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 176142 |
-| Test functions | 2581 |
+| Total Python LOC | 176444 |
+| Test functions | 2586 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-16T23:48:48+00:00`
+- Generated at: `2026-06-17T00:09:55+00:00`
 
-- Report source snapshot: `83ff760f`
+- Report source snapshot: `d1a4e33c`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_intents | src/core/rebalance/intents.py | 6 | 102 |
-| 2 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
-| 3 | _proof_pack_build_context | src/core/proof_packs/builder.py | 6 | 61 |
-| 4 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
-| 5 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
-| 6 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
-| 7 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
-| 8 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
-| 9 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
-| 10 | resolve_cio_model_change_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 47 |
+| 1 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
+| 2 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
+| 3 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
+| 4 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
+| 5 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
+| 6 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
+| 7 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
+| 8 | resolve_cio_model_change_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 47 |
+| 9 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
+| 10 | value_position | src/core/valuation.py | 6 | 45 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-16T23:48:48+00:00`
+- Generated at: `2026-06-17T00:09:55+00:00`
 
-- Report source snapshot: `83ff760f`
+- Report source snapshot: `d1a4e33c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-16T23:48:48+00:00`
+- Generated at: `2026-06-17T00:09:55+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `83ff760f`
+- Report source snapshot: `d1a4e33c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 175839 | 176142 | +303 |
-| Test functions | 2576 | 2581 | +5 |
+| Total Python LOC | 176142 | 176444 | +302 |
+| Test functions | 2581 | 2586 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -41,7 +41,7 @@
 | 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2461 |
+| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/dpm_source_context.py | 1918 |
 | 10 | src/core/proof_packs/builder.py | 1900 |
@@ -52,14 +52,14 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2908 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2966 |
 | 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
-| 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/core/proof_packs/builder.py | 1900 |
+| 9 | src/core/proof_packs/builder.py | 1939 |
+| 10 | src/core/dpm_source_context.py | 1918 |
 
 ## Largest Functions
 

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -134,6 +134,13 @@ class _ProofPackBuildContext:
     correlation_id: str
 
 
+@dataclass(frozen=True)
+class _ProofPackSourceContext:
+    source_hashes: dict[str, str]
+    source_analytics: dict[str, ProofPackSourceAnalytics]
+    source_refs: list[DpmProofPackSourceRef]
+
+
 def build_proof_pack_from_run(
     *,
     run: DpmRunRecord,
@@ -355,6 +362,48 @@ def _proof_pack_build_context(
     direct_regime_stress_context: AuthoritativeRegimeStressContext | None,
 ) -> _ProofPackBuildContext:
     resolved_created_at = created_at or datetime.now(timezone.utc)
+    source_context = _proof_pack_source_context(
+        run=run,
+        alternative_set=alternative_set,
+        selected_alternative=selected_alternative,
+        mandate_twin=mandate_twin,
+        mandate_health=mandate_health,
+        direct_regime_stress_context=direct_regime_stress_context,
+    )
+    result = _rebalance_result_from_run(run)
+    return _ProofPackBuildContext(
+        created_at=resolved_created_at,
+        generated_at=resolved_created_at.isoformat(),
+        result=result,
+        run_artifact_hash=_run_artifact_hash(run),
+        source_hashes=source_context.source_hashes,
+        source_analytics=source_context.source_analytics,
+        source_refs=source_context.source_refs,
+        proof_pack_id=_proof_pack_id(
+            source_type=source_type,
+            run=run,
+            alternative_set=alternative_set,
+            selected_alternative=selected_alternative,
+        ),
+        portfolio_id=_resolve_portfolio_id(run=run, alternative_set=alternative_set),
+        correlation_id=_resolve_proof_pack_correlation_id(
+            correlation_id=correlation_id,
+            selection=selection,
+            run=run,
+            created_at=resolved_created_at,
+        ),
+    )
+
+
+def _proof_pack_source_context(
+    *,
+    run: DpmRunRecord | None,
+    alternative_set: ConstructionAlternativeSet | None,
+    selected_alternative: ConstructionAlternative | None,
+    mandate_twin: DpmMandateDigitalTwin | None,
+    mandate_health: DpmMandateHealthSnapshot | None,
+    direct_regime_stress_context: AuthoritativeRegimeStressContext | None,
+) -> _ProofPackSourceContext:
     source_hashes = _source_hashes(
         run=run,
         alternative_set=alternative_set,
@@ -377,31 +426,21 @@ def _proof_pack_build_context(
         mandate_health=mandate_health,
     )
     source_refs.extend(analytics.source_ref for analytics in source_analytics.values())
-    run_artifact = build_dpm_run_artifact(run=run) if run is not None else None
-    return _ProofPackBuildContext(
-        created_at=resolved_created_at,
-        generated_at=resolved_created_at.isoformat(),
-        result=RebalanceResult.model_validate(run.result_json) if run is not None else None,
-        run_artifact_hash=(
-            run_artifact.evidence.hashes.artifact_hash if run_artifact is not None else None
-        ),
+    return _ProofPackSourceContext(
         source_hashes=source_hashes,
         source_analytics=source_analytics,
         source_refs=source_refs,
-        proof_pack_id=_proof_pack_id(
-            source_type=source_type,
-            run=run,
-            alternative_set=alternative_set,
-            selected_alternative=selected_alternative,
-        ),
-        portfolio_id=_resolve_portfolio_id(run=run, alternative_set=alternative_set),
-        correlation_id=_resolve_proof_pack_correlation_id(
-            correlation_id=correlation_id,
-            selection=selection,
-            run=run,
-            created_at=resolved_created_at,
-        ),
     )
+
+
+def _rebalance_result_from_run(run: DpmRunRecord | None) -> RebalanceResult | None:
+    return RebalanceResult.model_validate(run.result_json) if run is not None else None
+
+
+def _run_artifact_hash(run: DpmRunRecord | None) -> str | None:
+    if run is None:
+        return None
+    return build_dpm_run_artifact(run=run).evidence.hashes.artifact_hash
 
 
 def _resolve_proof_pack_correlation_id(

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -208,6 +208,19 @@ class _SellQuantityDecision:
     sell_quantity_before_tax: Decimal | None
 
 
+@dataclass(frozen=True)
+class _TargetIntentContext:
+    instrument_id: str
+    side: Literal["BUY", "SELL"]
+    requested_quantity: Decimal
+    quantity: Decimal
+    unit_value: Decimal
+    base_rate: Decimal
+    price_currency: str
+    threshold: Money | None
+    sell_quantity_before_tax: Decimal | None
+
+
 def _target_trade_delta(
     *,
     target_instrument_value: Decimal,
@@ -492,6 +505,109 @@ def _security_trade_intent(
     )
 
 
+def _target_intent_context(
+    *,
+    instrument_id: str,
+    target_weight: Decimal,
+    portfolio: PortfolioSnapshot,
+    market_data: MarketDataSnapshot,
+    shelf: list[ShelfEntry],
+    options: EngineOptions,
+    total_val: Decimal,
+    dq_log: dict[str, list[str]],
+    diagnostics: DiagnosticsData,
+    suppressed: list[SuppressedIntent],
+    tax_budget: _TaxBudgetAccumulator,
+) -> _TargetIntentContext | None:
+    market_context = _intent_market_context(
+        instrument_id=instrument_id,
+        portfolio=portfolio,
+        market_data=market_data,
+        dq_log=dq_log,
+    )
+    if market_context is None:
+        return None
+    price_ent, rate, curr = market_context
+
+    curr_instr_val, unit_value = _current_instrument_value_and_unit_value(
+        position=curr,
+        price=price_ent,
+    )
+    target_instr_val = (total_val * target_weight) / rate
+    trade_delta = _target_trade_delta(
+        target_instrument_value=target_instr_val,
+        current_instrument_value=curr_instr_val,
+        unit_value=unit_value,
+    )
+    sell_quantity = _sell_quantity_after_safety_limits(
+        instrument_id=instrument_id,
+        side=trade_delta.side,
+        requested_quantity=trade_delta.raw_quantity,
+        position=curr,
+        options=options,
+        sell_price=unit_value,
+        price_currency=price_ent.currency,
+        base_rate=rate,
+        market_data=market_data,
+        dq_log=dq_log,
+        tax_budget=tax_budget,
+        diagnostics=diagnostics,
+    )
+    shelf_ent = next((s for s in shelf if s.instrument_id == instrument_id), None)
+    threshold = _trade_notional_threshold(options=options, shelf_entry=shelf_ent)
+    notional = sell_quantity.quantity * unit_value
+
+    if _suppress_dust_trade(
+        instrument_id=instrument_id,
+        notional=notional,
+        notional_currency=price_ent.currency,
+        threshold=threshold,
+        options=options,
+        suppressed=suppressed,
+    ):
+        return None
+
+    return _TargetIntentContext(
+        instrument_id=instrument_id,
+        side=trade_delta.side,
+        requested_quantity=trade_delta.raw_quantity,
+        quantity=sell_quantity.quantity,
+        unit_value=unit_value,
+        base_rate=rate,
+        price_currency=price_ent.currency,
+        threshold=threshold,
+        sell_quantity_before_tax=sell_quantity.sell_quantity_before_tax,
+    )
+
+
+def _append_security_trade_intent(
+    *,
+    intents: list[SecurityTradeIntent],
+    context: _TargetIntentContext,
+    portfolio_base_currency: str,
+    tax_awareness_enabled: bool,
+) -> None:
+    if context.quantity <= Decimal("0"):
+        return
+
+    intents.append(
+        _security_trade_intent(
+            intent_id=f"oi_{len(intents) + 1}",
+            side=context.side,
+            instrument_id=context.instrument_id,
+            quantity=context.quantity,
+            unit_value=context.unit_value,
+            base_rate=context.base_rate,
+            price_currency=context.price_currency,
+            portfolio_base_currency=portfolio_base_currency,
+            threshold=context.threshold,
+            requested_quantity=context.requested_quantity,
+            sell_quantity_before_tax=context.sell_quantity_before_tax,
+            tax_awareness_enabled=tax_awareness_enabled,
+        )
+    )
+
+
 def _tax_impact_from_budget(
     *,
     tax_budget: _TaxBudgetAccumulator,
@@ -551,78 +667,28 @@ def generate_intents(
 
     target_dict = _target_weight_by_instrument(targets)
     for i_id, target_w in target_dict.items():
-        market_context = _intent_market_context(
+        intent_context = _target_intent_context(
             instrument_id=i_id,
             portfolio=portfolio,
             market_data=market_data,
-            dq_log=dq_log,
-        )
-        if market_context is None:
-            continue
-        price_ent, rate, curr = market_context
-
-        curr_instr_val, unit_value = _current_instrument_value_and_unit_value(
-            position=curr,
-            price=price_ent,
-        )
-
-        target_instr_val = (total_val * target_w) / rate
-
-        trade_delta = _target_trade_delta(
-            target_instrument_value=target_instr_val,
-            current_instrument_value=curr_instr_val,
-            unit_value=unit_value,
-        )
-        side = trade_delta.side
-        requested_quantity = trade_delta.raw_quantity
-        sell_quantity = _sell_quantity_after_safety_limits(
-            instrument_id=i_id,
-            side=side,
-            requested_quantity=requested_quantity,
-            position=curr,
+            shelf=shelf,
             options=options,
-            sell_price=unit_value,
-            price_currency=price_ent.currency,
-            base_rate=rate,
-            market_data=market_data,
+            total_val=total_val,
+            target_weight=target_w,
             dq_log=dq_log,
             tax_budget=tax_budget,
             diagnostics=diagnostics,
-        )
-        quantity = sell_quantity.quantity
-
-        notional = quantity * unit_value
-
-        shelf_ent = next((s for s in shelf if s.instrument_id == i_id), None)
-        threshold = _trade_notional_threshold(options=options, shelf_entry=shelf_ent)
-
-        if _suppress_dust_trade(
-            instrument_id=i_id,
-            notional=notional,
-            notional_currency=price_ent.currency,
-            threshold=threshold,
-            options=options,
             suppressed=suppressed,
-        ):
+        )
+        if intent_context is None:
             continue
 
-        if quantity > 0:
-            intents.append(
-                _security_trade_intent(
-                    intent_id=f"oi_{len(intents) + 1}",
-                    side=side,
-                    instrument_id=i_id,
-                    quantity=quantity,
-                    unit_value=unit_value,
-                    base_rate=rate,
-                    price_currency=price_ent.currency,
-                    portfolio_base_currency=portfolio.base_currency,
-                    threshold=threshold,
-                    requested_quantity=requested_quantity,
-                    sell_quantity_before_tax=sell_quantity.sell_quantity_before_tax,
-                    tax_awareness_enabled=options.enable_tax_awareness,
-                )
-            )
+        _append_security_trade_intent(
+            intents=intents,
+            context=intent_context,
+            portfolio_base_currency=portfolio.base_currency,
+            tax_awareness_enabled=options.enable_tax_awareness,
+        )
 
     tax_impact = None
     if options.enable_tax_awareness:

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 from src.core.rebalance.engine import _generate_fx_and_simulate, run_simulation
 from src.core.rebalance.intents import (
     _TaxBudgetAccumulator,
+    _TargetIntentContext,
+    _append_security_trade_intent,
     _TaxBudgetLotAllowance,
     _apply_tax_budget_lot_allowance,
     _available_holding_constraint_applies,
@@ -16,6 +18,7 @@ from src.core.rebalance.intents import (
     _sell_quantity_after_safety_limits,
     _suppress_dust_trade,
     _target_trade_delta,
+    _target_intent_context,
     _target_weight_by_instrument,
     _tax_impact_from_budget,
     _tax_budget_lot_allowance,
@@ -351,6 +354,142 @@ def test_target_weight_by_instrument_projects_latest_target_weight() -> None:
         "EQ_1": Decimal("0.60"),
         "EQ_2": Decimal("0.25"),
     }
+
+
+def test_target_intent_context_returns_buy_context_for_supported_target() -> None:
+    portfolio = portfolio_snapshot(
+        portfolio_id="pf_buy_context",
+        base_currency="SGD",
+        positions=[],
+        cash_balances=[cash("SGD", "1000")],
+    )
+    market_data = market_data_snapshot(prices=[price("EQ_1", "10", "SGD")], fx_rates=[])
+    diagnostics = empty_diagnostics()
+    tax_budget = _TaxBudgetAccumulator(
+        total_realized_gain_base=Decimal("0"),
+        total_realized_loss_base=Decimal("0"),
+        tax_budget_used_base=Decimal("0"),
+        tax_budget_limit_base=None,
+    )
+
+    context = _target_intent_context(
+        instrument_id="EQ_1",
+        target_weight=Decimal("0.50"),
+        portfolio=portfolio,
+        market_data=market_data,
+        shelf=[shelf_entry("EQ_1", status="APPROVED")],
+        options=EngineOptions(),
+        total_val=Decimal("1000"),
+        dq_log=diagnostics.data_quality,
+        diagnostics=diagnostics,
+        suppressed=diagnostics.suppressed_intents,
+        tax_budget=tax_budget,
+    )
+
+    assert context == _TargetIntentContext(
+        instrument_id="EQ_1",
+        side="BUY",
+        requested_quantity=Decimal("50"),
+        quantity=Decimal("50"),
+        unit_value=Decimal("10"),
+        base_rate=Decimal("1"),
+        price_currency="SGD",
+        threshold=None,
+        sell_quantity_before_tax=None,
+    )
+    assert diagnostics.suppressed_intents == []
+
+
+def test_target_intent_context_records_suppressed_dust_trade() -> None:
+    portfolio = portfolio_snapshot(
+        portfolio_id="pf_dust_context",
+        base_currency="SGD",
+        positions=[],
+        cash_balances=[cash("SGD", "1000")],
+    )
+    market_data = market_data_snapshot(prices=[price("EQ_1", "10", "SGD")], fx_rates=[])
+    diagnostics = empty_diagnostics()
+    tax_budget = _TaxBudgetAccumulator(
+        total_realized_gain_base=Decimal("0"),
+        total_realized_loss_base=Decimal("0"),
+        tax_budget_used_base=Decimal("0"),
+        tax_budget_limit_base=None,
+    )
+
+    context = _target_intent_context(
+        instrument_id="EQ_1",
+        target_weight=Decimal("0.05"),
+        portfolio=portfolio,
+        market_data=market_data,
+        shelf=[shelf_entry("EQ_1", status="APPROVED")],
+        options=EngineOptions(
+            suppress_dust_trades=True,
+            min_trade_notional=Money(amount=Decimal("100"), currency="SGD"),
+        ),
+        total_val=Decimal("1000"),
+        dq_log=diagnostics.data_quality,
+        diagnostics=diagnostics,
+        suppressed=diagnostics.suppressed_intents,
+        tax_budget=tax_budget,
+    )
+
+    assert context is None
+    assert len(diagnostics.suppressed_intents) == 1
+    assert diagnostics.suppressed_intents[0].instrument_id == "EQ_1"
+    assert diagnostics.suppressed_intents[0].intended_notional == Money(
+        amount=Decimal("50"),
+        currency="SGD",
+    )
+
+
+def test_append_security_trade_intent_numbers_positive_contexts_only() -> None:
+    intents: list[SecurityTradeIntent] = []
+    positive_context = _TargetIntentContext(
+        instrument_id="EQ_1",
+        side="BUY",
+        requested_quantity=Decimal("10"),
+        quantity=Decimal("10"),
+        unit_value=Decimal("5"),
+        base_rate=Decimal("1"),
+        price_currency="SGD",
+        threshold=None,
+        sell_quantity_before_tax=None,
+    )
+    zero_context = _TargetIntentContext(
+        instrument_id="EQ_2",
+        side="BUY",
+        requested_quantity=Decimal("0"),
+        quantity=Decimal("0"),
+        unit_value=Decimal("5"),
+        base_rate=Decimal("1"),
+        price_currency="SGD",
+        threshold=None,
+        sell_quantity_before_tax=None,
+    )
+
+    _append_security_trade_intent(
+        intents=intents,
+        context=positive_context,
+        portfolio_base_currency="SGD",
+        tax_awareness_enabled=False,
+    )
+    _append_security_trade_intent(
+        intents=intents,
+        context=zero_context,
+        portfolio_base_currency="SGD",
+        tax_awareness_enabled=False,
+    )
+    _append_security_trade_intent(
+        intents=intents,
+        context=positive_context,
+        portfolio_base_currency="SGD",
+        tax_awareness_enabled=False,
+    )
+
+    assert [(intent.intent_id, intent.instrument_id) for intent in intents] == [
+        ("oi_1", "EQ_1"),
+        ("oi_2", "EQ_1"),
+    ]
 
 
 def test_sell_quantity_after_safety_limits_bypasses_non_sell_quantity() -> None:

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -1718,6 +1718,64 @@ def test_proof_pack_build_context_attaches_direct_regime_source_hashes_and_refs(
     )
 
 
+def test_proof_pack_source_context_merges_analytics_hashes_and_refs() -> None:
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+    alternative_set = build_alternative_set(
+        alternative_set_id="cas_source_context",
+        portfolio_id="pf_proof_pack_1",
+        as_of="2026-05-03",
+        alternatives=[alternative],
+    ).model_copy(update={"generated_at": CREATED_AT})
+
+    source_context = builder_module._proof_pack_source_context(
+        run=_run_record(result=result),
+        alternative_set=alternative_set,
+        selected_alternative=alternative,
+        mandate_twin=None,
+        mandate_health=None,
+        direct_regime_stress_context=AuthoritativeRegimeStressContext(
+            supportability_status="READY",
+            source_system="lotus-risk",
+            scenario_pack_id="CIO_REGIME_CONTEXT_Q4",
+            worst_case_loss_pct=Decimal("0.0400"),
+            maximum_allowed_loss_pct=Decimal("0.1000"),
+            cio_approval_ref="CIO-APPROVAL-CONTEXT-Q4",
+            effective_from=date(2026, 10, 1),
+            reason_codes=["REGIME_SCENARIO_WITHIN_POLICY"],
+        ),
+    )
+
+    assert source_context.source_hashes["rebalance_run"].startswith("sha256:")
+    assert source_context.source_hashes["alternative_set"].startswith("sha256:")
+    assert source_context.source_hashes["selected_alternative"].startswith("sha256:")
+    assert source_context.source_hashes["regime_stress_context"].startswith("sha256:")
+    assert source_context.source_analytics["regime_stress"].facts["scenario_pack_id"] == (
+        "CIO_REGIME_CONTEXT_Q4"
+    )
+    assert any(
+        ref.source_system == "lotus-risk"
+        and ref.source_type == "RegimeScenarioPackEvaluation"
+        and ref.source_id == "CIO_REGIME_CONTEXT_Q4"
+        for ref in source_context.source_refs
+    )
+
+
+def test_run_artifact_hash_and_result_helpers_hydrate_run_evidence() -> None:
+    result = _ready_rebalance_result()
+    run = _run_record(result=result)
+
+    hydrated_result = builder_module._rebalance_result_from_run(run)
+    artifact_hash = builder_module._run_artifact_hash(run)
+
+    assert hydrated_result is not None
+    assert hydrated_result.rebalance_run_id == result.rebalance_run_id
+    assert artifact_hash is not None
+    assert artifact_hash.startswith("sha256:")
+    assert builder_module._rebalance_result_from_run(None) is None
+    assert builder_module._run_artifact_hash(None) is None
+
+
 def test_source_refs_preserve_manage_artifact_and_mandate_supportability() -> None:
     result = _ready_rebalance_result()
     run = _run_record(result=result)


### PR DESCRIPTION
## Summary
- Extract rebalance intent target-context and append helpers so `generate_intents` drops out of the source-hotspot list while preserving target, dust, tax, and safety behavior.
- Extract proof-pack source evidence context, run-result hydration, and run-artifact hash helpers so `_proof_pack_build_context` becomes a small orchestration helper.
- Refresh quality evidence and ledger entries through `BACKEND-REVIEW-20260617-943`.

## Evidence
- `python -m ruff check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`
- `python -m ruff format --check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`
- `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`
- `python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py -q` (`36 passed`)
- `python -m radon cc src/core/rebalance/intents.py -s` (`generate_intents` A(4), `_target_intent_context` A(5))
- `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` (`98 passed`)
- `python -m radon cc src/core/proof_packs/builder.py -s` (`_proof_pack_build_context` A(2), `_proof_pack_source_context` A(3))
- `python scripts/engineering_health_report.py`
- `make check` (`2785 passed`)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- service leakage scan returned no matches: `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"`
- `git diff --check`
- `git fetch origin --prune; git branch -r --no-merged origin/main` (only this active feature branch)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Reported movement
- Refreshed reports are sourced from `d1a4e33c`.
- Test functions: 2586.
- Service boundary findings: 0.
- Router infrastructure imports: 0.
- Current top-ten source hotspot list no longer includes `generate_intents` or `_proof_pack_build_context`.

## Residual risk
- This PR improves internal maintainability and testability only; it does not change API contracts, proof-pack schemas, target-weight methodology, execution posture, or global bank-buyable readiness.
- Remaining B-grade source hotspots are still tracked in `quality/complexity_report.md` for future focused slices.