### PR TITLE
Refactor campaign workflow page helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24045,3 +24045,61 @@ and improves internal transaction-cost source posture maintainability only.
   PM-quality review-action builder hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-957: Campaign workflow page helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/waves/campaign_workflow_board.py`,
+  `src/core/waves/campaign_workflow_automation.py`, and
+  `tests/unit/dpm/waves/test_campaign_discovery.py`.
+- Bank-buyable control area: architecture, campaign supportability, and testing.
+- Finding: `build_bulk_review_campaign_workflow_board_page` and
+  `build_bulk_review_campaign_workflow_automation_page` each combined row projection,
+  closed-row filtering, requested status/action filtering, page count aggregation, payload
+  assembly, and content hashing in one page-builder function. That kept two read-only campaign
+  workflow projections harder to inspect even though each step is deterministic and testable.
+- Action: extracted helpers for workflow-board and workflow-automation row projection, filter
+  matching, count aggregation, and page-payload construction; added direct helper tests for
+  filtered rows, status/action counts, capability-posture preservation, and hashed page payloads
+  while preserving external page models and API route behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff check src/core/waves/campaign_workflow_board.py src/core/waves/campaign_workflow_automation.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m ruff format --check src/core/waves/campaign_workflow_board.py src/core/waves/campaign_workflow_automation.py tests/unit/dpm/waves/test_campaign_discovery.py`,
+  `python -m mypy --config-file mypy.ini src/core/waves/campaign_workflow_board.py src/core/waves/campaign_workflow_automation.py`,
+  `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py tests/unit/dpm/api/test_waves_api.py -q`,
+  and `python -m radon cc src/core/waves/campaign_workflow_board.py src/core/waves/campaign_workflow_automation.py -s`;
+  the focused wave core/API suites reported 240 passed, and radon reports
+  `build_bulk_review_campaign_workflow_board_page` and
+  `build_bulk_review_campaign_workflow_automation_page` at A(1) with every function in both
+  modules at A grade.
+- Residual risk: this slice improves read-only campaign workflow maintainability only. It does
+  not change workflow-board next-action semantics, automation readiness classification,
+  assignment-task mutation behavior, external workflow ownership boundaries, API contracts, or
+  global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal campaign read-model
+  maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-958: Campaign workflow reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the campaign workflow-board and workflow-automation helper extractions, the
+  checked-in quality reports needed to reflect the updated branch head, test-function count, and
+  current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `3ea6b511`, record 820 Python files, 2612 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes
+  `build_bulk_review_campaign_workflow_board_page` or
+  `build_bulk_review_campaign_workflow_automation_page`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining valuation, wave-search,
+  portfolio-memory facet, OpenAPI enrichment, enterprise-readiness, execution, PM-quality, outcome
+  snapshot, or source-context hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T01:50:54+00:00`
+- Generated at: `2026-06-17T02:09:12+00:00`
 
-- Report source snapshot: `979d0260`
+- Report source snapshot: `3ea6b511`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 177465 |
-| Test functions | 2610 |
+| Total Python LOC | 177749 |
+| Test functions | 2612 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T01:50:54+00:00`
+- Generated at: `2026-06-17T02:09:12+00:00`
 
