### PR TITLE
Refactor heuristic target generation helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23942,3 +23942,34 @@ and improves internal transaction-cost source posture maintainability only.
   OpenAPI, enterprise-readiness, or execution hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-953: Heuristic target-generation control helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/rebalance/targets.py` and
+  `tests/unit/core/test_target_generation_helpers.py`.
+- Bank-buyable control area: architecture, deterministic rebalance behavior, and testing.
+- Finding: `generate_targets_heuristic` combined sell-only excess redistribution, group
+  constraints, tradeable target normalization, single-position capping, cash-buffer enforcement,
+  and worst-status projection in one orchestration function. That kept target-generation posture
+  harder to audit despite the individual control helpers already being deterministic and
+  side-effect scoped.
+- Action: extracted target-weight posture, tradeable scaling, worst-status selection, and
+  heuristic target-control status helpers; added direct tests for tradeable versus locked capacity
+  projection, status precedence, overweight tradeable normalization, and combined cap/cash-buffer
+  pending-review behavior while preserving the existing target trace output contract.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/rebalance/targets.py tests/unit/core/test_target_generation_helpers.py`,
+  `python -m ruff format --check src/core/rebalance/targets.py tests/unit/core/test_target_generation_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/targets.py`,
+  `python -m pytest tests/unit/core/test_target_generation_helpers.py -q`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_core_flows.py tests/unit/core/test_target_generation_solver_fallbacks.py -q`,
+  and `python -m radon cc src/core/rebalance/targets.py -s`; the focused helper suite reported
+  19 passed, the nearby engine/solver behavior suites reported 24 passed, and radon reports
+  `generate_targets_heuristic` reduced from B(6) to A(2).
+- Residual risk: this slice improves heuristic target-generation maintainability only. It does not
+  change rebalance methodology, target trace response models, solver behavior, downstream
+  contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal rebalance target-generation
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23973,3 +23973,23 @@ and improves internal transaction-cost source posture maintainability only.
   contracts, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal rebalance target-generation
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-954: Target-generation reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the heuristic target-generation helper extraction, the checked-in quality reports
+  needed to reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `8be6baf4`, record 820 Python files, 2608 test functions, keep service boundary findings and
+  router infrastructure imports at 0, and the current top-ten source hotspot list no longer
+  includes `generate_targets_heuristic`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining campaign, valuation, search,
+  OpenAPI, enterprise-readiness, or execution hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T01:12:19+00:00`
+- Generated at: `2026-06-17T01:31:58+00:00`
 
-- Report source snapshot: `801b4b6e`
+- Report source snapshot: `8be6baf4`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 177146 |
-| Test functions | 2604 |
+| Total Python LOC | 177305 |
+| Test functions | 2608 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T01:12:19+00:00`
+- Generated at: `2026-06-17T01:31:58+00:00`
 
-- Report source snapshot: `801b4b6e`
+- Report source snapshot: `8be6baf4`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | generate_targets_heuristic | src/core/rebalance/targets.py | 6 | 49 |
-| 2 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
-| 3 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
-| 4 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
-| 5 | value_position | src/core/valuation.py | 6 | 45 |
-| 6 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
-| 7 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
-| 8 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
-| 9 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
-| 10 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
+| 1 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
+| 2 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
+| 3 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
+| 4 | value_position | src/core/valuation.py | 6 | 45 |
+| 5 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
+| 6 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
+| 7 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
+| 8 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
+| 9 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
+| 10 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T01:12:19+00:00`
+- Generated at: `2026-06-17T01:31:58+00:00`
 
-- Report source snapshot: `801b4b6e`
+- Report source snapshot: `8be6baf4`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T01:12:19+00:00`
+- Generated at: `2026-06-17T01:31:58+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `801b4b6e`
+- Report source snapshot: `8be6baf4`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 820 | 820 | +0 |
-| Total Python LOC | 176963 | 177146 | +183 |
-| Test functions | 2598 | 2604 | +6 |
+| Total Python LOC | 177146 | 177305 | +159 |
+| Test functions | 2604 | 2608 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/rebalance/targets.py
+++ b/src/core/rebalance/targets.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Literal, TypeAlias, cast
 
