### PR TITLE
Add demo certification CI evidence lane

### DIFF
--- a/.github/workflows/demo-certification.yml
+++ b/.github/workflows/demo-certification.yml
@@ -1,0 +1,67 @@
+name: Demo Certification
+
+on:
+  workflow_dispatch:
+    inputs:
+      lotus_manage_base_url:
+        description: "Reachable lotus-manage base URL for live demo certification."
+        required: true
+      lotus_core_control_base_url:
+        description: "Reachable lotus-core control base URL."
+        required: true
+      lotus_core_query_base_url:
+        description: "Reachable lotus-core query base URL."
+        required: true
+      portfolio_id:
+        description: "Canonical portfolio id for demo certification."
+        required: true
+        default: "PB_SG_GLOBAL_BAL_001"
+      as_of:
+        description: "Canonical as-of date for demo certification."
+        required: true
+        default: "2026-04-10"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  live-api-demo-certification:
+    name: Demo Certification / Live API Evidence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+
+      - name: Install
+        run: make install-ci
+
+      - name: Run Demo Certification
+        env:
+          LOTUS_MANAGE_BASE_URL: ${{ inputs.lotus_manage_base_url }}
+          LOTUS_CORE_CONTROL_BASE_URL: ${{ inputs.lotus_core_control_base_url }}
+          LOTUS_CORE_QUERY_BASE_URL: ${{ inputs.lotus_core_query_base_url }}
+          LOTUS_MANAGE_CANONICAL_PORTFOLIO_ID: ${{ inputs.portfolio_id }}
+          LOTUS_MANAGE_CANONICAL_AS_OF: ${{ inputs.as_of }}
+          LOTUS_MANAGE_DEMO_CERT_OUTPUT: output/live-api/demo-certification/summary.json
+        run: make demo-certify
+
+      - name: Upload Demo Certification Evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: demo-certification-evidence
+          path: output/live-api/demo-certification/
+          if-no-files-found: warn

--- a/.github/workflows/quality-baseline.yml
+++ b/.github/workflows/quality-baseline.yml
@@ -125,6 +125,12 @@ jobs:
           PY
           spectral lint openapi.json --ruleset .spectral.yaml 2>&1 | tee output/quality-baseline/spectral.txt
 
+      - name: Demo Certification Contract
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python -m pytest tests/unit/test_validate_live_api.py tests/unit/test_run_demo_pack_live.py 2>&1 | tee output/quality-baseline/demo-certification-contract.txt
+
       - name: Upload Quality Baseline Logs
         if: always()
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: architecture-gate complexity-gate duplicate-implementation-gate dead-code-gate dependency-hygiene-gate workflow-policy-gate quality-report-gate coverage-gate static-quality-gates install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate api-vocabulary-gate service-boundary-gate router-infrastructure-gate live-api-validate live-api-validate-core format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down
+.PHONY: architecture-gate complexity-gate duplicate-implementation-gate dead-code-gate dependency-hygiene-gate workflow-policy-gate quality-report-gate coverage-gate static-quality-gates install install-ci check check-all test test-unit test-integration test-e2e test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate api-vocabulary-gate service-boundary-gate router-infrastructure-gate live-api-validate live-api-validate-core demo-certify format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down
 
 COVERAGE_FAIL_UNDER ?= 99
 
@@ -94,6 +94,9 @@ live-api-validate:
 
 live-api-validate-core:
 	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://manage.dev.lotus} --skip-demo-pack --core-base-url $${LOTUS_CORE_CONTROL_BASE_URL:-http://core-control.dev.lotus} --core-base-url $${LOTUS_CORE_QUERY_BASE_URL:-http://core-query.dev.lotus} --expect-core-dpm-route $${LOTUS_MANAGE_EXPECT_CORE_DPM_ROUTE:-absent} --expect-stateful-core-sourcing $${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-available} --portfolio-id $${LOTUS_MANAGE_CANONICAL_PORTFOLIO_ID:-PB_SG_GLOBAL_BAL_001} --as-of $${LOTUS_MANAGE_CANONICAL_AS_OF:-2026-04-10}
