### PR TITLE
Refactor PM quality scoring helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23893,3 +23893,31 @@ and improves internal transaction-cost source posture maintainability only.
   methodology, external API contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal PM-quality source-signal
   hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-951: PM-quality indicator result helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/pm_quality/scoring.py` and
+  `tests/unit/dpm/pm_quality/test_pm_operating_quality.py`.
+- Bank-buyable control area: architecture, scoring supportability, and testing.
+- Finding: `_indicator_result` combined indicator signal filtering, required-evidence blocking,
+  score averaging, worst-state selection, reason-code aggregation, and source-ref de-duplication.
+  That kept PM operating-quality indicator projection harder to review than the surrounding
+  policy scoring helpers.
+- Action: extracted helpers for indicator-specific signal selection, blocked indicator results,
+  evaluated reason-code projection, and indicator source-ref de-duplication; added direct tests for
+  missing required evidence, evaluated degraded posture, reason-code fallback, and source-ref
+  de-duplication.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m ruff format --check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m mypy --config-file mypy.ini src/core/pm_quality/scoring.py`,
+  `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py -q`, and
+  `python -m radon cc src/core/pm_quality/scoring.py -s`; the focused PM-quality suite reported
+  37 passed, and radon reports `_indicator_result` reduced from C(11) to A(4).
+- Residual risk: this slice improves PM-quality indicator projection maintainability only. It does
+  not change PM operating-quality policy semantics, score thresholds, source-state ranking,
+  external API contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal PM-quality scoring
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23864,3 +23864,32 @@ and improves internal transaction-cost source posture maintainability only.
   campaign/search/OpenAPI/observability hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-950: PM-quality outcome-review signal helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/pm_quality/scoring.py` and
+  `tests/unit/dpm/pm_quality/test_pm_operating_quality.py`.
+- Bank-buyable control area: architecture, source-lineage supportability, and testing.
+- Finding: `_signals_from_outcome_reviews` combined post-trade outcome-review source-ref
+  projection, outcome-discipline scoring, source-quality posture scoring, optional report/AI
+  handoff evidence projection, and list assembly. That kept PM operating-quality source signal
+  mapping harder to audit despite the surrounding score-run orchestration already being
+  policy-driven.
+- Action: extracted pure helpers for outcome-review refs, outcome-discipline signals,
+  source-quality signals, optional handoff evidence signals, and handoff refs; added direct tests
+  for review source posture, fallback source-quality reason codes, and report/AI handoff evidence
+  projection while preserving the existing score-run output shape.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m ruff format --check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py`,
+  `python -m mypy --config-file mypy.ini src/core/pm_quality/scoring.py`,
+  `python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py -q`, and
+  `python -m radon cc src/core/pm_quality/scoring.py -s`; the focused PM-quality suite reported
+  34 passed, and radon reports `_signals_from_outcome_reviews` at A(4).
+- Residual risk: this slice improves PM-quality source signal maintainability only. It does not
+  change PM operating-quality policy semantics, score thresholds, source-owned outcome review
+  methodology, external API contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal PM-quality source-signal
+  hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23921,3 +23921,24 @@ and improves internal transaction-cost source posture maintainability only.
   external API contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal PM-quality scoring
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-952: PM-quality scoring reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the PM-quality outcome-review signal and indicator-result helper extractions, the
+  checked-in quality reports needed to reflect the updated branch head, test-function count, and
+  current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `801b4b6e`, record 820 Python files, 2604 test functions, keep service boundary findings and
+  router infrastructure imports at 0, and the current top-ten source hotspot list no longer
+  includes `_signals_from_outcome_reviews`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining rebalance, campaign, search,
+  OpenAPI, enterprise-readiness, or execution hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T00:52:02+00:00`
+- Generated at: `2026-06-17T01:12:19+00:00`
 
-- Report source snapshot: `05c33ddc`
+- Report source snapshot: `801b4b6e`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 176963 |
-| Test functions | 2598 |
+| Total Python LOC | 177146 |
+| Test functions | 2604 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T00:52:02+00:00`
+- Generated at: `2026-06-17T01:12:19+00:00`
 
