### PR TITLE
Refactor PM review action builder helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24411,3 +24411,56 @@ and improves internal transaction-cost source posture maintainability only.
   or target-cash hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-971: PM operating quality review action helpers
+
+- Date: 2026-06-17
+- Scope: `src/api/routers/pm_operating_quality_review_action_builder.py` and
+  `tests/unit/api/test_pm_operating_quality_review_action_builder.py`.
+- Bank-buyable control area: architecture, API error translation, auditability, and testing.
+- Finding: `build_review_action` combined score-run target lookup, fairness-analysis target
+  lookup, stable HTTP not-found translation, domain review-action construction, validation-error
+  translation, and fallback correlation-id selection inside one router helper. That made the
+  review-action route adapter harder to inspect even though each step has a narrow responsibility.
+- Action: extracted target resolution helpers for score-run and fairness-analysis review targets,
+  isolated review-action construction with validation translation, and added direct unit tests for
+  both target families, both stable missing-target HTTP codes, header correlation-id use, actor-id
+  fallback, and domain validation-error mapping.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/api/routers/pm_operating_quality_review_action_builder.py tests/unit/api/test_pm_operating_quality_review_action_builder.py`,
+  `python -m ruff check src/api/routers/pm_operating_quality_review_action_builder.py tests/unit/api/test_pm_operating_quality_review_action_builder.py`,
+  `python -m ruff format --check src/api/routers/pm_operating_quality_review_action_builder.py tests/unit/api/test_pm_operating_quality_review_action_builder.py`,
+  `python -m mypy --config-file mypy.ini src/api/routers/pm_operating_quality_review_action_builder.py tests/unit/api/test_pm_operating_quality_review_action_builder.py`,
+  `python -m pytest tests/unit/api/test_pm_operating_quality_review_action_builder.py -q`,
+  and `python -m radon cc src/api/routers/pm_operating_quality_review_action_builder.py -s`; the
+  focused review-action builder suite reported 5 passed, and radon reports `build_review_action`
+  reduced from B(6) to A(1) with every extracted helper at A grade.
+- Residual risk: this slice improves PM operating quality review-action adapter maintainability
+  only. It does not change route contracts, repository behavior, PM-quality scoring, fairness
+  analysis methodology, broader approval workflow boundaries, review-action persistence semantics,
+  or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal PM operating quality router
+  maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-972: PM operating quality review action reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the PM operating quality review-action helper extraction, the checked-in quality
+  reports needed to reflect the updated branch head, test-function count, and current source
+  hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `abd76e4c`, record 821 Python files, 2628 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `build_review_action`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining outcome snapshot, source-context,
+  proof-pack, rebalance-intent, workflow-gate, wave source-analytics, async payload, target-cash, or
+  workflow-decision query hotspots, or certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T05:12:42+00:00`
+- Generated at: `2026-06-17T05:33:19+00:00`
 
-- Report source snapshot: `1776aa5f`
+- Report source snapshot: `abd76e4c`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -10,9 +10,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 820 |
-| Total Python LOC | 178412 |
-| Test functions | 2624 |
+| Python files | 821 |
+| Total Python LOC | 178683 |
+| Test functions | 2628 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T05:12:42+00:00`
+- Generated at: `2026-06-17T05:33:19+00:00`
 
-- Report source snapshot: `1776aa5f`
+- Report source snapshot: `abd76e4c`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_review_action | src/api/routers/pm_operating_quality_review_action_builder.py | 6 | 37 |
-| 2 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
-| 3 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
-| 4 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
-| 5 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
-| 6 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
-| 7 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
-| 8 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
-| 9 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
-| 10 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
+| 1 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
+| 2 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
+| 3 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
+| 4 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
+| 5 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 6 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 7 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
+| 8 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 9 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
+| 10 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T05:12:42+00:00`
+- Generated at: `2026-06-17T05:33:19+00:00`
 
-- Report source snapshot: `1776aa5f`
+- Report source snapshot: `abd76e4c`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T05:12:42+00:00`
+- Generated at: `2026-06-17T05:33:19+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `1776aa5f`
+- Report source snapshot: `abd76e4c`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 820 | 820 | +0 |
-| Total Python LOC | 178307 | 178412 | +105 |
-| Test functions | 2622 | 2624 | +2 |
+| Python files | 820 | 821 | +1 |
+| Total Python LOC | 178412 | 178683 | +271 |
+| Test functions | 2624 | 2628 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/routers/pm_operating_quality_review_action_builder.py
+++ b/src/api/routers/pm_operating_quality_review_action_builder.py
@@ -24,21 +24,71 @@ def build_review_action(
     fairness_repository: DpmPmQualityFairnessAnalysisRepository,
     review_action_builder: Callable[..., DpmPmQualityReviewAction],
 ) -> DpmPmQualityReviewAction:
