### PR TITLE
Refactor valuation position helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24103,3 +24103,55 @@ and improves internal transaction-cost source posture maintainability only.
   snapshot, or source-context hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-959: Position valuation helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/valuation.py` and
+  `tests/unit/dpm/engine/test_engine_valuation_service.py`.
+- Bank-buyable control area: architecture, deterministic valuation behavior, and testing.
+- Finding: `ValuationService.value_position` combined price lookup, valuation-mode currency
+  selection, instrument-currency value selection, FX conversion, and response-model construction
+  in one method. That made position valuation behavior harder to inspect and test directly despite
+  each step being deterministic and side-effect free.
+- Action: extracted focused valuation helpers for price selection, price value defaulting,
+  trusted-snapshot currency and market-value selection, base-currency conversion, and price-money
+  projection; added direct tests for calculated price/FX behavior and trusted snapshot market-value
+  behavior while preserving the existing response shape and trusted-snapshot price-money
+  projection semantics.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format --check src/core/valuation.py tests/unit/dpm/engine/test_engine_valuation_service.py`,
+  `python -m ruff check src/core/valuation.py tests/unit/dpm/engine/test_engine_valuation_service.py`,
+  `python -m mypy --config-file mypy.ini src/core/valuation.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_valuation_service.py -q`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_core_flows.py tests/unit/dpm/engine/coverage/test_engine_universe_data_quality.py -q`,
+  and `python -m radon cc src/core/valuation.py -s`; the focused valuation suite reported
+  10 passed, the adjacent engine suites reported 16 passed, and radon reports
+  `ValuationService.value_position` at A(1) after extraction.
+- Residual risk: this slice improves valuation maintainability only. It does not change valuation
+  methodology, public API contracts, DPM engine orchestration, missing-market-data handling, or
+  global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal valuation maintainability
+  hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-960: Valuation reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the valuation helper extraction, the checked-in quality reports needed to reflect
+  the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `c00c1dcb`, record 820 Python files, 2614 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `ValuationService.value_position`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining wave-search, portfolio-memory facet,
+  OpenAPI enrichment, enterprise-readiness, execution, PM-quality, outcome snapshot, or
+  source-context hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T02:09:12+00:00`
+- Generated at: `2026-06-17T02:27:59+00:00`
 
-- Report source snapshot: `3ea6b511`
+- Report source snapshot: `c00c1dcb`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 177749 |
-| Test functions | 2612 |
+| Total Python LOC | 177888 |
+| Test functions | 2614 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T02:09:12+00:00`
+- Generated at: `2026-06-17T02:27:59+00:00`
 
-- Report source snapshot: `3ea6b511`
+- Report source snapshot: `c00c1dcb`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | value_position | src/core/valuation.py | 6 | 45 |
-| 2 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
-| 3 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
-| 4 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
-| 5 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
-| 6 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
-| 7 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
-| 8 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
-| 9 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
-| 10 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
+| 1 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
+| 2 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
+| 3 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
+| 4 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
+| 5 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
+| 6 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
+| 7 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
+| 8 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
+| 9 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
+| 10 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T02:09:12+00:00`
+- Generated at: `2026-06-17T02:27:59+00:00`
 
-- Report source snapshot: `3ea6b511`
+- Report source snapshot: `c00c1dcb`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T02:09:12+00:00`
+- Generated at: `2026-06-17T02:27:59+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `3ea6b511`
+- Report source snapshot: `c00c1dcb`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 820 | 820 | +0 |
-| Total Python LOC | 177465 | 177749 | +284 |
-| Test functions | 2610 | 2612 | +2 |
+| Total Python LOC | 177749 | 177888 | +139 |
+| Test functions | 2612 | 2614 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -38,7 +38,7 @@
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3066 |
-| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2856 |
+| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2960 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |

--- a/src/core/valuation.py
+++ b/src/core/valuation.py
@@ -14,6 +14,7 @@ from src.core.models import (
     PortfolioSnapshot,
     Position,
     PositionSummary,
+    Price,
     ShelfEntry,
     SimulatedState,
     ValuationMode,
@@ -58,41 +59,104 @@ class ValuationService:
         """
         Calculates position value based on options.valuation_mode.
         """
-        price_ent = next(
-            (p for p in market_data.prices if p.instrument_id == position.instrument_id), None
+        price = _position_price(position=position, market_data=market_data)
+        currency = _position_valuation_currency(
+            position=position,
+            price=price,
+            base_ccy=base_ccy,
+            options=options,
         )
-
-        price_val = Decimal("0")
-        currency = base_ccy
-
-        if price_ent:
-            price_val = price_ent.price
-            currency = price_ent.currency
-
-        mv_instr_ccy = Decimal("0")
-
-        is_trust = options.valuation_mode == ValuationMode.TRUST_SNAPSHOT
-        if is_trust and position.market_value:
-            mv_instr_ccy = position.market_value.amount
-            currency = position.market_value.currency
-        else:
-            mv_instr_ccy = position.quantity * price_val
-
-        rate = get_fx_rate(market_data, currency, base_ccy)
-        if rate is None:
-            mv_base = Decimal("0")
-        else:
-            mv_base = mv_instr_ccy * rate
+        price_value = _position_price_value(price=price)
+        value_in_instrument_ccy = _position_value_in_instrument_ccy(
+            position=position,
+            price_value=price_value,
+            options=options,
+        )
+        value_in_base_ccy = _position_value_in_base_ccy(
+            market_data=market_data,
+            instrument_value=value_in_instrument_ccy,
+            instrument_currency=currency,
+            base_ccy=base_ccy,
+        )
 
         return PositionSummary(
             instrument_id=position.instrument_id,
             quantity=position.quantity,
             instrument_currency=currency,
-            price=Money(amount=price_val, currency=currency) if price_ent else None,
-            value_in_instrument_ccy=Money(amount=mv_instr_ccy, currency=currency),
-            value_in_base_ccy=Money(amount=mv_base, currency=base_ccy),
+            price=_position_price_money(price=price, currency=currency),
+            value_in_instrument_ccy=Money(amount=value_in_instrument_ccy, currency=currency),
+            value_in_base_ccy=Money(amount=value_in_base_ccy, currency=base_ccy),
             weight=Decimal("0"),
         )
+
+
+def _position_price(
+    *,
+    position: Position,
+    market_data: MarketDataSnapshot,
+) -> Optional[Price]:
+    return next(
+        (price for price in market_data.prices if price.instrument_id == position.instrument_id),
+        None,
+    )
+
+
+def _position_price_value(*, price: Optional[Price]) -> Decimal:
+    if price is None:
+        return Decimal("0")
+    return price.price
+
+
+def _position_valuation_currency(
+    *,
+    position: Position,
+    price: Optional[Price],
+    base_ccy: str,
+    options: EngineOptions,
+) -> str:
+    if _uses_trusted_market_value(position=position, options=options):
+        assert position.market_value is not None
+        return position.market_value.currency
+    if price is not None:
+        return price.currency
+    return base_ccy
+
+
+def _position_value_in_instrument_ccy(
+    *,
+    position: Position,
+    price_value: Decimal,
+    options: EngineOptions,
+) -> Decimal:
+    if _uses_trusted_market_value(position=position, options=options):
+        assert position.market_value is not None
+        return position.market_value.amount
+    return position.quantity * price_value
+
+
+def _uses_trusted_market_value(*, position: Position, options: EngineOptions) -> bool:
+    return (
+        options.valuation_mode == ValuationMode.TRUST_SNAPSHOT and position.market_value is not None
+    )
+
+
+def _position_value_in_base_ccy(
+    *,
+    market_data: MarketDataSnapshot,
+    instrument_value: Decimal,
+    instrument_currency: str,
+    base_ccy: str,
+) -> Decimal:
+    rate = get_fx_rate(market_data, instrument_currency, base_ccy)
+    if rate is None:
+        return Decimal("0")
+    return instrument_value * rate
+
+
+def _position_price_money(*, price: Optional[Price], currency: str) -> Optional[Money]:
+    if price is None:
+        return None
+    return Money(amount=price.price, currency=currency)
 
 
 def _cash_value_in_base(

--- a/tests/unit/dpm/engine/test_engine_valuation_service.py
+++ b/tests/unit/dpm/engine/test_engine_valuation_service.py
@@ -14,10 +14,17 @@ from src.core.models import (
     PositionSummary,
     Price,
     ShelfEntry,
+    ValuationMode,
 )
 from src.core.valuation import (
     _allocation_by_attribute_metrics,
     _position_allocation_maps,
+    _position_price,
+    _position_price_money,
+    _position_price_value,
+    _position_valuation_currency,
+    _position_value_in_base_ccy,
+    _position_value_in_instrument_ccy,
     _safe_total_value,
     _valued_position_summaries,
     _cash_value_in_base,
@@ -102,6 +109,74 @@ def test_valued_position_summaries_records_missing_price_and_fx_gaps() -> None:
         "price_missing": ["MISSING_PRICE"],
         "fx_missing": ["EUR/USD"],
     }
+
+
+def test_position_valuation_helpers_apply_calculated_price_and_fx() -> None:
+    position = Position(instrument_id="EUR_STOCK", quantity=Decimal("2"))
+    price = Price(instrument_id="EUR_STOCK", price=Decimal("50"), currency="EUR")
+    market_data = market_data_snapshot(
+        prices=[price],
+        fx_rates=[fx("EUR/USD", "1.2")],
+    )
+    options = EngineOptions(valuation_mode=ValuationMode.CALCULATED)
+
+    selected_price = _position_price(position=position, market_data=market_data)
+    price_value = _position_price_value(price=selected_price)
+    instrument_currency = _position_valuation_currency(
+        position=position,
+        price=selected_price,
+        base_ccy="USD",
+        options=options,
+    )
+    instrument_value = _position_value_in_instrument_ccy(
+        position=position,
+        price_value=price_value,
+        options=options,
+    )
+
+    assert selected_price == price
+    assert instrument_currency == "EUR"
+    assert price_value == Decimal("50")
+    assert instrument_value == Decimal("100")
+    assert _position_value_in_base_ccy(
+        market_data=market_data,
+        instrument_value=instrument_value,
+        instrument_currency=instrument_currency,
+        base_ccy="USD",
+    ) == Decimal("120.0")
+    assert _position_price_money(price=selected_price, currency=instrument_currency) == Money(
+        amount=Decimal("50"),
+        currency="EUR",
+    )
+
+
+def test_position_valuation_helpers_prefer_trusted_snapshot_market_value() -> None:
+    position = Position(
+        instrument_id="EUR_STOCK",
+        quantity=Decimal("2"),
+        market_value=Money(amount=Decimal("125"), currency="CHF"),
+    )
+    price = Price(instrument_id="EUR_STOCK", price=Decimal("50"), currency="EUR")
+    options = EngineOptions(valuation_mode=ValuationMode.TRUST_SNAPSHOT)
+
+    instrument_currency = _position_valuation_currency(
+        position=position,
+        price=price,
+        base_ccy="USD",
+        options=options,
+    )
+    instrument_value = _position_value_in_instrument_ccy(
+        position=position,
+        price_value=price.price,
+        options=options,
+    )
+
+    assert instrument_currency == "CHF"
+    assert instrument_value == Decimal("125")
+    assert _position_price_money(price=price, currency=instrument_currency) == Money(
+        amount=Decimal("50"),
+        currency="CHF",
+    )
 
 
 def test_position_allocation_maps_apply_shelf_asset_class_and_attributes() -> None:


### PR DESCRIPTION
## Summary
- Extract deterministic position valuation helpers from ValuationService.value_position.
- Add direct helper tests for calculated price/FX valuation and trusted snapshot market-value selection.
- Refresh quality reports and codebase review ledger entries BACKEND-REVIEW-20260617-959 and BACKEND-REVIEW-20260617-960.

## Evidence
- python -m ruff format --check src/core/valuation.py tests/unit/dpm/engine/test_engine_valuation_service.py
- python -m ruff check src/core/valuation.py tests/unit/dpm/engine/test_engine_valuation_service.py
- python -m mypy --config-file mypy.ini src/core/valuation.py
- python -m pytest tests/unit/dpm/engine/test_engine_valuation_service.py -q: 10 passed
- python -m pytest tests/unit/dpm/engine/test_engine_core_flows.py tests/unit/dpm/engine/coverage/test_engine_universe_data_quality.py -q: 16 passed
- python -m radon cc src/core/valuation.py -s: ValuationService.value_position is A(1)
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- service leakage scan returned no matches
- git diff --check
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage: DiffCount 0
- make check: 2813 passed

## Residual risk
- Maintainability hardening only; no valuation methodology, API contract, or global bank-buyable readiness claim.
- Remaining source hotspots are tracked in quality/complexity_report.md for later slices.