### PR TITLE
Refactor proof pack turnover cost payload

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24569,3 +24569,57 @@ and improves internal transaction-cost source posture maintainability only.
   readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-977: Proof-pack turnover and cost payload helpers
+
+- Date: 2026-06-17
+- Scope: `src/core/proof_packs/builder.py` and
+  `tests/unit/dpm/proof_packs/test_proof_pack_builder.py`.
+- Bank-buyable control area: architecture, proof-pack evidence supportability, and testing.
+- Finding: `_turnover_and_cost_section_payload` combined selected-alternative metric extraction,
+  missing-metric degradation, transaction-cost authority context merging, reason-code
+  de-duplication, and section-state precedence in one helper. That made the proof-pack turnover
+  and cost section harder to inspect even though each rule is deterministic and auditable.
+- Action: extracted helpers for selected construction comparison metrics, base turnover/cost
+  supportability posture, missing transaction-cost context payloads, and source-owned
+  transaction-cost context payloads; added direct tests for selected-metric projection,
+  authority-context-missing degradation, and preservation of missing-metric reason codes when
+  source-owned transaction-cost evidence is present.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m ruff format --check src/core/proof_packs/builder.py tests/unit/dpm/proof_packs/test_proof_pack_builder.py`,
+  `python -m mypy --config-file mypy.ini src/core/proof_packs/builder.py`,
+  `python -m pytest tests/unit/dpm/proof_packs/test_proof_pack_builder.py -q`, and
+  `python -m radon cc src/core/proof_packs/builder.py -s`; the focused proof-pack builder suite
+  reported 104 passed, and radon reports `_turnover_and_cost_section_payload` reduced from B(6)
+  to A(2) with the extracted helpers at A grade.
+- Residual risk: this slice improves proof-pack turnover and cost section maintainability only. It
+  does not change proof-pack API contracts, construction alternative generation, source-owned
+  transaction-cost methodology, source analytics extraction, report rendering, or global
+  bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal proof-pack section
+  maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-978: Proof-pack turnover and cost reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the proof-pack turnover and cost helper extraction, the checked-in quality reports
+  needed to reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `91775b44`, record 821 Python files, 2636 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `_turnover_and_cost_section_payload`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining rebalance-intent, workflow-gate, wave
+  source-analytics, async payload, target-cash, workflow-decision query, risk-authority client,
+  outcome core-source, or proof-pack governance hotspots, or certify global bank-buyable
+  readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T06:10:23+00:00`
+- Generated at: `2026-06-17T06:30:29+00:00`
 
-- Report source snapshot: `d129b616`
+- Report source snapshot: `91775b44`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 821 |
-| Total Python LOC | 178839 |
-| Test functions | 2633 |
+| Total Python LOC | 178931 |
+| Test functions | 2636 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T06:10:23+00:00`
+- Generated at: `2026-06-17T06:30:29+00:00`
 
-- Report source snapshot: `d129b616`
+- Report source snapshot: `91775b44`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _turnover_and_cost_section_payload | src/core/proof_packs/builder.py | 6 | 35 |
-| 2 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
-| 3 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
-| 4 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
-| 5 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
-| 6 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
-| 7 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
-| 8 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
-| 9 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
-| 10 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
+| 1 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
+| 2 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 3 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 4 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
+| 5 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 6 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
+| 7 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
+| 8 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
+| 9 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
+| 10 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 6 | 27 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T06:10:23+00:00`
+- Generated at: `2026-06-17T06:30:29+00:00`
 
-- Report source snapshot: `d129b616`
+- Report source snapshot: `91775b44`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T06:10:23+00:00`
+- Generated at: `2026-06-17T06:30:29+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `d129b616`
+- Report source snapshot: `91775b44`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 821 | 821 | +0 |
-| Total Python LOC | 178737 | 178839 | +102 |
-| Test functions | 2630 | 2633 | +3 |
+| Total Python LOC | 178839 | 178931 | +92 |
+| Test functions | 2633 | 2636 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -44,7 +44,7 @@
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
 | 9 | src/core/proof_packs/builder.py | 1979 |
-| 10 | src/core/dpm_source_context.py | 1918 |
+| 10 | src/core/dpm_source_context.py | 1929 |
 
 ### current branch
 
@@ -52,13 +52,13 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3066 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3126 |
 | 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2960 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