+
+demo-certify:
+	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://manage.dev.lotus} --skip-demo-pack --core-base-url $${LOTUS_CORE_CONTROL_BASE_URL:-http://core-control.dev.lotus} --core-base-url $${LOTUS_CORE_QUERY_BASE_URL:-http://core-query.dev.lotus} --expect-core-dpm-route $${LOTUS_MANAGE_EXPECT_CORE_DPM_ROUTE:-absent} --expect-stateful-core-sourcing $${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-available} --portfolio-id $${LOTUS_MANAGE_CANONICAL_PORTFOLIO_ID:-PB_SG_GLOBAL_BAL_001} --as-of $${LOTUS_MANAGE_CANONICAL_AS_OF:-2026-04-10} --json-output $${LOTUS_MANAGE_DEMO_CERT_OUTPUT:-output/live-api/demo-certification/summary.json}
 
 migration-smoke:
 	python -m pytest tests/unit/shared/dependencies/test_postgres_migrations.py tests/unit/shared/dependencies/test_production_cutover_contract.py -q

--- a/README.md
+++ b/README.md
@@ -586,6 +586,11 @@ Repo-native gate mapping:
   because RFC-087 source products and stateful manage gates are active. Set
   `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=disabled` only when deliberately validating a
   non-source-ready local runtime.
+- `make demo-certify`
+  app-level demo certification against the canonical live stack. It writes machine-readable
+  evidence to `output/live-api/demo-certification/summary.json` by default and asserts capability
+  truth, stateful source-backed construction, supportability persistence, metrics, and retired
+  route absence for `PB_SG_GLOBAL_BAL_001` as of `2026-04-10`.
 - `make mesh-contract-validate`
   repo-native domain product, trust telemetry, and observability monitoring contract validation
   against Lotus platform governance
@@ -645,6 +650,10 @@ Operationally important truths:
    stateful source-backed construction over `TransactionCostCurve:v1`,
    `PortfolioCashflowProjection:v1`, `ClientRestrictionProfile:v1`, and
    `SustainabilityPreferenceProfile:v1`, not only stateful simulate lineage.
+   Demo certification uses the same proof family through `make demo-certify`; the GitHub
+   `Demo Certification` workflow is manual because normal hosted CI runners do not own the
+   canonical local stack, while Quality Baseline keeps the deterministic command-contract tests
+   visible as report-only evidence.
 5. `DPM_CORE_TRANSACTION_COST_LOOKBACK_DAYS` defaults to 400 days so low-turnover private-banking
    portfolios can consume observed booked-fee evidence without treating it as predictive execution
    cost, venue, or market-impact methodology.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -950,7 +950,9 @@ Use these commands as the primary local contract:
    `make ci-local-docker`
 6. canonical host runtime
    `make run-canonical`
-7. domain-data-product contract validation
+7. app-level demo certification
+   `make demo-certify`
+8. domain-data-product contract validation
    `make domain-product-validate`
 
 ## Validation And CI Expectations
@@ -977,7 +979,10 @@ Important validation expectations:
 7. current operational evidence docs under `docs/demo/` and runbooks should preserve canonical
    `lotus-manage` service, image, and ingress identity while clearly labeling historical local-only
    debug paths.
-8. RFC/docs/wiki/context work must include stranded-truth reconciliation before RFC start, final
+8. app-level demo certification is repo-native through `make demo-certify`; it is exposed through a
+   manual GitHub workflow with uploaded evidence and report-only command-contract coverage until the
+   canonical live stack is proven stable inside CI.
+9. RFC/docs/wiki/context work must include stranded-truth reconciliation before RFC start, final
    closure, post-merge audit, and move-on to the next RFC. Run `git fetch origin --prune` and
    `git branch -r --no-merged origin/main`, inspect unmerged branches touching `docs/rfcs/`,
    `wiki/`, `README.md`, `REPOSITORY-ENGINEERING-CONTEXT.md`, `AGENTS.md`, contracts, standards,

