### PR TITLE
Filter external Starlette CI warning

### DIFF
--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24891,3 +24891,26 @@ and improves internal transaction-cost source posture maintainability only.
   readiness or convert broader report-only baselines into hard release thresholds.
 - Wiki decision: no wiki source change required; this is repository-local quality evidence with no
   operator-facing contract change.
+
+## BACKEND-REVIEW-20260619-989: Starlette TestClient warning hygiene
+
+- Date: 2026-06-19
+- Scope: `pyproject.toml`, `scripts/__init__.py`, `scripts/ci_warning_filters.py`,
+  `scripts/openapi_quality_gate.py`, `scripts/api_vocabulary_inventory.py`,
+  `tests/unit/test_ci_warning_filters.py`, and this ledger.
+- Bank-buyable control area: CI warning hygiene and operational signal quality.
+- Finding: PR #559 removed the warning from pytest paths that reported through
+  `fastapi.testclient`, but Main Releasability still surfaced the same external
+  Starlette/httpx TestClient deprecation through app-importing CI scripts.
+- Action: added a narrow CI warning helper for the exact external Starlette TestClient/httpx
+  message, reused it before app imports in OpenAPI and vocabulary gate scripts, and broadened the
+  pytest filter to the same exact message/category without suppressing unrelated deprecations.
+- Status: hardened.
+- Evidence: focused warning-filter tests verify the known warning is suppressed and unrelated
+  deprecation warnings remain visible.
+- Residual risk: this suppresses a known third-party compatibility warning while keeping project
+  warnings visible. It does not address action-internal GitHub/Node deprecation warnings emitted by
+  upstream actions, and it does not replace the eventual dependency-level remediation when the
+  FastAPI/Starlette/httpx stack exposes a warning-free supported path.
+- Wiki decision: no wiki source change required; this is repository-local CI warning hygiene with
+  no operator-facing contract change.

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -24903,8 +24903,9 @@ and improves internal transaction-cost source posture maintainability only.
   `fastapi.testclient`, but Main Releasability still surfaced the same external
   Starlette/httpx TestClient deprecation through app-importing CI scripts.
 - Action: added a narrow CI warning helper for the exact external Starlette TestClient/httpx