-- Report source snapshot: `05c33ddc`
+- Report source snapshot: `801b4b6e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _signals_from_outcome_reviews | src/core/pm_quality/scoring.py | 6 | 52 |
-| 2 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
-| 3 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
-| 4 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
-| 5 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
-| 6 | value_position | src/core/valuation.py | 6 | 45 |
-| 7 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
-| 8 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
-| 9 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
-| 10 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
+| 1 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
+| 2 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
+| 3 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
+| 4 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
+| 5 | value_position | src/core/valuation.py | 6 | 45 |
+| 6 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
+| 7 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
+| 8 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
+| 9 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
+| 10 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T00:52:02+00:00`
+- Generated at: `2026-06-17T01:12:19+00:00`
 
-- Report source snapshot: `05c33ddc`
+- Report source snapshot: `801b4b6e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T00:52:02+00:00`
+- Generated at: `2026-06-17T01:12:19+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `05c33ddc`
+- Report source snapshot: `801b4b6e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 819 | 820 | +1 |
-| Total Python LOC | 176584 | 176963 | +379 |
-| Test functions | 2589 | 2598 | +9 |
+| Python files | 820 | 820 | +0 |
+| Total Python LOC | 176963 | 177146 | +183 |
+| Test functions | 2598 | 2604 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/pm_quality/scoring.py
+++ b/src/core/pm_quality/scoring.py
@@ -591,35 +591,58 @@ def _indicator_result(
     weight: DpmPmQualityWeight,
     signals: list[_PmQualitySignal],
 ) -> DpmPmQualityIndicatorResult:
-    indicator_signals = [signal for signal in signals if signal.indicator == weight.indicator]
+    indicator_signals = _indicator_signals(weight=weight, signals=signals)
     if len(indicator_signals) < weight.minimum_evidence_count:
-        return DpmPmQualityIndicatorResult(
-            indicator=weight.indicator,
-            score=None,
-            weight=weight.weight,
-            state="BLOCKED",
-            evidence_count=len(indicator_signals),
-            reason_codes=[f"{weight.indicator}_REQUIRED_EVIDENCE_MISSING"],
-            source_refs=[],
-        )
+        return _blocked_indicator_result(weight=weight, evidence_count=len(indicator_signals))
 
-    scores = [signal.score for signal in indicator_signals]
-    score = _mean(scores)
-    states = [signal.state for signal in indicator_signals]
-    state = _worst_state(states)
-    reason_codes = sorted(
-        {reason for signal in indicator_signals for reason in signal.reason_codes}
-    )
-    refs = _dedupe_refs([ref for signal in indicator_signals for ref in signal.source_refs])
     return DpmPmQualityIndicatorResult(
         indicator=weight.indicator,
-        score=score,
+        score=_mean([signal.score for signal in indicator_signals]),
         weight=weight.weight,
-        state=state,
+        state=_worst_state([signal.state for signal in indicator_signals]),
         evidence_count=len(indicator_signals),
-        reason_codes=reason_codes or [f"{weight.indicator}_EVALUATED"],
-        source_refs=refs,
+        reason_codes=_indicator_reason_codes(weight=weight, signals=indicator_signals),
+        source_refs=_indicator_source_refs(indicator_signals),
     )
+
+
+def _indicator_signals(
+    *,
+    weight: DpmPmQualityWeight,
+    signals: list[_PmQualitySignal],
+) -> list[_PmQualitySignal]:
+    return [signal for signal in signals if signal.indicator == weight.indicator]
+
+
+def _blocked_indicator_result(
+    *,
+    weight: DpmPmQualityWeight,
+    evidence_count: int,
+) -> DpmPmQualityIndicatorResult:
+    return DpmPmQualityIndicatorResult(
+        indicator=weight.indicator,
+        score=None,
+        weight=weight.weight,
+        state="BLOCKED",
+        evidence_count=evidence_count,
+        reason_codes=[f"{weight.indicator}_REQUIRED_EVIDENCE_MISSING"],
+        source_refs=[],
+    )
+
+
+def _indicator_reason_codes(
+    *,
+    weight: DpmPmQualityWeight,
+    signals: list[_PmQualitySignal],
+) -> list[str]:
+    reason_codes = sorted({reason for signal in signals for reason in signal.reason_codes})
+    return reason_codes or [f"{weight.indicator}_EVALUATED"]
+
+
+def _indicator_source_refs(
+    signals: list[_PmQualitySignal],
+) -> list[DpmOutcomeSourceRef]:
+    return _dedupe_refs([ref for signal in signals for ref in signal.source_refs])
 
 
 def _weighted_score(results: list[DpmPmQualityIndicatorResult]) -> Decimal:

--- a/src/core/pm_quality/scoring.py
+++ b/src/core/pm_quality/scoring.py
@@ -367,53 +367,82 @@ def _signals_from_outcome_reviews(
 ) -> list[_PmQualitySignal]:
     signals: list[_PmQualitySignal] = []
     for review in outcome_reviews:
-        review_ref = DpmOutcomeSourceRef(
-            source_system="lotus-manage",
-            source_type="PostTradeOutcomeReview",
-            source_id=review.outcome_review_id,
-            source_version=review.outcome_review_version,
-            content_hash=review.content_hash,
-        )
-        dimension_scores = [_state_score(result.state) for result in review.dimension_results]
-        if dimension_scores:
-            signals.append(
-                _PmQualitySignal(
-                    indicator="OUTCOME_DISCIPLINE",
-                    score=_mean(dimension_scores),
-                    state=review.state,
-                    reason_codes=sorted(
-                        {result.reason_code for result in review.dimension_results}
-                    ),
-                    source_refs=[review_ref],
-                    as_of_date=review.review_window.as_of_date,
-                )
-            )
-        signals.append(
-            _PmQualitySignal(
-                indicator="SOURCE_QUALITY",
-                score=_state_score(review.supportability.state),
-                state=review.supportability.state,
-                reason_codes=review.supportability.reason_codes
-                or ["OUTCOME_REVIEW_SOURCE_POSTURE"],
-                source_refs=[review_ref, *review.source_lineage],
-                as_of_date=review.review_window.as_of_date,
-            )
-        )
-        if review.report_input_ref or review.ai_evidence_ref:
-            refs = [
-                ref for ref in [review.report_input_ref, review.ai_evidence_ref] if ref is not None
-            ]
-            signals.append(
-                _PmQualitySignal(
-                    indicator="EVIDENCE_COMPLETENESS",
-                    score=Decimal("100"),
-                    state="READY",
-                    reason_codes=["OUTCOME_REVIEW_HANDOFF_EVIDENCE_AVAILABLE"],
-                    source_refs=[review_ref, *refs],
-                    as_of_date=review.review_window.as_of_date,
-                )
-            )
+        review_ref = _outcome_review_ref(review)
+        outcome_signal = _outcome_discipline_signal(review=review, review_ref=review_ref)
+        if outcome_signal is not None:
+            signals.append(outcome_signal)
+        signals.append(_outcome_source_quality_signal(review=review, review_ref=review_ref))
+        handoff_signal = _outcome_handoff_evidence_signal(review=review, review_ref=review_ref)
+        if handoff_signal is not None:
+            signals.append(handoff_signal)
     return signals