--- a/docs/architecture/CODEBASE-REVIEW-LEDGER.md
+++ b/docs/architecture/CODEBASE-REVIEW-LEDGER.md
@@ -29625,3 +29625,75 @@ and improves internal transaction-cost source posture maintainability only.
   `lotus-ci-enforcement-governance` guidance already directs agents to promote deterministic,
   measured, low-noise gates; this slice applies that guidance locally and does not change the
   platform operating contract.
+
+## BACKEND-REVIEW-20260620-0912: App-level demo certification pipeline posture
+
+- Date: 2026-06-20
+- Scope: `scripts/validate_live_api.py`, `Makefile`, `.github/workflows/demo-certification.yml`,
+  `.github/workflows/quality-baseline.yml`, `scripts/workflow_policy_gate.py`,
+  `tests/unit/test_validate_live_api.py`, `tests/unit/test_run_demo_pack_live.py`,
+  `tests/unit/test_local_docker_runtime_contract.py`, `tests/unit/test_ci_workflow_gate_enforcement.py`,
+  README, wiki validation guidance, repository engineering context, generated quality reports, and
+  this ledger.
+- Bank-buyable control area: repeatable app-level demo proof, canonical live API evidence,
+  capability-truth drift prevention, supportability/observability proof, and low-noise CI lane
+  placement for future agent work.
+- Quality intake: the existing owner pattern is FastAPI routers in `src/api/routers/*`,
+  orchestration in `src/api/services/*`, domain logic in `src/core/*`, persistence in
+  `src/infrastructure/*`, and integration capability truth at
+  `/api/v1/integration/capabilities`. Source truth is `REPOSITORY-ENGINEERING-CONTEXT.md`,
+  `wiki/Supported-Features.md`, `wiki/Validation-and-CI.md`, OpenAPI, domain/trust contracts, and
+  canonical front-office seed truth for `PB_SG_GLOBAL_BAL_001`. Closest meaningful tests are
+  `tests/unit/test_validate_live_api.py`, `tests/unit/test_run_demo_pack_live.py`,
+  `tests/e2e/demo/test_demo_scenarios.py`, `tests/integration/test_openapi_certification_matrix.py`,
+  and DPM supportability/API integration tests. Repo-native validation uses `make demo-certify`,
+  `make live-api-validate-core`, focused pytest, workflow-policy gate, and generated report
+  freshness. The measurable quality signal is machine-readable live certification evidence with
+  zero failed probes, preserved capability truth, expected construction figures, supportability
+  persistence, metrics exposure, and retired-route absence.
+- Finding: `lotus-manage` already had a strong live API validator, but no repo-native
+  demo-certification command with stable evidence defaults and no CI-visible posture that future
+  agents could discover. Making the live command PR-blocking would be noisy because normal hosted
+  runners do not own the canonical local stack.
+- Action: added `make demo-certify` as the repo-native app-level command using canonical manage/core
+  URLs, `PB_SG_GLOBAL_BAL_001`, and `2026-04-10` defaults. The validator now writes certification
+  metadata into the JSON summary. Added a manual GitHub `Demo Certification` workflow that runs the
+  same command against caller-supplied reachable canonical URLs and uploads evidence. Added a
+  report-only Quality Baseline step for deterministic command-contract tests and extended workflow
+  policy expectations so the new workflow keeps read-only permissions and pinned artifact actions.
+  Updated README, wiki validation guidance, repository context, and generated scorecard/baseline
+  truth.
+- Status: hardened.
+- Evidence:
+  `python -m ruff format --check scripts\validate_live_api.py tests\unit\test_validate_live_api.py tests\unit\test_local_docker_runtime_contract.py tests\unit\test_ci_workflow_gate_enforcement.py scripts\engineering_health_report.py`,
+  `python -m ruff check scripts\validate_live_api.py tests\unit\test_validate_live_api.py tests\unit\test_local_docker_runtime_contract.py tests\unit\test_ci_workflow_gate_enforcement.py scripts\workflow_policy_gate.py scripts\engineering_health_report.py`,
+  `python -m pytest tests\unit\test_validate_live_api.py tests\unit\test_run_demo_pack_live.py tests\unit\test_local_docker_runtime_contract.py tests\unit\test_ci_workflow_gate_enforcement.py`
+  reported 41 passed, `make workflow-policy-gate`, `python scripts\engineering_health_report.py --check`,
+  and `make demo-certify` passed. `make demo-certify` wrote
+  `output/live-api/demo-certification/summary.json` with 14 probes, 0 failures, canonical
+  `PB_SG_GLOBAL_BAL_001` metadata, READY stateful core-sourcing lineage, source-backed construction
+  over `TransactionCostCurve`, `PortfolioCashflowProjection`, `ClientRestrictionProfile`, and
+  `SustainabilityPreferenceProfile`, expected first-wave construction figures, PostgreSQL
+  supportability summary, bounded supportability metrics, and retired core DPM route absence on
+  both core-control and core-query. The governed canonical Workbench validation also passed for
+  `PB_SG_GLOBAL_BAL_001`, writing `live-validation-summary.json` and 29 `demo_ready` screenshots to
+  `C:\Users\Sandeep\projects\lotus-workbench\output\playwright\live-canonical\lotus-manage-main-20260620-090006`.
+  The aggregate `make check` gate then passed with 2,960 passed and 13 skipped unit tests after
+  completing the static, contract, architecture, duplicate, dependency, dead-code, workflow-policy,
+  quality-report, and unit-test phases.
+- CI-enforcement decision: no new live demo gate is promoted to blocking in this slice. The
+  deterministic contract coverage is report-only in Quality Baseline, and the live command is
+  manual with uploaded evidence until canonical stack availability, repeated-run stability,
+  false-positive posture, lane placement, and exception policy are proven.
+- Stranded truth: `git fetch origin --prune` succeeded and `git branch -r --no-merged origin/main`
+  returned no unmerged remote branches to classify before this CI/demo-certification slice.
+- Residual risk: the live demo command is environment-dependent and should remain manual/report-only
+  in CI until repeated canonical-stack runs prove low-noise stability in the intended lane.
+- Wiki decision: wiki source changed because validation/operator truth changed. Run wiki check-only
+  before merge and publish from `main` after merge. Pre-merge check-only currently reports expected
+  drift for `Validation-and-CI.md` because this branch intentionally updates repo-authored wiki
+  source ahead of publication.
+- Guidance decision: no platform skill or agent-context source update required. Existing
+  `lotus-demo-readiness-certification`, `lotus-ci-enforcement-governance`, and
+  `lotus-backend-delivery-governance` guidance already covers this manual/report-only promotion
+  posture; this slice applies the current guidance locally.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-20T00:45:09+00:00`
+- Generated at: `2026-06-20T01:18:12+00:00`
 
-- Report source snapshot: `ae2ddfbb+worktree`
+- Report source snapshot: `2643af7b+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 878 |
-| Total Python LOC | 185387 |
-| Test functions | 2745 |
+| Total Python LOC | 185475 |
+| Test functions | 2748 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 
@@ -43,6 +43,7 @@
 | Security | `bandit` + project-scoped `pip-audit` via `quality-baseline.yml` and `make security-audit` | 2 - active/new-regression |
 | Documentation gaps | current docs tests plus planned docs scorecard | planned |
 | Observability gaps | `scripts/validate_observability_contracts.py`; richer runtime gap report planned | 2 - active/new-regression |
