### PR TITLE
Refactor wave search summary helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24155,3 +24155,54 @@ and improves internal transaction-cost source posture maintainability only.
   source-context hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-961: Wave search summary helpers
+
+- Date: 2026-06-17
+- Scope: `src/api/services/wave_search.py` and
+  `tests/unit/dpm/waves/test_wave_search.py`.
+- Bank-buyable control area: architecture, read-model supportability, and testing.
+- Finding: `search_wave_summaries` combined repository filter forwarding, supportability-state
+  filtering, latest-event selection, and wave-search response projection in one service function.
+  That kept a small but user-facing read model harder to inspect and made edge cases such as
+  eventless waves visible only through the final response projection.
+- Action: extracted helpers for searchable summary construction, supportability-state matching,
+  wave summary projection, and latest-event selection; added direct tests for supportability
+  filtering, latest-event projection, eventless wave projection, and match semantics while
+  preserving the existing public service export and route-facing response behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format --check src/api/services/wave_search.py tests/unit/dpm/waves/test_wave_search.py`,
+  `python -m ruff check src/api/services/wave_search.py tests/unit/dpm/waves/test_wave_search.py`,
+  `python -m mypy --config-file mypy.ini src/api/services/wave_search.py`,
+  `python -m pytest tests/unit/dpm/waves/test_wave_search.py -q`,
+  `python -m pytest tests/unit/dpm/api/test_waves_api.py tests/unit/dpm/waves/test_wave_service_public_surface.py -q`,
+  and `python -m radon cc src/api/services/wave_search.py -s`; the focused wave-search suite
+  reported 7 passed, the nearby API/service suites reported 133 passed, and radon reports
+  `search_wave_summaries` reduced from B(6) to A(3) with every function in the module at A grade.
+- Residual risk: this slice improves wave search maintainability only. It does not change
+  repository paging/filter semantics, wave supportability classification, route contracts,
+  campaign workflow behavior, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal wave-search maintainability
+  hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-962: Wave search reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the wave search helper extraction, the checked-in quality reports needed to
+  reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `054a7737`, record 820 Python files, 2618 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `search_wave_summaries`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining portfolio-memory facet, OpenAPI
+  enrichment, enterprise-readiness, execution, PM-quality, outcome snapshot, source-context,
+  proof-pack, or rebalance-intent hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T02:27:59+00:00`
+- Generated at: `2026-06-17T04:02:16+00:00`
 
-- Report source snapshot: `c00c1dcb`
+- Report source snapshot: `054a7737`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 177888 |
-| Test functions | 2614 |
+| Total Python LOC | 178002 |
+| Test functions | 2618 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T02:27:59+00:00`
+- Generated at: `2026-06-17T04:02:16+00:00`
 
-- Report source snapshot: `c00c1dcb`
+- Report source snapshot: `054a7737`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | search_wave_summaries | src/api/services/wave_search.py | 6 | 43 |
-| 2 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
-| 3 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
-| 4 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
-| 5 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
-| 6 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
-| 7 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
-| 8 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
-| 9 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
-| 10 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
+| 1 | build_search_facet_counts | src/core/portfolio_memory/search_facets.py | 6 | 43 |
+| 2 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
+| 3 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
+| 4 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
+| 5 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
+| 6 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
+| 7 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
+| 8 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
+| 9 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
+| 10 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T02:27:59+00:00`
+- Generated at: `2026-06-17T04:02:16+00:00`
 
-- Report source snapshot: `c00c1dcb`
+- Report source snapshot: `054a7737`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T02:27:59+00:00`
+- Generated at: `2026-06-17T04:02:16+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `c00c1dcb`
+- Report source snapshot: `054a7737`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 820 | 820 | +0 |
-| Total Python LOC | 177749 | 177888 | +139 |
-| Test functions | 2612 | 2614 | +2 |
+| Total Python LOC | 177888 | 178002 | +114 |
+| Test functions | 2614 | 2618 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/services/wave_search.py
+++ b/src/api/services/wave_search.py
@@ -1,5 +1,5 @@
 from src.api.services.wave_supportability_payload import wave_supportability_payload
