### PR TITLE
Refactor OpenAPI collection example helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24258,3 +24258,54 @@ and improves internal transaction-cost source posture maintainability only.
   rebalance-intent, or workflow-gate hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-965: OpenAPI collection example helpers
+
+- Date: 2026-06-17
+- Scope: `src/api/openapi_enrichment.py` and
+  `tests/unit/api/test_openapi_enrichment_helpers.py`.
+- Bank-buyable control area: API quality, documentation supportability, and testing.
+- Finding: `_collection_example_from_schema` combined object-property expansion, array-item
+  example generation, object-map handling, default object examples, and the no-match return path in
+  one dispatcher. That made OpenAPI example enrichment harder to audit even though each schema
+  shape has distinct supportability behavior.
+- Action: extracted helpers for property-object examples, array examples, and object/map examples;
+  added direct helper tests for each schema shape while preserving generated OpenAPI examples and
+  the existing enrichment entry point.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`,
+  `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`,
+  `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q`,
+  `python scripts/openapi_quality_gate.py`, and
+  `python -m radon cc src/api/openapi_enrichment.py -s`; the focused OpenAPI enrichment helper
+  suite reported 36 passed, the OpenAPI quality gate passed, and radon reports
+  `_collection_example_from_schema` reduced from B(8) to A(3).
+- Residual risk: this slice improves OpenAPI enrichment maintainability only. It does not change
+  public route contracts, response schemas, vocabulary policy, generated operation coverage,
+  runtime behavior, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal OpenAPI enrichment hardening
+  with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-966: OpenAPI collection example reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the OpenAPI collection-example helper extraction, the checked-in quality reports
+  needed to reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `982fadf2`, record 820 Python files, 2621 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `_collection_example_from_schema`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining enterprise-readiness, execution,
+  PM-quality, outcome snapshot, source-context, proof-pack, rebalance-intent, workflow-gate, or
+  wave source-analytics hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T04:19:42+00:00`
+- Generated at: `2026-06-17T04:37:38+00:00`
 
-- Report source snapshot: `6d419e6a`
+- Report source snapshot: `982fadf2`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 178096 |
-| Test functions | 2620 |
+| Total Python LOC | 178198 |
+| Test functions | 2621 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T04:19:42+00:00`
+- Generated at: `2026-06-17T04:37:38+00:00`
 
-- Report source snapshot: `6d419e6a`
+- Report source snapshot: `982fadf2`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _collection_example_from_schema | src/api/openapi_enrichment.py | 6 | 41 |
-| 2 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
-| 3 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
-| 4 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
-| 5 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
-| 6 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
-| 7 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
-| 8 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
-| 9 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
-| 10 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 1 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
+| 2 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
+| 3 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
+| 4 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
+| 5 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
+| 6 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
+| 7 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
+| 8 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
+| 9 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 10 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T04:19:42+00:00`
+- Generated at: `2026-06-17T04:37:38+00:00`
 
-- Report source snapshot: `6d419e6a`
+- Report source snapshot: `982fadf2`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T04:19:42+00:00`
+- Generated at: `2026-06-17T04:37:38+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `6d419e6a`
+- Report source snapshot: `982fadf2`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 820 | 820 | +0 |
-| Total Python LOC | 178002 | 178096 | +94 |
-| Test functions | 2618 | 2620 | +2 |
+| Total Python LOC | 178096 | 178198 | +102 |
+| Test functions | 2620 | 2621 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/openapi_enrichment.py
+++ b/src/api/openapi_enrichment.py
@@ -241,6 +241,36 @@ def _collection_example_from_schema(
     schemas: dict[str, Any],
     seen_refs: set[str],
 ) -> tuple[bool, Any]:
+    for matched, example in (
+        _properties_example_from_schema(
+            prop_schema=prop_schema,
+            schemas=schemas,
+            seen_refs=seen_refs,
+        ),
+        _array_example_from_schema(
+            prop_name=prop_name,
+            prop_schema=prop_schema,
+            schemas=schemas,
+            seen_refs=seen_refs,
+        ),
+        _object_example_from_schema(
+            prop_name=prop_name,
+            prop_schema=prop_schema,
+            schemas=schemas,
+            seen_refs=seen_refs,
+        ),
+    ):
+        if matched:
+            return True, example
+    return False, None
+
+
+def _properties_example_from_schema(
+    *,
+    prop_schema: dict[str, Any],
+    schemas: dict[str, Any],
+    seen_refs: set[str],
+) -> tuple[bool, Any]:
     properties = prop_schema.get("properties")
     if isinstance(properties, dict):
         return True, {
@@ -253,7 +283,16 @@ def _collection_example_from_schema(
             for child_name, child_schema in properties.items()
             if isinstance(child_schema, dict)
         }
+    return False, None
 
+
+def _array_example_from_schema(
+    *,
+    prop_name: str,
+    prop_schema: dict[str, Any],
+    schemas: dict[str, Any],
+    seen_refs: set[str],
+) -> tuple[bool, Any]:
     schema_type = prop_schema.get("type")
     if schema_type == "array":
         item_schema = prop_schema.get("items", {})
@@ -262,6 +301,17 @@ def _collection_example_from_schema(
                 _example_from_schema(f"{prop_name}_item", item_schema, schemas, seen_refs)
             ]
         return True, []
+    return False, None
+
+
+def _object_example_from_schema(
+    *,
+    prop_name: str,
+    prop_schema: dict[str, Any],
+    schemas: dict[str, Any],
+    seen_refs: set[str],
+) -> tuple[bool, Any]:
+    schema_type = prop_schema.get("type")
     if schema_type == "object":
         additional_properties = prop_schema.get("additionalProperties")
         if isinstance(additional_properties, dict):

--- a/tests/unit/api/test_openapi_enrichment_helpers.py
+++ b/tests/unit/api/test_openapi_enrichment_helpers.py
@@ -1,4 +1,5 @@
 from src.api.openapi_enrichment import (
+    _array_example_from_schema,
     _composite_example_from_schema,
     _collection_example_from_schema,
     _description_context,
@@ -22,7 +23,9 @@ from src.api.openapi_enrichment import (
     _number_example_for_key,
     _operation_has_error_response,
     _operation_tag_for_path,
+    _object_example_from_schema,
     _path_http_operations,
+    _properties_example_from_schema,
     _schema_example_schemas,
     _ref_example_from_schema,
     _resolved_schema_example,
@@ -239,6 +242,55 @@ def test_openapi_enrichment_collects_object_array_and_map_examples() -> None:
     ) == (True, {"sample_key": "sample_value"})
     assert _collection_example_from_schema(
         prop_name="value",
+        prop_schema={"type": "string"},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (False, None)
+
+
+def test_openapi_enrichment_collection_helpers_separate_schema_shapes() -> None:
+    schemas = {
+        "Leaf": {
+            "type": "object",
+            "properties": {"currency": {"type": "string"}, "amount": {"type": "number"}},
+        }
+    }
+
+    assert _properties_example_from_schema(
+        prop_schema={
+            "properties": {
+                "leaf": {"$ref": "#/components/schemas/Leaf"},
+                "ignored": "bad",
+            }
+        },
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (True, {"leaf": {"currency": "USD", "amount": 10.5}})
+    assert _properties_example_from_schema(
+        prop_schema={"type": "object"},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (False, None)
+    assert _array_example_from_schema(
+        prop_name="items",
+        prop_schema={"type": "array", "items": {"type": "integer"}},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (True, [10])
+    assert _array_example_from_schema(
+        prop_name="items",
+        prop_schema={"type": "string"},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (False, None)
+    assert _object_example_from_schema(
+        prop_name="metadata",
+        prop_schema={"type": "object", "additionalProperties": {"type": "boolean"}},
+        schemas=schemas,
+        seen_refs=set(),
+    ) == (True, {"sample_key": True})
+    assert _object_example_from_schema(
+        prop_name="metadata",
         prop_schema={"type": "string"},
         schemas=schemas,
         seen_refs=set(),


### PR DESCRIPTION
## Summary
- Extract OpenAPI collection-example generation into focused helpers for property objects, arrays, and object/map schemas.
- Add direct helper tests while preserving generated OpenAPI examples and the `enrich_openapi_schema` entry point.
- Refresh quality reports and codebase review ledger entries `BACKEND-REVIEW-20260617-965` and `BACKEND-REVIEW-20260617-966`.

## Evidence
- `python -m ruff format src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m ruff check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m ruff format --check src/api/openapi_enrichment.py tests/unit/api/test_openapi_enrichment_helpers.py`
- `python -m mypy --config-file mypy.ini src/api/openapi_enrichment.py`
- `python -m pytest tests/unit/api/test_openapi_enrichment_helpers.py -q` -> 36 passed
- `python -m radon cc src/api/openapi_enrichment.py -s` -> `_collection_example_from_schema` A(3), reduced from B(8)
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- service leakage scan -> no findings
- `git diff --check`
- `make check` -> 2820 passed

## Governance
- OpenAPI/vocabulary gates passed; no public route-contract or response-schema behavior changed.
- Service boundary findings remain 0; router infrastructure imports remain 0; OpenAPI missing markers remain 0.
- `git fetch origin --prune` + `git branch -r --no-merged origin/main` returned no unmerged remote branches before PR creation.
- Wiki check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0; no wiki publication required.
- Residual risk: this is OpenAPI enrichment maintainability hardening only. It does not change public route contracts, response schemas, vocabulary policy, generated operation coverage, runtime behavior, or global bank-buyable readiness.