+| Demo certification | `make demo-certify` plus manual live workflow; command-contract tests in Quality Baseline | 1 - manual/report-only live evidence |
 
 ## Notes
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-20T00:45:09+00:00`
+- Generated at: `2026-06-20T01:18:12+00:00`
 
-- Report source snapshot: `ae2ddfbb+worktree`
+- Report source snapshot: `2643af7b+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-20T00:45:09+00:00`
+- Generated at: `2026-06-20T01:18:12+00:00`
 
-- Report source snapshot: `ae2ddfbb+worktree`
+- Report source snapshot: `2643af7b+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 
@@ -27,6 +27,7 @@
 | Security depth | Active project dependency gate | `make security-audit` runs high-severity Bandit over `src` plus project-scoped `python -m pip_audit .`; `quality-baseline.yml` captures the same scanner family as report-only evidence. |
 | Documentation coverage | Partially active | Docs current-state tests exist; add docs-gap scoring later. |
 | Observability | Partially active | Observability contract validator exists; add runtime posture scoring later. |
+| Demo certification | Manual/report-only live evidence | `make demo-certify` certifies canonical live API demo proof and writes JSON evidence; `demo-certification.yml` is manual, while `quality-baseline.yml` keeps deterministic command-contract tests report-only until CI has a stable canonical stack lane. |
 
 ## Progressive Gate Policy
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-20T00:45:09+00:00`
+- Generated at: `2026-06-20T01:18:12+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `ae2ddfbb+worktree`
+- Report source snapshot: `2643af7b+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 826 | 878 | +52 |
-| Total Python LOC | 179538 | 185387 | +5849 |
-| Test functions | 2651 | 2745 | +94 |
+| Python files | 878 | 878 | +0 |
+| Total Python LOC | 185387 | 185475 | +88 |
+| Test functions | 2745 | 2748 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,14 +37,14 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 6408 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3318 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3126 |
+| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 2960 |
 | 5 | tests/unit/test_documentation_current_state.py | 2721 |
 | 6 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2600 |
 | 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2531 |
-| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2423 |
-| 9 | src/core/proof_packs/builder.py | 2011 |
-| 10 | src/core/dpm_source_context.py | 1929 |
+| 8 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 2489 |
+| 9 | tests/unit/core/test_risk_realized_outcome_sources.py | 1811 |
+| 10 | tests/unit/api/test_pm_operating_quality_api.py | 1745 |
 
 ### current branch
 
@@ -75,8 +75,8 @@
 | 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
 | 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
 | 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
-| 9 | test_source_context_lifts_external_hedge_readiness_as_fail_closed_currency_context | tests/unit/dpm/construction/test_enrichment.py | 235 |
-| 10 | test_dpm_supportability_and_async_schemas_have_descriptions_and_examples | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 234 |
+| 9 | test_rolling_and_historical_attribution_helper_edges_are_explicit | tests/unit/core/test_risk_realized_outcome_sources.py | 236 |
+| 10 | test_source_context_lifts_external_hedge_readiness_as_fail_closed_currency_context | tests/unit/dpm/construction/test_enrichment.py | 235 |
 
 ### current branch
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -575,6 +575,11 @@ def build_baseline_report(context: HealthReportContext) -> str:
                     "`scripts/validate_observability_contracts.py`; richer runtime gap report planned",
                     "2 - active/new-regression",
                 ],
+                [
+                    "Demo certification",
+                    "`make demo-certify` plus manual live workflow; command-contract tests in Quality Baseline",
+                    "1 - manual/report-only live evidence",
+                ],
             ],
         ),
         "## Notes",
@@ -658,6 +663,13 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
             "Observability",
             "Partially active",
             "Observability contract validator exists; add runtime posture scoring later.",
+        ],
+        [
+            "Demo certification",
+            "Manual/report-only live evidence",
+            "`make demo-certify` certifies canonical live API demo proof and writes JSON evidence; "
+            "`demo-certification.yml` is manual, while `quality-baseline.yml` keeps deterministic "
+            "command-contract tests report-only until CI has a stable canonical stack lane.",
         ],
     ]
     sections = [

--- a/scripts/validate_live_api.py
+++ b/scripts/validate_live_api.py
@@ -3,6 +3,7 @@ import json
 import sys
 import uuid
 from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable, Literal, cast
 
@@ -877,14 +878,21 @@ def run_live_api_validation(
     return results
 
 
-def summarize(results: list[ProbeResult]) -> dict[str, Any]:
+def summarize(
+    results: list[ProbeResult],
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     failures = [asdict(result) for result in results if not result.ok]
-    return {
+    summary = {
         "total": len(results),
         "failed": len(failures),
         "failures": failures,
         "results": [asdict(result) for result in results],
     }
+    if metadata is not None:
+        summary["metadata"] = metadata
+    return summary
 
 
 def main() -> int:
@@ -949,7 +957,28 @@ def main() -> int:
         portfolio_id=args.portfolio_id,
         as_of=args.as_of,
     )
-    summary = summarize(results)
+    metadata = {
+        "certification": "lotus-manage-live-api-demo-certification",
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "base_url": args.base_url,
+        "include_demo_pack": not args.skip_demo_pack,
+        "core_base_urls": args.core_base_url,
+        "expect_core_dpm_route": args.expect_core_dpm_route,
+        "expect_stateful_core_sourcing": args.expect_stateful_core_sourcing,
+        "portfolio_id": args.portfolio_id,
+        "as_of": args.as_of,
+        "evidence_basis": [
+            "health readiness",
+            "integration capability publication",
+            "OpenAPI certification contract",
+            "stateful core-sourcing lineage",
+            "construction calculation invariants",
+            "async idempotency/correlation guard",
+            "PostgreSQL supportability summary",
+            "bounded supportability metric exposure",
+        ],
+    }
+    summary = summarize(results, metadata=metadata)
     rendered = json.dumps(summary, indent=2, sort_keys=True)
     print(rendered)
     if args.json_output is not None:

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -21,6 +21,7 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
     "pr-merge-gate.yml": {"contents": "read"},
     "main-releasability.yml": {"contents": "read"},
     "quality-baseline.yml": {"contents": "read"},
+    "demo-certification.yml": {"contents": "read"},
     "pr-auto-merge.yml": {"contents": "write", "pull-requests": "write"},
 }
 USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?([^\"'\s#]+)", re.MULTILINE)

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -22,6 +22,7 @@ ARTIFACT_WORKFLOWS = [
     Path(".github/workflows/pr-merge-gate.yml"),
     Path(".github/workflows/main-releasability.yml"),
     Path(".github/workflows/quality-baseline.yml"),
+    Path(".github/workflows/demo-certification.yml"),
 ]
 
 QUALITY_GATE_NAMES = [
@@ -179,6 +180,29 @@ def test_quality_baseline_uses_project_scoped_security_audit() -> None:
 
     assert "python -m pip_audit ." in workflow_text
     assert "pip-audit -r pyproject.toml" not in workflow_text
+
+
+def test_demo_certification_is_manual_and_evidence_backed() -> None:
+    workflow_text = Path(".github/workflows/demo-certification.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow_text
+    assert "schedule:" not in workflow_text
+    assert "pull_request:" not in workflow_text
+    assert "make demo-certify" in workflow_text
+    assert "LOTUS_MANAGE_DEMO_CERT_OUTPUT: output/live-api/demo-certification/summary.json" in (
+        workflow_text
+    )
+    assert "actions/upload-artifact@v7" in workflow_text
+
+
+def test_quality_baseline_keeps_demo_certification_contract_report_only() -> None:
+    workflow_text = Path(".github/workflows/quality-baseline.yml").read_text(encoding="utf-8")
+    block = _step_block(workflow_text, "Demo Certification Contract")
+
+    assert "continue-on-error: true" in block
+    assert "tests/unit/test_validate_live_api.py" in block
+    assert "tests/unit/test_run_demo_pack_live.py" in block
+    assert "make demo-certify" not in block
 
 
 def test_workflow_policy_gate_passes_current_repository_workflows() -> None:

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -82,6 +82,7 @@ def test_manage_core_live_validation_has_repo_native_command_and_docs() -> None:
     validation_wiki_text = Path("wiki/Validation-and-CI.md").read_text(encoding="utf-8")
 
     assert "live-api-validate-core:" in makefile_text
+    assert "demo-certify:" in makefile_text
     assert "--core-base-url $${LOTUS_CORE_CONTROL_BASE_URL:-http://core-control.dev.lotus}" in (
         makefile_text
     )
@@ -91,10 +92,13 @@ def test_manage_core_live_validation_has_repo_native_command_and_docs() -> None:
     assert (
         "--expect-stateful-core-sourcing $${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-available}"
     ) in makefile_text
+    assert "LOTUS_MANAGE_DEMO_CERT_OUTPUT" in makefile_text
     assert "`make live-api-validate-core`" in readme_text
+    assert "`make demo-certify`" in readme_text
     assert "RFC-087 certified source-data" in readme_text
     assert "products and canonical data is seeded" in readme_text
     assert "non-source-ready local runtime" in readme_text
     assert "make live-api-validate-core" in validation_wiki_text
+    assert "make demo-certify" in validation_wiki_text
     assert "RFC-087 certified composed DPM source-data products" in validation_wiki_text
     assert "canonical source-ready stack defaults" in validation_wiki_text

--- a/tests/unit/test_validate_live_api.py
+++ b/tests/unit/test_validate_live_api.py
@@ -304,6 +304,24 @@ def test_live_api_validation_probes_expected_contracts(monkeypatch) -> None:
     }
 
 
+def test_live_api_summary_can_include_demo_certification_metadata() -> None:
+    summary = summarize(
+        [],
+        metadata={
+            "certification": "lotus-manage-live-api-demo-certification",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "as_of": "2026-04-10",
+        },
+    )
+
+    assert summary["failed"] == 0
+    assert summary["metadata"] == {
+        "certification": "lotus-manage-live-api-demo-certification",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of": "2026-04-10",
+    }
+
+
 def test_live_api_validation_probes_stateful_source_backed_construction(monkeypatch) -> None:
     monkeypatch.setattr(
         "scripts.validate_live_api._load_demo_payload",

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -25,6 +25,9 @@
   The canonical source-ready stack defaults to
   `LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING=available`; set it to `disabled` only for a
   deliberately non-source-ready local runtime.
+- `make demo-certify`
+  app-level demo certification against the canonical live stack. The default evidence path is
+  `output/live-api/demo-certification/summary.json`.
 
 ## Live API evidence
 
@@ -67,6 +70,27 @@ Canonical core/manage proof mode must configure both `DPM_CORE_BASE_URL` and
 `DPM_CORE_QUERY_BASE_URL` for `lotus-manage`. `DPM_CORE_TRANSACTION_COST_LOOKBACK_DAYS` defaults to
 400 days so the observed-cost proof covers low-turnover private-banking portfolios without making
 predictive execution-cost or market-impact claims.
+
+For app-level demo certification, run:
+
+```bash
+make demo-certify
+```
+
+The command uses the same live API validator with canonical defaults for
+`PB_SG_GLOBAL_BAL_001` as of `2026-04-10`, writes machine-readable evidence, and exits non-zero if
+capability truth, stateful source-backed construction, expected construction figures,
+supportability persistence, metrics, or retired-route behavior are weak or failing.
+
+CI posture:
+
+1. the `Demo Certification` GitHub workflow is manual and uploads the evidence artifact for
+   caller-supplied reachable canonical URLs,
+2. `Quality Baseline` runs deterministic command-contract tests report-only so future agents see
+   drift without making environment-dependent live stack proof a noisy blocker,
+3. live demo certification should become blocking only after the canonical stack is available in
+   the intended CI lane and repeated runs prove baseline stability, false-positive posture, and
+   exception handling.
 
 ## Documentation contract proof
 


### PR DESCRIPTION
## Summary
- Add `make demo-certify` as the repo-native live API demo certification command for `lotus-manage`.
- Add a manual/report-only CI posture: manual `Demo Certification` workflow with uploaded evidence plus Quality Baseline command-contract tests.
- Add certification metadata to live API JSON evidence and update tests, README, wiki source, repo context, generated scorecards, and CODEBASE-REVIEW-LEDGER.

## Why
- Future agent work needs one deterministic command to certify supported demo API behavior without making environment-dependent live stack proof a noisy PR blocker.
- Per `lotus-ci-enforcement-governance`, this keeps live demo certification manual/report-only until repeated canonical stack runs prove stable, deterministic, low-noise, and policy-backed.

## Scope
- [x] Single RFC/slice scope
- [x] No unrelated refactors mixed in

## Risk / Rollback
- Risk: low; blocking CI gates are not expanded. The new live workflow is manual and requires caller-supplied reachable canonical URLs.
- Rollback: revert this commit to remove `make demo-certify`, the manual workflow, and related docs/tests/scorecard updates.

## Validation Evidence
- Static/local gate: [x] `make check` passed: 2,960 passed, 13 skipped
- PR-grade local gate: [ ] `make ci` not run; this slice is CI/docs/test wiring and `make check` plus live canonical proof were run locally
- Local PR parity gate: [ ] `make ci-local` not run; no Docker/runtime contract code changed
- Workflow policy: [x] `make workflow-policy-gate` passed
- Quality report freshness: [x] `python scripts/engineering_health_report.py --check` passed
- Duplicate implementation gate: [x] covered by `make check`
- Coverage gate: [ ] `make coverage-gate` not run separately
- OpenAPI contract: [x] covered by `make check`
- API vocabulary: [x] covered by `make check`
- No-alias contract: [x] covered by `make check`
- Security audit: [ ] not run; no dependency/security policy changes in this slice
- Targeted tests for changed area: [x] `python -m pytest tests\unit\test_validate_live_api.py tests\unit\test_run_demo_pack_live.py tests\unit\test_local_docker_runtime_contract.py tests\unit\test_ci_workflow_gate_enforcement.py` passed: 41 passed
- Live API demo proof: [x] `make demo-certify` passed with `output/live-api/demo-certification/summary.json`, 14 probes, 0 failures
- Canonical Workbench proof: [x] live validation passed for `PB_SG_GLOBAL_BAL_001`; evidence at `C:\Users\Sandeep\projects\lotus-workbench\output\playwright\live-canonical\lotus-manage-main-20260620-090006`
- Whitespace: [x] `git diff --check` passed

## CI Expectations
- [ ] Remote Feature Lane is green
- [ ] Pull Request Merge Gate is green
- [ ] Main Releasability is green or explicitly scheduled/manual for this change class
- [x] Heavy gates run in scheduled/manual tier where applicable: live demo certification is manual/report-only first

## Governance/Docs
- [x] RFC/docs updated where behavior or standards changed
- [x] API/OpenAPI/vocabulary updates included if contract changed: no API contract change
- [x] Stranded truth reconciliation run: `git fetch origin --prune`
- [x] Stranded truth reconciliation run: `git branch -r --no-merged origin/main`
- [x] Unmerged governance-bearing branches classified or none found
- Wiki decision: wiki source updated; pre-merge `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reports expected drift for `Validation-and-CI.md` until this PR is merged and published from main.
- Guidance decision: no platform skill/context source change required; current `lotus-demo-readiness-certification`, `lotus-ci-enforcement-governance`, and backend delivery guidance already cover this posture.

## Post-Merge Hygiene
- [ ] Delete remote feature branch
- [ ] Delete local feature branch
- [ ] Sync local main with origin/main (`local = remote = main`)