-from src.core.waves import DpmWaveRepository
+from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveEvent, DpmWaveRepository
 
 
 def search_wave_summaries(
@@ -19,32 +19,70 @@ def search_wave_summaries(
         limit=limit,
         offset=offset,
     )
-    items: list[dict[str, object]] = []
-    for wave in waves:
-        supportability = wave_supportability_payload(wave)
+    return [
+        summary
+        for wave in waves
         if (
-            supportability_state is not None
-            and supportability["supportability_state"] != supportability_state
-        ):
-            continue
-        items.append(
-            {
-                "wave_id": wave.wave_id,
-                "wave_state": wave.state,
-                "trigger_type": wave.trigger.trigger_type,
-                "trigger_id": wave.trigger.trigger_id,
-                "as_of_date": wave.as_of_date,
-                "created_at": wave.created_at,
-                "created_by": wave.created_by,
-                "item_count": len(wave.items),
-                "aggregate_metrics": wave.aggregate_metrics,
-                "supportability_state": supportability["supportability_state"],
-                "supportability_reason": supportability["reason"],
-                "latest_event_type": wave.events[-1].event_type if wave.events else None,
-                "latest_event_reason_code": wave.events[-1].reason_code if wave.events else None,
-            }
+            summary := _searchable_wave_summary(
+                wave=wave,
+                supportability_state=supportability_state,
+            )
         )
-    return items
+        is not None
+    ]
+
+
+def _searchable_wave_summary(
+    *,
+    wave: DpmRebalanceWave,
+    supportability_state: str | None,
+) -> dict[str, object] | None:
+    supportability = wave_supportability_payload(wave)
+    if not _matches_supportability_state(
+        supportability=supportability,
+        supportability_state=supportability_state,
+    ):
+        return None
+    return _wave_summary(wave=wave, supportability=supportability)
+
+
+def _matches_supportability_state(
+    *,
+    supportability: dict[str, object],
+    supportability_state: str | None,
+) -> bool:
+    if supportability_state is None:
+        return True
+    return supportability["supportability_state"] == supportability_state
+
+
+def _wave_summary(
+    *,
+    wave: DpmRebalanceWave,
+    supportability: dict[str, object],
+) -> dict[str, object]:
+    latest_event = _latest_wave_event(wave)
+    return {
+        "wave_id": wave.wave_id,
+        "wave_state": wave.state,
+        "trigger_type": wave.trigger.trigger_type,
+        "trigger_id": wave.trigger.trigger_id,
+        "as_of_date": wave.as_of_date,
+        "created_at": wave.created_at,
+        "created_by": wave.created_by,
+        "item_count": len(wave.items),
+        "aggregate_metrics": wave.aggregate_metrics,
+        "supportability_state": supportability["supportability_state"],
+        "supportability_reason": supportability["reason"],
+        "latest_event_type": latest_event.event_type if latest_event is not None else None,
+        "latest_event_reason_code": latest_event.reason_code if latest_event is not None else None,
+    }
+
+
+def _latest_wave_event(wave: DpmRebalanceWave) -> DpmRebalanceWaveEvent | None:
+    if not wave.events:
+        return None
+    return wave.events[-1]
 
 
 __all__ = ["search_wave_summaries"]

--- a/tests/unit/dpm/waves/test_wave_search.py
+++ b/tests/unit/dpm/waves/test_wave_search.py
@@ -1,6 +1,12 @@
 from datetime import datetime, timezone
 
-from src.api.services.wave_search import search_wave_summaries
+from src.api.services.wave_search import (
+    _latest_wave_event,
+    _matches_supportability_state,
+    _searchable_wave_summary,
+    _wave_summary,
+    search_wave_summaries,
+)
 from src.core.waves import (
     DpmRebalanceWave,
     DpmRebalanceWaveEvent,
@@ -39,7 +45,17 @@ def _wave(
     wave_id: str,
     item_state: str,
     event_reason: str = "WAVE_CREATED",
+    with_event: bool = True,
 ) -> DpmRebalanceWave:
+    events = []
+    if with_event:
+        events.append(
+            DpmRebalanceWaveEvent.model_construct(
+                event_type="STATE_TRANSITION",
+                reason_code=event_reason,
+            )
+        )
+
     return DpmRebalanceWave.model_construct(
         wave_id=wave_id,
         state="SOURCE_CHECKED",
@@ -65,12 +81,7 @@ def _wave(
             review_required_item_count=0,
             source_degraded_item_count=0,
         ),
-        events=[
-            DpmRebalanceWaveEvent.model_construct(
-                event_type="STATE_TRANSITION",
-                reason_code=event_reason,
-            )
-        ],
+        events=events,
     )
 
 
@@ -112,6 +123,71 @@ def test_search_wave_summaries_filters_by_supportability_state() -> None:
 
     assert [summary["wave_id"] for summary in summaries] == ["dwv_blocked"]
     assert summaries[0]["supportability_state"] == "blocked"
+
+
+def test_searchable_wave_summary_filters_non_matching_supportability_state() -> None:
+    summary = _searchable_wave_summary(
+        wave=_wave(wave_id="dwv_ready", item_state="SOURCE_READY"),
+        supportability_state="blocked",
+    )
+
+    assert summary is None
+
+
+def test_wave_summary_projects_latest_event_fields() -> None:
+    wave = _wave(
+        wave_id="dwv_degraded",
+        item_state="SOURCE_DEGRADED",
+        event_reason="SOURCE_RECHECK_REQUIRED",
+    )
+    supportability = {
+        "supportability_state": "degraded",
+        "reason": "wave_degraded_items",
+    }
+
+    summary = _wave_summary(wave=wave, supportability=supportability)
+
+    assert summary["wave_id"] == "dwv_degraded"
+    assert summary["item_count"] == 1
+    assert summary["supportability_state"] == "degraded"
+    assert summary["supportability_reason"] == "wave_degraded_items"
+    assert summary["latest_event_type"] == "STATE_TRANSITION"
+    assert summary["latest_event_reason_code"] == "SOURCE_RECHECK_REQUIRED"
+
+
+def test_wave_summary_projects_empty_latest_event_fields() -> None:
+    wave = _wave(
+        wave_id="dwv_no_event",
+        item_state="SOURCE_READY",
+        with_event=False,
+    )
+    supportability = {
+        "supportability_state": "ready",
+        "reason": "wave_supportability_ready",
+    }
+
+    summary = _wave_summary(wave=wave, supportability=supportability)
+
+    assert _latest_wave_event(wave) is None
+    assert summary["latest_event_type"] is None
+    assert summary["latest_event_reason_code"] is None
+
+
+def test_matches_supportability_state_allows_unfiltered_and_exact_match() -> None:
+    supportability = {"supportability_state": "ready"}
+
+    assert _matches_supportability_state(
+        supportability=supportability,
+        supportability_state=None,
+    )
+    assert _matches_supportability_state(
+        supportability=supportability,
+        supportability_state="ready",
+    )
+    assert not _matches_supportability_state(
+        supportability=supportability,
+        supportability_state="blocked",
+    )
 
 
 def test_wave_search_exports_only_search_builder() -> None:


### PR DESCRIPTION
## Summary
- Extract deterministic wave search summary helpers from search_wave_summaries.
- Add direct helper tests for supportability-state filtering, latest-event projection, eventless wave projection, and match semantics.
- Refresh quality reports and codebase review ledger entries BACKEND-REVIEW-20260617-961 and BACKEND-REVIEW-20260617-962.

## Evidence
- python -m ruff format --check src/api/services/wave_search.py tests/unit/dpm/waves/test_wave_search.py
- python -m ruff check src/api/services/wave_search.py tests/unit/dpm/waves/test_wave_search.py
- python -m mypy --config-file mypy.ini src/api/services/wave_search.py
- python -m pytest tests/unit/dpm/waves/test_wave_search.py -q: 7 passed
- python -m pytest tests/unit/dpm/api/test_waves_api.py tests/unit/dpm/waves/test_wave_service_public_surface.py -q: 133 passed
- python -m radon cc src/api/services/wave_search.py -s: search_wave_summaries reduced from B(6) to A(3); all functions A grade
- python scripts/openapi_quality_gate.py
- python scripts/api_vocabulary_inventory.py --validate-only
- service leakage scan returned no matches
- git diff --check
- powershell -ExecutionPolicy Bypass -File ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage: DiffCount 0
- make check: 2804 passed, 13 skipped

## Residual risk
- Maintainability hardening only; no wave repository filter semantics, supportability classification, route contract, or global bank-buyable readiness claim.
- Remaining source hotspots are tracked in quality/complexity_report.md for later slices.