-    target: DpmPmOperatingQualityScoreRun | DpmPmQualityFairnessAnalysis | None
+    target = _review_action_target(
+        request=request,
+        score_run_repository=score_run_repository,
+        fairness_repository=fairness_repository,
+    )
+    return _build_review_action_with_validation(
+        request=request,
+        target=target,
+        x_correlation_id=x_correlation_id,
+        review_action_builder=review_action_builder,
+    )
+
+
+def _review_action_target(
+    *,
+    request: DpmPmQualityReviewActionRequest,
+    score_run_repository: DpmPmQualityScoreRunRepository,
+    fairness_repository: DpmPmQualityFairnessAnalysisRepository,
+) -> DpmPmOperatingQualityScoreRun | DpmPmQualityFairnessAnalysis:
     if request.target_type == "SCORE_RUN":
-        target = score_run_repository.get_score_run(score_run_id=request.target_id)
-        if target is None:
-            raise pm_quality_not_found_http_exception(
-                code="PM_QUALITY_SCORE_RUN_NOT_FOUND",
-                identifier=request.target_id,
-            )
-    else:
-        target = fairness_repository.get_fairness_analysis(fairness_analysis_id=request.target_id)
-        if target is None:
-            raise pm_quality_not_found_http_exception(
-                code="PM_QUALITY_FAIRNESS_ANALYSIS_NOT_FOUND",
-                identifier=request.target_id,
-            )
+        return _score_run_review_action_target(
+            score_run_id=request.target_id,
+            score_run_repository=score_run_repository,
+        )
+    return _fairness_review_action_target(
+        fairness_analysis_id=request.target_id,
+        fairness_repository=fairness_repository,
+    )
+
+
+def _score_run_review_action_target(
+    *,
+    score_run_id: str,
+    score_run_repository: DpmPmQualityScoreRunRepository,
+) -> DpmPmOperatingQualityScoreRun:
+    target = score_run_repository.get_score_run(score_run_id=score_run_id)
+    if target is None:
+        raise pm_quality_not_found_http_exception(
+            code="PM_QUALITY_SCORE_RUN_NOT_FOUND",
+            identifier=score_run_id,
+        )
+    return target
+
+
+def _fairness_review_action_target(
+    *,
+    fairness_analysis_id: str,
+    fairness_repository: DpmPmQualityFairnessAnalysisRepository,
+) -> DpmPmQualityFairnessAnalysis:
+    target = fairness_repository.get_fairness_analysis(fairness_analysis_id=fairness_analysis_id)
+    if target is None:
+        raise pm_quality_not_found_http_exception(
+            code="PM_QUALITY_FAIRNESS_ANALYSIS_NOT_FOUND",
+            identifier=fairness_analysis_id,
+        )
+    return target
+
+
+def _build_review_action_with_validation(
+    *,
+    request: DpmPmQualityReviewActionRequest,
+    target: DpmPmOperatingQualityScoreRun | DpmPmQualityFairnessAnalysis,
+    x_correlation_id: str | None,
+    review_action_builder: Callable[..., DpmPmQualityReviewAction],
+) -> DpmPmQualityReviewAction:
     try:
         return review_action_builder(
             target=target,
@@ -49,7 +99,18 @@ def build_review_action(
             actor_id=request.actor_id,
             source_refs=request.source_refs,
             remediation_due_date=request.remediation_due_date,
-            correlation_id=x_correlation_id or request.actor_id,
+            correlation_id=_review_action_correlation_id(
+                request=request,
+                x_correlation_id=x_correlation_id,
+            ),
         )
     except ValueError as exc:
         raise pm_quality_validation_http_exception(exc) from exc
+
+
+def _review_action_correlation_id(
+    *,
+    request: DpmPmQualityReviewActionRequest,
+    x_correlation_id: str | None,
+) -> str:
+    return x_correlation_id or request.actor_id

--- a/tests/unit/api/test_pm_operating_quality_review_action_builder.py
+++ b/tests/unit/api/test_pm_operating_quality_review_action_builder.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from src.api.routers.pm_operating_quality_models import DpmPmQualityReviewActionRequest
+from src.api.routers.pm_operating_quality_review_action_builder import build_review_action
+from src.core.pm_quality import (
+    DpmPmOperatingQualityPolicy,
+    DpmPmOperatingQualityScoreRun,
+    DpmPmQualityEvidenceItem,
+    DpmPmQualityFairnessAnalysis,
+    DpmPmQualityFairnessSegmentInput,
+    DpmPmQualityGovernanceApproval,
+    DpmPmQualityReviewAction,
+    DpmPmQualityWeight,
+    PmQualityReviewActionTargetType,
+    build_pm_operating_quality_fairness_analysis,
+    build_pm_operating_quality_score_run,
+    build_pm_quality_review_action,
+)
+from src.infrastructure.pm_quality import (
+    InMemoryDpmPmQualityFairnessAnalysisRepository,
+    InMemoryDpmPmQualityScoreRunRepository,
+)
+
+
+def _policy() -> DpmPmOperatingQualityPolicy:
+    return DpmPmOperatingQualityPolicy(
+        policy_id="pmq_sg_dpm",
+        policy_version="2026.05",
+        enabled=True,
+        as_of_date="2026-05-12",
+        access_purpose="SUPERVISORY_CONTROL_REVIEW",
+        weights=[
+            DpmPmQualityWeight(
+                indicator="SOURCE_QUALITY",
+                weight=Decimal("100"),
+                minimum_evidence_count=1,
+            )
+        ],
+        governance_approval=DpmPmQualityGovernanceApproval(
+            approval_ref="PMQ-APPROVAL-2026-05",
+            approved_by="pm_quality_committee",
+            approved_at="2026-05-10T09:00:00Z",
+            fairness_review_ref="FAIRNESS-PMQ-2026-05",
+            fairness_reviewed_by="model_risk_governance",
+            fairness_reviewed_at="2026-05-10T10:00:00Z",
+        ),
+    )
+
+
+def _score_run(
+    *,
+    pm_id: str = "pm_001",
+    score: Decimal = Decimal("91"),
+    correlation_id: str = "corr-score",
+) -> DpmPmOperatingQualityScoreRun:
+    return build_pm_operating_quality_score_run(
+        pm_id=pm_id,
+        book_id="sg_dpm_book",
+        as_of_date="2026-05-12",
+        policy=_policy(),
+        evidence_items=[
+            DpmPmQualityEvidenceItem(
+                indicator="SOURCE_QUALITY",
+                evidence_state="READY",
+                score=score,
+                source_system="lotus-risk",
+                source_type="RiskMetricsReport",
+                source_id=f"risk-{pm_id}",
+            )
+        ],
+        outcome_reviews=[],
+        generated_by="ops",
+        correlation_id=correlation_id,
+    )
+
+
+def _fairness_analysis() -> DpmPmQualityFairnessAnalysis:
+    return build_pm_operating_quality_fairness_analysis(
+        policy_id="pmq_sg_dpm",
+        policy_version="2026.05",
+        as_of_date="2026-05-12",
+        segments=[
+            DpmPmQualityFairnessSegmentInput(
+                segment_id="balanced",
+                segment_type="MANDATE_TYPE",
+                display_name="Balanced mandates",
+                score_runs=[_score_run(pm_id="pm_001", score=Decimal("91"))],
+                source_refs=[],
+            ),
+            DpmPmQualityFairnessSegmentInput(
+                segment_id="growth",
+                segment_type="MANDATE_TYPE",
+                display_name="Growth mandates",
+                score_runs=[_score_run(pm_id="pm_002", score=Decimal("89"))],
+                source_refs=[],
+            ),
+        ],
+        minimum_segment_score_run_count=1,
+        maximum_average_score_spread=Decimal("15"),
+        generated_by="ops",
+        correlation_id="corr-fairness",
+    )
+
+
+def _review_action_request(
+    *,
+    target_type: PmQualityReviewActionTargetType = "SCORE_RUN",
+    target_id: str,
+    actor_id: str = "ops",
+) -> DpmPmQualityReviewActionRequest:
+    return DpmPmQualityReviewActionRequest(
+        target_type=target_type,
+        target_id=target_id,
+        action_type="ACKNOWLEDGE",
+        review_action_ref="PMQ-REVIEW-2026-05-001",
+        review_reason="Reviewed and acknowledged.",
+        actor_id=actor_id,
+        source_refs=[],
+    )
+
+
+def test_build_review_action_resolves_score_run_target_and_uses_header_correlation_id() -> None:
+    score_run_repository = InMemoryDpmPmQualityScoreRunRepository()
+    score_run = _score_run()
+    score_run_repository.save_score_run(score_run=score_run)
+
+    review_action = build_review_action(
+        request=_review_action_request(target_id=score_run.score_run_id),
+        x_correlation_id="corr-header",
+        score_run_repository=score_run_repository,
+        fairness_repository=InMemoryDpmPmQualityFairnessAnalysisRepository(),
+        review_action_builder=build_pm_quality_review_action,
+    )
+
+    assert review_action.target_type == "SCORE_RUN"
+    assert review_action.target_id == score_run.score_run_id
+    assert review_action.correlation_id == "corr-header"
+
+
+def test_build_review_action_resolves_fairness_target_and_falls_back_to_actor_id() -> None:
+    fairness_repository = InMemoryDpmPmQualityFairnessAnalysisRepository()
+    analysis = _fairness_analysis()
+    fairness_repository.save_fairness_analysis(analysis=analysis)
+
+    review_action = build_review_action(
+        request=_review_action_request(
+            target_type="FAIRNESS_ANALYSIS",
+            target_id=analysis.fairness_analysis_id,
+            actor_id="supervisor",
+        ),
+        x_correlation_id=None,
+        score_run_repository=InMemoryDpmPmQualityScoreRunRepository(),
+        fairness_repository=fairness_repository,
+        review_action_builder=build_pm_quality_review_action,
+    )
+
+    assert review_action.target_type == "FAIRNESS_ANALYSIS"
+    assert review_action.target_id == analysis.fairness_analysis_id
+    assert review_action.correlation_id == "supervisor"
+
+
+@pytest.mark.parametrize(
+    ("target_type", "detail"),
+    [
+        ("SCORE_RUN", "PM_QUALITY_SCORE_RUN_NOT_FOUND:missing"),
+        ("FAIRNESS_ANALYSIS", "PM_QUALITY_FAIRNESS_ANALYSIS_NOT_FOUND:missing"),
+    ],
+)
+def test_build_review_action_reports_missing_targets_with_stable_http_codes(
+    target_type: PmQualityReviewActionTargetType,
+    detail: str,
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        build_review_action(
+            request=_review_action_request(target_type=target_type, target_id="missing"),
+            x_correlation_id="corr",
+            score_run_repository=InMemoryDpmPmQualityScoreRunRepository(),
+            fairness_repository=InMemoryDpmPmQualityFairnessAnalysisRepository(),
+            review_action_builder=build_pm_quality_review_action,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == detail
+
+
+def test_build_review_action_translates_domain_validation_errors() -> None:
+    score_run_repository = InMemoryDpmPmQualityScoreRunRepository()
+    score_run = _score_run()
+    score_run_repository.save_score_run(score_run=score_run)
+
+    def rejected_review_action_builder(**_: Any) -> DpmPmQualityReviewAction:
+        raise ValueError("PM_QUALITY_REVIEW_ACTION_TARGET_TYPE_MISMATCH")
+
+    with pytest.raises(HTTPException) as exc_info:
+        build_review_action(
+            request=_review_action_request(target_id=score_run.score_run_id),
+            x_correlation_id="corr",
+            score_run_repository=score_run_repository,
+            fairness_repository=InMemoryDpmPmQualityFairnessAnalysisRepository(),
+            review_action_builder=rejected_review_action_builder,
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "PM_QUALITY_REVIEW_ACTION_TARGET_TYPE_MISMATCH"


### PR DESCRIPTION
## Summary
- Extract PM operating quality review-action target resolution and validation translation helpers from the router adapter.
- Add direct unit coverage for score-run and fairness-analysis review targets, missing-target HTTP codes, correlation-id fallback, and domain validation mapping.
- Refresh quality reports and codebase review ledger entries through BACKEND-REVIEW-20260617-972.

## Validation
- `python -m ruff format src\api\routers\pm_operating_quality_review_action_builder.py tests\unit\api\test_pm_operating_quality_review_action_builder.py`
- `python -m ruff check src\api\routers\pm_operating_quality_review_action_builder.py tests\unit\api\test_pm_operating_quality_review_action_builder.py`
- `python -m ruff format --check src\api\routers\pm_operating_quality_review_action_builder.py tests\unit\api\test_pm_operating_quality_review_action_builder.py`
- `python -m mypy --config-file mypy.ini src\api\routers\pm_operating_quality_review_action_builder.py tests\unit\api\test_pm_operating_quality_review_action_builder.py`
- `python -m pytest tests\unit\api\test_pm_operating_quality_review_action_builder.py -q` -> 5 passed
- `python -m radon cc src\api\routers\pm_operating_quality_review_action_builder.py -s` -> `build_review_action` A(1), helpers A grade
- `python scripts\engineering_health_report.py`
- `python scripts\openapi_quality_gate.py`
- `python scripts\api_vocabulary_inventory.py --validate-only`
- service leakage scan returned no findings
- `git diff --check origin/main..HEAD`
- `make check` -> 2828 passed

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no branches before PR.
- Wiki: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned DiffCount 0.
- Scope: internal router-helper maintainability and measurement evidence only; no API contract, route behavior, persistence, scoring, or operator-facing wiki truth changes.