### PR TITLE
Approve Lotus Idea as Manage mesh consumer

### DIFF
--- a/contracts/domain-data-products/lotus-manage-products.v1.json
+++ b/contracts/domain-data-products/lotus-manage-products.v1.json
@@ -56,7 +56,8 @@
       },
       "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
       "approved_consumers": [
-        "lotus-gateway"
+        "lotus-gateway",
+        "lotus-idea"
       ],
       "deprecation_policy": {
         "state": "not_deprecated",

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-31T09:54:30.644324+00:00",
+  "generatedAt": "2026-06-23T05:41:22.171929+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -17092,6 +17092,7 @@
         "lotus-gateway",
         "lotus-performance",
         "lotus-manage",
+        "lotus-idea",
         "UI",
         "UNKNOWN"
       ],

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-23T05:25:28+00:00`
+- Generated at: `2026-06-23T05:37:12+00:00`
 
-- Report source snapshot: `c2c47b04`
+- Report source snapshot: `4477ed3e+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 878 |
-| Total Python LOC | 185560 |
-| Test functions | 2750 |
+| Total Python LOC | 185594 |
+| Test functions | 2752 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-23T05:12:13+00:00`
+- Generated at: `2026-06-23T05:25:28+00:00`
 
-- Report source snapshot: `5dfbe1b3`
+- Report source snapshot: `c2c47b04`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,7 +11,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 878 |
-| Total Python LOC | 185555 |
+| Total Python LOC | 185560 |
 | Test functions | 2750 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-23T05:25:28+00:00`
+- Generated at: `2026-06-23T05:37:12+00:00`
 
-- Report source snapshot: `c2c47b04`
+- Report source snapshot: `4477ed3e+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-23T05:12:13+00:00`
+- Generated at: `2026-06-23T05:25:28+00:00`
 
