### PR TITLE
Refactor core eligibility shelf mapping

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24516,3 +24516,56 @@ and improves internal transaction-cost source posture maintainability only.
   readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-975: Core eligibility shelf mapping helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/dpm_source_context.py` and `tests/unit/dpm/core/test_dpm_source_context.py`.
+- Bank-buyable control area: architecture, source-data contract mapping, and testing.
+- Finding: `build_shelf_entries_from_core_eligibility` combined core supportability gating,
+  found-record filtering, engine shelf-entry construction, default settlement behavior, and
+  string-normalized eligibility attributes in one mapper. That made the core-to-manage product
+  shelf handoff harder to inspect even though filtering and attribute assembly are pure,
+  deterministic source-data mapping rules.
+- Action: extracted helpers for found eligibility-record selection, shelf-entry attribute
+  assembly, and single-record `ShelfEntry` construction; added direct tests for found-record
+  filtering, default asset-class and settlement-day behavior, restriction-code joining, nullable
+  attribute normalization, and preserved boolean/string eligibility attributes.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/core/dpm_source_context.py tests/unit/dpm/core/test_dpm_source_context.py`,
+  `python -m ruff check src/core/dpm_source_context.py tests/unit/dpm/core/test_dpm_source_context.py`,
+  `python -m ruff format --check src/core/dpm_source_context.py tests/unit/dpm/core/test_dpm_source_context.py`,
+  `python -m mypy --config-file mypy.ini src/core/dpm_source_context.py`,
+  `python -m pytest tests/unit/dpm/core/test_dpm_source_context.py -q`, and
+  `python -m radon cc src/core/dpm_source_context.py -s`; the focused source-context suite
+  reported 29 passed, and radon reports `build_shelf_entries_from_core_eligibility` reduced from
+  B(6) to A(4) with the extracted helpers at A grade.
+- Residual risk: this slice improves core eligibility shelf mapping maintainability only. It does
+  not change the core sourcing HTTP client, eligibility product contract, shelf semantics,
+  construction engine behavior, source-lineage semantics, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal source-data mapper
+  maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-976: Core eligibility shelf mapping reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the core eligibility shelf mapping helper extraction, the checked-in quality
+  reports needed to reflect the updated branch head, test-function count, and current source
+  hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `d129b616`, record 821 Python files, 2633 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `build_shelf_entries_from_core_eligibility`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining proof-pack, rebalance-intent,
+  workflow-gate, wave source-analytics, async payload, target-cash, workflow-decision query,
+  risk-authority client, or outcome core-source hotspots, or certify global bank-buyable
+  readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T05:51:22+00:00`
+- Generated at: `2026-06-17T06:10:23+00:00`
 
-- Report source snapshot: `b992f8f6`
+- Report source snapshot: `d129b616`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 821 |
-| Total Python LOC | 178737 |
-| Test functions | 2630 |
+| Total Python LOC | 178839 |
+| Test functions | 2633 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T05:51:22+00:00`
+- Generated at: `2026-06-17T06:10:23+00:00`
 