-  message, reused it before app imports in OpenAPI and vocabulary gate scripts, and broadened the
-  pytest filter to the same exact message/category without suppressing unrelated deprecations.
+  message and `starlette.exceptions.StarletteDeprecationWarning` category, reused it before app
+  imports in OpenAPI and vocabulary gate scripts, and broadened the pytest filter to the same exact
+  message/category without suppressing unrelated deprecations.
 - Status: hardened.
 - Evidence: focused warning-filter tests verify the known warning is suppressed and unrelated
   deprecation warnings remain visible.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ markers = [
   "e2e: end-to-end tests",
 ]
 filterwarnings = [
-  "ignore:Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead\\.:starlette.testclient.StarletteDeprecationWarning:fastapi\\.testclient",
+  "ignore:Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead\\.:DeprecationWarning",
 ]
 
 [tool.bandit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ markers = [
   "e2e: end-to-end tests",
 ]
 filterwarnings = [
-  "ignore:Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead\\.:DeprecationWarning",
+  "ignore:Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead\\.:starlette.exceptions.StarletteDeprecationWarning",
 ]
 
 [tool.bandit]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-local automation entry points and shared helpers."""

--- a/scripts/api_vocabulary_inventory.py
+++ b/scripts/api_vocabulary_inventory.py
@@ -13,6 +13,12 @@ PROJECT_ROOT_STR = str(PROJECT_ROOT)
 if PROJECT_ROOT_STR not in sys.path:
     sys.path.insert(0, PROJECT_ROOT_STR)
 
+from scripts.ci_warning_filters import (  # noqa: E402
+    suppress_external_starlette_testclient_httpx_warning,
+)
+
+suppress_external_starlette_testclient_httpx_warning()
+
 from src.app.main import app  # noqa: E402
 
 ALLOWED_METHODS = {"get", "post", "put", "patch", "delete"}
@@ -54,7 +60,7 @@ def _semantic_id(name: str) -> str:
 
 def _schema_type(schema: dict[str, Any]) -> str:
     if "$ref" in schema:
-        return schema["$ref"].rsplit("/", 1)[-1]
+        return str(schema["$ref"]).rsplit("/", 1)[-1]
     return str(schema.get("type", "object"))
 
 
@@ -62,7 +68,13 @@ def _resolve_schema(schema: dict[str, Any], components: dict[str, Any]) -> dict[
     ref = schema.get("$ref")
     if not isinstance(ref, str):
         return schema
-    return components.get("schemas", {}).get(ref.rsplit("/", 1)[-1], {})
+    schemas = components.get("schemas", {})
+    if not isinstance(schemas, dict):
+        return {}
+    resolved = schemas.get(ref.rsplit("/", 1)[-1], {})
+    if not isinstance(resolved, dict):
+        return {}
+    return resolved
 
 
 def _schema_variants(schema: dict[str, Any], components: dict[str, Any]) -> list[dict[str, Any]]:
@@ -124,9 +136,9 @@ def _extract_fields(
 ) -> list[dict[str, Any]]:
     variants = _schema_variants(schema, components)
     if variants:
-        fields: list[dict[str, Any]] = []
+        variant_fields: list[dict[str, Any]] = []
         for variant in variants:
-            fields.extend(
+            variant_fields.extend(
                 _extract_fields(
                     variant,
                     components=components,
@@ -134,7 +146,7 @@ def _extract_fields(
                     location=location,
                 )
             )
-        return fields
+        return variant_fields
 
     resolved = _resolve_schema(schema, components)
     properties = resolved.get("properties", {})

--- a/scripts/ci_warning_filters.py
+++ b/scripts/ci_warning_filters.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import warnings
 
+from starlette.exceptions import StarletteDeprecationWarning
+
 STARLETTE_TESTCLIENT_HTTPX_WARNING = (
     r"Using `httpx` with `starlette\.testclient` is deprecated; install `httpx2` instead\."
 )
@@ -12,5 +14,5 @@ def suppress_external_starlette_testclient_httpx_warning() -> None:
     warnings.filterwarnings(
         "ignore",
         message=STARLETTE_TESTCLIENT_HTTPX_WARNING,
-        category=DeprecationWarning,
+        category=StarletteDeprecationWarning,
     )

--- a/scripts/ci_warning_filters.py
+++ b/scripts/ci_warning_filters.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import warnings
+
+STARLETTE_TESTCLIENT_HTTPX_WARNING = (
+    r"Using `httpx` with `starlette\.testclient` is deprecated; install `httpx2` instead\."
+)
+
+
+def suppress_external_starlette_testclient_httpx_warning() -> None:
+    """Suppress a known third-party TestClient import warning in CI entry points."""
+    warnings.filterwarnings(
+        "ignore",
+        message=STARLETTE_TESTCLIENT_HTTPX_WARNING,
+        category=DeprecationWarning,
+    )

--- a/scripts/openapi_quality_gate.py
+++ b/scripts/openapi_quality_gate.py
@@ -10,6 +10,12 @@ PROJECT_ROOT_STR = str(PROJECT_ROOT)
 if PROJECT_ROOT_STR not in sys.path:
     sys.path.insert(0, PROJECT_ROOT_STR)
 
+from scripts.ci_warning_filters import (  # noqa: E402
+    suppress_external_starlette_testclient_httpx_warning,
+)
+
+suppress_external_starlette_testclient_httpx_warning()
+
 from src.app.main import app  # noqa: E402
 
 ALLOWED_METHODS = {"get", "post", "put", "patch", "delete"}

--- a/tests/unit/test_ci_warning_filters.py
+++ b/tests/unit/test_ci_warning_filters.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import warnings
+
+from scripts.ci_warning_filters import suppress_external_starlette_testclient_httpx_warning
+
+
+def test_suppresses_known_starlette_testclient_httpx_warning() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("default")
+        suppress_external_starlette_testclient_httpx_warning()
+
+        warnings.warn(
+            "Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
+    assert captured == []
+
+
+def test_does_not_suppress_unrelated_deprecation_warnings() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("default")
+        suppress_external_starlette_testclient_httpx_warning()
+
+        warnings.warn(
+            "project-owned deprecation warning",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
+    assert len(captured) == 1
+    assert str(captured[0].message) == "project-owned deprecation warning"

--- a/tests/unit/test_ci_warning_filters.py
+++ b/tests/unit/test_ci_warning_filters.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import warnings
 
+from starlette.exceptions import StarletteDeprecationWarning
+
 from scripts.ci_warning_filters import suppress_external_starlette_testclient_httpx_warning
 
 
@@ -12,7 +14,7 @@ def test_suppresses_known_starlette_testclient_httpx_warning() -> None:
 
         warnings.warn(
             "Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.",
-            DeprecationWarning,
+            StarletteDeprecationWarning,
             stacklevel=1,
         )
 


### PR DESCRIPTION
## Summary
- add a shared CI warning filter for the known external Starlette/httpx TestClient deprecation
- apply the filter before app imports in OpenAPI and API vocabulary gate scripts
- keep unrelated deprecation warnings visible with direct warning-filter tests
- tighten small typing issues in the vocabulary script exposed by direct script mypy
- record review evidence in the codebase ledger

## Validation
- python -m ruff check scripts\__init__.py scripts\ci_warning_filters.py scripts\openapi_quality_gate.py scripts\api_vocabulary_inventory.py tests\unit\test_ci_warning_filters.py
- python -m ruff format --check scripts\__init__.py scripts\ci_warning_filters.py scripts\openapi_quality_gate.py scripts\api_vocabulary_inventory.py tests\unit\test_ci_warning_filters.py
- python -m mypy --config-file mypy.ini scripts\ci_warning_filters.py scripts\openapi_quality_gate.py scripts\api_vocabulary_inventory.py
- python -m pytest tests\unit\test_ci_warning_filters.py tests\unit\test_openapi_quality_gate.py
- python scripts\openapi_quality_gate.py
- python scripts\api_vocabulary_inventory.py --validate-only
- git diff --check
- service leakage scan: no matches
- make check: 2841 passed, 13 skipped

## Governance
- Stranded truth: git branch -r --no-merged origin/main returned no branches
- Open PRs before PR creation: none
- Wiki drift: DiffCount 0; no wiki publication required
- Residual risk: action-internal GitHub/Node deprecation warnings remain outside repo-owned Python code