### PR TITLE
Refactor workflow suitability gate reasons

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24675,3 +24675,55 @@ and improves internal transaction-cost source posture maintainability only.
   readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-981: Workflow suitability gate reason helper
+
+- Date: 2026-06-17
+- Scope: `src/core/common/workflow_gates.py` and
+  `tests/unit/dpm/engine/test_engine_workflow_gates.py`.
+- Bank-buyable control area: architecture, workflow gate maintainability, and testing.
+- Finding: `_suitability_reasons` combined suitability issue filtering, severity-to-gate-reason
+  mapping, high/medium counter updates, and aggregate result assembly in one loop. That made the
+  compliance/risk workflow gate policy harder to inspect even though single-issue mapping is a
+  deterministic domain rule.
+- Action: extracted `_suitability_issue_reason` and a named `_SuitabilityIssueGateReason` result
+  to make per-issue workflow gate contribution explicit; added direct tests for new high and
+  medium issue mapping, non-new issue suppression, low-severity suppression, and aggregate count
+  preservation while keeping existing workflow gate decision precedence intact.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src/core/common/workflow_gates.py tests/unit/dpm/engine/test_engine_workflow_gates.py`,
+  `python -m ruff check src/core/common/workflow_gates.py tests/unit/dpm/engine/test_engine_workflow_gates.py`,
+  `python -m ruff format --check src/core/common/workflow_gates.py tests/unit/dpm/engine/test_engine_workflow_gates.py`,
+  `python -m mypy --config-file mypy.ini src/core/common/workflow_gates.py`,
+  `python -m pytest tests/unit/dpm/engine/test_engine_workflow_gates.py -q`, and
+  `python -m radon cc src/core/common/workflow_gates.py -s`; the focused workflow-gate suite
+  reported 11 passed, and radon reports `_suitability_reasons` reduced from B(6) to A(4) with the
+  extracted issue helper at A(4).
+- Residual risk: this slice improves internal workflow-gate suitability reason maintainability
+  only. It does not change gate precedence, API contracts, suitability methodology,
+  policy-pack semantics, approval workflows, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal workflow gate maintainability
+  hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260617-982: Workflow suitability reports refreshed
+
+- Date: 2026-06-17
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the workflow suitability gate helper extraction, the checked-in quality reports
+  needed to reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts/engineering_health_report.py`; the refreshed reports are sourced from
+  `334b4435+worktree`, record 821 Python files, 2642 test functions, keep service boundary
+  findings and router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the
+  current top-ten source hotspot list no longer includes `_suitability_reasons`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining wave source-analytics, projected
+  cash-FX intent, async payload, target-cash, workflow-decision query, risk-authority client,
+  outcome core-source, proof-pack governance, or advise-authority client hotspots, or certify
+  global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T06:52:09+00:00`
+- Generated at: `2026-06-17T07:14:34+00:00`
 
-- Report source snapshot: `1c94bb1d+worktree`
+- Report source snapshot: `334b4435+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 821 |
-| Total Python LOC | 178989 |
-| Test functions | 2639 |
+| Total Python LOC | 179138 |
+| Test functions | 2642 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T06:52:09+00:00`
+- Generated at: `2026-06-17T07:14:34+00:00`
 
-- Report source snapshot: `1c94bb1d+worktree`
+- Report source snapshot: `334b4435+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _suitability_reasons | src/core/common/workflow_gates.py | 6 | 32 |
-| 2 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
-| 3 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
-| 4 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
-| 5 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
-| 6 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
-| 7 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
-| 8 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
-| 9 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 6 | 27 |
-| 10 | _decision_summary | src/core/proof_packs/builder.py | 6 | 27 |
+| 1 | _source_analytics_from_alternative | src/core/waves/source_analytics.py | 6 | 32 |
+| 2 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
+| 3 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 4 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
+| 5 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
+| 6 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
+| 7 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
+| 8 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 6 | 27 |
+| 9 | _decision_summary | src/core/proof_packs/builder.py | 6 | 27 |
+| 10 | _tactical_house_view_cohort_from_response | src/infrastructure/advise_authority/client.py | 6 | 26 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T06:52:09+00:00`
+- Generated at: `2026-06-17T07:14:34+00:00`
 
-- Report source snapshot: `1c94bb1d+worktree`
+- Report source snapshot: `334b4435+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T06:52:09+00:00`
+- Generated at: `2026-06-17T07:14:34+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `1c94bb1d+worktree`
+- Report source snapshot: `334b4435+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 821 | 821 | +0 |
-| Total Python LOC | 178931 | 178989 | +58 |
-| Test functions | 2636 | 2639 | +3 |
+| Total Python LOC | 178989 | 179138 | +149 |
+| Test functions | 2639 | 2642 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/common/workflow_gates.py
+++ b/src/core/common/workflow_gates.py
@@ -9,6 +9,7 @@ from src.core.models import (
     GateDecisionSummary,
     GateReason,
     RuleResult,
+    SuitabilityIssue,
     SuitabilityResult,
 )
 
@@ -53,6 +54,13 @@ class _GateRouteDecision:
     gate: _GateName
     next_step: _NextStep
     applies: _GateRoutePredicate
+
+
+@dataclass(frozen=True)
+class _SuitabilityIssueGateReason:
+    reason: GateReason
+    high_count: int
+    medium_count: int
 
 
 _GATE_ROUTE_PRECEDENCE: tuple[_GateRouteDecision, ...] = (
@@ -156,29 +164,43 @@ def _suitability_reasons(
     new_high = 0
     new_medium = 0
     for issue in suitability.issues:
-        if issue.status_change != "NEW":
+        issue_reason = _suitability_issue_reason(issue)
+        if issue_reason is None:
             continue
-        if issue.severity == "HIGH":
-            new_high += 1
-            reasons.append(
-                GateReason(
-                    reason_code="NEW_HIGH_SUITABILITY_ISSUE",
-                    severity="HIGH",
-                    source="SUITABILITY",
-                    details={"issue_id": issue.issue_id, "issue_key": issue.issue_key},
-                )
-            )
-        elif issue.severity == "MEDIUM":
-            new_medium += 1
-            reasons.append(
-                GateReason(
-                    reason_code="NEW_MEDIUM_SUITABILITY_ISSUE",
-                    severity="MEDIUM",
-                    source="SUITABILITY",
-                    details={"issue_id": issue.issue_id, "issue_key": issue.issue_key},
-                )
-            )
+        reasons.append(issue_reason.reason)
+        new_high += issue_reason.high_count
+        new_medium += issue_reason.medium_count
     return reasons, new_high, new_medium
+
+
+def _suitability_issue_reason(
+    issue: SuitabilityIssue,
+) -> _SuitabilityIssueGateReason | None:
+    if issue.status_change != "NEW":
+        return None
+    if issue.severity == "HIGH":
+        return _SuitabilityIssueGateReason(
+            reason=GateReason(
+                reason_code="NEW_HIGH_SUITABILITY_ISSUE",
+                severity="HIGH",
+                source="SUITABILITY",
+                details={"issue_id": issue.issue_id, "issue_key": issue.issue_key},
+            ),
+            high_count=1,
+            medium_count=0,
+        )
+    if issue.severity == "MEDIUM":
+        return _SuitabilityIssueGateReason(
+            reason=GateReason(
+                reason_code="NEW_MEDIUM_SUITABILITY_ISSUE",
+                severity="MEDIUM",
+                source="SUITABILITY",
+                details={"issue_id": issue.issue_id, "issue_key": issue.issue_key},
+            ),
+            high_count=0,
+            medium_count=1,
+        )
+    return None
 
 
 def evaluate_gate_decision(

--- a/tests/unit/dpm/engine/test_engine_workflow_gates.py
+++ b/tests/unit/dpm/engine/test_engine_workflow_gates.py
@@ -4,6 +4,8 @@ from typing import Literal
 from src.core.common.workflow_gates import (
     _select_gate_route,
     _sorted_gate_reasons,
+    _suitability_issue_reason,
+    _suitability_reasons,
     evaluate_gate_decision,
 )
 from src.core.models import (
@@ -49,21 +51,12 @@ def _diagnostics(
 
 
 def _high_suitability_result() -> SuitabilityResult:
-    issue = SuitabilityIssue(
+    issue = _suitability_issue(
         issue_id="SUIT_ISSUER_MAX",
         issue_key="ISSUER_MAX|X",
         dimension="ISSUER",
         severity="HIGH",
         status_change="NEW",
-        summary="Issuer concentration exceeded",
-        details={},
-        evidence=SuitabilityEvidence(
-            as_of="md_1",
-            snapshot_ids=SuitabilityEvidenceSnapshotIds(
-                portfolio_snapshot_id="pf_1",
-                market_data_snapshot_id="md_1",
-            ),
-        ),
     )
     return SuitabilityResult(
         summary=SuitabilitySummary(
@@ -75,6 +68,140 @@ def _high_suitability_result() -> SuitabilityResult:
         issues=[issue],
         recommended_gate="COMPLIANCE_REVIEW",
     )
+
+
+def _suitability_issue(
+    *,
+    issue_id: str,
+    issue_key: str,
+    dimension: Literal[
+        "CONCENTRATION",
+        "ISSUER",
+        "LIQUIDITY",
+        "GOVERNANCE",
+        "CASH",
+        "DATA_QUALITY",
+    ],
+    severity: Literal["LOW", "MEDIUM", "HIGH"],
+    status_change: Literal["NEW", "PERSISTENT", "RESOLVED"],
+) -> SuitabilityIssue:
+    return SuitabilityIssue(
+        issue_id=issue_id,
+        issue_key=issue_key,
+        dimension=dimension,
+        severity=severity,
+        status_change=status_change,
+        summary=f"{dimension} suitability issue",
+        details={},
+        evidence=SuitabilityEvidence(
+            as_of="md_1",
+            snapshot_ids=SuitabilityEvidenceSnapshotIds(
+                portfolio_snapshot_id="pf_1",
+                market_data_snapshot_id="md_1",
+            ),
+        ),
+    )
+
+
+def test_suitability_issue_reason_maps_new_high_and_medium_issues() -> None:
+    high_reason = _suitability_issue_reason(
+        _suitability_issue(
+            issue_id="SUIT_HIGH",
+            issue_key="ISSUER_MAX|X",
+            dimension="ISSUER",
+            severity="HIGH",
+            status_change="NEW",
+        )
+    )
+    medium_reason = _suitability_issue_reason(
+        _suitability_issue(
+            issue_id="SUIT_MEDIUM",
+            issue_key="CONCENTRATION_MAX|Y",
+            dimension="CONCENTRATION",
+            severity="MEDIUM",
+            status_change="NEW",
+        )
+    )
+
+    assert high_reason is not None
+    assert high_reason.reason.reason_code == "NEW_HIGH_SUITABILITY_ISSUE"
+    assert high_reason.high_count == 1
+    assert high_reason.medium_count == 0
+    assert medium_reason is not None
+    assert medium_reason.reason.reason_code == "NEW_MEDIUM_SUITABILITY_ISSUE"
+    assert medium_reason.high_count == 0
+    assert medium_reason.medium_count == 1
+
+
+def test_suitability_issue_reason_ignores_non_new_or_low_issues() -> None:
+    assert (
+        _suitability_issue_reason(
+            _suitability_issue(
+                issue_id="SUIT_PERSISTENT",
+                issue_key="ISSUER_MAX|X",
+                dimension="ISSUER",
+                severity="HIGH",
+                status_change="PERSISTENT",
+            )
+        )
+        is None
+    )
+    assert (
+        _suitability_issue_reason(
+            _suitability_issue(
+                issue_id="SUIT_LOW",
+                issue_key="MIN_TRADE|Z",
+                dimension="LIQUIDITY",
+                severity="LOW",
+                status_change="NEW",
+            )
+        )
+        is None
+    )
+
+
+def test_suitability_reasons_aggregates_new_issue_counts() -> None:
+    reasons, new_high, new_medium = _suitability_reasons(
+        SuitabilityResult(
+            summary=SuitabilitySummary(
+                new_count=3,
+                resolved_count=0,
+                persistent_count=1,
+                highest_severity_new="HIGH",
+            ),
+            issues=[
+                _suitability_issue(
+                    issue_id="SUIT_HIGH",
+                    issue_key="ISSUER_MAX|X",
+                    dimension="ISSUER",
+                    severity="HIGH",
+                    status_change="NEW",
+                ),
+                _suitability_issue(
+                    issue_id="SUIT_MEDIUM",
+                    issue_key="CONCENTRATION_MAX|Y",
+                    dimension="CONCENTRATION",
+                    severity="MEDIUM",
+                    status_change="NEW",
+                ),
+                _suitability_issue(
+                    issue_id="SUIT_PERSISTENT",
+                    issue_key="ISSUER_MAX|X",
+                    dimension="ISSUER",
+                    severity="HIGH",
+                    status_change="PERSISTENT",
+                ),
+            ],
+            recommended_gate="COMPLIANCE_REVIEW",
+        )
+    )
+
+    assert [reason.reason_code for reason in reasons] == [
+        "NEW_HIGH_SUITABILITY_ISSUE",
+        "NEW_MEDIUM_SUITABILITY_ISSUE",
+    ]
+    assert new_high == 1
+    assert new_medium == 1
 
 
 def test_workflow_gate_blocked_dominates() -> None:


### PR DESCRIPTION
## Summary
- Extracted `_suitability_issue_reason` and `_SuitabilityIssueGateReason` to make workflow-gate suitability reason mapping explicit.
- Added direct tests for new high/medium suitability issue mapping, non-new suppression, low-severity suppression, and aggregate count preservation.
- Refreshed quality reports and codebase review ledger entries `BACKEND-REVIEW-20260617-981` and `BACKEND-REVIEW-20260617-982`.

## Bank-Buyable Control Movement
- Architecture / maintainability: `_suitability_reasons` reduced from B(6) to A(4); extracted issue helper is A(4).
- Testing: focused workflow-gate suite increased by three direct helper tests.
- CI measurement: refreshed `quality/*` reports; current top-ten source hotspot list no longer includes `_suitability_reasons`.

## Behavior
- Behavior preserved. This is an internal helper extraction for deterministic workflow suitability gate reason mapping.
- No API, OpenAPI, policy-pack contract, approval workflow, runtime, or wiki/operator-facing contract change.

## Local Evidence
- `python -m ruff format src\core\common\workflow_gates.py tests\unit\dpm\engine\test_engine_workflow_gates.py`
- `python -m ruff check src\core\common\workflow_gates.py tests\unit\dpm\engine\test_engine_workflow_gates.py`
- `python -m ruff format --check src\core\common\workflow_gates.py tests\unit\dpm\engine\test_engine_workflow_gates.py`
- `python -m mypy --config-file mypy.ini src\core\common\workflow_gates.py`
- `python -m pytest tests\unit\dpm\engine\test_engine_workflow_gates.py -q` -> 11 passed
- `python -m radon cc src\core\common\workflow_gates.py -s`
- `python scripts\openapi_quality_gate.py`
- `python scripts\api_vocabulary_inventory.py --validate-only`
- service leakage scan: no matches
- `python scripts\engineering_health_report.py`
- `git diff --check`
- `make check` -> 2845 passed

## Governance / Hygiene
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no output
- `gh pr list --state open --limit 100 --json number,title,headRefName,url` -> `[]` before PR creation
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` -> DiffCount 0

## Residual Risk
- Remaining hotspot work is intentionally deferred to later slices; this PR does not certify global bank-buyable readiness.
