### PR TITLE
Refactor tax budget lot scan stop policy

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24623,3 +24623,55 @@ and improves internal transaction-cost source posture maintainability only.
   readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-979: Tax-budget lot-scan stop helper
+
+- Date: 2026-06-17
+- Scope: `src/core/rebalance/intents.py` and
+  `tests/unit/dpm/engine/test_engine_safety_rules.py`.
+- Bank-buyable control area: architecture, tax-aware rebalance maintainability, and testing.
+- Finding: `_tax_budget_limited_quantity_from_lots` combined tax-lot allowance lookup, depleted-lot
+  continuation, exhausted-budget stop handling, accumulator mutation, remaining-quantity updates,
+  and partial-allowance stop handling in one loop. That made the tax-aware lot-scan branch policy
+  harder to inspect even though each stop rule is deterministic.
+- Action: extracted `_tax_budget_allowance_stops_lot_scan` to name the depleted, exhausted, and
+  partial-allowance stop policy; added direct tests for depleted remaining quantity, empty-lot
+  continuation, zero allowance, partial allowance, and full-allowance continuation while preserving
+  existing tax-budget sell-quantity behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m ruff check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m ruff format --check src/core/rebalance/intents.py tests/unit/dpm/engine/test_engine_safety_rules.py`,
+  `python -m mypy --config-file mypy.ini src/core/rebalance/intents.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_safety_rules.py -q`, and
+  `python -m radon cc src/core/rebalance/intents.py -s`; the focused safety-rule suite reported
+  39 passed, and radon reports `_tax_budget_limited_quantity_from_lots` reduced from B(6) to A(5)
+  with the extracted stop helper at A(3).
+- Residual risk: this slice improves internal rebalance tax-budget lot-scan maintainability only.
+  It does not change tax methodology, API contracts, execution routing, source-lot ordering,
+  portfolio-memory evidence, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal rebalance maintainability
+  hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-980: Tax-budget lot-scan reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the tax-budget lot-scan helper extraction, the checked-in quality reports needed
+  to reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `1c94bb1d+worktree`, record 821 Python files, 2639 test functions, keep service boundary
+  findings and router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the
+  current top-ten source hotspot list no longer includes `_tax_budget_limited_quantity_from_lots`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining workflow-gate, wave
+  source-analytics, async payload, target-cash, workflow-decision query, risk-authority client,
+  outcome core-source, or proof-pack governance hotspots, or certify global bank-buyable
+  readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T06:30:29+00:00`
+- Generated at: `2026-06-17T06:52:09+00:00`
 
-- Report source snapshot: `91775b44`
+- Report source snapshot: `1c94bb1d+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 821 |
-| Total Python LOC | 178931 |
-| Test functions | 2636 |
+| Total Python LOC | 178989 |
+| Test functions | 2639 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T06:30:29+00:00`
+- Generated at: `2026-06-17T06:52:09+00:00`
 
-- Report source snapshot: `91775b44`
+- Report source snapshot: `1c94bb1d+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _tax_budget_limited_quantity_from_lots | src/core/rebalance/intents.py | 6 | 34 |
-| 2 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
-| 3 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
-| 4 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
-| 5 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
-| 6 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
-| 7 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
-| 8 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
-| 9 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
-| 10 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 6 | 27 |
+| 1 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
+| 2 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 3 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
+| 4 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 5 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
+| 6 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
+| 7 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
+| 8 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
+| 9 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 6 | 27 |
+| 10 | _decision_summary | src/core/proof_packs/builder.py | 6 | 27 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T06:30:29+00:00`
+- Generated at: `2026-06-17T06:52:09+00:00`
 
-- Report source snapshot: `91775b44`
+- Report source snapshot: `1c94bb1d+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T06:30:29+00:00`
+- Generated at: `2026-06-17T06:52:09+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `91775b44`
+- Report source snapshot: `1c94bb1d+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 821 | 821 | +0 |
-| Total Python LOC | 178839 | 178931 | +92 |
-| Test functions | 2633 | 2636 | +3 |
+| Total Python LOC | 178931 | 178989 | +58 |
+| Test functions | 2636 | 2639 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,13 +37,13 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3066 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3126 |
 | 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2960 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
 | 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
-| 9 | src/core/proof_packs/builder.py | 1979 |
+| 9 | src/core/proof_packs/builder.py | 2011 |
 | 10 | src/core/dpm_source_context.py | 1929 |
 
 ### current branch

--- a/src/core/rebalance/intents.py
+++ b/src/core/rebalance/intents.py
@@ -307,6 +307,18 @@ def _tax_budget_sale_allowance(
     )
 
 
