### PR TITLE
Refactor wave source resolver helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23781,3 +23781,34 @@ and improves internal transaction-cost source posture maintainability only.
   hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-947: Risk-event portfolio resolution helpers
+
+- Date: 2026-06-17
+- Scope: `src/api/routers/wave_portfolio_resolution.py`,
+  `src/api/routers/wave_risk_event_validation.py`, and
+  `tests/unit/api/test_wave_portfolio_resolution.py`.
+- Bank-buyable control area: architecture, source-authority supportability, and testing.
+- Finding: `_resolve_risk_event_portfolios` still combined request validation, source-authority
+  availability checks, lotus-risk authority call construction, source cohort readiness gating, and
+  resolved-portfolio projection in one router helper. That kept the RISK_EVENT source-owned cohort
+  path harder to review than the surrounding named trigger resolvers.
+- Action: extracted named router-owned helpers for risk-event authority request construction,
+  required risk authority client selection, lotus-risk affected cohort invocation, and cohort
+  readiness gating; added direct tests for risk-event authority input mapping and the incomplete or
+  empty source-cohort failure paths; tightened the risk-event cohort protocol to include the
+  `reason_codes` field required by readiness errors.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/wave_portfolio_resolution.py src/api/routers/wave_risk_event_validation.py tests/unit/api/test_wave_portfolio_resolution.py`,
+  `python -m ruff format --check src/api/routers/wave_portfolio_resolution.py src/api/routers/wave_risk_event_validation.py tests/unit/api/test_wave_portfolio_resolution.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/wave_portfolio_resolution.py src/api/routers/wave_risk_event_validation.py`,
+  `python -m pytest tests/unit/api/test_wave_portfolio_resolution.py tests/unit/api/test_wave_risk_event_validation.py -q`,
+  and `python -m radon cc src/api/routers/wave_portfolio_resolution.py -s`; the focused API helper
+  suites reported 14 passed, and radon reports `_resolve_risk_event_portfolios` reduced from B(6)
+  to A(1).
+- Residual risk: this slice improves RISK_EVENT router helper maintainability only. It does not
+  change lotus-risk authority semantics, resolved portfolio payload schemas, source-ref lineage,
+  external API contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal source-resolution supportability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23812,3 +23812,33 @@ and improves internal transaction-cost source posture maintainability only.
   external API contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal source-resolution supportability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-948: Core source resolver request helpers
+
+- Date: 2026-06-17
+- Scope: `src/api/routers/wave_core_source_resolution.py` and
+  `tests/unit/api/test_wave_core_source_resolution.py`.
+- Bank-buyable control area: architecture, source-authority supportability, and testing.
+- Finding: `resolve_pm_book_portfolios` and `resolve_cio_model_change_portfolios` each combined
+  caller-supplied portfolio rejection, required selector normalization, lotus-core resolver
+  invocation, source-readiness gating, empty-cohort blocking, and resolved portfolio projection.
+  That left two source-owned cohort discovery paths B-grade and harder to audit than their
+  projection helpers.
+- Action: extracted domain-specific request-shaping dataclasses and helpers for PM-book membership
+  and CIO model-change affected cohort queries; separated lotus-core resolver invocation from
+  source-readiness checks; added direct tests for normalized source-query construction and
+  incomplete or empty source-cohort rejection for both flows.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/api/routers/wave_core_source_resolution.py tests/unit/api/test_wave_core_source_resolution.py`,
+  `python -m ruff format --check src/api/routers/wave_core_source_resolution.py tests/unit/api/test_wave_core_source_resolution.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/wave_core_source_resolution.py`,
+  `python -m pytest tests/unit/api/test_wave_core_source_resolution.py tests/unit/api/test_wave_pm_book_projection.py tests/unit/api/test_wave_cio_model_change_projection.py -q`,
+  and `python -m radon cc src/api/routers/wave_core_source_resolution.py -s`; the focused core
+  source resolver and projection suites reported 14 passed, and radon reports both
+  `resolve_pm_book_portfolios` and `resolve_cio_model_change_portfolios` reduced from B(6) to A(1).
+- Residual risk: this slice improves router-side source resolver maintainability only. It does not
+  change lotus-core resolver semantics, source product contracts, projection payload schemas,
+  external API contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal source-resolution supportability
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23842,3 +23842,25 @@ and improves internal transaction-cost source posture maintainability only.
   external API contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal source-resolution supportability
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-949: Source resolver hotspot reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the risk-event, PM-book, and CIO model-change source resolver helper extractions,
+  the checked-in quality reports needed to reflect the updated branch head, test-function count,
+  and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `05c33ddc`, record 820 Python files, 2598 test functions, keep service boundary findings and
+  router infrastructure imports at 0, and the current top-ten source hotspot list no longer
+  includes `_resolve_risk_event_portfolios`, `resolve_pm_book_portfolios`, or
+  `resolve_cio_model_change_portfolios`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining PM-quality/rebalance/wave
+  campaign/search/OpenAPI/observability hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T00:29:44+00:00`
+- Generated at: `2026-06-17T00:52:02+00:00`
 
-- Report source snapshot: `927a03e1`
+- Report source snapshot: `05c33ddc`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -10,9 +10,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 819 |
-| Total Python LOC | 176584 |
-| Test functions | 2589 |
+| Python files | 820 |
+| Total Python LOC | 176963 |
+| Test functions | 2598 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T00:29:44+00:00`
+- Generated at: `2026-06-17T00:52:02+00:00`
 
