### PR TITLE
Extract projected cash FX intent helpers

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24781,3 +24781,59 @@ and improves internal transaction-cost source posture maintainability only.
   certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260619-985: Projected cash FX intent resolution helpers
+
+- Date: 2026-06-19
+- Scope: `src/core/rebalance/execution.py` and
+  `tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py`.
+- Bank-buyable control area: architecture, rebalance execution maintainability, and testing.
+- Finding: `_append_projected_cash_fx_intents` combined projected-cash iteration, FX resolution,
+  missing-FX diagnostics, blocking behavior, intent appending, and funding-currency dependency map
+  updates in one loop. That made cash-funding and sweep behavior harder to inspect even though
+  each resolution step is deterministic.
+- Action: extracted `_apply_projected_cash_fx_resolution`,
+  `_record_projected_cash_fx_missing_pair`, and `_append_projected_cash_fx_intent` so missing-FX
+  diagnostics, blocking decisions, and intent/dependency-map updates are named separately; added
+  direct helper tests for funding-intent append behavior and nonblocking missing-FX diagnostics
+  while preserving the existing aggregate append behavior.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format src\core\rebalance\execution.py tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py`,
+  `python -m ruff check src\core\rebalance\execution.py tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py`,
+  `python -m ruff format --check src\core\rebalance\execution.py tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py`,
+  `python -m mypy --config-file mypy.ini src\core\rebalance\execution.py`,
+  `python -m pytest tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py`,
+  `python scripts\openapi_quality_gate.py`,
+  `python scripts\api_vocabulary_inventory.py --validate-only`,
+  service leakage scan, `git diff --check`, and
+  `python -m radon cc src\core\rebalance\execution.py -s`; the focused engine intent simulation
+  suite reported 25 passed, and radon reports `_append_projected_cash_fx_intents` reduced from
+  B(6) to A(3) with `_apply_projected_cash_fx_resolution` at A(2).
+- Residual risk: this slice improves internal rebalance execution maintainability only. It does
+  not change FX methodology, order dependency semantics, API contracts, gateway behavior,
+  Workbench behavior, or global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is internal rebalance execution
+  maintainability hardening with no operator-facing contract change.
+
+## BACKEND-REVIEW-20260619-986: Projected cash FX reports refreshed
+
+- Date: 2026-06-19
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after the projected cash FX helper extraction, the checked-in quality reports needed to
+  reflect the updated branch head, test-function count, and current source hotspot list.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts\engineering_health_report.py`; the refreshed reports are sourced from
+  `9302f776`, record 821 Python files, 2647 test functions, keep service boundary findings and
+  router infrastructure imports at 0, keep OpenAPI missing markers at 0, and the current top-ten
+  source hotspot list no longer includes `_append_projected_cash_fx_intents`.
+- Residual risk: this slice updates report truth only. It does not promote report-only complexity
+  baselines into stricter thresholds, remediate the remaining async payload, target-cash,
+  workflow-decision query, risk-authority client, outcome core-source, proof-pack governance,
+  advise-authority client, campaign-definition repository, or construction-readiness hotspots, or
+  certify global bank-buyable readiness.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-17T07:36:52+00:00`
+- Generated at: `2026-06-19T02:55:08+00:00`
 
-- Report source snapshot: `696d2f7b+worktree`
+- Report source snapshot: `9302f776`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 821 |
-| Total Python LOC | 179248 |
-| Test functions | 2644 |
+| Total Python LOC | 179371 |
+| Test functions | 2647 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-17T07:36:52+00:00`
+- Generated at: `2026-06-19T02:55:08+00:00`
 
-- Report source snapshot: `696d2f7b+worktree`
+- Report source snapshot: `9302f776`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 
@@ -32,16 +32,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | _append_projected_cash_fx_intents | src/core/rebalance/execution.py | 6 | 30 |
-| 2 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
-| 3 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
-| 4 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
-| 5 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
-| 6 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
-| 7 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 6 | 27 |
-| 8 | _decision_summary | src/core/proof_packs/builder.py | 6 | 27 |
-| 9 | _tactical_house_view_cohort_from_response | src/infrastructure/advise_authority/client.py | 6 | 26 |
-| 10 | list_definitions | src/infrastructure/waves/campaign_definitions.py | 6 | 26 |
+| 1 | resolve_analyze_async_execution_payload | src/api/services/rebalance_async_operation_payload.py | 6 | 29 |
+| 2 | _apply_min_cash_buffer | src/core/rebalance/targets.py | 6 | 29 |
+| 3 | build_workflow_decision_filter_query | src/infrastructure/rebalance_runs/workflow_decision_query.py | 6 | 29 |
+| 4 | _risk_context_from_concentration_response | src/infrastructure/risk_authority/client.py | 6 | 29 |
+| 5 | _transaction_money_value | src/core/outcomes/core_sources.py | 6 | 27 |
+| 6 | _proof_pack_governance_section_payload | src/core/proof_packs/builder.py | 6 | 27 |
+| 7 | _decision_summary | src/core/proof_packs/builder.py | 6 | 27 |
+| 8 | _tactical_house_view_cohort_from_response | src/infrastructure/advise_authority/client.py | 6 | 26 |
+| 9 | list_definitions | src/infrastructure/waves/campaign_definitions.py | 6 | 26 |
+| 10 | currency_overlay_reason_codes | src/api/services/construction_method_readiness.py | 6 | 25 |
 
 ### Most Complex Current Test Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-17T07:36:52+00:00`
