### PR TITLE
Enforce router infrastructure boundary in CI

### DIFF
--- a/.github/workflows/feature-lane.yml
+++ b/.github/workflows/feature-lane.yml
@@ -53,6 +53,8 @@ jobs:
         run: make api-vocabulary-gate
       - name: Service Boundary Gate
         run: make service-boundary-gate
+      - name: Router Infrastructure Gate
+        run: make router-infrastructure-gate
       - name: Architecture Gate
         run: make architecture-gate
       - name: Complexity Gate

--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -53,6 +53,8 @@ jobs:
         run: make api-vocabulary-gate
       - name: Service Boundary Gate
         run: make service-boundary-gate
+      - name: Router Infrastructure Gate
+        run: make router-infrastructure-gate
       - name: Migration Contract Smoke
         run: make migration-smoke
       - name: Architecture Gate

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -53,6 +53,8 @@ jobs:
         run: make api-vocabulary-gate
       - name: Service Boundary Gate
         run: make service-boundary-gate
+      - name: Router Infrastructure Gate
+        run: make router-infrastructure-gate
       - name: Migration Contract Smoke
         run: make migration-smoke
       - name: Architecture Gate

--- a/.github/workflows/quality-baseline.yml
+++ b/.github/workflows/quality-baseline.yml
@@ -70,6 +70,12 @@ jobs:
           set -o pipefail
           python scripts/service_boundary_gate.py 2>&1 | tee output/quality-baseline/service-boundary.txt
 
+      - name: Router Infrastructure Gate
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python scripts/router_infrastructure_gate.py 2>&1 | tee output/quality-baseline/router-infrastructure.txt
+
       - name: Complexity Baseline
         continue-on-error: true
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: architecture-gate complexity-gate dead-code-gate dependency-hygiene-gate install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate api-vocabulary-gate service-boundary-gate live-api-validate live-api-validate-core format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down
+.PHONY: architecture-gate complexity-gate dead-code-gate dependency-hygiene-gate install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate api-vocabulary-gate service-boundary-gate router-infrastructure-gate live-api-validate live-api-validate-core format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down
 
 COVERAGE_FAIL_UNDER ?= 99
 
@@ -15,10 +15,10 @@ pre-commit:
 	pre-commit run --all-files
 
 check: lint no-alias-gate typecheck typecheck-tests-critical openapi-gate api-vocabulary-gate \
-	service-boundary-gate mesh-contract-validate architecture-gate complexity-gate \
+	service-boundary-gate router-infrastructure-gate mesh-contract-validate architecture-gate complexity-gate \
 	dependency-hygiene-gate dead-code-gate test
 
-ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate service-boundary-gate migration-smoke test-all security-audit
+ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate service-boundary-gate router-infrastructure-gate migration-smoke test-all security-audit
 
 test:
 	$(MAKE) test-unit
@@ -62,6 +62,7 @@ ci-local: lint check-deps
 	$(MAKE) openapi-gate
 	$(MAKE) api-vocabulary-gate
 	$(MAKE) service-boundary-gate
+	$(MAKE) router-infrastructure-gate
 	$(MAKE) typecheck
 
 ci-local-docker:
@@ -89,6 +90,9 @@ api-vocabulary-gate:
 
 service-boundary-gate:
 	python scripts/service_boundary_gate.py
+
+router-infrastructure-gate:
+	python scripts/router_infrastructure_gate.py
 
 live-api-validate:
 	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://127.0.0.1:8001}

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24837,3 +24837,57 @@ and improves internal transaction-cost source posture maintainability only.
   certify global bank-buyable readiness.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260619-987: Router infrastructure boundary CI enforcement