@@ -15,6 +16,15 @@ from src.core.models import (
 from src.core.target_generation import build_target_trace, generate_targets_solver
 
 _GroupConstraintStatus: TypeAlias = Literal["READY", "BLOCKED"]
+_TargetGenerationStatus: TypeAlias = Literal["READY", "BLOCKED", "PENDING_REVIEW"]
+
+
+@dataclass(frozen=True)
+class _TargetWeightPosture:
+    total_weight: Decimal
+    locked_weight: Decimal
+    tradeable_weight: Decimal
+    available_tradeable_weight: Decimal
 
 
 def _build_shelf_attr_indexes(
@@ -329,26 +339,62 @@ def _cap_tradeable_targets_to_available_weight(
     *,
     eligible_targets: dict[str, Decimal],
     buy_set: set[str],
-) -> str:
-    total_w = sum(eligible_targets.values())
-    if total_w <= Decimal("1.0001"):
+) -> _TargetGenerationStatus:
+    posture = _target_weight_posture(eligible_targets=eligible_targets, buy_set=buy_set)
+    if posture.total_weight <= Decimal("1.0001"):
         return "READY"
 
-    tradeable_keys = [k for k in eligible_targets if k in buy_set]
-    locked_w = sum(v for k, v in eligible_targets.items() if k not in buy_set)
-    available_space = max(Decimal("0.0"), Decimal("1.0") - locked_w)
-    status = "PENDING_REVIEW" if locked_w > Decimal("1.0") else "READY"
+    status: _TargetGenerationStatus = (
+        "PENDING_REVIEW" if posture.locked_weight > Decimal("1.0") else "READY"
+    )
+    _scale_tradeable_targets(
+        eligible_targets=eligible_targets,
+        buy_set=buy_set,
+        tradeable_weight=posture.tradeable_weight,
+        available_tradeable_weight=posture.available_tradeable_weight,
+    )
+    if posture.tradeable_weight > posture.available_tradeable_weight:
+        return "PENDING_REVIEW"
+    return status
 
-    tradeable_w = sum(eligible_targets[k] for k in tradeable_keys)
-    if tradeable_w <= available_space:
-        return status
 
-    if tradeable_w > Decimal("0.0"):
-        scale = available_space / tradeable_w
-        for k in tradeable_keys:
-            eligible_targets[k] *= scale
+def _target_weight_posture(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+) -> _TargetWeightPosture:
+    total_weight = sum(eligible_targets.values(), Decimal("0.0"))
+    locked_weight = sum(
+        (
+            weight
+            for instrument_id, weight in eligible_targets.items()
+            if instrument_id not in buy_set
+        ),
+        Decimal("0.0"),
+    )
+    tradeable_weight = total_weight - locked_weight
+    return _TargetWeightPosture(
+        total_weight=total_weight,
+        locked_weight=locked_weight,
+        tradeable_weight=tradeable_weight,
+        available_tradeable_weight=max(Decimal("0.0"), Decimal("1.0") - locked_weight),
+    )
 
-    return "PENDING_REVIEW"
+
+def _scale_tradeable_targets(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+    tradeable_weight: Decimal,
+    available_tradeable_weight: Decimal,
+) -> None:
+    if tradeable_weight <= available_tradeable_weight or tradeable_weight <= Decimal("0.0"):
+        return
+
+    scale = available_tradeable_weight / tradeable_weight
+    for instrument_id in eligible_targets:
+        if instrument_id in buy_set:
+            eligible_targets[instrument_id] *= scale
 
 
 def _apply_single_position_max_weight(
@@ -445,6 +491,48 @@ def _apply_min_cash_buffer(
     return "PENDING_REVIEW"
 
 
+def _target_generation_status(
+    current: _TargetGenerationStatus,
+    candidate: _TargetGenerationStatus,
+) -> _TargetGenerationStatus:
+    if candidate == "BLOCKED" or current == "BLOCKED":
+        return "BLOCKED"
+    if candidate == "PENDING_REVIEW" or current == "PENDING_REVIEW":
+        return "PENDING_REVIEW"
+    return "READY"
+
+
+def _heuristic_target_control_status(
+    *,
+    eligible_targets: dict[str, Decimal],
+    buy_set: set[str],
+    options: EngineOptions,
+) -> _TargetGenerationStatus:
+    status: _TargetGenerationStatus = _cap_tradeable_targets_to_available_weight(
+        eligible_targets=eligible_targets,
+        buy_set=buy_set,
+    )
+
+    if options.single_position_max_weight is not None:
+        status = _target_generation_status(
+            status,
+            _apply_single_position_max_weight(
+                eligible_targets=eligible_targets,
+                buy_set=buy_set,
+                max_weight=options.single_position_max_weight,
+            ),
+        )
+
+    return _target_generation_status(
+        status,
+        _apply_min_cash_buffer(
+            eligible_targets=eligible_targets,
+            buy_set=buy_set,
+            min_cash_buffer_pct=options.min_cash_buffer_pct,
+        ),
+    )
+
+
 def generate_targets_heuristic(
     model: ModelPortfolio,
     eligible_targets: dict[str, Decimal],
@@ -456,41 +544,28 @@ def generate_targets_heuristic(
     base_ccy: str,
     diagnostics: DiagnosticsData,
 ) -> tuple[list[Any], str]:
-    status = "READY"
     buy_set = set(buy_list)
 
-    status = redistribute_sell_only_excess(
-        eligible_targets=eligible_targets,
-        buy_set=buy_set,
-        sell_only_excess=sell_only_excess,
+    status: _TargetGenerationStatus = cast(
+        _TargetGenerationStatus,
+        redistribute_sell_only_excess(
+            eligible_targets=eligible_targets,
+            buy_set=buy_set,
+            sell_only_excess=sell_only_excess,
+        ),
     )
 
     group_status = apply_group_constraints(eligible_targets, buy_list, shelf, options, diagnostics)
     if group_status == "BLOCKED":
         return [], "BLOCKED"
 
-    cap_status = _cap_tradeable_targets_to_available_weight(
-        eligible_targets=eligible_targets,
-        buy_set=buy_set,
-    )
-    if cap_status == "PENDING_REVIEW":
-        status = "PENDING_REVIEW"
-
-    if options.single_position_max_weight is not None:
-        single_position_status = _apply_single_position_max_weight(
+    status = _target_generation_status(
+        status,
+        _heuristic_target_control_status(
             eligible_targets=eligible_targets,
             buy_set=buy_set,
-            max_weight=options.single_position_max_weight,
-        )
-        if single_position_status == "PENDING_REVIEW":
-            status = "PENDING_REVIEW"
-
-    cash_buffer_status = _apply_min_cash_buffer(
-        eligible_targets=eligible_targets,
-        buy_set=buy_set,
-        min_cash_buffer_pct=options.min_cash_buffer_pct,
+            options=options,
+        ),
     )
-    if cash_buffer_status == "PENDING_REVIEW":
-        status = "PENDING_REVIEW"
 
     return build_target_trace(model, eligible_targets, buy_list, total_val, base_ccy), status

--- a/tests/unit/core/test_target_generation_helpers.py
+++ b/tests/unit/core/test_target_generation_helpers.py
@@ -8,7 +8,12 @@ from src.core.models import (
     ModelTarget,
     ShelfEntry,
 )
-from src.core.rebalance.targets import _apply_group_constraint
+from src.core.rebalance.targets import (
+    _apply_group_constraint,
+    _heuristic_target_control_status,
+    _target_generation_status,
+    _target_weight_posture,
+)
 from src.core.target_generation import (
     _apply_solver_values,
     _build_solver_problem,
@@ -261,6 +266,85 @@ def test_apply_group_constraint_blocks_when_no_redistribution_recipient() -> Non
     assert status == "BLOCKED"
     assert "NO_ELIGIBLE_REDISTRIBUTION_DESTINATION" in diagnostics.warnings
     assert diagnostics.group_constraint_events[0].status == "BLOCKED"
+
+
+def test_target_weight_posture_separates_tradeable_and_locked_capacity() -> None:
+    posture = _target_weight_posture(
+        eligible_targets={
+            "BUY_1": Decimal("0.45"),
+            "BUY_2": Decimal("0.25"),
+            "LOCKED": Decimal("0.20"),
+        },
+        buy_set={"BUY_1", "BUY_2"},
+    )
+
+    assert posture.total_weight == Decimal("0.90")
+    assert posture.locked_weight == Decimal("0.20")
+    assert posture.tradeable_weight == Decimal("0.70")
+    assert posture.available_tradeable_weight == Decimal("0.80")
+
+
+def test_target_generation_status_preserves_worst_target_posture() -> None:
+    assert _target_generation_status("READY", "PENDING_REVIEW") == "PENDING_REVIEW"
+    assert _target_generation_status("PENDING_REVIEW", "READY") == "PENDING_REVIEW"
+    assert _target_generation_status("READY", "BLOCKED") == "BLOCKED"
+    assert _target_generation_status("BLOCKED", "READY") == "BLOCKED"
+
+
+def test_heuristic_target_control_status_scales_overweight_tradeable_targets() -> None:
+    eligible_targets = {
+        "BUY_1": Decimal("0.80"),
+        "BUY_2": Decimal("0.40"),
+        "LOCKED": Decimal("0.20"),
+    }
+
+    status = _heuristic_target_control_status(
+        eligible_targets=eligible_targets,
+        buy_set={"BUY_1", "BUY_2"},
+        options=EngineOptions(),
+    )
+
+    assert status == "PENDING_REVIEW"
+    assert eligible_targets["LOCKED"] == Decimal("0.20")
+    assert abs(eligible_targets["BUY_1"] - Decimal("0.5333333333333333333333333333")) < Decimal(
+        "0.000000000000000000000000001"
+    )
+    assert abs(eligible_targets["BUY_2"] - Decimal("0.2666666666666666666666666667")) < Decimal(
+        "0.000000000000000000000000001"
+    )
+
+
+def test_heuristic_target_control_status_preserves_pending_review_for_caps_and_cash_buffer() -> (
+    None
+):
+    eligible_targets = {
+        "BUY_1": Decimal("0.80"),
+        "BUY_2": Decimal("0.15"),
+        "LOCKED": Decimal("0.04"),
+    }
+
+    status = _heuristic_target_control_status(
+        eligible_targets=eligible_targets,
+        buy_set={"BUY_1", "BUY_2"},
+        options=EngineOptions(
+            single_position_max_weight=Decimal("0.50"),
+            min_cash_buffer_pct=Decimal("0.10"),
+        ),
+    )
+
+    assert status == "PENDING_REVIEW"
+    assert eligible_targets["BUY_1"] <= Decimal("0.50")
+    assert (
+        sum(
+            (
+                weight
+                for instrument_id, weight in eligible_targets.items()
+                if instrument_id in {"BUY_1", "BUY_2"}
+            ),
+            Decimal("0.0"),
+        )
+        - Decimal("0.86")
+    ) < Decimal("0.000000000000000000000000001")
 
 
 def test_apply_solver_values_quantizes_and_fails_closed_without_values() -> None:


### PR DESCRIPTION
## Summary
- Extract heuristic target-generation helper functions for target-weight posture, tradeable scaling, worst-status selection, and target-control status orchestration.
- Add direct helper tests for locked/tradeable capacity projection, status precedence, overweight tradeable normalization, and combined single-position/cash-buffer pending-review posture.
- Refresh quality reports and review ledger through BACKEND-REVIEW-20260617-954.

## Evidence
- python -m ruff check src/core/rebalance/targets.py tests/unit/core/test_target_generation_helpers.py
- python -m ruff format --check src/core/rebalance/targets.py tests/unit/core/test_target_generation_helpers.py
- python -m mypy --config-file mypy.ini src/core/rebalance/targets.py
- python -m pytest tests/unit/core/test_target_generation_helpers.py tests/unit/dpm/engine/test_engine_core_flows.py tests/unit/core/test_target_generation_solver_fallbacks.py -q
- python -m radon cc src/core/rebalance/targets.py -s: generate_targets_heuristic reduced from B(6) to A(2)
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- service leakage scan: no findings
- git diff --check
- powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage: DiffCount 0
- make check: 2807 passed

## Residual risk
- Internal rebalance target-generation maintainability refactor only; no intended API behavior, solver behavior, or target trace contract change.
- Quality reports remain report-only and do not claim full bank-buyable readiness.
- Remaining current source hotspots include campaign page builders, valuation, wave search, search facets, OpenAPI enrichment, enterprise readiness middleware, and settlement-flow projection.