### PR TITLE
Refine proof pack section hotspot helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23732,3 +23732,30 @@ and improves internal transaction-cost source posture maintainability only.
   regenerated bodies, external API contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal proof-pack supportability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-945: Proof-pack rule-result projection helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, proof-pack policy evidence, and testing.
+- Finding: `_rule_results_section_payload` combined failed-rule selection, hard-fail state
+  classification, fail-count metrics, reason-code projection, and section assembly. That kept
+  proof-pack policy evidence projection less directly auditable than the surrounding payload
+  helpers.
+- Action: extracted helpers for failed-rule selection, section-state classification, metrics, and
+  reason-code projection; added direct tests for mixed pass/soft-fail/hard-fail rule results while
+  preserving existing section payload shape.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`, and
+  `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder suite
+  reported 101 passed, and radon reports `_rule_results_section_payload` at A(2).
+- Residual risk: this slice improves internal proof-pack rule-result projection maintainability
+  only. It does not change policy rule semantics, hard/soft severity interpretation, proof-pack
+  schemas, external API contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal proof-pack policy-evidence
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23703,3 +23703,32 @@ and improves internal transaction-cost source posture maintainability only.
   hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-944: Proof-pack section dispatch helper
+
+- Date: 2026-06-17
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, proof-pack supportability, and testing.
+- Finding: `_section_payload` still combined pre-run section dispatch, missing-source-run blocking,
+  run-bound dispatch, source-context dispatch, governance dispatch, and unhandled-section
+  assertion in one helper. That kept the proof-pack section dispatch boundary harder to review
+  despite the individual section payload helpers already being named and tested.
+- Action: extracted the run-present section dispatch into `_run_present_section_payload`; added
+  direct tests for run-bound, source-context, governance, and unhandled-section routing while
+  preserving existing section payload text, metrics, and reason-code behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`, and
+  `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder suite
+  reported 100 passed, and radon reports `_section_payload` at A(3) with
+  `_run_present_section_payload` at A(4).
+- Residual risk: this slice improves internal proof-pack section dispatch maintainability only.
+  Several proof-pack payload helpers remain B-grade candidates for future focused slices; this
+  slice does not change proof-pack schemas, section ordering, content hashes beyond equivalent
+  regenerated bodies, external API contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal proof-pack supportability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23759,3 +23759,25 @@ and improves internal transaction-cost source posture maintainability only.
   schemas, external API contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal proof-pack policy-evidence
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-946: Proof-pack dispatch hotspot reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`,
+  `quality/architecture_rules.md`, `quality/api_governance_rules.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the proof-pack section dispatch and rule-result projection helper extractions, the
+  checked-in quality reports needed to reflect the updated branch head, test-function count, and
+  current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `927a03e1`, record 2589 test functions, keep service boundary findings and router
+  infrastructure imports at 0, and the current top-ten source hotspot list no longer includes
+  `_section_payload`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining router/source/PM-quality/rebalance
+  hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T00:09:55+00:00`
+- Generated at: `2026-06-17T00:29:44+00:00`
 
-- Report source snapshot: `d1a4e33c`
+- Report source snapshot: `927a03e1`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 819 |
-| Total Python LOC | 176444 |
-| Test functions | 2586 |
+| Total Python LOC | 176584 |
+| Test functions | 2589 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T00:09:55+00:00`
+- Generated at: `2026-06-17T00:29:44+00:00`
 