+
+- Date: 2026-06-19
+- Scope: `.github/workflows/feature-lane.yml`, `.github/workflows/pr-merge-gate.yml`,
+  `.github/workflows/main-releasability.yml`, `.github/workflows/quality-baseline.yml`,
+  `Makefile`, `pyproject.toml`, `scripts/router_infrastructure_gate.py`,
+  `scripts/engineering_health_report.py`, `tests/unit/test_router_infrastructure_gate.py`,
+  `tests/unit/test_engineering_health_report.py`, and `quality/ci_quality_gates.md`.
+- Bank-buyable control area: CI enforcement, architecture boundary governance, and warning hygiene.
+- Finding: the quality reports had repeatedly measured router infrastructure imports at zero, but
+  that remediated boundary was still report-only truth. CI also emitted a known third-party
+  Starlette TestClient deprecation warning from `fastapi.testclient`, creating warning noise even
+  though the current application code does not own the deprecated call path.
+- Action: added `scripts/router_infrastructure_gate.py` with direct tests, wired
+  `make router-infrastructure-gate` into `make check`, `make ci`, `make ci-local`, Feature Lane,
+  PR Merge Gate, Main Releasability, and the Quality Baseline artifact capture; updated the
+  scorecard generator and CI-quality documentation to mark router infrastructure imports as an
+  active gate; added a narrow pytest warning filter for the external
+  `fastapi.testclient`/Starlette deprecation.
+- Status: hardened.
+- Evidence:
+  `python scripts\router_infrastructure_gate.py`,
+  `python -m pytest tests\unit\test_router_infrastructure_gate.py tests\unit\test_engineering_health_report.py tests\unit\dpm\engine\coverage\test_engine_intent_simulation.py`,
+  `python -m ruff format scripts\router_infrastructure_gate.py tests\unit\test_router_infrastructure_gate.py tests\unit\test_engineering_health_report.py scripts\engineering_health_report.py`, and
+  `python -m ruff check scripts\router_infrastructure_gate.py tests\unit\test_router_infrastructure_gate.py tests\unit\test_engineering_health_report.py scripts\engineering_health_report.py`;
+  the focused suite reported 35 passed and the router infrastructure gate passed against the
+  current router tree.
+- Residual risk: this slice promotes one already-remediated architecture boundary to blocking CI.
+  It does not promote report-only complexity thresholds, OpenAPI marker debt, documentation score,
+  observability runtime scoring, or third-party GitHub action/node deprecation warnings into hard
+  enterprise gates.
+- Wiki decision: no wiki source change required; this is repository-local CI enforcement and
+  quality-evidence guidance with no operator-facing runtime contract change.
+
+## BACKEND-REVIEW-20260619-988: Router infrastructure gate reports refreshed
+
+- Date: 2026-06-19
+- Scope: `quality/baseline_report.md`, `quality/refactor_health_report.md`,
+  `quality/quality_scorecard.md`, `quality/complexity_report.md`, and this ledger.
+- Bank-buyable control area: CI measurement and operational evidence.
+- Finding: after adding router infrastructure boundary enforcement, checked-in quality reports
+  needed to reflect the new active gate posture, updated source snapshot, and current zero router
+  infrastructure imports.
+- Action: regenerated the repository quality reports with `scripts/engineering_health_report.py`.
+- Status: refreshed.
+- Evidence: `python scripts\engineering_health_report.py`; the refreshed reports are sourced from
+  `84343223+worktree`, record 823 Python files, 2649 test functions, keep service boundary
+  findings and router infrastructure imports at 0, keep OpenAPI missing markers at 0, and list
+  `scripts/router_infrastructure_gate.py` as the active router infrastructure gate.
+- Residual risk: this slice updates report truth only. It does not certify global bank-buyable
+  readiness or convert broader report-only baselines into hard release thresholds.
+- Wiki decision: no wiki source change required; this is repository-local quality evidence with no
+  operator-facing contract change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ markers = [
   "integration: integration tests",
   "e2e: end-to-end tests",
 ]