+
+
+def _outcome_review_ref(review: DpmPostTradeOutcomeReview) -> DpmOutcomeSourceRef:
+    return DpmOutcomeSourceRef(
+        source_system="lotus-manage",
+        source_type="PostTradeOutcomeReview",
+        source_id=review.outcome_review_id,
+        source_version=review.outcome_review_version,
+        content_hash=review.content_hash,
+    )
+
+
+def _outcome_discipline_signal(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    review_ref: DpmOutcomeSourceRef,
+) -> _PmQualitySignal | None:
+    dimension_scores = [_state_score(result.state) for result in review.dimension_results]
+    if not dimension_scores:
+        return None
+    return _PmQualitySignal(
+        indicator="OUTCOME_DISCIPLINE",
+        score=_mean(dimension_scores),
+        state=review.state,
+        reason_codes=sorted({result.reason_code for result in review.dimension_results}),
+        source_refs=[review_ref],
+        as_of_date=review.review_window.as_of_date,
+    )
+
+
+def _outcome_source_quality_signal(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    review_ref: DpmOutcomeSourceRef,
+) -> _PmQualitySignal:
+    return _PmQualitySignal(
+        indicator="SOURCE_QUALITY",
+        score=_state_score(review.supportability.state),
+        state=review.supportability.state,
+        reason_codes=review.supportability.reason_codes or ["OUTCOME_REVIEW_SOURCE_POSTURE"],
+        source_refs=[review_ref, *review.source_lineage],
+        as_of_date=review.review_window.as_of_date,
+    )
+
+
+def _outcome_handoff_evidence_signal(
+    *,
+    review: DpmPostTradeOutcomeReview,
+    review_ref: DpmOutcomeSourceRef,
+) -> _PmQualitySignal | None:
+    refs = _outcome_handoff_refs(review)
+    if not refs:
+        return None
+    return _PmQualitySignal(
+        indicator="EVIDENCE_COMPLETENESS",
+        score=Decimal("100"),
+        state="READY",
+        reason_codes=["OUTCOME_REVIEW_HANDOFF_EVIDENCE_AVAILABLE"],
+        source_refs=[review_ref, *refs],
+        as_of_date=review.review_window.as_of_date,
+    )
+
+
+def _outcome_handoff_refs(
+    review: DpmPostTradeOutcomeReview,
+) -> list[DpmOutcomeSourceRef]:
+    return [ref for ref in [review.report_input_ref, review.ai_evidence_ref] if ref is not None]
 
 
 def _validate_lookback_window(

--- a/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
+++ b/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
@@ -584,6 +584,66 @@ def test_pm_quality_outcome_review_signal_helpers_project_handoff_evidence() -> 
     assert handoff.source_refs == [review_ref, report_ref, ai_ref]
 
 
+def test_pm_quality_indicator_result_helpers_block_missing_required_evidence() -> None:
+    weight = DpmPmQualityWeight(
+        indicator="SOURCE_QUALITY",
+        weight=Decimal("100"),
+        minimum_evidence_count=2,
+    )
+    source_ref = _source_ref()
+    signal = scoring._PmQualitySignal(
+        indicator="SOURCE_QUALITY",
+        score=Decimal("90"),
+        state="READY",
+        reason_codes=["SOURCE_READY"],
+        source_refs=[source_ref],
+    )
+
+    result = scoring._indicator_result(weight, [signal])
+
+    assert scoring._indicator_signals(weight=weight, signals=[signal]) == [signal]
+    assert result.score is None
+    assert result.state == "BLOCKED"
+    assert result.evidence_count == 1
+    assert result.reason_codes == ["SOURCE_QUALITY_REQUIRED_EVIDENCE_MISSING"]
+    assert result.source_refs == []
+
+
+def test_pm_quality_indicator_result_helpers_project_evaluated_signal_posture() -> None:
+    weight = DpmPmQualityWeight(indicator="SOURCE_QUALITY", weight=Decimal("100"))
+    source_ref = _source_ref()
+    ready_signal = scoring._PmQualitySignal(
+        indicator="SOURCE_QUALITY",
+        score=Decimal("90"),
+        state="READY",
+        reason_codes=["SOURCE_READY"],
+        source_refs=[source_ref],
+    )
+    degraded_signal = scoring._PmQualitySignal(
+        indicator="SOURCE_QUALITY",
+        score=Decimal("70"),
+        state="DEGRADED",
+        reason_codes=["SOURCE_DEGRADED"],
+        source_refs=[source_ref],
+    )
+
+    result = scoring._indicator_result(weight, [ready_signal, degraded_signal])
+
+    assert result.score == Decimal("80.00")
+    assert result.state == "DEGRADED"
+    assert result.evidence_count == 2
+    assert result.reason_codes == ["SOURCE_DEGRADED", "SOURCE_READY"]
+    assert result.source_refs == [source_ref]
+
+
+def test_pm_quality_indicator_reason_codes_fall_back_to_evaluated_code() -> None:
+    weight = DpmPmQualityWeight(indicator="OUTCOME_DISCIPLINE", weight=Decimal("100"))
+
+    assert scoring._indicator_reason_codes(weight=weight, signals=[]) == [
+        "OUTCOME_DISCIPLINE_EVALUATED"
+    ]
+
+
 def test_pm_quality_score_run_source_ref_helper_collects_scope_and_governance_refs() -> None:
     indicator_ref = DpmOutcomeSourceRef(
         source_system="lotus-risk",

--- a/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
+++ b/tests/unit/dpm/pm_quality/test_pm_operating_quality.py
@@ -513,6 +513,77 @@ def test_pm_operating_quality_score_run_uses_configured_policy_and_source_refs()
     assert any(ref.source_type == "DPM_OUTCOME_REPORT_INPUT" for ref in score_run.source_refs)
 
 
+def test_pm_quality_outcome_review_signal_helpers_project_review_source_posture() -> None:
+    review = _review()
+    review_ref = scoring._outcome_review_ref(review)
+
+    discipline = scoring._outcome_discipline_signal(review=review, review_ref=review_ref)
+    source_quality = scoring._outcome_source_quality_signal(review=review, review_ref=review_ref)
+
+    assert discipline is not None
+    assert discipline.indicator == "OUTCOME_DISCIPLINE"
+    assert discipline.state == review.state
+    assert discipline.as_of_date == review.review_window.as_of_date
+    assert discipline.source_refs == [review_ref]
+    assert discipline.reason_codes == sorted(
+        {result.reason_code for result in review.dimension_results}
+    )
+
+    assert source_quality.indicator == "SOURCE_QUALITY"
+    assert source_quality.state == review.supportability.state
+    assert source_quality.reason_codes == review.supportability.reason_codes
+    assert source_quality.source_refs == [review_ref, *review.source_lineage]
+
+
+def test_pm_quality_outcome_review_signal_helpers_handle_missing_handoff_evidence() -> None:
+    review = _review().model_copy(
+        update={
+            "supportability": _review().supportability.model_copy(update={"reason_codes": []}),
+            "report_input_ref": None,
+            "ai_evidence_ref": None,
+        }
+    )
+    review_ref = scoring._outcome_review_ref(review)
+
+    assert scoring._outcome_handoff_refs(review) == []
+    assert scoring._outcome_handoff_evidence_signal(review=review, review_ref=review_ref) is None
+    assert scoring._outcome_source_quality_signal(
+        review=review, review_ref=review_ref
+    ).reason_codes == ["OUTCOME_REVIEW_SOURCE_POSTURE"]
+
+
+def test_pm_quality_outcome_review_signal_helpers_project_handoff_evidence() -> None:
+    report_ref = DpmOutcomeSourceRef(
+        source_system="lotus-report",
+        source_type="DPM_OUTCOME_REPORT_INPUT",
+        source_id="report_001",
+        content_hash="sha256:report",
+    )
+    ai_ref = DpmOutcomeSourceRef(
+        source_system="lotus-ai",
+        source_type="DPM_OUTCOME_AI_EVIDENCE_INPUT",
+        source_id="ai_001",
+        content_hash="sha256:ai",
+    )
+    review = _review().model_copy(
+        update={
+            "report_input_ref": report_ref,
+            "ai_evidence_ref": ai_ref,
+        }
+    )
+    review_ref = scoring._outcome_review_ref(review)
+
+    handoff = scoring._outcome_handoff_evidence_signal(review=review, review_ref=review_ref)
+
+    assert scoring._outcome_handoff_refs(review) == [report_ref, ai_ref]
+    assert handoff is not None
+    assert handoff.indicator == "EVIDENCE_COMPLETENESS"
+    assert handoff.score == Decimal("100")
+    assert handoff.state == "READY"
+    assert handoff.reason_codes == ["OUTCOME_REVIEW_HANDOFF_EVIDENCE_AVAILABLE"]
+    assert handoff.source_refs == [review_ref, report_ref, ai_ref]
+
+
 def test_pm_quality_score_run_source_ref_helper_collects_scope_and_governance_refs() -> None:
     indicator_ref = DpmOutcomeSourceRef(
         source_system="lotus-risk",


### PR DESCRIPTION
## Summary
- Extract PM-quality outcome-review signal helpers from scoring orchestration.
- Extract PM-quality indicator result helpers for blocked/evaluated signal projection.
- Refresh engineering health reports and ledger through BACKEND-REVIEW-20260617-952.

## Evidence
- python -m ruff format src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py
- python -m ruff check src/core/pm_quality/scoring.py tests/unit/dpm/pm_quality/test_pm_operating_quality.py
- python -m mypy --config-file mypy.ini src/core/pm_quality/scoring.py
- python -m pytest tests/unit/dpm/pm_quality/test_pm_operating_quality.py -q
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- service leakage scan: no findings
- git diff --check
- powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage: DiffCount 0
- make check

## Residual risk
- Internal PM-quality scoring refactor only; no intended API behavior change.
- This does not claim full bank-buyable readiness. It closes one maintainability slice and records remaining source hotspots in refreshed reports.