### PR TITLE
Refactor campaign assignment plan helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -23993,3 +23993,34 @@ and improves internal transaction-cost source posture maintainability only.
   OpenAPI, enterprise-readiness, or execution hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-955: Campaign assignment-plan page helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/waves/campaign_assignment_plan.py` and
+  `tests/unit/dpm/waves/test_campaign_discovery.py`.
+- Bank-buyable control area: architecture, campaign supportability, and testing.
+- Finding: `build_bulk_review_campaign_assignment_plan_page` combined assignment-plan item
+  projection, closed-row filtering, escalation-tier filtering, next-action filtering, page count
+  aggregation, payload assembly, and content hashing in one page-builder function. That made the
+  read-only campaign assignment plan harder to review even though each step is deterministic and
+  independently testable.
+- Action: extracted helpers for assignment-plan row projection, filter matching, count
+  aggregation, and page-payload construction; added direct helper tests for next-action filtering,
+  escalation/SLA counts, and hashed page payload construction while preserving the external page
+  model and API route behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_assignment_plan.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_assignment_plan.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_plan.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py tests/unit/dpm/api/test_waves_api.py -q`,
+  and `python -m radon cc src/core/waves/campaign_assignment_plan.py -s`; the focused wave
+  core/API suites reported 238 passed, and radon reports
+  `build_bulk_review_campaign_assignment_plan_page` reduced from C(14) to A(1) with every
+  function in the module at A grade.
+- Residual risk: this slice improves read-only campaign assignment-plan maintainability only. It
+  does not change campaign assignment semantics, workflow-board derivation, API contracts,
+  external workflow ownership, maker-checker controls, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal campaign read-model
+  maintainability hardening with no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24024,3 +24024,24 @@ and improves internal transaction-cost source posture maintainability only.
   external workflow ownership, maker-checker controls, or global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is internal campaign read-model
   maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-956: Campaign assignment-plan reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the campaign assignment-plan helper extraction, the checked-in quality reports
+  needed to reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `979d0260`, record 820 Python files, 2610 test functions, keep service boundary findings and
+  router infrastructure imports at 0, and the current top-ten source hotspot list no longer
+  includes `build_bulk_review_campaign_assignment_plan_page`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining campaign workflow automation,
+  campaign workflow board, valuation, search, OpenAPI, enterprise-readiness, execution, or
+  PM-quality review-action builder hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T01:31:58+00:00`
+- Generated at: `2026-06-17T01:50:54+00:00`
 
-- Report source snapshot: `8be6baf4`
+- Report source snapshot: `979d0260`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 177305 |
-| Test functions | 2608 |
+| Total Python LOC | 177465 |
+| Test functions | 2610 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T01:31:58+00:00`
+- Generated at: `2026-06-17T01:50:54+00:00`
 
