### PR TITLE
Enforce rebase auto-merge workflow policy

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -5,8 +5,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   queue-auto-merge:
@@ -17,14 +16,19 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Enable auto-merge queue (merge commit)
+      - name: Enable auto-merge queue (rebase)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.LOTUS_AUTOMERGE_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::LOTUS_AUTOMERGE_TOKEN is required for automatic rebase merge so post-merge releasability dispatch is triggered by a non-GITHUB_TOKEN actor. Skipping auto-merge; use an authorized human or release actor to rebase merge this PR."
+            exit 0
+          fi
           set +e
-          output=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --merge --delete-branch 2>&1)
+          output=$(gh pr merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --auto --rebase --delete-branch 2>&1)
           code=$?
           set -e
           if [ "$code" -eq 0 ]; then

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -991,6 +991,10 @@ Important validation expectations:
    because RFC-0036 through RFC-0042 work previously exposed a failure mode where
    `docs/rfcs/RFC-worktobedone.md` and an RFC-0041 post-closure documentation correction were
    stranded on unmerged side branches instead of reaching `main`.
+10. PR auto-merge follows the platform linear-history posture: `.github/workflows/pr-auto-merge.yml`
+    uses `LOTUS_AUTOMERGE_TOKEN`, queues `gh pr merge --auto --rebase --delete-branch`, skips
+    cleanly with a warning when the token is absent, and is protected by `make workflow-policy-gate`.
+    The helper must not authenticate with `GITHUB_TOKEN` or queue merge commits.
 
 ## Standards And RFCs That Govern This Repository
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-20T01:18:12+00:00`
+- Generated at: `2026-06-23T05:12:13+00:00`
 
-- Report source snapshot: `2643af7b+worktree`
+- Report source snapshot: `5dfbe1b3`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 878 |
-| Total Python LOC | 185475 |
-| Test functions | 2748 |
+| Total Python LOC | 185555 |
+| Test functions | 2750 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-20T01:18:12+00:00`
+- Generated at: `2026-06-23T05:12:13+00:00`
 