-- Report source snapshot: `5dfbe1b3`
+- Report source snapshot: `c2c47b04`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-23T05:25:28+00:00`
+- Generated at: `2026-06-23T05:37:12+00:00`
 
-- Report source snapshot: `c2c47b04`
+- Report source snapshot: `4477ed3e+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-23T05:12:13+00:00`
+- Generated at: `2026-06-23T05:25:28+00:00`
 
-- Report source snapshot: `5dfbe1b3`
+- Report source snapshot: `c2c47b04`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-23T05:12:13+00:00`
+- Generated at: `2026-06-23T05:25:28+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `5dfbe1b3`
+- Report source snapshot: `c2c47b04`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 878 | 878 | +0 |
-| Total Python LOC | 185475 | 185555 | +80 |
-| Test functions | 2748 | 2750 | +2 |
+| Total Python LOC | 185555 | 185560 | +5 |
+| Test functions | 2750 | 2750 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-23T05:25:28+00:00`
+- Generated at: `2026-06-23T05:37:12+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `c2c47b04`
+- Report source snapshot: `4477ed3e+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 878 | 878 | +0 |
-| Total Python LOC | 185555 | 185560 | +5 |
-| Test functions | 2750 | 2750 | +0 |
+| Total Python LOC | 185555 | 185594 | +39 |
+| Test functions | 2750 | 2752 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/routers/integration_capabilities_models.py
+++ b/src/api/routers/integration_capabilities_models.py
@@ -6,7 +6,14 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 
-ConsumerSystem = Literal["lotus-gateway", "lotus-performance", "lotus-manage", "UI", "UNKNOWN"]
+ConsumerSystem = Literal[
+    "lotus-gateway",
+    "lotus-performance",
+    "lotus-manage",
+    "lotus-idea",
+    "UI",
+    "UNKNOWN",
+]
 
 
 CAPABILITIES_RESPONSE_EXAMPLES = {

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -29,3 +29,15 @@ def test_integration_capabilities_honors_explicit_query_context() -> None:
     body = response.json()
     assert body["consumer_system"] == "lotus-performance"
     assert body["tenant_id"] == "tenant-x"
+
+
+def test_integration_capabilities_accepts_lotus_idea_context() -> None:
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/integration/capabilities?consumer_system=lotus-idea&tenant_id=default"
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["consumer_system"] == "lotus-idea"
+    assert body["tenant_id"] == "default"

--- a/tests/unit/dpm/api/test_integration_capabilities_api.py
+++ b/tests/unit/dpm/api/test_integration_capabilities_api.py
@@ -71,6 +71,21 @@ def test_integration_capabilities_does_not_publish_stateful_without_resolver(mon
     assert body["workflows"][0]["enabled"] is False
 
 
+def test_integration_capabilities_accepts_lotus_idea_consumer() -> None:
+    with TestClient(app) as client:
+        response = client.get(
+            "/api/v1/integration/capabilities?consumer_system=lotus-idea&tenant_id=default"
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["consumer_system"] == "lotus-idea"
+    assert body["tenant_id"] == "default"
+    assert "manage.observability.action_register_supportability" in {
+        item["key"] for item in body["features"]
+    }
+
+
 def test_integration_capabilities_can_publish_both_supported_input_modes(monkeypatch):
     monkeypatch.setenv("DPM_CAP_INPUT_MODE_STATELESS_ENABLED", "true")
     monkeypatch.setenv("DPM_CAP_INPUT_MODE_PORTFOLIO_ID_ENABLED", "true")

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -267,7 +267,7 @@ def test_manage_product_declaration_publishes_manage_owned_products() -> None:
     product = by_name["PortfolioActionRegister"]
     assert product["product_version"] == "v1"
     assert product["lifecycle_status"] == "active"
-    assert product["approved_consumers"] == ["lotus-gateway"]
+    assert product["approved_consumers"] == ["lotus-gateway", "lotus-idea"]
     assert product["serving_plane"] == "query_control_plane_service"
     assert product["current_routes"] == [
         "/api/v1/rebalance/supportability/summary",

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -22,6 +22,7 @@ PRODUCT_DECLARATION_PATH = (
 REQUEST_MODELS_PATH = ROOT / "src" / "api" / "request_models.py"
 UPSTREAM_FAMILY_MAP_PATH = ROOT / "docs" / "standards" / "RFC-0082-upstream-contract-family-map.md"
 DECLARATION_README_PATH = ROOT / "contracts" / "domain-data-products" / "README.md"
+MESH_WIKI_PATH = ROOT / "wiki" / "Mesh-Data-Products.md"
 
 
 def _load_consumer_declaration() -> dict:
@@ -268,6 +269,10 @@ def test_manage_product_declaration_publishes_manage_owned_products() -> None:
     assert product["product_version"] == "v1"
     assert product["lifecycle_status"] == "active"
     assert product["approved_consumers"] == ["lotus-gateway", "lotus-idea"]
+    mesh_wiki = MESH_WIKI_PATH.read_text(encoding="utf-8")
+    normalized_mesh_wiki = " ".join(mesh_wiki.split())
+    assert "Approved consumers: `lotus-gateway`, `lotus-idea`" in mesh_wiki
+    assert "it does not own rebalance execution" in normalized_mesh_wiki
     assert product["serving_plane"] == "query_control_plane_service"
     assert product["current_routes"] == [
         "/api/v1/rebalance/supportability/summary",

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -13,6 +13,9 @@
 - Lotus Idea boundary: `lotus-idea` may consume this product as governed management-action
   evidence for opportunity intelligence and conversion orchestration; it does not own rebalance
   execution, PM operating controls, model-portfolio decisions, order routing, or OMS execution.
+- Supportability discovery: direct Idea consumers may call
+  `/api/v1/integration/capabilities?consumer_system=lotus-idea&tenant_id=<tenant>` before
+  consuming action-register evidence.
 - Implemented route families:
   - `/api/v1/rebalance/supportability/summary`
   - `/api/v1/rebalance/runs/{rebalance_run_id}/artifact`

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -7,8 +7,12 @@
 ## Governed products
 
 - Product ID: `lotus-manage:PortfolioActionRegister:v1`
-- Product role: governed portfolio action register for management, reporting, gateway, and
-  Workbench discovery flows
+- Product role: governed portfolio action register for management, reporting, gateway,
+  Workbench discovery flows, and Lotus Idea opportunity intelligence consumption
+- Approved consumers: `lotus-gateway`, `lotus-idea`
+- Lotus Idea boundary: `lotus-idea` may consume this product as governed management-action
+  evidence for opportunity intelligence and conversion orchestration; it does not own rebalance
+  execution, PM operating controls, model-portfolio decisions, order routing, or OMS execution.
 - Implemented route families:
   - `/api/v1/rebalance/supportability/summary`
   - `/api/v1/rebalance/runs/{rebalance_run_id}/artifact`


### PR DESCRIPTION
## Scope
Approve `lotus-idea` as a governed mesh consumer for `PortfolioActionRegister`, refresh Manage quality evidence, and update repo-local mesh wiki source so operator-facing data-product truth matches the contract.

This does not transfer rebalance execution authority, PM operating controls, model-portfolio decision ownership, order routing, or OMS execution to Lotus Idea.

## Validation
- `make domain-product-validate` passed on the rebased branch.
- `python -m pytest tests/unit/test_domain_data_product_contracts.py -q` passed locally (`7 passed`) after adding the wiki/current-state guard.
- `python scripts/workflow_policy_gate.py` passed on the updated `main` workflow policy baseline.
- `python scripts/engineering_health_report.py --check` passed after refreshing quality evidence.
- `git diff --check` passed.
- Earlier full local proof on this PR: `make check` passed, including lint, format, monetary guard, no-alias, mypy, OpenAPI, API vocabulary, service/router boundaries, domain-product/trust/observability contracts, import/complexity/dependency/dead-code gates, quality report gate, and unit suite (`2973 passed`, `13 skipped`).

## Wiki
Repo-local `wiki/Mesh-Data-Products.md` changed. `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage` reports the expected `Mesh-Data-Products.md` drift because PR source is ahead of the published GitHub wiki. Publish after merge with `..\lotus-platform\automation\Sync-RepoWikis.ps1 -Publish -Repository lotus-manage`.

## Merge Hygiene
The branch was rebased onto `main` after PR #565 merged the workflow helper policy fix. Current PR scope is only the Manage data-product consumer declaration, regression guard, wiki truth, and quality evidence refresh.