-- Report source snapshot: `8be6baf4`
+- Report source snapshot: `979d0260`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_bulk_review_campaign_assignment_plan_page | src/core/waves/campaign_assignment_plan.py | 6 | 49 |
-| 2 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
-| 3 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
-| 4 | value_position | src/core/valuation.py | 6 | 45 |
-| 5 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
-| 6 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
-| 7 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
-| 8 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
-| 9 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
-| 10 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
+| 1 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
+| 2 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
+| 3 | value_position | src/core/valuation.py | 6 | 45 |
+| 4 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
+| 5 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
+| 6 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
+| 7 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
+| 8 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
+| 9 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
+| 10 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T01:31:58+00:00`
+- Generated at: `2026-06-17T01:50:54+00:00`
 
-- Report source snapshot: `8be6baf4`
+- Report source snapshot: `979d0260`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T01:31:58+00:00`
+- Generated at: `2026-06-17T01:50:54+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `8be6baf4`
+- Report source snapshot: `979d0260`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 820 | 820 | +0 |
-| Total Python LOC | 177146 | 177305 | +159 |
-| Test functions | 2604 | 2608 | +4 |
+| Total Python LOC | 177305 | 177465 | +160 |
+| Test functions | 2608 | 2610 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -53,7 +53,7 @@
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3066 |
-| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
+| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2856 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |

--- a/src/core/waves/campaign_assignment_plan.py
+++ b/src/core/waves/campaign_assignment_plan.py
@@ -148,7 +148,33 @@ def build_bulk_review_campaign_assignment_plan_page(
     limit: int,
     offset: int,
 ) -> DpmBulkReviewCampaignAssignmentPlanPage:
-    items = [
+    items = _filtered_assignment_plan_items(
+        items=_assignment_plan_items(
+            definitions=definitions,
+            requested_as_of_date=requested_as_of_date,
+            actor_id=actor_id,
+            active_on=active_on,
+        ),
+        include_closed=include_closed,
+        escalation_tier=escalation_tier,
+        next_action=next_action,
+    )
+    payload = _assignment_plan_page_payload(
+        items=items,
+        limit=limit,
+        offset=offset,
+    )
+    return DpmBulkReviewCampaignAssignmentPlanPage.model_validate(payload)
+
+
+def _assignment_plan_items(
+    *,
+    definitions: list[DpmBulkReviewCampaignDefinition],
+    requested_as_of_date: str | None,
+    actor_id: str | None,
+    active_on: date | None,
+) -> list[DpmBulkReviewCampaignAssignmentPlanItem]:
+    return [
         build_bulk_review_campaign_assignment_plan_item(
             definition=definition,
             requested_as_of_date=requested_as_of_date or definition.as_of_date,
@@ -157,21 +183,93 @@ def build_bulk_review_campaign_assignment_plan_page(
         )
         for definition in definitions
     ]
-    if not include_closed:
-        items = [item for item in items if item.workflow_board.board_status != "CLOSED"]
-    if escalation_tier is not None:
-        items = [item for item in items if item.escalation_tier == escalation_tier]
-    if next_action is not None:
-        items = [item for item in items if item.next_action == next_action]
 
-    escalation_tier_counts: dict[str, int] = {}
-    sla_posture_counts: dict[str, int] = {}
-    for item in items:
-        escalation_tier_counts[item.escalation_tier] = (
-            escalation_tier_counts.get(item.escalation_tier, 0) + 1
+
+def _filtered_assignment_plan_items(
+    *,
+    items: list[DpmBulkReviewCampaignAssignmentPlanItem],
+    include_closed: bool,
+    escalation_tier: CampaignAssignmentEscalationTier | None,
+    next_action: CampaignWorkflowNextAction | None,
+) -> list[DpmBulkReviewCampaignAssignmentPlanItem]:
+    return [
+        item
+        for item in items
+        if _assignment_plan_item_matches(
+            item=item,
+            include_closed=include_closed,
+            escalation_tier=escalation_tier,
+            next_action=next_action,
         )
-        sla_posture_counts[item.sla_posture] = sla_posture_counts.get(item.sla_posture, 0) + 1
+    ]
 
+
+def _assignment_plan_item_matches(
+    *,
+    item: DpmBulkReviewCampaignAssignmentPlanItem,
+    include_closed: bool,
+    escalation_tier: CampaignAssignmentEscalationTier | None,
+    next_action: CampaignWorkflowNextAction | None,
+) -> bool:
+    return all(
+        (
+            _assignment_plan_closed_filter_matches(item=item, include_closed=include_closed),
+            _assignment_plan_escalation_filter_matches(
+                item=item,
+                escalation_tier=escalation_tier,
+            ),
+            _assignment_plan_next_action_filter_matches(item=item, next_action=next_action),
+        )
+    )
+
+
+def _assignment_plan_closed_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignAssignmentPlanItem,
+    include_closed: bool,
+) -> bool:
+    if include_closed:
+        return True
+    return item.workflow_board.board_status != "CLOSED"
+
+
+def _assignment_plan_escalation_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignAssignmentPlanItem,
+    escalation_tier: CampaignAssignmentEscalationTier | None,
+) -> bool:
+    if escalation_tier is None:
+        return True
+    return item.escalation_tier == escalation_tier
+
+
+def _assignment_plan_next_action_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignAssignmentPlanItem,
+    next_action: CampaignWorkflowNextAction | None,
+) -> bool:
+    if next_action is None:
+        return True
+    return item.next_action == next_action
+
+
+def _assignment_plan_counts(
+    items: list[DpmBulkReviewCampaignAssignmentPlanItem],
+    field_name: Literal["escalation_tier", "sla_posture"],
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        value = getattr(item, field_name)
+        counts[value] = counts.get(value, 0) + 1
+    return counts
+
+
+def _assignment_plan_page_payload(
+    *,
+    items: list[DpmBulkReviewCampaignAssignmentPlanItem],
+    limit: int,
+    offset: int,
+) -> dict[str, object]:
     payload: dict[str, object] = {
         "product_name": "BulkReviewCampaignAssignmentPlan",
         "product_version": "v1",
@@ -179,12 +277,12 @@ def build_bulk_review_campaign_assignment_plan_page(
         "limit": limit,
         "offset": offset,
         "count": len(items),
-        "escalation_tier_counts": escalation_tier_counts,
-        "sla_posture_counts": sla_posture_counts,
+        "escalation_tier_counts": _assignment_plan_counts(items, "escalation_tier"),
+        "sla_posture_counts": _assignment_plan_counts(items, "sla_posture"),
         "content_hash": "",
     }
     payload["content_hash"] = _hash_payload(payload)
-    return DpmBulkReviewCampaignAssignmentPlanPage.model_validate(payload)
+    return payload
 
 
 def _classify_assignment_plan(

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -45,6 +45,9 @@ from src.core.waves.campaign_workflow_board import (
 )
 from src.core.waves.campaign_assignment_plan import (
     DpmBulkReviewCampaignAssignmentPlanPage,
+    _assignment_plan_counts,
+    _assignment_plan_page_payload,
+    _filtered_assignment_plan_items,
     build_bulk_review_campaign_assignment_plan_item,
     build_bulk_review_campaign_assignment_plan_page,
 )
@@ -729,6 +732,65 @@ def test_campaign_assignment_plan_page_filters_tier_and_counts() -> None:
     assert page.sla_posture_counts == {"ATTENTION": 1}
     assert page.items[0].next_action == "RECORD_APPROVAL_DECISION"
     assert page.content_hash.startswith("sha256:")
+
+
+def test_campaign_assignment_plan_helpers_filter_and_count_rows() -> None:
+    ready = build_bulk_review_campaign_assignment_plan_item(
+        definition=_definition(),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+    approval_required = build_bulk_review_campaign_assignment_plan_item(
+        definition=_definition(approval_ref=None, approved_by=None, approved_at=None),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+    unauthorized = build_bulk_review_campaign_assignment_plan_item(
+        definition=_definition(entitled_actor_ids=["ops"]),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+
+    filtered = _filtered_assignment_plan_items(
+        items=[ready, approval_required, unauthorized],
+        include_closed=False,
+        escalation_tier=None,
+        next_action="REVIEW_ACTOR_ENTITLEMENT",
+    )
+
+    assert [item.campaign_id for item in filtered] == [unauthorized.campaign_id]
+    assert _assignment_plan_counts([ready, approval_required, unauthorized], "escalation_tier") == {
+        "PM": 1,
+        "GOVERNANCE": 1,
+        "OPS": 1,
+    }
+    assert _assignment_plan_counts([ready, approval_required, unauthorized], "sla_posture") == {
+        "ON_TRACK": 1,
+        "ATTENTION": 1,
+        "BREACHED_OR_BLOCKED": 1,
+    }
+
+
+def test_campaign_assignment_plan_page_payload_hashes_filtered_rows() -> None:
+    assignment_plan = build_bulk_review_campaign_assignment_plan_item(
+        definition=_definition(approval_ref=None, approved_by=None, approved_at=None),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+
+    payload = _assignment_plan_page_payload(items=[assignment_plan], limit=25, offset=5)
+
+    assert payload["product_name"] == "BulkReviewCampaignAssignmentPlan"
+    assert payload["limit"] == 25
+    assert payload["offset"] == 5
+    assert payload["count"] == 1
+    assert payload["escalation_tier_counts"] == {"GOVERNANCE": 1}
+    assert payload["sla_posture_counts"] == {"ATTENTION": 1}
+    assert str(payload["content_hash"]).startswith("sha256:")
 
 
 def test_campaign_assignment_actions_record_append_only_posture() -> None:


### PR DESCRIPTION
## Summary
- extract campaign assignment-plan page helpers for item projection, filter matching, count aggregation, and payload hashing
- add direct helper tests covering filtered rows, aggregate counts, and deterministic payload hash inputs
- refresh codebase review ledger and quality reports through BACKEND-REVIEW-20260617-956

## Validation
- `python -m ruff check src/core/waves/campaign_assignment_plan.py tests/unit/dpm/waves/test_campaign_discovery.py`
- `python -m ruff format --check src/core/waves/campaign_assignment_plan.py tests/unit/dpm/waves/test_campaign_discovery.py`
- `python -m mypy --config-file mypy.ini src/core/waves/campaign_assignment_plan.py`
- `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py tests/unit/dpm/api/test_waves_api.py -q` -> 238 passed
- `python -m radon cc src/core/waves/campaign_assignment_plan.py -s` -> all functions A grade; `build_bulk_review_campaign_assignment_plan_page` is A(1)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- service leakage scan for FastAPI/router imports in `src/api/services` -> no findings
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0
- `make check` -> 2809 passed

## Residual Risk
- Internal campaign read-model maintainability change only; no API semantics or campaign workflow behavior intended.
- Quality reports are evidence-only updates. Remaining source hotspots are recorded in `quality/complexity_report.md` for future slices.
- No bank-buyable readiness claim is made by this PR.