-- Report source snapshot: `979d0260`
+- Report source snapshot: `3ea6b511`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_bulk_review_campaign_workflow_automation_page | src/core/waves/campaign_workflow_automation.py | 6 | 48 |
-| 2 | build_bulk_review_campaign_workflow_board_page | src/core/waves/campaign_workflow_board.py | 6 | 47 |
-| 3 | value_position | src/core/valuation.py | 6 | 45 |
-| 4 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
-| 5 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
-| 6 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
-| 7 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
-| 8 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
-| 9 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
-| 10 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
+| 1 | value_position | src/core/valuation.py | 6 | 45 |
+| 2 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
+| 3 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
+| 4 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
+| 5 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
+| 6 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
+| 7 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
+| 8 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
+| 9 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
+| 10 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T01:50:54+00:00`
+- Generated at: `2026-06-17T02:09:12+00:00`
 
-- Report source snapshot: `979d0260`
+- Report source snapshot: `3ea6b511`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T01:50:54+00:00`
+- Generated at: `2026-06-17T02:09:12+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `979d0260`
+- Report source snapshot: `3ea6b511`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 820 | 820 | +0 |
-| Total Python LOC | 177305 | 177465 | +160 |
-| Test functions | 2608 | 2610 | +2 |
+| Total Python LOC | 177465 | 177749 | +284 |
+| Test functions | 2610 | 2612 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -38,7 +38,7 @@
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3066 |
-| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2794 |
+| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2856 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
@@ -53,7 +53,7 @@
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3066 |
-| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2856 |
+| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2960 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |

--- a/src/core/waves/campaign_workflow_automation.py
+++ b/src/core/waves/campaign_workflow_automation.py
@@ -349,7 +349,30 @@ def build_bulk_review_campaign_workflow_automation_page(
     limit: int,
     offset: int,
 ) -> DpmBulkReviewCampaignWorkflowAutomationPage:
-    items = [
+    items = _filtered_workflow_automation_items(
+        items=_workflow_automation_items(
+            definitions=definitions,
+            requested_as_of_date=requested_as_of_date,
+            actor_id=actor_id,
+            active_on=active_on,
+        ),
+        include_closed=include_closed,
+        automation_status=automation_status,
+        automation_action=automation_action,
+    )
+    return DpmBulkReviewCampaignWorkflowAutomationPage.model_validate(
+        _workflow_automation_page_payload(items=items, limit=limit, offset=offset)
+    )
+
+
+def _workflow_automation_items(
+    *,
+    definitions: list[DpmBulkReviewCampaignDefinition],
+    requested_as_of_date: str | None,
+    actor_id: str | None,
+    active_on: date | None,
+) -> list[DpmBulkReviewCampaignWorkflowAutomationItem]:
+    return [
         build_bulk_review_campaign_workflow_automation_item(
             definition=definition,
             requested_as_of_date=requested_as_of_date or definition.as_of_date,
@@ -358,19 +381,89 @@ def build_bulk_review_campaign_workflow_automation_page(
         )
         for definition in definitions
     ]
-    if not include_closed:
-        items = [item for item in items if item.automation_status != "CLOSED"]
-    if automation_status is not None:
-        items = [item for item in items if item.automation_status == automation_status]
-    if automation_action is not None:
-        items = [item for item in items if item.automation_action == automation_action]
 
+
+def _filtered_workflow_automation_items(
+    *,
+    items: list[DpmBulkReviewCampaignWorkflowAutomationItem],
+    include_closed: bool,
+    automation_status: CampaignWorkflowAutomationStatus | None,
+    automation_action: CampaignWorkflowAutomationAction | None,
+) -> list[DpmBulkReviewCampaignWorkflowAutomationItem]:
+    return [
+        item
+        for item in items
+        if _workflow_automation_item_matches(
+            item=item,
+            include_closed=include_closed,
+            automation_status=automation_status,
+            automation_action=automation_action,
+        )
+    ]
+
+
+def _workflow_automation_item_matches(
+    *,
+    item: DpmBulkReviewCampaignWorkflowAutomationItem,
+    include_closed: bool,
+    automation_status: CampaignWorkflowAutomationStatus | None,
+    automation_action: CampaignWorkflowAutomationAction | None,
+) -> bool:
+    return (
+        _workflow_automation_closed_filter_matches(item=item, include_closed=include_closed)
+        and _workflow_automation_status_filter_matches(
+            item=item,
+            automation_status=automation_status,
+        )
+        and _workflow_automation_action_filter_matches(
+            item=item,
+            automation_action=automation_action,
+        )
+    )
+
+
+def _workflow_automation_closed_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignWorkflowAutomationItem,
+    include_closed: bool,
+) -> bool:
+    return include_closed or item.automation_status != "CLOSED"
+
+
+def _workflow_automation_status_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignWorkflowAutomationItem,
+    automation_status: CampaignWorkflowAutomationStatus | None,
+) -> bool:
+    return automation_status is None or item.automation_status == automation_status
+
+
+def _workflow_automation_action_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignWorkflowAutomationItem,
+    automation_action: CampaignWorkflowAutomationAction | None,
+) -> bool:
+    return automation_action is None or item.automation_action == automation_action
+
+
+def _workflow_automation_counts(
+    items: list[DpmBulkReviewCampaignWorkflowAutomationItem],
+) -> tuple[dict[str, int], dict[str, int]]:
     status_counts: dict[str, int] = {}
     action_counts: dict[str, int] = {}
     for item in items:
         status_counts[item.automation_status] = status_counts.get(item.automation_status, 0) + 1
         action_counts[item.automation_action] = action_counts.get(item.automation_action, 0) + 1
+    return status_counts, action_counts
 
+
+def _workflow_automation_page_payload(
+    *,
+    items: list[DpmBulkReviewCampaignWorkflowAutomationItem],
+    limit: int,
+    offset: int,
+) -> dict[str, object]:
+    status_counts, action_counts = _workflow_automation_counts(items)
     payload: dict[str, object] = {
         "product_name": "BulkReviewCampaignWorkflowAutomation",
         "product_version": "v1",
@@ -384,7 +477,7 @@ def build_bulk_review_campaign_workflow_automation_page(
         "content_hash": "",
     }
     payload["content_hash"] = _content_hash(payload)
-    return DpmBulkReviewCampaignWorkflowAutomationPage.model_validate(payload)
+    return payload
 
 
 def _classify_automation(

--- a/src/core/waves/campaign_workflow_board.py
+++ b/src/core/waves/campaign_workflow_board.py
@@ -174,7 +174,30 @@ def build_bulk_review_campaign_workflow_board_page(
     limit: int,
     offset: int,
 ) -> DpmBulkReviewCampaignWorkflowBoardPage:
-    items = [
+    items = _filtered_workflow_board_items(
+        items=_workflow_board_items(
+            definitions=definitions,
+            requested_as_of_date=requested_as_of_date,
+            actor_id=actor_id,
+            active_on=active_on,
+        ),
+        include_closed=include_closed,
+        board_status=board_status,
+        next_action=next_action,
+    )
+    return DpmBulkReviewCampaignWorkflowBoardPage.model_validate(
+        _workflow_board_page_payload(items=items, limit=limit, offset=offset)
+    )
+
+
+def _workflow_board_items(
+    *,
+    definitions: list[DpmBulkReviewCampaignDefinition],
+    requested_as_of_date: str | None,
+    actor_id: str | None,
+    active_on: date | None,
+) -> list[DpmBulkReviewCampaignWorkflowBoardItem]:
+    return [
         build_bulk_review_campaign_workflow_board_item(
             definition=definition,
             requested_as_of_date=requested_as_of_date or definition.as_of_date,
@@ -183,19 +206,83 @@ def build_bulk_review_campaign_workflow_board_page(
         )
         for definition in definitions
     ]
-    if not include_closed:
-        items = [item for item in items if item.board_status != "CLOSED"]
-    if board_status is not None:
-        items = [item for item in items if item.board_status == board_status]
-    if next_action is not None:
-        items = [item for item in items if item.next_action == next_action]
 
+
+def _filtered_workflow_board_items(
+    *,
+    items: list[DpmBulkReviewCampaignWorkflowBoardItem],
+    include_closed: bool,
+    board_status: CampaignWorkflowBoardStatus | None,
+    next_action: CampaignWorkflowNextAction | None,
+) -> list[DpmBulkReviewCampaignWorkflowBoardItem]:
+    return [
+        item
+        for item in items
+        if _workflow_board_item_matches(
+            item=item,
+            include_closed=include_closed,
+            board_status=board_status,
+            next_action=next_action,
+        )
+    ]
+
+
+def _workflow_board_item_matches(
+    *,
+    item: DpmBulkReviewCampaignWorkflowBoardItem,
+    include_closed: bool,
+    board_status: CampaignWorkflowBoardStatus | None,
+    next_action: CampaignWorkflowNextAction | None,
+) -> bool:
+    return (
+        _workflow_board_closed_filter_matches(item=item, include_closed=include_closed)
+        and _workflow_board_status_filter_matches(item=item, board_status=board_status)
+        and _workflow_board_next_action_filter_matches(item=item, next_action=next_action)
+    )
+
+
+def _workflow_board_closed_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignWorkflowBoardItem,
+    include_closed: bool,
+) -> bool:
+    return include_closed or item.board_status != "CLOSED"
+
+
+def _workflow_board_status_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignWorkflowBoardItem,
+    board_status: CampaignWorkflowBoardStatus | None,
+) -> bool:
+    return board_status is None or item.board_status == board_status
+
+
+def _workflow_board_next_action_filter_matches(
+    *,
+    item: DpmBulkReviewCampaignWorkflowBoardItem,
+    next_action: CampaignWorkflowNextAction | None,
+) -> bool:
+    return next_action is None or item.next_action == next_action
+
+
+def _workflow_board_counts(
+    items: list[DpmBulkReviewCampaignWorkflowBoardItem],
+) -> tuple[dict[str, int], dict[str, int]]:
     status_counts: dict[str, int] = {}
     next_action_counts: dict[str, int] = {}
     for item in items:
         status_counts[item.board_status] = status_counts.get(item.board_status, 0) + 1
         next_action_counts[item.next_action] = next_action_counts.get(item.next_action, 0) + 1
+    return status_counts, next_action_counts
 
+
+def _workflow_board_page_payload(
+    *,
+    items: list[DpmBulkReviewCampaignWorkflowBoardItem],
+    limit: int,
+    offset: int,
+) -> dict[str, object]:
+    status_counts, next_action_counts = _workflow_board_counts(items)
     payload: dict[str, object] = {
         "product_name": "BulkReviewCampaignWorkflowBoard",
         "product_version": "v1",
@@ -208,7 +295,7 @@ def build_bulk_review_campaign_workflow_board_page(
         "content_hash": "",
     }
     payload["content_hash"] = _hash_payload(payload)
-    return DpmBulkReviewCampaignWorkflowBoardPage.model_validate(payload)
+    return payload
 
 
 def _classify_workflow_board_posture(

--- a/tests/unit/dpm/waves/test_campaign_discovery.py
+++ b/tests/unit/dpm/waves/test_campaign_discovery.py
@@ -40,6 +40,9 @@ from src.core.waves.campaign_approval_inbox import (
 )
 from src.core.waves.campaign_workflow_board import (
     DpmBulkReviewCampaignWorkflowBoardPage,
+    _filtered_workflow_board_items,
+    _workflow_board_counts,
+    _workflow_board_page_payload,
     build_bulk_review_campaign_workflow_board_item,
     build_bulk_review_campaign_workflow_board_page,
 )
@@ -53,6 +56,9 @@ from src.core.waves.campaign_assignment_plan import (
 )
 from src.core.waves.campaign_workflow_automation import (
     DpmBulkReviewCampaignWorkflowAutomationPage,
+    _filtered_workflow_automation_items,
+    _workflow_automation_counts,
+    _workflow_automation_page_payload,
     build_bulk_review_campaign_workflow_automation_item,
     build_bulk_review_campaign_workflow_automation_page,
 )
@@ -667,6 +673,56 @@ def test_campaign_workflow_board_page_filters_next_action_and_counts() -> None:
     assert page.count == 1
     assert page.status_counts == {"ATTENTION_FOR_ACTOR": 1}
     assert page.next_action_counts == {"RECORD_APPROVAL_DECISION": 1}
+    assert page.items[0].next_action == "RECORD_APPROVAL_DECISION"
+    assert page.content_hash.startswith("sha256:")
+
+
+def test_campaign_workflow_board_helpers_filter_count_and_hash_rows() -> None:
+    ready = build_bulk_review_campaign_workflow_board_item(
+        definition=_definition(),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+    approval_required = build_bulk_review_campaign_workflow_board_item(
+        definition=_definition(approval_ref=None, approved_by=None, approved_at=None),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+    retired = DpmBulkReviewCampaignDefinition.model_validate(
+        {
+            **_definition().model_dump(mode="python"),
+            "campaign_id": "campaign-holdings-retired-board-20260510",
+            "status": "RETIRED",
+            "retired_at": "2026-05-11T08:00:00Z",
+            "retired_by": "ops",
+            "retirement_reason": "Campaign completed.",
+            "retirement_correlation_id": "corr-campaign-definition-retire-board",
+            "content_hash": "",
+        }
+    )
+    closed = build_bulk_review_campaign_workflow_board_item(
+        definition=retired,
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 16),
+    )
+
+    filtered = _filtered_workflow_board_items(
+        items=[ready, approval_required, closed],
+        include_closed=False,
+        board_status="ATTENTION_FOR_ACTOR",
+        next_action=None,
+    )
+    status_counts, next_action_counts = _workflow_board_counts(filtered)
+    payload = _workflow_board_page_payload(items=filtered, limit=50, offset=0)
+    page = DpmBulkReviewCampaignWorkflowBoardPage.model_validate(payload)
+
+    assert [item.campaign_id for item in filtered] == [approval_required.campaign_id]
+    assert status_counts == {"ATTENTION_FOR_ACTOR": 1}
+    assert next_action_counts == {"RECORD_APPROVAL_DECISION": 1}
+    assert page.count == 1
     assert page.items[0].next_action == "RECORD_APPROVAL_DECISION"
     assert page.content_hash.startswith("sha256:")
 
@@ -1395,6 +1451,54 @@ def test_campaign_workflow_automation_filters_actions_and_closed_rows() -> None:
     assert closed_item.proposed_task_ref is None
     assert filtered.count == 1
     assert filtered.items[0].campaign_id == "campaign-holdings-retired-automation-20260510"
+
+
+def test_campaign_workflow_automation_helpers_filter_count_and_hash_rows() -> None:
+    candidate = build_bulk_review_campaign_workflow_automation_item(
+        definition=_definition(),
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 10),
+    )
+    retired = DpmBulkReviewCampaignDefinition.model_validate(
+        {
+            **_definition().model_dump(mode="python"),
+            "campaign_id": "campaign-holdings-retired-automation-helper-20260510",
+            "status": "RETIRED",
+            "retired_at": "2026-05-11T08:00:00Z",
+            "retired_by": "ops",
+            "retirement_reason": "Campaign completed.",
+            "retirement_correlation_id": "corr-campaign-definition-retire-automation-helper",
+            "content_hash": "",
+        }
+    )
+    closed = build_bulk_review_campaign_workflow_automation_item(
+        definition=retired,
+        requested_as_of_date="2026-05-10",
+        actor_id="pm_001",
+        active_on=date(2026, 5, 10),
+    )
+
+    filtered = _filtered_workflow_automation_items(
+        items=[candidate, closed],
+        include_closed=True,
+        automation_status=None,
+        automation_action="NO_AUTOMATION_CLOSED",
+    )
+    status_counts, action_counts = _workflow_automation_counts(filtered)
+    payload = _workflow_automation_page_payload(items=filtered, limit=50, offset=0)
+    page = DpmBulkReviewCampaignWorkflowAutomationPage.model_validate(payload)
+
+    assert [item.campaign_id for item in filtered] == [
+        "campaign-holdings-retired-automation-helper-20260510"
+    ]
+    assert status_counts == {"CLOSED": 1}
+    assert action_counts == {"NO_AUTOMATION_CLOSED": 1}
+    assert page.count == 1
+    assert page.capability_posture.content_hash == candidate.capability_posture.content_hash
+    assert page.content_hash == hash_canonical_payload(
+        strip_keys(page.model_dump(mode="json"), exclude={"content_hash"})
+    )
 
 
 def test_campaign_operating_pages_reject_inconsistent_summary_metadata() -> None:


### PR DESCRIPTION
## Summary
- extract campaign workflow-board page helpers for row projection, filter matching, count aggregation, and payload hashing
- extract campaign workflow-automation page helpers using the same read-model pattern
- add direct helper tests for filtered rows, status/action counts, capability-posture preservation, and deterministic page hashes
- refresh codebase review ledger and quality reports through BACKEND-REVIEW-20260617-958

## Validation
- `python -m ruff check src/core/waves/campaign_workflow_board.py src/core/waves/campaign_workflow_automation.py tests/unit/dpm/waves/test_campaign_discovery.py`
- `python -m ruff format --check src/core/waves/campaign_workflow_board.py src/core/waves/campaign_workflow_automation.py tests/unit/dpm/waves/test_campaign_discovery.py`
- `python -m mypy --config-file mypy.ini src/core/waves/campaign_workflow_board.py src/core/waves/campaign_workflow_automation.py`
- `python -m pytest tests/unit/dpm/waves/test_campaign_discovery.py tests/unit/dpm/api/test_waves_api.py -q` -> 240 passed
- `python -m radon cc src/core/waves/campaign_workflow_board.py src/core/waves/campaign_workflow_automation.py -s` -> all functions A grade; both page builders are A(1)
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- service leakage scan for FastAPI/router imports in `src/api/services` -> no findings
- `git diff --check`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0
- `make check` -> 2811 passed

## Quality Evidence
- Reports sourced from `3ea6b511` record 820 Python files, 2612 test functions, service boundary findings 0, router infrastructure imports 0, and OpenAPI missing markers 0.
- Current top-ten source hotspots no longer include `build_bulk_review_campaign_workflow_board_page` or `build_bulk_review_campaign_workflow_automation_page`.

## Residual Risk
- Internal campaign read-model maintainability change only; no workflow-board next-action semantics, automation readiness classification, assignment-task mutation behavior, external workflow ownership boundary, or API contract behavior is intended to change.
- Quality reports are evidence-only updates. Remaining source hotspots are recorded in `quality/complexity_report.md` for future slices.
- No bank-buyable readiness claim is made by this PR.