+- Generated at: `2026-06-19T02:55:08+00:00`
 
-- Report source snapshot: `696d2f7b+worktree`
+- Report source snapshot: `9302f776`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-17T07:36:52+00:00`
+- Generated at: `2026-06-19T02:55:08+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `696d2f7b+worktree`
+- Report source snapshot: `9302f776`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 821 | 821 | +0 |
-| Total Python LOC | 179138 | 179248 | +110 |
-| Test functions | 2642 | 2644 | +2 |
+| Total Python LOC | 179274 | 179371 | +97 |
+| Test functions | 2645 | 2647 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -42,7 +42,7 @@
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
-| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
+| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2423 |
 | 9 | src/core/proof_packs/builder.py | 2011 |
 | 10 | src/core/dpm_source_context.py | 1929 |
 
@@ -57,7 +57,7 @@
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
-| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2410 |
+| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2423 |
 | 9 | src/core/proof_packs/builder.py | 2011 |
 | 10 | src/core/dpm_source_context.py | 1929 |
 

--- a/src/core/rebalance/execution.py
+++ b/src/core/rebalance/execution.py
@@ -394,25 +394,77 @@ def _append_projected_cash_fx_intents(
 ) -> tuple[bool, dict[str, str]]:
     fx_intent_id_by_currency: dict[str, str] = {}
     for ccy, bal in projected_cash.items():
