### PR TITLE
Refactor expected outcome supportability roll-up

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24464,3 +24464,55 @@ and improves internal transaction-cost source posture maintainability only.
   workflow-decision query hotspots, or certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-973: Expected outcome supportability roll-up helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/outcomes/snapshots.py` and
+  `tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`.
+- Bank-buyable control area: architecture, outcome evidence supportability, and testing.
+- Finding: `_roll_up_expected_supportability` combined evidence-state collection, supportability
+  precedence selection, reason-code assembly, and supportability DTO creation. That made the
+  expected-outcome snapshot path harder to inspect even though state collection and precedence are
+  deterministic, domain-level rules.
+- Action: extracted helpers for expected supportability state collection and highest-state
+  precedence selection; added direct tests for roll-up precedence and construction/proof-pack/wave/
+  handoff state collection while preserving the assembled expected-snapshot behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m ruff check src/core/outcomes/snapshots.py tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py`,
+  `python -m mypy --config-file mypy.ini src/core/outcomes/snapshots.py`,
+  `python -m pytest tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py -q`,
+  and `python -m radon cc src/core/outcomes/snapshots.py -s`; the focused expected-snapshot suite
+  reported 31 passed, and radon reports `_roll_up_expected_supportability` reduced from B(6) to
+  A(1) with the extracted helpers at A grade.
+- Residual risk: this slice improves expected outcome snapshot supportability maintainability only.
+  It does not change outcome-review route contracts, source-lineage semantics, proof-pack
+  semantics, construction methodology, wave handoff behavior, supportability precedence, or global
+  bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal outcome evidence
+  maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-974: Expected outcome supportability reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the expected outcome supportability helper extraction, the checked-in quality
+  reports needed to reflect the updated branch head, test-function count, and current source
+  hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `b992f8f6`, record 821 Python files, 2630 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `_roll_up_expected_supportability`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining source-context, proof-pack,
+  rebalance-intent, workflow-gate, wave source-analytics, async payload, target-cash,
+  workflow-decision query, or risk-authority client hotspots, or certify global bank-buyable
+  readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T05:33:19+00:00`
+- Generated at: `2026-06-17T05:51:22+00:00`
 
-- Report source snapshot: `abd76e4c`
+- Report source snapshot: `b992f8f6`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 821 |
-| Total Python LOC | 178683 |
-| Test functions | 2628 |
+| Total Python LOC | 178737 |
+| Test functions | 2630 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T05:33:19+00:00`
+- Generated at: `2026-06-17T05:51:22+00:00`
 