-| 9 | src/core/proof_packs/builder.py | 1979 |
+| 9 | src/core/proof_packs/builder.py | 2011 |
 | 10 | src/core/dpm_source_context.py | 1929 |
 
 ## Largest Functions

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -10,6 +10,7 @@ from src.core.construction.models import (
     ConstructionAlternative,
     ConstructionAlternativeSelection,
     ConstructionAlternativeSet,
+    ConstructionComparisonMetrics,
 )
 from src.core.proof_packs.models import (
     DpmPreTradeProofPack,
@@ -1129,34 +1130,65 @@ def _turnover_and_cost_section_payload(
     source_analytics: dict[str, ProofPackSourceAnalytics],
 ) -> tuple[ProofPackSectionState, str, dict[str, Any], dict[str, Any], list[str]]:
     transaction_cost_context = source_analytics.get("transaction_cost")
-    metrics = (
-        selected_alternative.comparison_metrics.model_dump(mode="json")
-        if selected_alternative
-        else {}
+    metrics = _turnover_comparison_metrics(selected_alternative)
+    if transaction_cost_context is None:
+        return _turnover_payload_without_transaction_cost_context(metrics)
+    return _turnover_payload_with_transaction_cost_context(
+        metrics=metrics,
+        transaction_cost_context=transaction_cost_context,
     )
-    facts: dict[str, Any] = {}
-    reason_codes = [] if metrics else ["DPM_TURNOVER_COST_METRICS_MISSING"]
-    state: ProofPackSectionState = "READY" if metrics else "DEGRADED"
-    summary = "Turnover and cost evidence captured when construction metrics are available."
 
-    if transaction_cost_context is not None:
-        facts = transaction_cost_context.facts
-        metrics = {**metrics, **transaction_cost_context.metrics}
-        reason_codes.extend(transaction_cost_context.reason_codes)
-        state = _lowest_section_state([state, transaction_cost_context.state])
-        summary = (
-            "Turnover metrics and source-owned observed transaction-cost evidence are attached."
-        )
-    elif metrics:
-        reason_codes.append("DPM_TRANSACTION_COST_AUTHORITY_CONTEXT_MISSING")
+
+def _turnover_comparison_metrics(
+    selected_alternative: ConstructionAlternative | None,
+) -> dict[str, Any]:
+    if selected_alternative is None:
+        return {}
+    return _turnover_comparison_metrics_payload(selected_alternative.comparison_metrics)
+
+
+def _turnover_comparison_metrics_payload(
+    comparison_metrics: ConstructionComparisonMetrics,
+) -> dict[str, Any]:
+    return comparison_metrics.model_dump(mode="json")
+
+
+def _turnover_base_posture(
+    metrics: dict[str, Any],
+) -> tuple[ProofPackSectionState, list[str]]:
+    if metrics:
+        return "READY", []
+    return "DEGRADED", ["DPM_TURNOVER_COST_METRICS_MISSING"]
+
+
+def _turnover_payload_without_transaction_cost_context(
+    metrics: dict[str, Any],
+) -> _SectionPayload:
+    state, reason_codes = _turnover_base_posture(metrics)
+    if metrics:
         state = "DEGRADED"
-
+        reason_codes.append("DPM_TRANSACTION_COST_AUTHORITY_CONTEXT_MISSING")
     return (
         state,
-        summary,
-        facts,
+        "Turnover and cost evidence captured when construction metrics are available.",
+        {},
         metrics,
         sorted(set(reason_codes)),
+    )
+
+
+def _turnover_payload_with_transaction_cost_context(
+    *,
+    metrics: dict[str, Any],
+    transaction_cost_context: ProofPackSourceAnalytics,
+) -> _SectionPayload:
+    state, reason_codes = _turnover_base_posture(metrics)
+    return (
+        _lowest_section_state([state, transaction_cost_context.state]),
+        "Turnover metrics and source-owned observed transaction-cost evidence are attached.",
+        transaction_cost_context.facts,
+        {**metrics, **transaction_cost_context.metrics},
+        sorted(set([*reason_codes, *transaction_cost_context.reason_codes])),
     )
 
 

--- a/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_builder.py
@@ -1187,6 +1187,66 @@ def test_turnover_and_cost_section_payload_degrades_without_selected_metrics() -
     assert reason_codes == ["DPM_TURNOVER_COST_METRICS_MISSING"]
 
 
+def test_turnover_comparison_metrics_returns_selected_alternative_metrics() -> None:
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+
+    metrics = builder_module._turnover_comparison_metrics(alternative)
+
+    assert metrics["turnover_weight"] == "1.0000"
+    assert metrics["trade_count"] == 2
+    assert metrics["estimated_transaction_cost"] is None
+
+
+def test_turnover_payload_without_transaction_cost_context_degrades_selected_metrics() -> None:
+    result = _ready_rebalance_result()
+    alternative = build_rebalance_result_alternative(result=result)
+    metrics = builder_module._turnover_comparison_metrics(alternative)
+
+    state, summary, facts, payload_metrics, reason_codes = (
+        builder_module._turnover_payload_without_transaction_cost_context(metrics)
+    )
+
+    assert state == "DEGRADED"
+    assert summary == "Turnover and cost evidence captured when construction metrics are available."
+    assert facts == {}
+    assert payload_metrics["turnover_weight"] == "1.0000"
+    assert reason_codes == ["DPM_TRANSACTION_COST_AUTHORITY_CONTEXT_MISSING"]
+
+
+def test_turnover_payload_with_transaction_cost_context_preserves_missing_metrics_reason() -> None:
+    transaction_cost = ProofPackSourceAnalytics(
+        family="transaction_cost",
+        state="READY",
+        summary="Observed transaction-cost evidence is attached.",
+        facts={"source_system": "lotus-core"},
+        metrics={"returned_curve_point_count": 1},
+        reason_codes=["TRANSACTION_COST_CURVE_READY"],
+        source_ref=_source_ref(),
+        source_hash_key="transaction_cost_context",
+        content_hash="sha256:transaction-cost-curve-proof",
+    )
+
+    state, summary, facts, metrics, reason_codes = (
+        builder_module._turnover_payload_with_transaction_cost_context(
+            metrics={},
+            transaction_cost_context=transaction_cost,
+        )
+    )
+
+    assert state == "DEGRADED"
+    assert (
+        summary
+        == "Turnover metrics and source-owned observed transaction-cost evidence are attached."
+    )
+    assert facts == {"source_system": "lotus-core"}
+    assert metrics == {"returned_curve_point_count": 1}
+    assert reason_codes == [
+        "DPM_TURNOVER_COST_METRICS_MISSING",
+        "TRANSACTION_COST_CURVE_READY",
+    ]
+
+
 def test_turnover_and_cost_section_payload_merges_source_cost_context() -> None:
     result = _ready_rebalance_result()
     alternative = build_rebalance_result_alternative(result=result)


### PR DESCRIPTION
## Summary
- Refactor proof-pack turnover/cost section assembly into focused helpers for selected construction metrics, base supportability posture, missing authority context, and source-owned transaction-cost context merge.
- Add direct helper tests for selected-metric projection, transaction-cost-authority missing degradation, and preserving missing-metric reason codes when source cost evidence is attached.
- Refresh quality reports and codebase review ledger through `BACKEND-REVIEW-20260617-978`.

## Evidence
Static:
- `python -m ruff format src\core\proof_packs\builder.py tests\unit\dpm\proof_packs\test_proof_pack_builder.py`
- `python -m ruff check src\core\proof_packs\builder.py tests\unit\dpm\proof_packs\test_proof_pack_builder.py`
- `python -m ruff format --check src\core\proof_packs\builder.py tests\unit\dpm\proof_packs\test_proof_pack_builder.py`
- `python -m mypy --config-file mypy.ini src\core\proof_packs\builder.py`

Unit:
- `python -m pytest tests\unit\dpm\proof_packs\test_proof_pack_builder.py -q` -> 104 passed
- `make check` -> 2839 passed

Governance:
- `python scripts\engineering_health_report.py`
- `python scripts\openapi_quality_gate.py`
- `python scripts\api_vocabulary_inventory.py --validate-only`
- `git diff --check origin/main..HEAD`
- service leakage scan returned no findings: `rg -n "from src\.api\.routers|import src\.api\.routers|HTTPException|status\.HTTP|from fastapi|import fastapi|from starlette|import starlette" src/api/services -g "*.py"`
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0

Complexity:
- `python -m radon cc src\core\proof_packs\builder.py -s` reports `_turnover_and_cost_section_payload` reduced from B(6) to A(2); extracted helpers are A-grade.

Stranded truth:
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged remote branches

## Notes
- No API contract, source-owned transaction-cost methodology, construction alternative generation, or wiki/operator truth changed.
- This is one proof-pack maintainability slice; it does not claim global bank-buyable readiness.