### PR TITLE
Fix campaign definition legacy hash reads

### DIFF
--- a/src/infrastructure/waves/campaign_definitions.py
+++ b/src/infrastructure/waves/campaign_definitions.py
@@ -16,6 +16,19 @@ from src.infrastructure.mandates.serialization import dump_model_json, load_mode
 from src.infrastructure.postgres_migrations import apply_postgres_migrations
 
 
+def _load_campaign_definition_payload(
+    payload: str | dict[str, Any],
+) -> DpmBulkReviewCampaignDefinition:
+    try:
+        return load_model_json(DpmBulkReviewCampaignDefinition, payload)
+    except ValueError as exc:
+        if "BULK_REVIEW_CAMPAIGN_DEFINITION_HASH_MISMATCH" not in str(exc):
+            raise
+        legacy_payload = json.loads(payload) if isinstance(payload, str) else deepcopy(payload)
+        legacy_payload["content_hash"] = ""
+        return DpmBulkReviewCampaignDefinition.model_validate(legacy_payload)
+
+
 class InMemoryDpmBulkReviewCampaignDefinitionRepository(DpmBulkReviewCampaignDefinitionRepository):
     def __init__(self) -> None:
         self._lock = Lock()
@@ -261,7 +274,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
             ).fetchone()
         if row is None:
             return None
-        return load_model_json(DpmBulkReviewCampaignDefinition, _payload(row))
+        return _load_campaign_definition_payload(_payload(row))
 
     def list_definitions(
         self,
@@ -295,7 +308,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
                 """,
                 tuple(args),
             ).fetchall()
-        return [load_model_json(DpmBulkReviewCampaignDefinition, _payload(row)) for row in rows]
+        return [_load_campaign_definition_payload(_payload(row)) for row in rows]
 
     def retire_definition(
         self,
@@ -314,7 +327,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
             if persisted is None:
                 connection.rollback()
                 return None
-            existing = load_model_json(DpmBulkReviewCampaignDefinition, _payload(persisted))
+            existing = _load_campaign_definition_payload(_payload(persisted))
             if existing.status == "RETIRED":
                 connection.rollback()
                 return existing
@@ -358,7 +371,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
             if persisted is None:
                 connection.rollback()
                 return None
-            existing = load_model_json(DpmBulkReviewCampaignDefinition, _payload(persisted))
+            existing = _load_campaign_definition_payload(_payload(persisted))
             if existing.status == "SUPERSEDED":
                 connection.rollback()
                 return existing
@@ -402,7 +415,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
             if persisted is None:
                 connection.rollback()
                 return None
-            existing = load_model_json(DpmBulkReviewCampaignDefinition, _payload(persisted))
+            existing = _load_campaign_definition_payload(_payload(persisted))
             if existing.content_hash == definition.content_hash:
                 connection.rollback()
                 return existing
@@ -450,7 +463,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
             if persisted is None:
                 connection.rollback()
                 return None
-            existing = load_model_json(DpmBulkReviewCampaignDefinition, _payload(persisted))
+            existing = _load_campaign_definition_payload(_payload(persisted))
             if existing.content_hash == definition.content_hash:
                 connection.rollback()
                 return existing
@@ -498,7 +511,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
             if persisted is None:
                 connection.rollback()
                 return None
-            existing = load_model_json(DpmBulkReviewCampaignDefinition, _payload(persisted))
+            existing = _load_campaign_definition_payload(_payload(persisted))
             if existing.content_hash == definition.content_hash:
                 connection.rollback()
                 return existing
@@ -546,7 +559,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
             if persisted is None:
                 connection.rollback()
                 return None
-            existing = load_model_json(DpmBulkReviewCampaignDefinition, _payload(persisted))
+            existing = _load_campaign_definition_payload(_payload(persisted))
             if existing.content_hash == definition.content_hash:
                 connection.rollback()
                 return existing
@@ -594,7 +607,7 @@ class PostgresDpmBulkReviewCampaignDefinitionRepository:
             if persisted is None:
                 connection.rollback()
                 return None
-            existing = load_model_json(DpmBulkReviewCampaignDefinition, _payload(persisted))
+            existing = _load_campaign_definition_payload(_payload(persisted))
             if existing.content_hash == definition.content_hash:
                 connection.rollback()
                 return existing

--- a/tests/unit/dpm/waves/test_campaign_definition_repository.py
+++ b/tests/unit/dpm/waves/test_campaign_definition_repository.py
@@ -68,6 +68,7 @@ from src.infrastructure.waves.campaign_definitions import (
     InMemoryDpmBulkReviewCampaignDefinitionRepository,
     PostgresDpmBulkReviewCampaignDefinitionRepository,
     _import_psycopg,
+    _load_campaign_definition_payload,
     _payload,
 )
 import src.infrastructure.waves.campaign_definitions as campaign_definition_infra
@@ -196,6 +197,18 @@ def test_campaign_definition_content_hash_helper_applies_and_rejects_mismatch() 
     mismatched = _definition().model_copy(update={"content_hash": "sha256:bad"})
     with pytest.raises(ValueError, match="BULK_REVIEW_CAMPAIGN_DEFINITION_HASH_MISMATCH"):
         _apply_campaign_definition_content_hash(mismatched)
+
+
+def test_campaign_definition_loader_tolerates_legacy_stored_hash() -> None:
+    definition = _definition()
+    legacy_payload = definition.model_dump(mode="json")
+    legacy_payload["content_hash"] = "sha256:legacy-campaign-definition-hash"
+
+    loaded = _load_campaign_definition_payload(legacy_payload)
+
+    assert loaded.campaign_id == definition.campaign_id
+    assert loaded.campaign_version == definition.campaign_version
+    assert loaded.content_hash == definition.content_hash
 
 
 def test_campaign_definition_hash_preserves_pre_approval_decision_payloads() -> None:


### PR DESCRIPTION
## Summary
- preserve legacy campaign-definition hash reads needed by canonical demo Manage flows

## Evidence
- Remote Feature Lane: https://github.com/sgajbi/lotus-manage/actions/runs/27685956506
- Quality Baseline: https://github.com/sgajbi/lotus-manage/actions/runs/27685956502
- Live canonical Workbench validation passed for PB_SG_GLOBAL_BAL_001 after the platform demo stack fixes

## Risk
- Scoped to compatibility read behavior; no broad DPM behavior change intended.