+def _tax_budget_allowance_stops_lot_scan(
+    *,
+    allowance: _TaxBudgetLotAllowance | None,
+    remaining_quantity: Decimal,
+) -> bool:
+    if allowance is None:
+        return remaining_quantity <= Decimal("0")
+    if allowance.allowed_quantity <= Decimal("0"):
+        return True
+    return allowance.allowed_quantity < allowance.requested_quantity
+
+
 def _tax_budget_limited_quantity_from_lots(
     *,
     sorted_lots: list[tuple[Any, Decimal]],
@@ -327,17 +339,21 @@ def _tax_budget_limited_quantity_from_lots(
             tax_budget=tax_budget,
         )
         if allowance is None:
-            if remaining <= Decimal("0"):
+            if _tax_budget_allowance_stops_lot_scan(
+                allowance=allowance,
+                remaining_quantity=remaining,
+            ):
                 break
             continue
-        if allowance.allowed_quantity <= Decimal("0"):
-            break
 
         _apply_tax_budget_lot_allowance(allowance=allowance, tax_budget=tax_budget)
         allowed_qty += allowance.allowed_quantity
         remaining -= allowance.allowed_quantity
 
-        if allowance.allowed_quantity < allowance.requested_quantity:
+        if _tax_budget_allowance_stops_lot_scan(
+            allowance=allowance,
+            remaining_quantity=remaining,
+        ):
             break
 
     return allowed_qty

--- a/tests/unit/dpm/engine/test_engine_safety_rules.py
+++ b/tests/unit/dpm/engine/test_engine_safety_rules.py
@@ -22,6 +22,7 @@ from src.core.rebalance.intents import (
     _target_weight_by_instrument,
     _tax_impact_from_budget,
     _tax_budget_lot_allowance,
+    _tax_budget_allowance_stops_lot_scan,
     _tax_budget_limited_quantity_from_lots,
     _tax_budget_limited_sell_quantity,
     _tax_budget_sale_allowance,
@@ -713,6 +714,47 @@ def test_tax_budget_limited_quantity_from_lots_skips_empty_lots_and_stops_on_par
     assert allowed_quantity == Decimal("5")
     assert tax_budget.total_realized_gain_base == Decimal("50")
     assert tax_budget.tax_budget_used_base == Decimal("50")
+
+
+def test_tax_budget_allowance_stops_lot_scan_for_depleted_remaining_quantity() -> None:
+    assert _tax_budget_allowance_stops_lot_scan(
+        allowance=None,
+        remaining_quantity=Decimal("0"),
+    )
+    assert not _tax_budget_allowance_stops_lot_scan(
+        allowance=None,
+        remaining_quantity=Decimal("2"),
+    )
+
+
+def test_tax_budget_allowance_stops_lot_scan_for_zero_or_partial_allowance() -> None:
+    assert _tax_budget_allowance_stops_lot_scan(
+        allowance=_TaxBudgetLotAllowance(
+            requested_quantity=Decimal("5"),
+            allowed_quantity=Decimal("0"),
+            realized_base=Decimal("0"),
+        ),
+        remaining_quantity=Decimal("5"),
+    )
+    assert _tax_budget_allowance_stops_lot_scan(
+        allowance=_TaxBudgetLotAllowance(
+            requested_quantity=Decimal("5"),
+            allowed_quantity=Decimal("2"),
+            realized_base=Decimal("20"),
+        ),
+        remaining_quantity=Decimal("3"),
+    )
+
+
+def test_tax_budget_allowance_continues_lot_scan_for_full_allowance() -> None:
+    assert not _tax_budget_allowance_stops_lot_scan(
+        allowance=_TaxBudgetLotAllowance(
+            requested_quantity=Decimal("5"),
+            allowed_quantity=Decimal("5"),
+            realized_base=Decimal("50"),
+        ),
+        remaining_quantity=Decimal("5"),
+    )
 
 
 def test_tax_budget_lot_allowance_returns_zero_when_gain_budget_exhausted() -> None:


### PR DESCRIPTION
## Summary
- Extracted `_tax_budget_allowance_stops_lot_scan` to make tax-budget lot scan stop policy explicit.
- Added direct tests for depleted remaining quantity, empty-lot continuation, zero allowance, partial allowance, and full-allowance continuation.
- Refreshed quality reports and codebase review ledger entries `BACKEND-REVIEW-20260617-979` and `BACKEND-REVIEW-20260617-980`.

## Bank-Buyable Control Movement
- Architecture / maintainability: `_tax_budget_limited_quantity_from_lots` reduced from B(6) to A(5); extracted helper is A(3).
- Testing: focused safety-rule suite increased by three direct helper tests.
- CI measurement: refreshed `quality/*` reports; current top-ten source hotspot list no longer includes `_tax_budget_limited_quantity_from_lots`.

## Behavior
- Behavior preserved. This is an internal helper extraction for deterministic tax-budget lot-scan branching.
- No API, OpenAPI, source-product, tax methodology, persistence, runtime, or wiki/operator-facing contract change.

## Local Evidence
- `python -m ruff format src\core\rebalance\intents.py tests\unit\dpm\engine\test_engine_safety_rules.py`
- `python -m ruff check src\core\rebalance\intents.py tests\unit\dpm\engine\test_engine_safety_rules.py`
- `python -m ruff format --check src\core\rebalance\intents.py tests\unit\dpm\engine\test_engine_safety_rules.py`
- `python -m mypy --config-file mypy.ini src\core\rebalance\intents.py`
- `python -m pytest tests\unit\dpm\engine\test_engine_safety_rules.py -q` -> 39 passed
- `python -m radon cc src\core\rebalance\intents.py -s | Select-String -Pattern "tax_budget"`
- `python scripts\openapi_quality_gate.py`
- `python scripts\api_vocabulary_inventory.py --validate-only`
- service leakage scan: no matches
- `python scripts\engineering_health_report.py`
- `git diff --check origin/main..HEAD`
- `make check` -> 2842 passed

## Governance / Hygiene
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no output
- `gh pr list --state open --limit 100 --json number,title,headRefName,url` -> `[]` before PR creation
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0

## Residual Risk
- Remaining hotspot work is intentionally deferred to later slices; this PR does not certify global bank-buyable readiness.