-- Report source snapshot: `d1a4e33c`
+- Report source snapshot: `927a03e1`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _section_payload | src/core/proof_packs/builder.py | 6 | 65 |
-| 2 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
-| 3 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
-| 4 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
-| 5 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
-| 6 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
-| 7 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
-| 8 | resolve_cio_model_change_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 47 |
-| 9 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
-| 10 | value_position | src/core/valuation.py | 6 | 45 |
+| 1 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
+| 2 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
+| 3 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
+| 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
+| 5 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
+| 6 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
+| 7 | resolve_cio_model_change_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 47 |
+| 8 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
+| 9 | value_position | src/core/valuation.py | 6 | 45 |
+| 10 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T00:09:55+00:00`
+- Generated at: `2026-06-17T00:29:44+00:00`
 
-- Report source snapshot: `d1a4e33c`
+- Report source snapshot: `927a03e1`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T00:09:55+00:00`
+- Generated at: `2026-06-17T00:29:44+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `d1a4e33c`
+- Report source snapshot: `927a03e1`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 819 | 819 | +0 |
-| Total Python LOC | 176142 | 176444 | +302 |
-| Test functions | 2581 | 2586 | +5 |
+| Total Python LOC | 176444 | 176584 | +140 |
+| Test functions | 2586 | 2589 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,21 +37,6 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2908 |
-| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
-| 5 | tests/unit/test_documentation_current_state.py | 2721 |
-| 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
-| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
-| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
-| 9 | src/core/dpm_source_context.py | 1918 |
-| 10 | src/core/proof_packs/builder.py | 1900 |
-
-### current branch
-
-| Rank | File | Lines |
-| --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
-| 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2966 |
 | 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
@@ -59,6 +44,21 @@
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/proof_packs/builder.py | 1939 |
+| 10 | src/core/dpm_source_context.py | 1918 |
+
+### current branch
+
+| Rank | File | Lines |
+| --- | --- | --- |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
+| 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3066 |
+| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
+| 5 | tests/unit/test_documentation_current_state.py | 2721 |
+| 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
+| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
+| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
+| 9 | src/core/proof_packs/builder.py | 1979 |
 | 10 | src/core/dpm_source_context.py | 1918 |
 
 ## Largest Functions

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -1454,6 +1454,30 @@ def _section_payload(
         return pre_run_payload
     if result is None:
         return ("BLOCKED", "Source rebalance run is missing.", {}, {}, ["DPM_SOURCE_RUN_MISSING"])
+
+    return _run_present_section_payload(
+        section_type=section_type,
+        result=result,
+        run=run,
+        selected_alternative=selected_alternative,
+        selection=selection,
+        source_ref_count=source_ref_count,
+        source_analytics=source_analytics,
+        workflow_decisions=workflow_decisions,
+    )
+
+
+def _run_present_section_payload(
+    *,
+    section_type: ProofPackSectionType,
+    result: RebalanceResult,
+    run: DpmRunRecord | None,
+    selected_alternative: ConstructionAlternative | None,
+    selection: ConstructionAlternativeSelection | None,
+    source_ref_count: int,
+    source_analytics: dict[str, ProofPackSourceAnalytics],
+    workflow_decisions: list[DpmRunWorkflowDecisionRecord],
+) -> _SectionPayload:
     run_bound_payload = _run_bound_section_payload(
         section_type=section_type,
         result=result,

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -34,7 +34,7 @@ from src.core.proof_packs.source_analytics import (
 from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthSnapshot
 from src.core.rebalance_runs.artifact import build_dpm_run_artifact
 from src.core.rebalance_runs.models import DpmRunRecord, DpmRunWorkflowDecisionRecord
-from src.core.models import ExcludedInstrument, GateDecision, RebalanceResult
+from src.core.models import ExcludedInstrument, GateDecision, RebalanceResult, RuleResult
 
 PROOF_PACK_VERSION = "1.0"
 
@@ -800,14 +800,30 @@ def _tax_impact_section_payload(*, result: RebalanceResult) -> _SectionPayload:
 
 
 def _rule_results_section_payload(*, result: RebalanceResult) -> _SectionPayload:
-    failed = [rule for rule in result.rule_results if rule.status == "FAIL"]
+    failed = _failed_rule_results(result)
     return (
-        "BLOCKED" if any(rule.severity == "HARD" for rule in failed) else "READY",
+        _rule_results_section_state(failed),
         "Rule results captured from manage policy engine.",
         {"rule_results": [rule.model_dump(mode="json") for rule in result.rule_results]},
-        {"fail_count": len(failed)},
-        [rule.reason_code for rule in failed],
+        _rule_results_metrics(failed),
+        _rule_results_reason_codes(failed),
     )
+
+
+def _failed_rule_results(result: RebalanceResult) -> list[RuleResult]:
+    return [rule for rule in result.rule_results if rule.status == "FAIL"]
+
+
+def _rule_results_section_state(failed_rules: list[RuleResult]) -> ProofPackSectionState:
+    return "BLOCKED" if any(rule.severity == "HARD" for rule in failed_rules) else "READY"
+
+
+def _rule_results_metrics(failed_rules: list[RuleResult]) -> dict[str, int]:
+    return {"fail_count": len(failed_rules)}
+
+
+def _rule_results_reason_codes(failed_rules: list[RuleResult]) -> list[str]:
+    return [rule.reason_code for rule in failed_rules]
 
 
 def _proof_pack_governance_section_payload(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -1361,6 +1361,65 @@ def test_run_source_context_section_payload_ignores_unhandled_sections() -> None
     )
 
 
+def test_run_present_section_payload_dispatches_run_source_and_governance_sections() -> None:
+    result = _ready_rebalance_result()
+    run = _run_record(result=result)
+
+    before_state = builder_module._run_present_section_payload(
+        section_type="before_state",
+        result=result,
+        run=run,
+        selected_alternative=None,
+        selection=None,
+        source_ref_count=0,
+        source_analytics={},
+        workflow_decisions=[],
+    )
+    source_context = builder_module._run_present_section_payload(
+        section_type="scenario_and_regime_evidence",
+        result=result,
+        run=run,
+        selected_alternative=None,
+        selection=None,
+        source_ref_count=0,
+        source_analytics={},
+        workflow_decisions=[],
+    )
+    governance = builder_module._run_present_section_payload(
+        section_type="lineage",
+        result=result,
+        run=run,
+        selected_alternative=None,
+        selection=None,
+        source_ref_count=2,
+        source_analytics={},
+        workflow_decisions=[],
+    )
+
+    assert before_state[0] == "READY"
+    assert before_state[1] == "Before-state summary captured from source run artifact."
+    assert source_context[0] == "DEGRADED"
+    assert source_context[4] == ["DPM_SCENARIO_CONTEXT_MISSING"]
+    assert governance[0] == "READY"
+    assert governance[3] == {"source_ref_count": 2}
+
+
+def test_run_present_section_payload_rejects_unhandled_section_type() -> None:
+    result = _ready_rebalance_result()
+
+    with pytest.raises(AssertionError, match="Unhandled proof-pack section type"):
+        builder_module._run_present_section_payload(
+            section_type="unsupported",
+            result=result,
+            run=_run_record(result=result),
+            selected_alternative=None,
+            selection=None,
+            source_ref_count=0,
+            source_analytics={},
+            workflow_decisions=[],
+        )
+
+
 def test_direct_run_proof_pack_generates_every_section_with_truthful_states() -> None:
     run = _run_record()
     decision = DpmRunWorkflowDecisionRecord(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -595,6 +595,47 @@ def test_rule_results_section_payload_blocks_on_hard_failed_policy_rule() -> Non
     assert reason_codes == ["DPM_NO_SHORTING"]
 
 
+def test_rule_result_projection_helpers_classify_failed_policy_rules() -> None:
+    hard_fail = RuleResult(
+        rule_id="NO_SHORTING",
+        severity="HARD",
+        status="FAIL",
+        measured=Decimal("-1"),
+        threshold={"minimum_weight": Decimal("0")},
+        reason_code="DPM_NO_SHORTING",
+    )
+    soft_fail = RuleResult(
+        rule_id="CASH_BUFFER",
+        severity="SOFT",
+        status="FAIL",
+        measured=Decimal("0.01"),
+        threshold={"minimum_weight": Decimal("0.03")},
+        reason_code="DPM_CASH_BUFFER_LOW",
+    )
+    pass_rule = RuleResult(
+        rule_id="MAX_WEIGHT",
+        severity="HARD",
+        status="PASS",
+        measured=Decimal("0.10"),
+        threshold={"maximum_weight": Decimal("0.20")},
+        reason_code="DPM_MAX_WEIGHT_OK",
+    )
+    result = _ready_rebalance_result().model_copy(
+        update={"rule_results": [pass_rule, soft_fail, hard_fail]}
+    )
+
+    failed_rules = builder_module._failed_rule_results(result)
+
+    assert [rule.rule_id for rule in failed_rules] == ["CASH_BUFFER", "NO_SHORTING"]
+    assert builder_module._rule_results_section_state(failed_rules) == "BLOCKED"
+    assert builder_module._rule_results_section_state([soft_fail]) == "READY"
+    assert builder_module._rule_results_metrics(failed_rules) == {"fail_count": 2}
+    assert builder_module._rule_results_reason_codes(failed_rules) == [
+        "DPM_CASH_BUFFER_LOW",
+        "DPM_NO_SHORTING",
+    ]
+
+
 def test_run_bound_section_payload_dispatches_state_policy_and_diagnostics() -> None:
     result = _ready_rebalance_result().model_copy(update={"intents": []})
 


### PR DESCRIPTION
## Summary
- Extract proof-pack run-present section dispatch so `_section_payload` is a smaller orchestration helper.
- Extract proof-pack rule-result projection helpers for failed-rule selection, section-state classification, metrics, and reason codes.
- Refresh quality reports and ledger entries through `BACKEND-REVIEW-20260617-946`.

## Evidence
- `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`
- `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`
- `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q` (`101 passed`)
- `python -m radon cc src/core/proof_packs/builder.py -s` (`_section_payload` A(3), `_run_present_section_payload` A(4), `_rule_results_section_payload` A(2))
- `python scripts/engineering_health_report.py`
- `make check` (`2788 passed`)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- service leakage scan returned no matches: `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"`
- `git diff --check`
- `git fetch origin --prune; git branch -r --no-merged origin/main` (only this active feature branch)
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` (DiffCount 0)

## Reported movement
- Refreshed reports are sourced from `927a03e1`.
- Test functions: 2589.
- Service boundary findings: 0.
- Router infrastructure imports: 0.
- Current top-ten source hotspot list no longer includes `_section_payload`.

## Residual risk
- This PR improves internal proof-pack maintainability and testability only; it does not change proof-pack schemas, section ordering, API contracts, policy semantics, or global bank-buyable readiness.
- Remaining source hotspots are tracked in `quality/complexity_report.md` and now start with router/source resolution and PM-quality/rebalance/campaign helpers.