### PR TITLE
Refactor enterprise audit middleware helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24309,3 +24309,55 @@ and improves internal transaction-cost source posture maintainability only.
   wave source-analytics hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-967: Enterprise audit middleware helpers
+
+- Date: 2026-06-17
+- Scope: `src/api/enterprise_readiness.py` and
+  `tests/unit/api/test_enterprise_readiness_hardening.py`.
+- Bank-buyable control area: security, auditability, observability supportability, and testing.
+- Finding: `build_enterprise_audit_middleware` kept payload-size parsing, authorization-denial
+  audit emission, denial response construction, policy-version response headers, and successful
+  write-audit emission inside the nested middleware function. That made the enterprise audit path
+  harder to inspect even though each step is deterministic and independently testable.
+- Action: extracted helpers for request content-length parsing, write-payload limit checks, audit
+  identity projection, denied-write audit emission, authorization-denied responses, policy-version
+  header attachment, and successful write-audit emission; added direct helper tests while
+  preserving middleware behavior and existing FastAPI registration.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`,
+  `python -m ruff check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`,
+  `python -m ruff format --check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`,
+  `python -m mypy --config-file mypy.ini src/api/enterprise_readiness.py`,
+  `python -m pytest tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py -q`,
+  and `python -m radon cc src/api/enterprise_readiness.py -s`; the focused enterprise readiness
+  suites reported 19 passed, and radon reports `build_enterprise_audit_middleware` at A(1) with
+  every middleware helper at A grade.
+- Residual risk: this slice improves enterprise audit middleware maintainability only. It does not
+  change authorization policy, audit event schema, redaction policy, runtime configuration
+  semantics, route contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal enterprise-readiness
+  maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-968: Enterprise audit middleware reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the enterprise audit middleware helper extraction, the checked-in quality reports
+  needed to reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `dfe98e3e`, record 820 Python files, 2622 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `build_enterprise_audit_middleware` or the nested
+  `middleware` entry from `src/api/enterprise_readiness.py`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining execution, PM-quality, outcome
+  snapshot, source-context, proof-pack, rebalance-intent, workflow-gate, wave source-analytics, or
+  async payload hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T04:37:38+00:00`
+- Generated at: `2026-06-17T04:54:32+00:00`
 
-- Report source snapshot: `982fadf2`
+- Report source snapshot: `dfe98e3e`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 178198 |
-| Test functions | 2621 |
+| Total Python LOC | 178307 |
+| Test functions | 2622 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T04:37:38+00:00`
+- Generated at: `2026-06-17T04:54:32+00:00`
 
-- Report source snapshot: `982fadf2`
+- Report source snapshot: `dfe98e3e`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_enterprise_audit_middleware | src/api/enterprise_readiness.py | 6 | 40 |
-| 2 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
-| 3 | middleware | src/api/enterprise_readiness.py | 6 | 37 |
-| 4 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
-| 5 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
-| 6 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
-| 7 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
-| 8 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
-| 9 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
-| 10 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 1 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
+| 2 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
+| 3 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
+| 4 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
+| 5 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
+| 6 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
+| 7 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 8 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 9 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
+| 10 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T04:37:38+00:00`
+- Generated at: `2026-06-17T04:54:32+00:00`
 
-- Report source snapshot: `982fadf2`
+- Report source snapshot: `dfe98e3e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T04:37:38+00:00`
+- Generated at: `2026-06-17T04:54:32+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `982fadf2`
+- Report source snapshot: `dfe98e3e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 820 | 820 | +0 |
-| Total Python LOC | 178096 | 178198 | +102 |
-| Test functions | 2620 | 2621 | +1 |
+| Total Python LOC | 178198 | 178307 | +109 |
+| Test functions | 2621 | 2622 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/enterprise_readiness.py
+++ b/src/api/enterprise_readiness.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
@@ -23,6 +24,14 @@ _REDACT_FIELDS = {
     "account_number",
     "client_email",
 }
+
+
+@dataclass(frozen=True)
+class _AuditIdentity:
+    actor_id: str
+    tenant_id: str
+    role: str
+    correlation_id: str | None
 
 
 def _env_enabled(name: str, default: str = "true") -> bool:
@@ -203,43 +212,85 @@ def emit_audit_event(
     )
 
 
+def _request_content_length(request: Request) -> int:
+    try:
+        return int(request.headers.get("content-length", "0"))
+    except ValueError:
+        return 0
+
+
+def _write_payload_too_large(request: Request, *, max_write_payload_bytes: int) -> bool:
+    return (
+        request.method in _WRITE_METHODS
+        and _request_content_length(request) > max_write_payload_bytes
+    )
+
+
+def _audit_identity_from_request(request: Request) -> _AuditIdentity:
+    return _AuditIdentity(
+        actor_id=request.headers.get("X-Actor-Id", "unknown"),
+        tenant_id=request.headers.get("X-Tenant-Id", "default"),
+        role=request.headers.get("X-Role", "unknown"),
+        correlation_id=request.headers.get("X-Correlation-Id"),
+    )
+
+
+def _emit_denied_write_audit(request: Request, *, reason: str | None) -> None:
+    identity = _audit_identity_from_request(request)
+    emit_audit_event(
+        action=f"DENY {request.method} {request.url.path}",
+        actor_id=identity.actor_id,
+        tenant_id=identity.tenant_id,
+        role=identity.role,
+        correlation_id=identity.correlation_id,
+        metadata={"reason": reason},
+    )
+
+
+def _authorization_denied_response(reason: str | None) -> JSONResponse:
+    return JSONResponse(
+        status_code=403,
+        content={"detail": "authorization_policy_denied", "reason": reason},
+    )
+
+
+def _attach_policy_version_header(response: Response) -> None:
+    response.headers["X-Enterprise-Policy-Version"] = enterprise_policy_version()
+
+
+def _emit_write_audit_if_needed(request: Request, response: Response) -> None:
+    if request.method not in _WRITE_METHODS:
+        return
+    identity = _audit_identity_from_request(request)
+    emit_audit_event(
+        action=f"{request.method} {request.url.path}",
+        actor_id=identity.actor_id,
+        tenant_id=identity.tenant_id,
+        role=identity.role,
+        correlation_id=identity.correlation_id,
+        metadata={"status_code": response.status_code},
+    )
+
+
 def build_enterprise_audit_middleware() -> MiddlewareCallable:
     async def middleware(request: Request, call_next: MiddlewareNext) -> Response:
         max_write_payload_bytes = _env_int("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", 1_048_576)
-        try:
-            content_length = int(request.headers.get("content-length", "0"))
-        except ValueError:
-            content_length = 0
-        if request.method in _WRITE_METHODS and content_length > max_write_payload_bytes:
+        if _write_payload_too_large(
+            request,
+            max_write_payload_bytes=max_write_payload_bytes,
+        ):
             return JSONResponse(status_code=413, content={"detail": "payload_too_large"})
 
         authorized, reason = authorize_write_request(
             request.method, request.url.path, dict(request.headers)
         )
         if not authorized:
-            emit_audit_event(
-                action=f"DENY {request.method} {request.url.path}",
-                actor_id=request.headers.get("X-Actor-Id", "unknown"),
-                tenant_id=request.headers.get("X-Tenant-Id", "default"),
-                role=request.headers.get("X-Role", "unknown"),
-                correlation_id=request.headers.get("X-Correlation-Id"),
-                metadata={"reason": reason},
-            )
-            return JSONResponse(
-                status_code=403, content={"detail": "authorization_policy_denied", "reason": reason}
-            )
+            _emit_denied_write_audit(request, reason=reason)
+            return _authorization_denied_response(reason)
 
         response = await call_next(request)
-        response.headers["X-Enterprise-Policy-Version"] = enterprise_policy_version()
-        if request.method in _WRITE_METHODS:
-            emit_audit_event(
-                action=f"{request.method} {request.url.path}",
-                actor_id=request.headers.get("X-Actor-Id", "unknown"),
-                tenant_id=request.headers.get("X-Tenant-Id", "default"),
-                role=request.headers.get("X-Role", "unknown"),
-                correlation_id=request.headers.get("X-Correlation-Id"),
-                metadata={"status_code": response.status_code},
-            )
+        _attach_policy_version_header(response)
+        _emit_write_audit_if_needed(request, response)
         return response
 
     return middleware