-- Report source snapshot: `abd76e4c`
+- Report source snapshot: `b992f8f6`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _roll_up_expected_supportability | src/core/outcomes/snapshots.py | 6 | 36 |
-| 2 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
-| 3 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
-| 4 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
-| 5 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
-| 6 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
-| 7 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
-| 8 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
-| 9 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
-| 10 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
+| 1 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
+| 2 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
+| 3 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
+| 4 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 5 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 6 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
+| 7 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 8 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
+| 9 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
+| 10 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T05:33:19+00:00`
+- Generated at: `2026-06-17T05:51:22+00:00`
 
-- Report source snapshot: `abd76e4c`
+- Report source snapshot: `b992f8f6`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T05:33:19+00:00`
+- Generated at: `2026-06-17T05:51:22+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `abd76e4c`
+- Report source snapshot: `b992f8f6`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 820 | 821 | +1 |
-| Total Python LOC | 178412 | 178683 | +271 |
-| Test functions | 2624 | 2628 | +4 |
+| Python files | 821 | 821 | +0 |
+| Total Python LOC | 178683 | 178737 | +54 |
+| Test functions | 2628 | 2630 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/outcomes/snapshots.py
+++ b/src/core/outcomes/snapshots.py
@@ -417,24 +417,15 @@ def _roll_up_expected_supportability(
     wave_item: DpmRebalanceWaveItem | None,
     handoff: DpmWaveHandoffRef | None,
 ) -> DpmOutcomeSupportability:
-    states: list[OutcomeDimensionState] = [
-        _construction_state(alternative_set, selected_alternative),
-        _proof_pack_state(proof_pack.status),
-    ]
-    if wave_item:
-        states.append(_wave_item_state(wave_item))
-    if handoff:
-        states.append("READY")
-    if "BLOCKED" in states:
-        state: OutcomeDimensionState = "BLOCKED"
-    elif "PENDING_REVIEW" in states:
-        state = "PENDING_REVIEW"
-    elif "DEGRADED" in states:
-        state = "DEGRADED"
-    else:
-        state = "READY"
+    states = _expected_supportability_states(
+        alternative_set=alternative_set,
+        selected_alternative=selected_alternative,
+        proof_pack=proof_pack,
+        wave_item=wave_item,
+        handoff=handoff,
+    )
     return DpmOutcomeSupportability(
-        state=state,
+        state=_highest_expected_supportability_state(states),
         reason_codes=_expected_reason_codes(
             alternative_set=alternative_set,
             selected_alternative=selected_alternative,
@@ -445,6 +436,37 @@ def _roll_up_expected_supportability(
         required_source=True,
         explanation="Expected snapshot supportability rolled up from manage pre-trade artifacts.",
     )
+
+
+def _expected_supportability_states(
+    *,
+    alternative_set: ConstructionAlternativeSet,
+    selected_alternative: ConstructionAlternative,
+    proof_pack: DpmPreTradeProofPack,
+    wave_item: DpmRebalanceWaveItem | None,
+    handoff: DpmWaveHandoffRef | None,
+) -> list[OutcomeDimensionState]:
+    states: list[OutcomeDimensionState] = [
+        _construction_state(alternative_set, selected_alternative),
+        _proof_pack_state(proof_pack.status),
+    ]
+    if wave_item is not None:
+        states.append(_wave_item_state(wave_item))
+    if handoff is not None:
+        states.append("READY")
+    return states
+
+
+def _highest_expected_supportability_state(
+    states: list[OutcomeDimensionState],
+) -> OutcomeDimensionState:
+    if "BLOCKED" in states:
+        return "BLOCKED"
+    if "PENDING_REVIEW" in states:
+        return "PENDING_REVIEW"
+    if "DEGRADED" in states:
+        return "DEGRADED"
+    return "READY"
 
 
 def _source_lineage(

--- a/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
+++ b/tests/unit/dpm/outcomes/test_expected_snapshot_assembly.py
@@ -13,9 +13,11 @@ from src.core.construction.vocabulary import ConstructionMethod, ConstructionMet
 from src.core.models import Money
 from src.core.outcomes.snapshots import (
     DpmExpectedSnapshotAssemblyError,
+    _expected_supportability_states,
     _find_handoff,
     _find_wave_item,
     _handoff_lookup_required,
+    _highest_expected_supportability_state,
     _highest_construction_outcome_state,
     _proof_pack_state,
     _validate_handoff_linkage,
@@ -314,6 +316,36 @@ def test_highest_construction_outcome_state_applies_supportability_precedence(
     expected: str | None,
 ) -> None:
     assert _highest_construction_outcome_state(*states) == expected
+
+
+@pytest.mark.parametrize(
+    ("states", "expected"),
+    [
+        (["READY", "DEGRADED"], "DEGRADED"),
+        (["DEGRADED", "PENDING_REVIEW"], "PENDING_REVIEW"),
+        (["PENDING_REVIEW", "BLOCKED"], "BLOCKED"),
+        (["READY", "READY"], "READY"),
+    ],
+)
+def test_highest_expected_supportability_state_applies_rollup_precedence(
+    states: list[str],
+    expected: str,
+) -> None:
+    assert _highest_expected_supportability_state(states) == expected
+
+
+def test_expected_supportability_states_include_construction_proof_pack_wave_and_handoff() -> None:
+    wave = _wave(item_state="SOURCE_DEGRADED")
+    wave_item = _find_wave_item(wave=wave, wave_item_id="dwi_outcome_001")
+    handoff = _find_handoff(wave=wave, handoff_ref_id="dwh_outcome_001")
+
+    assert _expected_supportability_states(
+        alternative_set=_alternative_set(source_supportability_state="PENDING_REVIEW"),
+        selected_alternative=_alternative_set().alternatives[0],
+        proof_pack=_proof_pack(status="BLOCKED"),
+        wave_item=wave_item,
+        handoff=handoff,
+    ) == ["PENDING_REVIEW", "BLOCKED", "DEGRADED", "READY"]
 
 
 def test_expected_snapshot_preserves_construction_proof_pack_wave_and_handoff_lineage() -> None:


### PR DESCRIPTION
## Summary
- Extract expected outcome supportability state collection and precedence helpers from the snapshot assembly roll-up.
- Add direct tests for roll-up precedence and construction/proof-pack/wave/handoff state collection.
- Refresh quality reports and codebase review ledger entries through BACKEND-REVIEW-20260617-974.

## Validation
- `python -m ruff format src\core\outcomes\snapshots.py tests\unit\dpm\outcomes\test_expected_snapshot_assembly.py`
- `python -m ruff check src\core\outcomes\snapshots.py tests\unit\dpm\outcomes\test_expected_snapshot_assembly.py`
- `python -m mypy --config-file mypy.ini src\core\outcomes\snapshots.py`
- `python -m pytest tests\unit\dpm\outcomes\test_expected_snapshot_assembly.py -q` -> 31 passed
- `python -m radon cc src\core\outcomes\snapshots.py -s` -> `_roll_up_expected_supportability` A(1), extracted helpers A grade
- `python scripts\engineering_health_report.py`
- `python scripts\openapi_quality_gate.py`
- `python scripts\api_vocabulary_inventory.py --validate-only`
- service leakage scan returned no findings
- `git diff --check origin/main..HEAD`
- `make check` -> 2833 passed

## Governance
- Stranded truth: `git branch -r --no-merged origin/main` returned no branches before PR.
- Wiki: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned DiffCount 0.
- Scope: internal core outcome supportability maintainability and measurement evidence only; no route contract, supportability precedence, persistence, or operator-facing wiki truth changes.