### PR TITLE
Refactor settlement cash-flow helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24361,3 +24361,53 @@ and improves internal transaction-cost source posture maintainability only.
   async payload hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-969: Settlement cash-flow helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/rebalance/execution.py` and
+  `tests/unit/dpm/engine/test_engine_settlement_awareness.py`.
+- Bank-buyable control area: architecture, resilience, settlement supportability, and testing.
+- Finding: `_apply_intent_settlement_flows` combined intent ordering, security-trade cash-flow
+  settlement, FX-spot cash-flow settlement, notional absence handling, settlement-day lookup, and
+  currency ladder initialization in one dispatcher. That made the settlement-awareness path harder
+  to inspect even though security settlement and FX settlement have distinct cash-flow rules.
+- Action: extracted security-trade settlement-flow, security-trade signed-amount, and FX-spot
+  settlement-flow helpers; added direct helper tests for security-side settlement timing and FX
+  sell/buy currency movement while preserving the existing end-to-end settlement cash-flow shape.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/core/rebalance/execution.py tests/unit/dpm/engine/test_engine_settlement_awareness.py`,
+  `python -m ruff check src/core/rebalance/execution.py tests/unit/dpm/engine/test_engine_settlement_awareness.py`,
+  `python -m ruff format --check src/core/rebalance/execution.py tests/unit/dpm/engine/test_engine_settlement_awareness.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/execution.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_settlement_awareness.py -q`,
+  and `python -m radon cc src/core/rebalance/execution.py -s`; the focused settlement-awareness
+  suite reported 8 passed, and radon reports `_apply_intent_settlement_flows` reduced from B(6) to
+  A(4) with the extracted settlement-flow helpers at A grade.
+- Residual risk: this slice improves settlement cash-flow maintainability only. It does not change
+  settlement policy, overdraft policy, FX generation, order dependency linking, reconciliation,
+  execution behavior, route contracts, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal rebalance execution
+  maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-970: Settlement cash-flow reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the settlement cash-flow helper extraction, the checked-in quality reports needed
+  to reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `1776aa5f`, record 820 Python files, 2624 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `_apply_intent_settlement_flows`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining PM-quality, outcome snapshot,
+  source-context, proof-pack, rebalance-intent, workflow-gate, wave source-analytics, async payload,
+  or target-cash hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T04:54:32+00:00`
+- Generated at: `2026-06-17T05:12:42+00:00`
 
-- Report source snapshot: `dfe98e3e`
+- Report source snapshot: `1776aa5f`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 820 |
-| Total Python LOC | 178307 |
-| Test functions | 2622 |
+| Total Python LOC | 178412 |
+| Test functions | 2624 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T04:54:32+00:00`
+- Generated at: `2026-06-17T05:12:42+00:00`
 