-        resolution = _projected_cash_fx_resolution(
+        blocked = _apply_projected_cash_fx_resolution(
             currency=ccy,
             balance=bal,
             base_currency=portfolio.base_currency,
             market_data=market_data,
             intent_id=f"oi_fx_{len(intents) + 1}",
             options=options,
+            intents=intents,
+            diagnostics=diagnostics,
+            fx_intent_id_by_currency=fx_intent_id_by_currency,
         )
-        if resolution.missing_fx_pair is not None:
-            diagnostics.data_quality.setdefault("fx_missing", []).append(resolution.missing_fx_pair)
-        if resolution.blocked:
+        if blocked:
             return True, fx_intent_id_by_currency
-        if resolution.intent is None:
-            continue
-        intents.append(resolution.intent)
-        if resolution.funding_currency is not None:
-            fx_intent_id_by_currency[resolution.funding_currency] = resolution.intent.intent_id
 
     return False, fx_intent_id_by_currency
+
+
+def _apply_projected_cash_fx_resolution(
+    *,
+    currency: str,
+    balance: Decimal,
+    base_currency: str,
+    market_data: MarketDataSnapshot,
+    intent_id: str,
+    options: EngineOptions,
+    intents: list[OrderIntent],
+    diagnostics: DiagnosticsData,
+    fx_intent_id_by_currency: dict[str, str],
+) -> bool:
+    resolution = _projected_cash_fx_resolution(
+        currency=currency,
+        balance=balance,
+        base_currency=base_currency,
+        market_data=market_data,
+        intent_id=intent_id,
+        options=options,
+    )
+    _record_projected_cash_fx_missing_pair(
+        diagnostics=diagnostics,
+        missing_fx_pair=resolution.missing_fx_pair,
+    )
+    if resolution.blocked:
+        return True
+    _append_projected_cash_fx_intent(
+        resolution=resolution,
+        intents=intents,
+        fx_intent_id_by_currency=fx_intent_id_by_currency,
+    )
+    return False
+
+
+def _record_projected_cash_fx_missing_pair(
+    *,
+    diagnostics: DiagnosticsData,
+    missing_fx_pair: str | None,
+) -> None:
+    if missing_fx_pair is not None:
+        diagnostics.data_quality.setdefault("fx_missing", []).append(missing_fx_pair)
+
+
+def _append_projected_cash_fx_intent(
+    *,
+    resolution: _ProjectedCashFxResolution,
+    intents: list[OrderIntent],
+    fx_intent_id_by_currency: dict[str, str],
+) -> None:
+    if resolution.intent is None:
+        return
+    intents.append(resolution.intent)
+    if resolution.funding_currency is not None:
+        fx_intent_id_by_currency[resolution.funding_currency] = resolution.intent.intent_id
 
 
 def _projected_cash_fx_resolution(

--- a/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
+++ b/tests/unit/dpm/engine/coverage/test_engine_intent_simulation.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from src.core.rebalance.execution import (
     _after_simulation_options,
     _apply_execution_intents,
+    _apply_projected_cash_fx_resolution,
     _append_projected_cash_fx_intents,
     _blocked_simulation_result_from_rules,
     _fx_intent_for_projected_cash_balance,
@@ -232,6 +233,50 @@ class TestIntentDependenciesAndSimulation:
         assert blocked is True
         assert fx_map == {}
         assert intents == []
+        assert diagnostics.data_quality == {"fx_missing": ["EUR/USD"]}
+
+    def test_apply_projected_cash_fx_resolution_appends_funding_intent(self):
+        diagnostics = empty_diagnostics()
+        intents = []
+        fx_map = {}
+
+        blocked = _apply_projected_cash_fx_resolution(
+            currency="EUR",
+            balance=Decimal("-100"),
+            base_currency="USD",
+            market_data=market_data_snapshot(fx_rates=[fx("EUR/USD", "1.2")]),
+            intent_id="oi_fx_7",
+            options=EngineOptions(fx_buffer_pct=Decimal("0.05")),
+            intents=intents,
+            diagnostics=diagnostics,
+            fx_intent_id_by_currency=fx_map,
+        )
+
+        assert blocked is False
+        assert [intent.intent_id for intent in intents] == ["oi_fx_7"]
+        assert fx_map == {"EUR": "oi_fx_7"}
+        assert diagnostics.data_quality == {}
+
+    def test_apply_projected_cash_fx_resolution_records_nonblocking_missing_fx(self):
+        diagnostics = empty_diagnostics()
+        intents = []
+        fx_map = {}
+
+        blocked = _apply_projected_cash_fx_resolution(
+            currency="EUR",
+            balance=Decimal("-100"),
+            base_currency="USD",
+            market_data=market_data_snapshot(),
+            intent_id="oi_fx_missing",
+            options=EngineOptions(block_on_missing_fx=False),
+            intents=intents,
+            diagnostics=diagnostics,
+            fx_intent_id_by_currency=fx_map,
+        )
+
+        assert blocked is False
+        assert intents == []
+        assert fx_map == {}
         assert diagnostics.data_quality == {"fx_missing": ["EUR/USD"]}
 
     def test_projected_cash_fx_resolution_maps_missing_fx_and_funding_intent(self):


### PR DESCRIPTION
## Summary
- Extract projected cash FX resolution, diagnostics, and intent append helpers from rebalance execution.
- Add direct helper tests for funding-intent append behavior and nonblocking missing-FX diagnostics.
- Refresh codebase review ledger and quality reports for the measured source hotspot movement.

## Evidence
- `python -m ruff format src\core\rebalance\execution.py tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py`
- `python -m ruff check src\core\rebalance\execution.py tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py`
- `python -m ruff format --check src\core\rebalance\execution.py tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py`
- `python -m mypy --config-file mypy.ini src\core\rebalance\execution.py`
- `python -m pytest tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py` (25 passed)
- `python -m radon cc src\core\rebalance\execution.py -s` (`_append_projected_cash_fx_intents` B(6) -> A(3); new helper A(2))
- `python scripts\openapi_quality_gate.py`
- `python scripts\api_vocabulary_inventory.py --validate-only`
- service leakage scan: no matches
- `git diff --check`
- `python scripts\engineering_health_report.py`
- `make check` (2837 passed, 13 skipped)

## Governance
- OpenAPI quality gate passed.
- API vocabulary inventory gate passed with no drift.
- Service boundary scan returned no matches.
- `git fetch origin --prune` completed.
- `git branch -r --no-merged origin/main` returned no unmerged remote branches.
- `gh pr list --state open --limit 100 --json number,title,headRefName,url` returned `[]` before PR creation.
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned DiffCount 0.

## Residual risk
- This is internal rebalance execution maintainability hardening only.
- It does not change FX methodology, order dependency semantics, API contracts, gateway behavior, Workbench behavior, or certify global bank-buyable readiness.