-- Report source snapshot: `2643af7b+worktree`
+- Report source snapshot: `5dfbe1b3`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-20T01:18:12+00:00`
+- Generated at: `2026-06-23T05:12:13+00:00`
 
-- Report source snapshot: `2643af7b+worktree`
+- Report source snapshot: `5dfbe1b3`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-20T01:18:12+00:00`
+- Generated at: `2026-06-23T05:12:13+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `2643af7b+worktree`
+- Report source snapshot: `5dfbe1b3`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +13,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 878 | 878 | +0 |
-| Total Python LOC | 185387 | 185475 | +88 |
-| Test functions | 2745 | 2748 | +3 |
+| Total Python LOC | 185475 | 185555 | +80 |
+| Test functions | 2748 | 2750 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -22,7 +22,7 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
     "main-releasability.yml": {"contents": "read"},
     "quality-baseline.yml": {"contents": "read"},
     "demo-certification.yml": {"contents": "read"},
-    "pr-auto-merge.yml": {"contents": "write", "pull-requests": "write"},
+    "pr-auto-merge.yml": {"contents": "read"},
 }
 USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?([^\"'\s#]+)", re.MULTILINE)
 VERSION_TAG_PATTERN = re.compile(r"^v\d+(?:\.\d+){0,2}$")
@@ -184,6 +184,36 @@ def coverage_gate_violations(workflow_path: Path) -> list[str]:
     return violations
 
 
+def auto_merge_workflow_violations(workflow_path: Path) -> list[str]:
+    if workflow_path.name != "pr-auto-merge.yml":
+        return []
+    text = workflow_path.read_text(encoding="utf-8")
+    violations: list[str] = []
+    required_tokens = {
+        "secrets.LOTUS_AUTOMERGE_TOKEN": (
+            "auto-merge must use LOTUS_AUTOMERGE_TOKEN so the merge actor is not GITHUB_TOKEN"
+        ),
+        "LOTUS_AUTOMERGE_TOKEN is required": (
+            "auto-merge must warn and skip cleanly when LOTUS_AUTOMERGE_TOKEN is absent"
+        ),
+        "--auto --rebase --delete-branch": (
+            "auto-merge must queue rebase merge and branch deletion for linear history"
+        ),
+        "timeout-minutes: 10": "auto-merge workflow must have a bounded job timeout",
+    }
+    for token, reason in required_tokens.items():
+        if token not in text:
+            violations.append(f"{workflow_path.as_posix()}: {reason}")
+    forbidden_tokens = {
+        "github.token": "auto-merge must not authenticate with GITHUB_TOKEN",
+        "--auto --merge": "auto-merge must not queue merge commits",
+    }
+    for token, reason in forbidden_tokens.items():
+        if token in text:
+            violations.append(f"{workflow_path.as_posix()}: {reason}")
+    return violations
+
+
 def pr_template_policy_violations(template_path: Path = PR_TEMPLATE_PATH) -> list[str]:
     if not template_path.exists():
         return [f"{template_path.as_posix()}: PR template is missing"]
@@ -206,6 +236,7 @@ def evaluate_workflow_policy(workflow_dir: Path = WORKFLOW_DIR) -> list[str]:
         violations.extend(quality_report_gate_violations(workflow_path))
         violations.extend(duplicate_implementation_gate_violations(workflow_path))
         violations.extend(coverage_gate_violations(workflow_path))
+        violations.extend(auto_merge_workflow_violations(workflow_path))
     violations.extend(pr_template_policy_violations())
     return violations
 

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from scripts.workflow_policy_gate import (
     action_reference_violations,
+    auto_merge_workflow_violations,
     coverage_gate_violations,
     evaluate_workflow_policy,
     permission_violations,
@@ -209,6 +210,17 @@ def test_workflow_policy_gate_passes_current_repository_workflows() -> None:
     assert evaluate_workflow_policy() == []
 
 
+def test_pr_auto_merge_uses_governed_rebase_actor() -> None:
+    workflow_text = Path(".github/workflows/pr-auto-merge.yml").read_text(encoding="utf-8")
+
+    assert "secrets.LOTUS_AUTOMERGE_TOKEN" in workflow_text
+    assert "LOTUS_AUTOMERGE_TOKEN is required" in workflow_text
+    assert "--auto --rebase --delete-branch" in workflow_text
+    assert "timeout-minutes: 10" in workflow_text
+    assert "github.token" not in workflow_text
+    assert "--auto --merge" not in workflow_text
+
+
 def test_pr_template_policy_gate_passes_current_template() -> None:
     assert pr_template_policy_violations() == []
 
@@ -292,6 +304,43 @@ def test_workflow_policy_gate_rejects_permission_creep(tmp_path: Path) -> None:
         f"{workflow.as_posix()}: permissions must be {{'contents': 'read'}}, "
         "found {'contents': 'write', 'actions': 'write'}"
     ]
+
+
+def test_workflow_policy_gate_rejects_merge_commit_auto_merge(tmp_path: Path) -> None:
+    workflow = tmp_path / "pr-auto-merge.yml"
+    workflow.write_text(
+        "\n".join(
+            [
+                "permissions:",
+                "  contents: write",
+                "  pull-requests: write",
+                "jobs:",
+                "  queue-auto-merge:",
+                "    runs-on: ubuntu-latest",
+                "    steps:",
+                "      - name: Enable auto-merge queue (merge commit)",
+                "        env:",
+                "          GH_TOKEN: ${{ github.token }}",
+                "        run: gh pr merge 1 --auto --merge --delete-branch",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = auto_merge_workflow_violations(workflow)
+
+    assert (
+        f"{workflow.as_posix()}: auto-merge must use LOTUS_AUTOMERGE_TOKEN so the merge actor "
+        "is not GITHUB_TOKEN"
+    ) in violations
+    assert (
+        f"{workflow.as_posix()}: auto-merge must queue rebase merge and branch deletion for "
+        "linear history"
+    ) in violations
+    assert f"{workflow.as_posix()}: auto-merge must not authenticate with GITHUB_TOKEN" in (
+        violations
+    )
+    assert f"{workflow.as_posix()}: auto-merge must not queue merge commits" in violations
 
 
 def test_workflow_policy_gate_requires_blocking_quality_report_gate(tmp_path: Path) -> None:


### PR DESCRIPTION
## Scope
Align `pr-auto-merge.yml` with the platform linear-history standard so the helper uses `LOTUS_AUTOMERGE_TOKEN`, queues `gh pr merge --auto --rebase --delete-branch`, skips cleanly when the token is absent, and no longer authenticates with `GITHUB_TOKEN` or queues merge commits.

This is intentionally split out because `pull_request_target` runs the workflow from base `main`; the mesh-consumer PR cannot fix its own auto-merge helper until this lands on `main`.

## Validation
- `python scripts/workflow_policy_gate.py` passed.
- `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q` passed (`20 passed`).
- `python -m ruff check scripts/workflow_policy_gate.py tests/unit/test_ci_workflow_gate_enforcement.py` passed.
- `python scripts/engineering_health_report.py --check` passed after refreshing quality reports.
- `git diff --check HEAD~1..HEAD` passed before the evidence refresh.

## Wiki
No repo-local `wiki/` source changed; no wiki publication required.

## Merge Hygiene
Use normal non-squash linear merge policy. Delete this branch after merge.

## Known CI Note
The existing `Queue Auto Merge` check may still fail on this PR because `pull_request_target` reads the old workflow from base `main`. It is not a required branch-protection check; the PR is mergeable when required PR Merge Gate checks pass.