-- Report source snapshot: `dfe98e3e`
+- Report source snapshot: `1776aa5f`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _apply_intent_settlement_flows | src/core/rebalance/execution.py | 6 | 39 |
-| 2 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
-| 3 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
-| 4 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
-| 5 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
-| 6 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
-| 7 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
-| 8 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
-| 9 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
-| 10 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 1 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
+| 2 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
+| 3 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
+| 4 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
+| 5 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
+| 6 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 7 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 8 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
+| 9 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 10 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T04:54:32+00:00`
+- Generated at: `2026-06-17T05:12:42+00:00`
 
-- Report source snapshot: `dfe98e3e`
+- Report source snapshot: `1776aa5f`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T04:54:32+00:00`
+- Generated at: `2026-06-17T05:12:42+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `dfe98e3e`
+- Report source snapshot: `1776aa5f`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 820 | 820 | +0 |
-| Total Python LOC | 178198 | 178307 | +109 |
-| Test functions | 2621 | 2622 | +1 |
+| Total Python LOC | 178307 | 178412 | +105 |
+| Test functions | 2622 | 2624 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/rebalance/execution.py
+++ b/src/core/rebalance/execution.py
@@ -148,36 +148,69 @@ def _apply_intent_settlement_flows(
     options: EngineOptions,
 ) -> None:
     for intent in sorted(intents, key=lambda item: item.intent_id):
-        if intent.intent_type == "SECURITY_TRADE":
-            if intent.notional is None:
-                continue
-            settlement_day = settlement_days_by_instrument.get(intent.instrument_id, 2)
-            _ensure_settlement_currency(
+        if isinstance(intent, SecurityTradeIntent):
+            _apply_security_trade_settlement_flow(
                 flows=flows,
-                currency=intent.notional.currency,
+                intent=intent,
+                settlement_days_by_instrument=settlement_days_by_instrument,
                 horizon_days=horizon_days,
             )
-            signed_flow = (
-                intent.notional.amount if intent.side == "SELL" else -intent.notional.amount
+        elif isinstance(intent, FxSpotIntent):
+            _apply_fx_spot_settlement_flow(
+                flows=flows,
+                intent=intent,
+                horizon_days=horizon_days,
+                fx_settlement_days=options.fx_settlement_days,
             )
-            flows[intent.notional.currency][settlement_day] += signed_flow
-            continue
 
-        if intent.intent_type != "FX_SPOT":
-            continue
 
-        _ensure_settlement_currency(
-            flows=flows,
-            currency=intent.sell_currency,
-            horizon_days=horizon_days,
-        )
-        _ensure_settlement_currency(
-            flows=flows,
-            currency=intent.buy_currency,
-            horizon_days=horizon_days,
-        )
-        flows[intent.sell_currency][options.fx_settlement_days] -= intent.sell_amount_estimated
-        flows[intent.buy_currency][options.fx_settlement_days] += intent.buy_amount
+def _apply_security_trade_settlement_flow(
+    *,
+    flows: dict[str, list[Decimal]],
+    intent: SecurityTradeIntent,
+    settlement_days_by_instrument: dict[str, int],
+    horizon_days: int,
+) -> None:
+    if intent.notional is None:
+        return
+
+    settlement_day = settlement_days_by_instrument.get(intent.instrument_id, 2)
+    currency = intent.notional.currency
+    _ensure_settlement_currency(
+        flows=flows,
+        currency=currency,
+        horizon_days=horizon_days,
+    )
+    flows[currency][settlement_day] += _security_trade_settlement_amount(intent)
+
+
+def _security_trade_settlement_amount(intent: SecurityTradeIntent) -> Decimal:
+    if intent.notional is None:
+        return Decimal("0")
+    if intent.side == "SELL":
+        return intent.notional.amount
+    return -intent.notional.amount
+
+
+def _apply_fx_spot_settlement_flow(
+    *,
+    flows: dict[str, list[Decimal]],
+    intent: FxSpotIntent,
+    horizon_days: int,
+    fx_settlement_days: int,
+) -> None:
+    _ensure_settlement_currency(
+        flows=flows,
+        currency=intent.sell_currency,
+        horizon_days=horizon_days,
+    )
+    _ensure_settlement_currency(
+        flows=flows,
+        currency=intent.buy_currency,
+        horizon_days=horizon_days,
+    )
+    flows[intent.sell_currency][fx_settlement_days] -= intent.sell_amount_estimated
+    flows[intent.buy_currency][fx_settlement_days] += intent.buy_amount
 
 
 def _append_settlement_ladder_points(

--- a/tests/unit/dpm/engine/test_engine_settlement_awareness.py
+++ b/tests/unit/dpm/engine/test_engine_settlement_awareness.py
@@ -2,6 +2,8 @@ from decimal import Decimal
 
 from src.core.rebalance.engine import run_simulation
 from src.core.rebalance.execution import (
+    _apply_fx_spot_settlement_flow,
+    _apply_security_trade_settlement_flow,
     _append_settlement_ladder_points,
     _settlement_ladder_projection_for_currency,
     _settlement_cash_flows,
@@ -165,6 +167,76 @@ def test_settlement_cash_flows_apply_security_and_fx_settlement_days() -> None:
         Decimal("-80"),
         Decimal("-55"),
         Decimal("30"),
+    ]
+    assert flows["EUR"] == [
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("50"),
+        Decimal("0"),
+    ]
+
+
+def test_security_trade_settlement_flow_applies_side_and_instrument_settlement_day() -> None:
+    flows: dict[str, list[Decimal]] = {}
+
+    _apply_security_trade_settlement_flow(
+        flows=flows,
+        intent=SecurityTradeIntent(
+            intent_id="oi_sell_slow",
+            instrument_id="SLOW_FUND",
+            side="SELL",
+            quantity=Decimal("1"),
+            notional=Money(amount=Decimal("30"), currency="USD"),
+            notional_base=Money(amount=Decimal("30"), currency="USD"),
+        ),
+        settlement_days_by_instrument={"SLOW_FUND": 3},
+        horizon_days=3,
+    )
+    _apply_security_trade_settlement_flow(
+        flows=flows,
+        intent=SecurityTradeIntent(
+            intent_id="oi_buy_fast",
+            instrument_id="FAST_STOCK",
+            side="BUY",
+            quantity=Decimal("2"),
+            notional=Money(amount=Decimal("80"), currency="USD"),
+            notional_base=Money(amount=Decimal("80"), currency="USD"),
+        ),
+        settlement_days_by_instrument={"FAST_STOCK": 1},
+        horizon_days=3,
+    )
+
+    assert flows["USD"] == [
+        Decimal("0"),
+        Decimal("-80"),
+        Decimal("0"),
+        Decimal("30"),
+    ]
+
+
+def test_fx_spot_settlement_flow_applies_sell_and_buy_currency_on_fx_day() -> None:
+    flows: dict[str, list[Decimal]] = {}
+
+    _apply_fx_spot_settlement_flow(
+        flows=flows,
+        intent=FxSpotIntent(
+            intent_id="oi_fx_eur",
+            pair="EUR/USD",
+            buy_currency="EUR",
+            buy_amount=Decimal("50"),
+            sell_currency="USD",
+            sell_amount_estimated=Decimal("55"),
+            rationale=IntentRationale(code="FUNDING", message="Fund EUR purchase."),
+        ),
+        horizon_days=3,
+        fx_settlement_days=2,
+    )
+
+    assert flows["USD"] == [
+        Decimal("0"),
+        Decimal("0"),
+        Decimal("-55"),
+        Decimal("0"),
     ]
     assert flows["EUR"] == [
         Decimal("0"),


### PR DESCRIPTION
## Summary
- Extracted focused settlement cash-flow helpers for security-trade and FX-spot settlement movement in the rebalance execution core.
- Added direct settlement helper tests while preserving the existing settlement cash-flow behavior.
- Refreshed quality reports and codebase review ledger entries for this slice.

## Evidence
- `python -m ruff format src/core/rebalance/execution.py tests/unit/dpm/engine/test_engine_settlement_awareness.py`
- `python -m ruff check src/core/rebalance/execution.py tests/unit/dpm/engine/test_engine_settlement_awareness.py`
- `python -m ruff format --check src/core/rebalance/execution.py tests/unit/dpm/engine/test_engine_settlement_awareness.py`
- `python -m mypy --config-file mypy.ini src/core/rebalance/execution.py`
- `python -m pytest tests/unit/dpm/engine/test_engine_settlement_awareness.py -q` -> 8 passed
- `python -m radon cc src/core/rebalance/execution.py -s` -> `_apply_intent_settlement_flows` A(4), extracted helpers A-grade
- `python scripts/engineering_health_report.py`
- `python scripts/openapi_quality_gate.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`
- Service leakage scan for FastAPI/router imports in `src/api/services` -> no findings
- `git diff --check origin/main..HEAD`
- `make check` -> 2823 passed
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0
- `git branch -r --no-merged origin/main` -> no unmerged remote branches before PR creation

## Notes
- No public route contract, settlement policy, FX generation, dependency linking, reconciliation, or runtime behavior changed intentionally.
- No README/wiki/operator truth changed in this slice.
- Residual hotspots remain recorded in `quality/complexity_report.md`; this PR does not claim global bank-buyable readiness.