-- Report source snapshot: `b992f8f6`
+- Report source snapshot: `d129b616`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | build_shelf_entries_from_core_eligibility | src/core/dpm_source_context.py | 6 | 35 |
-| 2 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
-| 3 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
-| 4 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
-| 5 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
-| 6 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
-| 7 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
-| 8 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
-| 9 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
-| 10 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
+| 1 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
+| 2 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
+| 3 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 4 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 5 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
+| 6 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 7 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
+| 8 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
+| 9 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
+| 10 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T05:51:22+00:00`
+- Generated at: `2026-06-17T06:10:23+00:00`
 
-- Report source snapshot: `b992f8f6`
+- Report source snapshot: `d129b616`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T05:51:22+00:00`
+- Generated at: `2026-06-17T06:10:23+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `b992f8f6`
+- Report source snapshot: `d129b616`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 821 | 821 | +0 |
-| Total Python LOC | 178683 | 178737 | +54 |
-| Test functions | 2628 | 2630 | +2 |
+| Total Python LOC | 178737 | 178839 | +102 |
+| Test functions | 2630 | 2633 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -59,7 +59,7 @@
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/proof_packs/builder.py | 1979 |
-| 10 | src/core/dpm_source_context.py | 1918 |
+| 10 | src/core/dpm_source_context.py | 1929 |
 
 ## Largest Functions
 

--- a/src/core/dpm_source_context.py
+++ b/src/core/dpm_source_context.py
@@ -1713,41 +1713,52 @@ def _shelf_attribute_value(value: object) -> str:
     return str(value)
 
 
+def _eligible_core_eligibility_records(
+    response: DpmCoreInstrumentEligibilityBulkResponse,
+) -> list[DpmCoreInstrumentEligibilityRecord]:
+    return [record for record in response.eligibility if record.found]
+
+
+def _shelf_entry_attributes_from_core_eligibility(
+    record: DpmCoreInstrumentEligibilityRecord,
+) -> dict[str, str]:
+    return {
+        "buy_allowed": _shelf_attribute_value(record.buy_allowed),
+        "sell_allowed": _shelf_attribute_value(record.sell_allowed),
+        "eligibility_status": record.eligibility_status,
+        "country_of_risk": _shelf_attribute_value(record.country_of_risk),
+        "settlement_calendar_id": _shelf_attribute_value(record.settlement_calendar_id),
+        "ultimate_parent_issuer_id": _shelf_attribute_value(record.ultimate_parent_issuer_id),
+        "restriction_reason_codes": ",".join(record.restriction_reason_codes),
+        "source_record_id": _shelf_attribute_value(record.source_record_id),
+    }
+
+
+def _shelf_entry_from_core_eligibility(
+    record: DpmCoreInstrumentEligibilityRecord,
+) -> ShelfEntry:
+    return ShelfEntry(
+        instrument_id=record.security_id,
+        status=record.product_shelf_status,
+        asset_class=record.asset_class or "UNKNOWN",
+        issuer_id=record.issuer_id,
+        liquidity_tier=record.liquidity_tier,
+        settlement_days=record.settlement_days if record.settlement_days is not None else 2,
+        attributes=_shelf_entry_attributes_from_core_eligibility(record),
+    )
+
+
 def build_shelf_entries_from_core_eligibility(
     response: DpmCoreInstrumentEligibilityBulkResponse,
 ) -> list[ShelfEntry]:
     if response.supportability.state not in {"READY", "DEGRADED"}:
         raise DpmCoreContextIncompleteError(response.supportability.reason)
 
-    eligible_records = [record for record in response.eligibility if record.found]
+    eligible_records = _eligible_core_eligibility_records(response)
     if not eligible_records:
         raise DpmCoreContextIncompleteError("DPM_CORE_INSTRUMENT_ELIGIBILITY_EMPTY")
 
-    shelf_entries: list[ShelfEntry] = []
-    for record in eligible_records:
-        shelf_entries.append(
-            ShelfEntry(
-                instrument_id=record.security_id,
-                status=record.product_shelf_status,
-                asset_class=record.asset_class or "UNKNOWN",
-                issuer_id=record.issuer_id,
-                liquidity_tier=record.liquidity_tier,
-                settlement_days=record.settlement_days if record.settlement_days is not None else 2,
-                attributes={
-                    "buy_allowed": _shelf_attribute_value(record.buy_allowed),
-                    "sell_allowed": _shelf_attribute_value(record.sell_allowed),
-                    "eligibility_status": record.eligibility_status,
-                    "country_of_risk": _shelf_attribute_value(record.country_of_risk),
-                    "settlement_calendar_id": _shelf_attribute_value(record.settlement_calendar_id),
-                    "ultimate_parent_issuer_id": _shelf_attribute_value(
-                        record.ultimate_parent_issuer_id
-                    ),
-                    "restriction_reason_codes": ",".join(record.restriction_reason_codes),
-                    "source_record_id": _shelf_attribute_value(record.source_record_id),
-                },
-            )
-        )
-    return shelf_entries
+    return [_shelf_entry_from_core_eligibility(record) for record in eligible_records]
 
 
 def build_portfolio_snapshot_with_core_tax_lots(

--- a/tests/unit/dpm/core/test_dpm_source_context.py
+++ b/tests/unit/dpm/core/test_dpm_source_context.py
@@ -12,7 +12,10 @@ from src.core.dpm_source_context import (
     _core_coverage_fx_rates,
     _core_coverage_prices,
     _core_tax_lot_to_engine_lot,
+    _eligible_core_eligibility_records,
     _portfolio_position_with_tax_lots,
+    _shelf_entry_attributes_from_core_eligibility,
+    _shelf_entry_from_core_eligibility,
     build_batch_rebalance_request_from_core_context,
     build_core_resolver_payload,
     build_market_data_snapshot_from_core_coverage,
@@ -409,6 +412,94 @@ def test_core_instrument_eligibility_accepts_rfc087_record_aliases():
         "EQ_US_AAPL",
         "FO_PRIV_PRIVATE_CREDIT_A",
     ]
+
+
+def test_eligible_core_eligibility_records_keeps_only_found_records():
+    payload = _core_eligibility_payload()
+    payload["eligibility"].append(
+        {
+            "security_id": "UNKNOWN_SEC",
+            "found": False,
+            "eligibility_status": "UNKNOWN",
+            "product_shelf_status": "SUSPENDED",
+            "buy_allowed": False,
+            "sell_allowed": False,
+            "restriction_reason_codes": ["ELIGIBILITY_PROFILE_MISSING"],
+            "settlement_days": None,
+            "settlement_calendar_id": None,
+            "quality_status": "MISSING",
+        }
+    )
+    response = DpmCoreInstrumentEligibilityBulkResponse.model_validate(payload)
+
+    records = _eligible_core_eligibility_records(response)
+
+    assert [record.security_id for record in records] == [
+        "EQ_US_AAPL",
+        "FO_PRIV_PRIVATE_CREDIT_A",
+    ]
+
+
+def test_shelf_entry_from_core_eligibility_applies_defaults_and_attributes():
+    response = DpmCoreInstrumentEligibilityBulkResponse.model_validate(
+        _core_eligibility_payload(
+            eligibility=[
+                {
+                    "security_id": "ALT_FUND",
+                    "found": True,
+                    "eligibility_status": "SELL_ONLY",
+                    "product_shelf_status": "SELL_ONLY",
+                    "buy_allowed": False,
+                    "sell_allowed": True,
+                    "restriction_reason_codes": ["REVIEW_REQUIRED", "MIN_HOLD"],
+                    "settlement_days": None,
+                    "settlement_calendar_id": None,
+                    "issuer_id": "ALT_ISSUER",
+                    "asset_class": None,
+                    "country_of_risk": None,
+                    "source_record_id": None,
+                    "quality_status": "accepted",
+                }
+            ],
+            supportability={
+                "state": "READY",
+                "reason": "INSTRUMENT_ELIGIBILITY_READY",
+                "requested_count": 1,
+                "found_count": 1,
+                "missing_security_ids": [],
+            },
+        )
+    )
+
+    shelf_entry = _shelf_entry_from_core_eligibility(response.eligibility[0])
+
+    assert shelf_entry.instrument_id == "ALT_FUND"
+    assert shelf_entry.status == "SELL_ONLY"
+    assert shelf_entry.asset_class == "UNKNOWN"
+    assert shelf_entry.issuer_id == "ALT_ISSUER"
+    assert shelf_entry.settlement_days == 2
+    assert shelf_entry.attributes == {
+        "buy_allowed": "false",
+        "sell_allowed": "true",
+        "eligibility_status": "SELL_ONLY",
+        "country_of_risk": "",
+        "settlement_calendar_id": "",
+        "ultimate_parent_issuer_id": "",
+        "restriction_reason_codes": "REVIEW_REQUIRED,MIN_HOLD",
+        "source_record_id": "",
+    }
+
+
+def test_shelf_entry_attributes_from_core_eligibility_normalizes_string_values():
+    response = DpmCoreInstrumentEligibilityBulkResponse.model_validate(_core_eligibility_payload())
+
+    attributes = _shelf_entry_attributes_from_core_eligibility(response.eligibility[0])
+
+    assert attributes["buy_allowed"] == "true"
+    assert attributes["country_of_risk"] == "US"
+    assert attributes["settlement_calendar_id"] == "US_NYSE"
+    assert attributes["ultimate_parent_issuer_id"] == "APPLE_PARENT"
+    assert attributes["source_record_id"] == "AAPL-elig-20260401"
 
 
 def test_core_instrument_eligibility_rejects_missing_supportability():


### PR DESCRIPTION
## Summary
- Refactor core instrument eligibility to `ShelfEntry` mapping into focused helpers for found-record filtering, attribute assembly, and single-record shelf-entry construction.
- Add direct helper tests for found-record filtering, default asset-class/settlement behavior, restriction-code joining, nullable attribute normalization, and preserved eligibility attributes.
- Refresh quality reports and codebase review ledger through `BACKEND-REVIEW-20260617-976`.

## Evidence
Static:
- `python -m ruff format src\core\dpm_source_context.py tests\unit\dpm\core\test_dpm_source_context.py`
- `python -m ruff check src\core\dpm_source_context.py tests\unit\dpm\core\test_dpm_source_context.py`
- `python -m ruff format --check src\core\dpm_source_context.py tests\unit\dpm\core\test_dpm_source_context.py`
- `python -m mypy --config-file mypy.ini src\core\dpm_source_context.py`

Unit:
- `python -m pytest tests\unit\dpm\core\test_dpm_source_context.py -q` -> 29 passed
- `make check` -> 2836 passed

Governance:
- `python scripts\engineering_health_report.py`
- `python scripts\openapi_quality_gate.py`
- `python scripts\api_vocabulary_inventory.py --validate-only`
- `git diff --check origin/main..HEAD`
- service leakage scan returned no findings: `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0

Complexity:
- `python -m radon cc src\core\dpm_source_context.py -s` reports `build_shelf_entries_from_core_eligibility` reduced from B(6) to A(4); extracted helpers are A-grade.

Stranded truth:
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged remote branches

## Notes
- No API contract, router behavior, source-lineage semantics, or wiki/operator truth changed.
- This is one source-hotspot hardening slice; it does not claim global bank-buyable readiness.