+filterwarnings = [
+  "ignore:Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead\\.:starlette.testclient.StarletteDeprecationWarning:fastapi\\.testclient",
+]
 
 [tool.bandit]
 exclude_dirs = ["tests", ".venv", ".venv-codex", "output"]

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-19T02:55:08+00:00`
+- Generated at: `2026-06-19T03:14:37+00:00`
 
-- Report source snapshot: `9302f776`
+- Report source snapshot: `84343223+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -10,9 +10,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 821 |
-| Total Python LOC | 179371 |
-| Test functions | 2647 |
+| Python files | 823 |
+| Total Python LOC | 179465 |
+| Test functions | 2649 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 
@@ -35,7 +35,7 @@
 | Largest files/functions | `quality/refactor_health_report.md` | 1 - baseline |
 | OpenAPI completeness | `scripts/openapi_quality_gate.py` plus this report | 2 - active/new-regression |
 | Service boundary leakage | service leakage scan plus this report | 2 - active/new-regression |
-| Router infrastructure imports | reported as known baseline debt | 1 - baseline |
+| Router infrastructure imports | `scripts/router_infrastructure_gate.py` plus this report | 2 - active/new-regression |
 | Complexity/maintainability | `quality/complexity_report.md` | 1 - baseline |
 | Dead code | `make dead-code-gate` plus vulture baseline capture via `quality-baseline.yml` | 2 - active/new-regression |
 | Dependency hygiene | `make dependency-hygiene-gate`, `pip check`, and `make security-audit` | 2 - active/new-regression |

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -23,6 +23,8 @@ The following commands are active repository gates:
   - `make typecheck-tests-critical`
   - `python scripts/openapi_quality_gate.py`
   - `python scripts/api_vocabulary_inventory.py --validate-only`
+  - `python scripts/service_boundary_gate.py`
+  - `python scripts/router_infrastructure_gate.py`
   - `make mesh-contract-validate`
   - `make architecture-gate` (`python -m importlinter.cli import-linter lint --config .importlinter`)
   - `make complexity-gate` (`python -m radon cc src -s -n C`, `python -m radon mi src -s`)
@@ -47,6 +49,7 @@ The following commands are active repository gates:
 - Workflow file: `.github/workflows/feature-lane.yml`
 - Required lanes:
   - `ruff` + `mypy` + `no-alias` + `openapi` + `api-vocabulary` + `security-audit`
+  - `service-boundary-gate` + `router-infrastructure-gate`
   - `architecture-gate` + `complexity-gate` + `dependency-hygiene-gate` + `dead-code-gate`
   - unit tests
 
@@ -55,6 +58,7 @@ The following commands are active repository gates:
 - Workflow file: `.github/workflows/pr-merge-gate.yml`
 - Required lanes:
   - same static/type/openapi/vocabulary/security gates as Feature Lane
+  - `service-boundary-gate` + `router-infrastructure-gate`
   - `architecture-gate` + `complexity-gate` + `dependency-hygiene-gate` + `dead-code-gate`
   - migration smoke
   - matrix unit/integration/e2e tests with coverage upload
@@ -71,6 +75,7 @@ The following commands are active repository gates:
 The `quality-baseline.yml` workflow runs additional quality snapshots in report-only mode:
 
 - `ruff`, `mypy`, `coverage`
+- `service-boundary-gate` + `router-infrastructure-gate`
 - `importlinter`
 - `radon` + `xenon` complexity
 - `vulture` dead-code scan

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-19T02:55:08+00:00`
+- Generated at: `2026-06-19T03:14:37+00:00`
 
-- Report source snapshot: `9302f776`
+- Report source snapshot: `84343223+worktree`
 
 - Mode: report-only maintainability baseline using dependency-free AST branch counting.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-19T02:55:08+00:00`
+- Generated at: `2026-06-19T03:14:37+00:00`
 