-- Report source snapshot: `927a03e1`
+- Report source snapshot: `05c33ddc`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _resolve_risk_event_portfolios | src/api/routers/wave_portfolio_resolution.py | 6 | 57 |
-| 2 | resolve_pm_book_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 53 |
-| 3 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
-| 4 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
-| 5 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
-| 6 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
-| 7 | resolve_cio_model_change_portfolios | src/api/routers/wave_core_source_resolution.py | 6 | 47 |
-| 8 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
-| 9 | value_position | src/core/valuation.py | 6 | 45 |
-| 10 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
+| 1 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
+| 2 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
+| 3 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
+| 4 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
+| 5 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
+| 6 | value_position | src/core/valuation.py | 6 | 45 |
+| 7 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
+| 8 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
+| 9 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
+| 10 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T00:29:44+00:00`
+- Generated at: `2026-06-17T00:52:02+00:00`
 
-- Report source snapshot: `927a03e1`
+- Report source snapshot: `05c33ddc`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T00:29:44+00:00`
+- Generated at: `2026-06-17T00:52:02+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `927a03e1`
+- Report source snapshot: `05c33ddc`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 819 | 819 | +0 |
-| Total Python LOC | 176444 | 176584 | +140 |
-| Test functions | 2586 | 2589 | +3 |
+| Python files | 819 | 820 | +1 |
+| Total Python LOC | 176584 | 176963 | +379 |
+| Test functions | 2589 | 2598 | +9 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,13 +37,13 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 2966 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3066 |
 | 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
-| 9 | src/core/proof_packs/builder.py | 1939 |
+| 9 | src/core/proof_packs/builder.py | 1979 |
 | 10 | src/core/dpm_source_context.py | 1918 |
 
 ### current branch

--- a/src/api/routers/wave_core_source_resolution.py
+++ b/src/api/routers/wave_core_source_resolution.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
 from typing import Any
 
 from src.api.routers.wave_cio_model_change_projection import (
@@ -28,12 +30,42 @@ from src.api.services.core_resolver_service import (
 CoreResolverFactory = Callable[[], Any]
 
 
+@dataclass(frozen=True)
+class _PmBookMembershipRequest:
+    portfolio_manager_id: str
+    as_of_date: date
+    tenant_id: str | None
+    booking_center_code: str | None
+    portfolio_types: list[str]
+
+
+@dataclass(frozen=True)
+class _CioModelChangeCohortRequest:
+    model_portfolio_id: str
+    as_of_date: date
+    tenant_id: str | None
+    booking_center_code: str | None
+
+
 def resolve_pm_book_portfolios(
     *,
     request: DpmWavePreviewRequest,
     correlation_id: str,
     core_resolver_factory: CoreResolverFactory,
 ) -> list[dict[str, object]]:
+    membership_request = _pm_book_membership_request_for_wave(request)
+    membership = _resolve_pm_book_membership(
+        core_resolver_factory=core_resolver_factory,
+        membership_request=membership_request,
+        correlation_id=correlation_id,
+    )
+    _require_pm_book_membership_ready(membership)
+    return build_pm_book_resolved_portfolios(membership)
+
+
+def _pm_book_membership_request_for_wave(
+    request: DpmWavePreviewRequest,
+) -> _PmBookMembershipRequest:
     if request.portfolios:
         raise wave_service.DpmWaveValidationError(
             "PM_BOOK_REVIEW_REJECTS_CALLER_PORTFOLIOS",
@@ -50,13 +82,28 @@ def resolve_pm_book_portfolios(
         required_code="PM_BOOK_REVIEW_PORTFOLIO_TYPES_REQUIRED",
         required_message="PM_BOOK_REVIEW requires at least one portfolio type.",
     )
+    return _PmBookMembershipRequest(
+        portfolio_manager_id=portfolio_manager_id,
+        as_of_date=as_of_date,
+        tenant_id=request.tenant_id,
+        booking_center_code=request.booking_center_code,
+        portfolio_types=portfolio_types,
+    )
+
+
+def _resolve_pm_book_membership(
+    *,
+    core_resolver_factory: CoreResolverFactory,
+    membership_request: _PmBookMembershipRequest,
+    correlation_id: str,
+) -> Any:
     try:
-        membership = core_resolver_factory().resolve_portfolio_manager_book_membership(
-            portfolio_manager_id=portfolio_manager_id,
-            as_of_date=as_of_date,
-            tenant_id=request.tenant_id,
-            booking_center_code=request.booking_center_code,
-            portfolio_types=portfolio_types,
+        return core_resolver_factory().resolve_portfolio_manager_book_membership(
+            portfolio_manager_id=membership_request.portfolio_manager_id,
+            as_of_date=membership_request.as_of_date,
+            tenant_id=membership_request.tenant_id,
+            booking_center_code=membership_request.booking_center_code,
+            portfolio_types=membership_request.portfolio_types,
             include_inactive=False,
             correlation_id=correlation_id,
         )
@@ -70,6 +117,9 @@ def resolve_pm_book_portfolios(
             exc,
             default_code="DPM_CORE_PM_BOOK_MEMBERSHIP_INCOMPLETE",
         ) from exc
+
+
+def _require_pm_book_membership_ready(membership: Any) -> None:
     if membership.supportability.state != "READY":
         raise source_dependency_failed_http_exception(
             code=membership.supportability.reason,
@@ -80,7 +130,6 @@ def resolve_pm_book_portfolios(
             code="DPM_CORE_PM_BOOK_MEMBERSHIP_EMPTY",
             message="PM-book membership returned no affected portfolios.",
         )
-    return build_pm_book_resolved_portfolios(membership)
 
 
 def resolve_cio_model_change_portfolios(
@@ -89,6 +138,19 @@ def resolve_cio_model_change_portfolios(
     correlation_id: str,
     core_resolver_factory: CoreResolverFactory,
 ) -> list[dict[str, object]]:
+    cohort_request = _cio_model_change_cohort_request_for_wave(request)
+    cohort = _resolve_cio_model_change_cohort(
+        core_resolver_factory=core_resolver_factory,
+        cohort_request=cohort_request,
+        correlation_id=correlation_id,
+    )
+    _require_cio_model_change_cohort_ready(cohort)
+    return build_cio_model_change_resolved_portfolios(cohort)
+
+
+def _cio_model_change_cohort_request_for_wave(
+    request: DpmWavePreviewRequest,
+) -> _CioModelChangeCohortRequest:
     if request.portfolios:
         raise wave_service.DpmWaveValidationError(
             "CIO_MODEL_CHANGE_REJECTS_CALLER_PORTFOLIOS",
@@ -99,13 +161,26 @@ def resolve_cio_model_change_portfolios(
         required_code="CIO_MODEL_CHANGE_MODEL_PORTFOLIO_REQUIRED",
         required_message="CIO_MODEL_CHANGE requires model_portfolio_id.",
     )
-    as_of_date = parse_wave_as_of_date(request.as_of_date)
+    return _CioModelChangeCohortRequest(
+        model_portfolio_id=model_portfolio_id,
+        as_of_date=parse_wave_as_of_date(request.as_of_date),
+        tenant_id=request.tenant_id,
+        booking_center_code=request.booking_center_code,
+    )
+
+
+def _resolve_cio_model_change_cohort(
+    *,
+    core_resolver_factory: CoreResolverFactory,
+    cohort_request: _CioModelChangeCohortRequest,
+    correlation_id: str,
+) -> Any:
     try:
-        cohort = core_resolver_factory().resolve_cio_model_change_affected_cohort(
-            model_portfolio_id=model_portfolio_id,
-            as_of_date=as_of_date,
-            tenant_id=request.tenant_id,
-            booking_center_code=request.booking_center_code,
+        return core_resolver_factory().resolve_cio_model_change_affected_cohort(
+            model_portfolio_id=cohort_request.model_portfolio_id,
+            as_of_date=cohort_request.as_of_date,
+            tenant_id=cohort_request.tenant_id,
+            booking_center_code=cohort_request.booking_center_code,
             include_inactive_mandates=False,
             correlation_id=correlation_id,
         )
@@ -119,6 +194,9 @@ def resolve_cio_model_change_portfolios(
             exc,
             default_code="DPM_CORE_CIO_MODEL_CHANGE_COHORT_INCOMPLETE",
         ) from exc
+
+
+def _require_cio_model_change_cohort_ready(cohort: Any) -> None:
     if cohort.supportability.state != "READY":
         raise source_dependency_failed_http_exception(
             code=cohort.supportability.reason,
@@ -129,4 +207,3 @@ def resolve_cio_model_change_portfolios(
             code="DPM_CORE_CIO_MODEL_CHANGE_COHORT_EMPTY",
             message="CIO model-change affected cohort returned no portfolios.",
         )
-    return build_cio_model_change_resolved_portfolios(cohort)

--- a/src/api/routers/wave_portfolio_resolution.py
+++ b/src/api/routers/wave_portfolio_resolution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import date
 from decimal import Decimal
 
 from src.api.routers.wave_campaign_definition_resolution import (
@@ -18,10 +19,13 @@ from src.api.routers.wave_date_validation import parse_wave_as_of_date
 from src.api.routers.wave_portfolio_type_validation import (
     normalize_required_portfolio_types,
 )
-from src.api.routers.wave_request_models import DpmWavePreviewRequest
 from src.api.routers.wave_request_models import DpmTacticalHouseViewInput
+from src.api.routers.wave_request_models import DpmWavePortfolioInput
+from src.api.routers.wave_request_models import DpmWavePreviewRequest
 from src.api.routers.wave_required_text_validation import normalize_required_text
 from src.api.routers.wave_risk_event_validation import (
+    RiskEventAffectedCohort,
+    RiskEventCandidatePayloads,
     build_risk_event_candidate_payloads,
     build_risk_event_resolved_portfolios,
 )
@@ -54,6 +58,14 @@ class _PortfolioResolutionContext:
     risk_authority_client: RiskAuthorityClient | None
     campaign_definition_repository: DpmBulkReviewCampaignDefinitionRepository
     core_resolver_factory: Callable[[], object]
+
+
+@dataclass(frozen=True)
+class _RiskEventAuthorityRequest:
+    risk_event_id: str
+    as_of_date: date
+    candidate_payloads: RiskEventCandidatePayloads[DpmWavePortfolioInput]
+    minimum_impact_score: Decimal
 
 
 def resolve_portfolio_inputs_for_request(
@@ -257,6 +269,25 @@ def _resolve_risk_event_portfolios(
     correlation_id: str,
     risk_authority_client: RiskAuthorityClient | None,
 ) -> list[dict[str, object]]:
+    authority_request = _risk_event_authority_request_for_wave(request)
+    risk_authority = _required_risk_event_authority_client(risk_authority_client)
+    cohort = _risk_event_affected_cohort(
+        risk_authority_client=risk_authority,
+        authority_request=authority_request,
+        correlation_id=correlation_id,
+    )
+    _require_risk_event_cohort_ready(cohort)
+
+    return build_risk_event_resolved_portfolios(
+        cohort=cohort,
+        candidate_by_portfolio_id=authority_request.candidate_payloads.candidate_by_portfolio_id,
+        fallback_risk_event_id=authority_request.risk_event_id,
+    )
+
+
+def _risk_event_authority_request_for_wave(
+    request: DpmWavePreviewRequest,
+) -> _RiskEventAuthorityRequest:
     risk_event_id = normalize_required_text(
         request.risk_event_id,
         required_code="RISK_EVENT_ID_REQUIRED",
@@ -267,21 +298,38 @@ def _resolve_risk_event_portfolios(
             "RISK_EVENT_CANDIDATE_PORTFOLIOS_REQUIRED",
             "RISK_EVENT requires candidate portfolios with source-supplied exposure weights.",
         )
-    as_of_date = parse_wave_as_of_date(request.as_of_date)
-    if risk_authority_client is None:
-        raise source_unavailable_http_exception(
-            code="DPM_RISK_EVENT_COHORT_UNAVAILABLE",
-            message="DPM_RISK_BASE_URL is not configured.",
-        )
-
     candidate_payloads = build_risk_event_candidate_payloads(request.portfolios)
+    return _RiskEventAuthorityRequest(
+        risk_event_id=risk_event_id,
+        as_of_date=parse_wave_as_of_date(request.as_of_date),
+        candidate_payloads=candidate_payloads,
+        minimum_impact_score=Decimal(str(request.minimum_impact_score)),
+    )
 
+
+def _required_risk_event_authority_client(
+    risk_authority_client: RiskAuthorityClient | None,
+) -> RiskAuthorityClient:
+    if risk_authority_client is not None:
+        return risk_authority_client
+    raise source_unavailable_http_exception(
+        code="DPM_RISK_EVENT_COHORT_UNAVAILABLE",
+        message="DPM_RISK_BASE_URL is not configured.",
+    )
+
+
+def _risk_event_affected_cohort(
+    *,
+    risk_authority_client: RiskAuthorityClient,
+    authority_request: _RiskEventAuthorityRequest,
+    correlation_id: str,
+) -> RiskEventAffectedCohort:
     try:
-        cohort = risk_authority_client.risk_event_affected_cohort(
-            risk_event_id=risk_event_id,
-            as_of_date=as_of_date,
-            portfolios=candidate_payloads.risk_portfolios,
-            minimum_impact_score=Decimal(str(request.minimum_impact_score)),
+        return risk_authority_client.risk_event_affected_cohort(
+            risk_event_id=authority_request.risk_event_id,
+            as_of_date=authority_request.as_of_date,
+            portfolios=authority_request.candidate_payloads.risk_portfolios,
+            minimum_impact_score=authority_request.minimum_impact_score,
             correlation_id=correlation_id,
         )
     except RiskAuthorityUnavailableError as exc:
@@ -291,6 +339,8 @@ def _resolve_risk_event_portfolios(
             rejected_code="LOTUS_RISK_EVENT_COHORT_REJECTED",
         ) from exc
 
+
+def _require_risk_event_cohort_ready(cohort: RiskEventAffectedCohort) -> None:
     if cohort.calculation_supportability != "ready":
         raise source_dependency_failed_http_exception(
             code="DPM_RISK_EVENT_COHORT_INCOMPLETE",
@@ -302,9 +352,3 @@ def _resolve_risk_event_portfolios(
             code="DPM_RISK_EVENT_COHORT_EMPTY",
             message="Risk-event affected cohort returned no affected portfolios.",
         )
-
-    return build_risk_event_resolved_portfolios(
-        cohort=cohort,
-        candidate_by_portfolio_id=candidate_payloads.candidate_by_portfolio_id,
-        fallback_risk_event_id=risk_event_id,
-    )

--- a/src/api/routers/wave_risk_event_validation.py
+++ b/src/api/routers/wave_risk_event_validation.py
@@ -65,6 +65,9 @@ class RiskEventAffectedCohort(Protocol):
     def calculation_supportability(self) -> str: ...
 
     @property
+    def reason_codes(self) -> tuple[str, ...]: ...
+
+    @property
     def affected_portfolios(self) -> tuple[RiskEventAffectedPortfolio, ...]: ...
 
 

--- a/tests/unit/api/test_wave_core_source_resolution.py
+++ b/tests/unit/api/test_wave_core_source_resolution.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.routers.wave_core_source_resolution import (
+    _cio_model_change_cohort_request_for_wave,
+    _pm_book_membership_request_for_wave,
+    _require_cio_model_change_cohort_ready,
+    _require_pm_book_membership_ready,
+)
+from src.api.routers.wave_request_models import DpmWavePreviewRequest
+from src.api.services import wave_service
+
+
+def _pm_book_request(**overrides: object) -> DpmWavePreviewRequest:
+    payload: dict[str, object] = {
+        "trigger_type": "PM_BOOK_REVIEW",
+        "trigger_id": "wave-pm-book-20260519",
+        "rationale": "Review source-owned PM book membership.",
+        "as_of_date": "2026-05-19",
+        "actor_id": "pm_001",
+        "portfolio_manager_id": " PM_SG_DPM_001 ",
+        "tenant_id": "tenant-private-bank",
+        "booking_center_code": "SG",
+        "portfolio_types": [" discretionary ", "DPM"],
+    }
+    payload.update(overrides)
+    return DpmWavePreviewRequest.model_validate(payload)
+
+
+def _cio_model_change_request(**overrides: object) -> DpmWavePreviewRequest:
+    payload: dict[str, object] = {
+        "trigger_type": "CIO_MODEL_CHANGE",
+        "trigger_id": "wave-cio-model-change-20260519",
+        "rationale": "Review source-owned model-change affected mandates.",
+        "as_of_date": "2026-05-19",
+        "actor_id": "cio_001",
+        "model_portfolio_id": " MODEL_PB_SG_GLOBAL_BAL_DPM ",
+        "tenant_id": "tenant-private-bank",
+        "booking_center_code": "SG",
+    }
+    payload.update(overrides)
+    return DpmWavePreviewRequest.model_validate(payload)
+
+
+def _source_supportability(state: str = "READY", reason: str = "SOURCE_READY") -> object:
+    return SimpleNamespace(state=state, reason=reason)
+
+
+def test_pm_book_membership_request_for_wave_maps_source_query() -> None:
+    membership_request = _pm_book_membership_request_for_wave(_pm_book_request())
+
+    assert membership_request.portfolio_manager_id == "PM_SG_DPM_001"
+    assert membership_request.as_of_date.isoformat() == "2026-05-19"
+    assert membership_request.tenant_id == "tenant-private-bank"
+    assert membership_request.booking_center_code == "SG"
+    assert membership_request.portfolio_types == ["DISCRETIONARY", "DPM"]
+
+
+def test_pm_book_membership_request_for_wave_rejects_caller_supplied_portfolios() -> None:
+    request = _pm_book_request(
+        portfolios=[
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            }
+        ]
+    )
+
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _pm_book_membership_request_for_wave(request)
+
+    assert exc_info.value.code == "PM_BOOK_REVIEW_REJECTS_CALLER_PORTFOLIOS"
+
+
+def test_pm_book_membership_ready_helper_rejects_incomplete_or_empty_source_membership() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _require_pm_book_membership_ready(
+            SimpleNamespace(
+                supportability=_source_supportability(
+                    state="BLOCKED",
+                    reason="PM_BOOK_MEMBERSHIP_INCOMPLETE",
+                ),
+                members=[object()],
+            )
+        )
+    assert exc_info.value.status_code == 424
+    assert exc_info.value.detail["code"] == "PM_BOOK_MEMBERSHIP_INCOMPLETE"
+
+    with pytest.raises(HTTPException) as exc_info:
+        _require_pm_book_membership_ready(
+            SimpleNamespace(
+                supportability=_source_supportability(),
+                members=[],
+            )
+        )
+    assert exc_info.value.status_code == 424
+    assert exc_info.value.detail["code"] == "DPM_CORE_PM_BOOK_MEMBERSHIP_EMPTY"
+
+
+def test_cio_model_change_cohort_request_for_wave_maps_source_query() -> None:
+    cohort_request = _cio_model_change_cohort_request_for_wave(_cio_model_change_request())
+
+    assert cohort_request.model_portfolio_id == "MODEL_PB_SG_GLOBAL_BAL_DPM"
+    assert cohort_request.as_of_date.isoformat() == "2026-05-19"
+    assert cohort_request.tenant_id == "tenant-private-bank"
+    assert cohort_request.booking_center_code == "SG"
+
+
+def test_cio_model_change_cohort_request_for_wave_rejects_caller_supplied_portfolios() -> None:
+    request = _cio_model_change_request(
+        portfolios=[
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            }
+        ]
+    )
+
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _cio_model_change_cohort_request_for_wave(request)
+
+    assert exc_info.value.code == "CIO_MODEL_CHANGE_REJECTS_CALLER_PORTFOLIOS"
+
+
+def test_cio_model_change_cohort_ready_helper_rejects_incomplete_or_empty_source_cohort() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _require_cio_model_change_cohort_ready(
+            SimpleNamespace(
+                supportability=_source_supportability(
+                    state="BLOCKED",
+                    reason="CIO_MODEL_CHANGE_COHORT_INCOMPLETE",
+                ),
+                affected_mandates=[object()],
+            )
+        )
+    assert exc_info.value.status_code == 424
+    assert exc_info.value.detail["code"] == "CIO_MODEL_CHANGE_COHORT_INCOMPLETE"
+
+    with pytest.raises(HTTPException) as exc_info:
+        _require_cio_model_change_cohort_ready(
+            SimpleNamespace(
+                supportability=_source_supportability(),
+                affected_mandates=[],
+            )
+        )
+    assert exc_info.value.status_code == 424
+    assert exc_info.value.detail["code"] == "DPM_CORE_CIO_MODEL_CHANGE_COHORT_EMPTY"

--- a/tests/unit/api/test_wave_portfolio_resolution.py
+++ b/tests/unit/api/test_wave_portfolio_resolution.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 from decimal import Decimal
 
 import pytest
+from fastapi import HTTPException
 
 from src.api.routers.wave_portfolio_resolution import (
+    _require_risk_event_cohort_ready,
     _require_tactical_house_view_candidate_portfolios,
     _require_tactical_house_view_source_refs,
+    _risk_event_authority_request_for_wave,
     _required_tactical_house_view,
     _tactical_house_view_authority_request_for_wave,
     resolve_portfolio_inputs_for_request,
@@ -68,6 +71,59 @@ def _tactical_house_view_request(
     return DpmWavePreviewRequest.model_validate(payload)
 
 
+def _risk_event_request(
+    **overrides: object,
+) -> DpmWavePreviewRequest:
+    payload: dict[str, object] = {
+        "trigger_type": "RISK_EVENT",
+        "trigger_id": "wave-risk-event-20260519",
+        "rationale": "Review portfolios affected by a source-owned rate shock event.",
+        "as_of_date": "2026-05-19",
+        "actor_id": "pm_001",
+        "risk_event_id": " RISK_EVT_20260519 ",
+        "minimum_impact_score": 0.35,
+        "portfolios": [
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+                "portfolio_manager_id": "PM_SG_DPM_001",
+                "exposure_weights": {" equity ": 0.55, "fixed_income": 0.35},
+                "source_refs": [
+                    {
+                        "source_system": "lotus-core",
+                        "source_type": "RISK_EVENT_CANDIDATE_SET",
+                        "source_id": "candidate-set-20260519",
+                        "source_version": "2026-05-19",
+                        "supportability_state": "READY",
+                        "content_hash": "sha256:candidate-set",
+                    }
+                ],
+            }
+        ],
+    }
+    payload.update(overrides)
+    return DpmWavePreviewRequest.model_validate(payload)
+
+
+class _RiskEventCohort:
+    risk_event_id = "RISK_EVT_20260519"
+    product_name = "RiskEventAffectedCohort"
+    product_version = "RiskEventAffectedCohort:v1"
+    source_service = "lotus-risk"
+    request_fingerprint = "sha256:risk-event-cohort"
+    reason_codes = ("RISK_EVENT_AFFECTED_COHORT_READY",)
+
+    def __init__(
+        self,
+        *,
+        calculation_supportability: str = "ready",
+        affected_portfolios: tuple[object, ...] = (object(),),
+    ) -> None:
+        self.cohort_id = "risk-event-cohort-20260519"
+        self.calculation_supportability = calculation_supportability
+        self.affected_portfolios = affected_portfolios
+
+
 def test_tactical_house_view_authority_request_for_wave_maps_source_context() -> None:
     request = _tactical_house_view_request()
 
@@ -89,6 +145,24 @@ def test_tactical_house_view_authority_request_for_wave_maps_source_context() ->
     assert authority_request.min_exposure_weight == Decimal("0.05")
 
 
+def test_risk_event_authority_request_for_wave_maps_source_context() -> None:
+    request = _risk_event_request()
+
+    authority_request = _risk_event_authority_request_for_wave(request)
+
+    assert authority_request.risk_event_id == "RISK_EVT_20260519"
+    assert authority_request.as_of_date.isoformat() == "2026-05-19"
+    assert authority_request.minimum_impact_score == Decimal("0.35")
+    assert authority_request.candidate_payloads.risk_portfolios == [
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "mandate_id": "MANDATE_PB_SG_GLOBAL_BAL_001",
+            "portfolio_manager_id": "PM_SG_DPM_001",
+            "exposure_weights": {"EQUITY": 0.55, "FIXED_INCOME": 0.35},
+        }
+    ]
+
+
 def test_portfolio_resolution_dispatch_preserves_explicit_portfolio_payloads() -> None:
     request = _tactical_house_view_request(
         trigger_type="EXPLICIT_PORTFOLIO_LIST",
@@ -105,6 +179,36 @@ def test_portfolio_resolution_dispatch_preserves_explicit_portfolio_payloads() -
     )
 
     assert resolved == [portfolio.model_dump(mode="json") for portfolio in request.portfolios]
+
+
+def test_risk_event_resolution_helpers_reject_missing_source_evidence() -> None:
+    request = _risk_event_request(risk_event_id=" ")
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _risk_event_authority_request_for_wave(request)
+    assert exc_info.value.code == "RISK_EVENT_ID_REQUIRED"
+
+    request = _risk_event_request(portfolios=[])
+    with pytest.raises(wave_service.DpmWaveValidationError) as exc_info:
+        _risk_event_authority_request_for_wave(request)
+    assert exc_info.value.code == "RISK_EVENT_CANDIDATE_PORTFOLIOS_REQUIRED"
+
+
+def test_risk_event_cohort_ready_helper_rejects_incomplete_or_empty_source_cohort() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        _require_risk_event_cohort_ready(
+            _RiskEventCohort(
+                calculation_supportability="blocked",
+                affected_portfolios=(object(),),
+            )
+        )
+    assert exc_info.value.status_code == 424
+    assert exc_info.value.detail["code"] == "DPM_RISK_EVENT_COHORT_INCOMPLETE"
+    assert exc_info.value.detail["reason_codes"] == ["RISK_EVENT_AFFECTED_COHORT_READY"]
+
+    with pytest.raises(HTTPException) as exc_info:
+        _require_risk_event_cohort_ready(_RiskEventCohort(affected_portfolios=()))
+    assert exc_info.value.status_code == 424
+    assert exc_info.value.detail["code"] == "DPM_RISK_EVENT_COHORT_EMPTY"
 
 
 def test_tactical_house_view_resolution_helpers_reject_missing_source_evidence() -> None:


### PR DESCRIPTION
## Summary
- Extracted risk-event portfolio resolution helpers for authority request construction, risk authority selection, lotus-risk cohort invocation, and readiness gating.
- Extracted PM-book and CIO model-change core source resolver helpers for request shaping, lotus-core calls, and readiness gates.
- Added direct helper tests and refreshed repository quality reports / codebase review ledger through BACKEND-REVIEW-20260617-949.

## Evidence
- `python -m ruff check src/api/routers/wave_portfolio_resolution.py src/api/routers/wave_risk_event_validation.py tests/unit/api/test_wave_portfolio_resolution.py`
- `python -m ruff format --check src/api/routers/wave_portfolio_resolution.py src/api/routers/wave_risk_event_validation.py tests/unit/api/test_wave_portfolio_resolution.py`
- `python -m mypy --config-file mypy.ini src/api/routers/wave_portfolio_resolution.py src/api/routers/wave_risk_event_validation.py`
- `python -m pytest tests/unit/api/test_wave_portfolio_resolution.py tests/unit/api/test_wave_risk_event_validation.py -q` -> 14 passed
- `python -m radon cc src/api/routers/wave_portfolio_resolution.py -s` -> `_resolve_risk_event_portfolios` A(1)
- `python -m ruff check src/api/routers/wave_core_source_resolution.py tests/unit/api/test_wave_core_source_resolution.py`
- `python -m ruff format --check src/api/routers/wave_core_source_resolution.py tests/unit/api/test_wave_core_source_resolution.py`
- `python -m mypy --config-file mypy.ini src/api/routers/wave_core_source_resolution.py`
- `python -m pytest tests/unit/api/test_wave_core_source_resolution.py tests/unit/api/test_wave_pm_book_projection.py tests/unit/api/test_wave_cio_model_change_projection.py -q` -> 14 passed
- `python -m radon cc src/api/routers/wave_core_source_resolution.py -s` -> `resolve_pm_book_portfolios` A(1), `resolve_cio_model_change_portfolios` A(1)
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- service leakage scan -> no findings
- `git diff --check`
- `git fetch origin --prune; git branch -r --no-merged origin/main` -> only this active feature branch
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0
- `make check` -> 2784 passed, 13 skipped

## Residual Risk
- This is internal source-resolution maintainability hardening only.
- It does not change lotus-core or lotus-risk source product semantics, source-ref lineage schemas, external API contracts, or claim global bank-buyable readiness.
- Remaining source hotspot candidates are recorded in `quality/complexity_report.md`.