--- a/tests/unit/api/test_enterprise_readiness_hardening.py
+++ b/tests/unit/api/test_enterprise_readiness_hardening.py
@@ -1,15 +1,20 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from fastapi.testclient import TestClient
 import pytest
 
 from src.api.enterprise_readiness import (
+    _attach_policy_version_header,
+    _audit_identity_from_request,
     _authz_key_material_issue,
+    _authorization_denied_response,
     _has_service_identity,
+    _request_content_length,
     _missing_required_headers,
     _normalized_headers,
     _policy_version_issue,
     _provided_capabilities,
     _secret_rotation_issue,
+    _write_payload_too_large,
     _write_authorization_required,
     authorize_write_request,
     build_enterprise_audit_middleware,
@@ -17,6 +22,29 @@ from src.api.enterprise_readiness import (
     redact_sensitive,
     validate_enterprise_runtime_config,
 )
+
+
+def _request(
+    *,
+    method: str = "POST",
+    path: str = "/write",
+    headers: dict[str, str] | None = None,
+) -> Request:
+    raw_headers = [
+        (name.lower().encode("latin-1"), value.encode("latin-1"))
+        for name, value in (headers or {}).items()
+    ]
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": raw_headers,
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+        }
+    )
 
 
 def _enterprise_app() -> FastAPI:
@@ -168,6 +196,36 @@ def test_enterprise_middleware_treats_invalid_content_length_as_zero(monkeypatch
     )
 
     assert response.status_code == 200
+
+
+def test_enterprise_middleware_helpers_parse_size_and_audit_identity(monkeypatch) -> None:
+    monkeypatch.setenv("ENTERPRISE_POLICY_VERSION", "2.1.0")
+    request = _request(
+        headers={
+            "content-length": "6",
+            "X-Actor-Id": "actor",
+            "X-Tenant-Id": "tenant",
+            "X-Role": "operator",
+            "X-Correlation-Id": "corr",
+        }
+    )
+    invalid_length_request = _request(headers={"content-length": "not-a-number"})
+
+    identity = _audit_identity_from_request(request)
+    response = Response()
+    denied_response = _authorization_denied_response("missing_service_identity")
+    _attach_policy_version_header(response)
+
+    assert _request_content_length(request) == 6
+    assert _request_content_length(invalid_length_request) == 0
+    assert _write_payload_too_large(request, max_write_payload_bytes=5)
+    assert not _write_payload_too_large(request, max_write_payload_bytes=6)
+    assert identity.actor_id == "actor"
+    assert identity.tenant_id == "tenant"
+    assert identity.role == "operator"
+    assert identity.correlation_id == "corr"
+    assert response.headers["X-Enterprise-Policy-Version"] == "2.1.0"
+    assert denied_response.status_code == 403
 
 
 def test_enterprise_middleware_denies_and_audits_unauthorized_write(monkeypatch, caplog) -> None:


### PR DESCRIPTION
## Summary
- Extracted small enterprise audit middleware helpers for content-length parsing, write-payload guard evaluation, audit identity mapping, denial response construction, policy-version header attachment, and write audit emission.
- Added direct helper coverage while preserving middleware behavior.
- Refreshed engineering health reports and the codebase review ledger for this slice.

## Evidence
- `python -m ruff format src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`
- `python -m ruff check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`
- `python -m ruff format --check src/api/enterprise_readiness.py tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py`
- `python -m mypy --config-file mypy.ini src/api/enterprise_readiness.py`
- `python -m pytest tests/unit/api/test_enterprise_readiness.py tests/unit/api/test_enterprise_readiness_hardening.py -q` -> 19 passed
- `python -m radon cc src/api/enterprise_readiness.py -s` -> `build_enterprise_audit_middleware` A(1), extracted helpers A-grade
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- Service leakage scan for FastAPI/router imports in `src/api/services` -> no findings
- `git diff --check`
- `make check` -> 2821 passed
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0
- `git branch -r --no-merged origin/main` -> no unmerged remote branches before PR creation

## Notes
- No README/wiki/operator truth changed in this slice.
- This is a focused maintainability and CI-measurement-backed refactor; it does not claim bank-buyable readiness by itself.