-- Report source snapshot: `9302f776`
+- Report source snapshot: `84343223+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 
@@ -14,7 +14,7 @@
 | OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |
 | API vocabulary | Active gate | `scripts/api_vocabulary_inventory.py --validate-only`. |
 | Service boundary | Active gate | `scripts/service_boundary_gate.py`. |
-| Router infrastructure imports | Baseline debt | Current router infra imports: 0. |
+| Router infrastructure imports | Active gate | `scripts/router_infrastructure_gate.py`. |
 | OpenAPI 4xx/5xx response markers | Baseline debt | Current missing markers: 0. |
 | Complexity | Report-only baseline | `quality/complexity_report.md`; add thresholds after baseline review. |
 | Dead code | Active gate | `make dead-code-gate` runs vulture over `src` and `tests`; baseline workflow still captures expanded output. |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-19T02:55:08+00:00`
+- Generated at: `2026-06-19T03:14:37+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `9302f776`
+- Report source snapshot: `84343223+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 821 | 821 | +0 |
-| Total Python LOC | 179274 | 179371 | +97 |
-| Test functions | 2645 | 2647 | +2 |
+| Python files | 821 | 823 | +2 |
+| Total Python LOC | 179371 | 179465 | +94 |
+| Test functions | 2647 | 2649 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -536,8 +536,8 @@ def build_baseline_report(context: HealthReportContext) -> str:
                 ],
                 [
                     "Router infrastructure imports",
-                    "reported as known baseline debt",
-                    "1 - baseline",
+                    "`scripts/router_infrastructure_gate.py` plus this report",
+                    "2 - active/new-regression",
                 ],
                 [
                     "Complexity/maintainability",
@@ -584,8 +584,8 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
         ["Service boundary", "Active gate", "`scripts/service_boundary_gate.py`."],
         [
             "Router infrastructure imports",
-            "Baseline debt",
-            f"Current router infra imports: {len(context.current.router_infra_imports)}.",
+            "Active gate",
+            "`scripts/router_infrastructure_gate.py`.",
         ],
         [
             "OpenAPI 4xx/5xx response markers",

--- a/scripts/router_infrastructure_gate.py
+++ b/scripts/router_infrastructure_gate.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+
+ROUTER_DIR = Path("src/api/routers")
+ROUTER_INFRASTRUCTURE_PATTERNS = (
+    "from src.infrastructure",
+    "import src.infrastructure",
+)
+
+
+def _matching_lines(path: str, text: str, patterns: Iterable[str]) -> list[str]:
+    matches: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if any(pattern in line for pattern in patterns):
+            matches.append(f"{path}:{lineno}: {line.strip()}")
+    return matches
+
+
+def evaluate_router_infrastructure_imports(router_dir: Path = ROUTER_DIR) -> list[str]:
+    violations: list[str] = []
+    for path in sorted(router_dir.rglob("*.py")):
+        violations.extend(
+            _matching_lines(path.as_posix(), path.read_text(), ROUTER_INFRASTRUCTURE_PATTERNS)
+        )
+    return violations
+
+
+def main() -> int:
+    violations = evaluate_router_infrastructure_imports()
+    if violations:
+        print("Router infrastructure gate failed:")
+        print("\n".join(f"- {violation}" for violation in violations))
+        return 1
+    print("Router infrastructure gate passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -131,6 +131,10 @@ def test_baseline_report_declares_report_only_quality_coverage() -> None:
     assert "| Python files | 3 |" in report
     assert "| Router infrastructure imports | 1 |" in report
     assert (
+        "| Router infrastructure imports | `scripts/router_infrastructure_gate.py` plus this report | 2 - active/new-regression |"
+        in report
+    )
+    assert (
         "| Complexity/maintainability | `quality/complexity_report.md` | 1 - baseline |" in report
     )
     assert "does not enforce thresholds by itself" in report
@@ -143,6 +147,10 @@ def test_quality_scorecard_separates_active_gates_from_planned_gates() -> None:
     assert "- Report source snapshot: `abc1234`" in scorecard
     assert "| OpenAPI governance | Active gate | `scripts/openapi_quality_gate.py`. |" in scorecard
     assert "| Service boundary | Active gate | `scripts/service_boundary_gate.py`. |" in scorecard
+    assert (
+        "| Router infrastructure imports | Active gate | `scripts/router_infrastructure_gate.py`. |"
+        in scorecard
+    )
     assert "| Dependency architecture | Active gate |" in scorecard
     assert "| Dead code | Active gate |" in scorecard
     assert "| Complexity | Report-only baseline |" in scorecard

--- a/tests/unit/test_router_infrastructure_gate.py
+++ b/tests/unit/test_router_infrastructure_gate.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from scripts.router_infrastructure_gate import evaluate_router_infrastructure_imports
+
+
+def test_router_infrastructure_gate_detects_infrastructure_imports(tmp_path: Path) -> None:
+    router_dir = tmp_path / "src" / "api" / "routers"
+    router_dir.mkdir(parents=True)
+    (router_dir / "leaky_router.py").write_text(
+        "\n".join(
+            [
+                "from src.infrastructure.rebalance_runs.postgres import PostgresRunRepository",
+                "import src.infrastructure.authority_http",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = evaluate_router_infrastructure_imports(router_dir)
+
+    assert violations == [
+        f"{(router_dir / 'leaky_router.py').as_posix()}:1: "
+        "from src.infrastructure.rebalance_runs.postgres import PostgresRunRepository",
+        f"{(router_dir / 'leaky_router.py').as_posix()}:2: import src.infrastructure.authority_http",
+    ]
+
+
+def test_router_infrastructure_gate_allows_service_imports(tmp_path: Path) -> None:
+    router_dir = tmp_path / "src" / "api" / "routers"
+    router_dir.mkdir(parents=True)
+    (router_dir / "clean_router.py").write_text(
+        "\n".join(
+            [
+                "from src.api.services.rebalance_simulation_service import simulate",
+                "",
+                "def route() -> None:",
+                "    simulate",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert evaluate_router_infrastructure_imports(router_dir) == []


### PR DESCRIPTION
## Summary
- Add a dedicated router infrastructure boundary gate for the already-remediated zero-import baseline.
- Wire `make router-infrastructure-gate` into `make check`, `make ci`, local CI parity, Feature Lane, PR Merge Gate, Main Releasability, and Quality Baseline captures.
- Update quality reports, scorecard generator, CI-quality documentation, and ledger evidence.
- Filter the known external Starlette/FastAPI TestClient deprecation warning so test logs stay focused on actionable repo warnings.

## Evidence
- `python scripts\router_infrastructure_gate.py` (passed)
- `python -m ruff check scripts\router_infrastructure_gate.py scripts\engineering_health_report.py tests\unit\test_router_infrastructure_gate.py tests\unit\test_engineering_health_report.py`
- `python -m ruff format --check scripts\router_infrastructure_gate.py scripts\engineering_health_report.py tests\unit\test_router_infrastructure_gate.py tests\unit\test_engineering_health_report.py`
- `python -m mypy --config-file mypy.ini scripts\router_infrastructure_gate.py scripts\engineering_health_report.py`
- `python -m pytest tests\unit\test_router_infrastructure_gate.py tests\unit\test_engineering_health_report.py` (10 passed)
- `python scripts\engineering_health_report.py`
- `git diff --check`
- `make check` (2852 passed)

## Governance
- `git fetch origin --prune` completed.
- `git branch -r --no-merged origin/main` returned no unmerged remote branches.
- `gh pr list --state open --limit 100 --json number,title,headRefName,url` returned `[]` before PR creation.
- Wiki drift check: `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` returned DiffCount 0.

## Warning posture
- The repository-owned Starlette/FastAPI TestClient deprecation warning is filtered narrowly in pytest configuration.
- The remaining Node `Buffer()` deprecation warning observed in prior logs is emitted inside GitHub artifact action internals, not repository code; this PR does not mask or fork that third-party action behavior.

## Residual risk
- This promotes one stable, already-remediated architecture boundary to blocking CI.
- It does not convert broader report-only complexity, documentation, observability runtime scoring, or all third-party dependency deprecation baselines into hard enterprise gates.