### PR TITLE
Add Manage idea action-intake route proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,11 @@ Main runtime surfaces come from [src/api/main.py](src/api/main.py):
 - run supportability
   `/api/v1/rebalance/runs/*`, `/api/v1/rebalance/operations/*`, `/api/v1/rebalance/supportability/summary`,
   `/api/v1/rebalance/lineage/*`, `/api/v1/rebalance/idempotency/*`
+- idea action-intake route foundation
+  `/api/v1/rebalance/idea-action-intake` accepts source-safe `lotus-idea`
+  conversion-intent handoff evidence and returns a not-certified acknowledgement. It does not
+  create action-register records, approve rebalances, create orders, route OMS instructions,
+  contact clients, authorize publication, or promote a supported feature.
 - policy-pack supportability
   `/api/v1/rebalance/policies/*`
 - mandate digital twin and health

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -40,6 +40,11 @@ Current repository posture:
    product used by management execution request contracts,
 6. it carries the RFC-0091 repo-native producer declaration and telemetry fixture for
    `PortfolioActionRegister`,
+   including a not-certified `lotus-idea` action-intake route foundation at
+   `POST /api/v1/rebalance/idea-action-intake`. The route proves only source-safe conversion-intent
+   handoff acknowledgement for cross-repo readiness; it does not persist action-register records,
+   grant rebalance authority, create orders, route OMS instructions, contact clients, authorize
+   publication, or promote a supported feature.
 7. the service remains part of the canonical front-office validation path through `lotus-gateway`,
 8. current execution APIs support explicit `input_mode=stateless` caller-supplied portfolio,
    market-data, model, shelf, and option bundles,

--- a/contracts/domain-data-products/README.md
+++ b/contracts/domain-data-products/README.md
@@ -44,7 +44,8 @@ Current declarations:
    external OMS acknowledgement boundary evidence.
 2. `lotus-manage-products.v1.json`
    Producer declaration for `lotus-manage:PortfolioActionRegister:v1`, surfaced through the
-   implemented rebalance supportability, artifact, and workflow route families, and
+   implemented rebalance supportability, not-certified `lotus-idea` action-intake
+   route-foundation, artifact, and workflow route families, and
    `lotus-manage:BulkReviewCampaignMembership:v1`, surfaced through bounded
    `BULK_REVIEW_CAMPAIGN` rebalance wave preview/create over source-backed candidate portfolios
    with optional approval/expiry/actor-entitlement governance evidence and optional persisted
@@ -93,3 +94,7 @@ Current watchlist:
    `BENCHMARK_ASSIGNMENT_NOT_YET_SOURCED`. Keep benchmark composition, active-risk, performance
    attribution, benchmark analytics, and model-approval methodology in their owning source
    services.
+4. The `lotus-idea` action-intake route is route-foundation evidence only. It clears the
+   cross-repo missing-route proof when validated by `lotus-idea`, but it does not persist an action
+   register row, grant rebalance authority, create orders, authorize client publication, or promote
+   a supported feature.

--- a/contracts/domain-data-products/lotus-manage-products.v1.json
+++ b/contracts/domain-data-products/lotus-manage-products.v1.json
@@ -36,13 +36,14 @@
       "serving_plane": "query_control_plane_service",
       "current_routes": [
         "/api/v1/rebalance/supportability/summary",
+        "/api/v1/rebalance/idea-action-intake",
         "/api/v1/rebalance/runs/{rebalance_run_id}/artifact",
         "/api/v1/rebalance/runs/{rebalance_run_id}/workflow",
         "/api/v1/rebalance/workflow/decisions"
       ],
       "freshness_policy": {
         "freshness_class": "daily",
-        "max_allowed_age_description": "Portfolio action registers are refreshed from current management workflow state and governed portfolio-state inputs."
+        "max_allowed_age_description": "Portfolio action registers are refreshed from current management workflow state and governed portfolio-state inputs. The lotus-idea action-intake route is a not-certified route foundation for source-safe conversion-intent handoff only; it does not create action-register records, grant rebalance authority, create orders, authorize client publication, or promote a supported feature."
       },
       "completeness_policy": {
         "default_status": "complete",

--- a/contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json
+++ b/contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "lotus-manage.idea-action-intake.v1",
+  "repository": "lotus-manage",
+  "approved_producer_repository": "lotus-idea",
+  "approved_producer_product": "lotus-idea:IdeaCandidate:v1",
+  "owned_product": "lotus-manage:PortfolioActionRegister:v1",
+  "source_authority": "lotus-manage",
+  "lifecycle_status": "implemented",
+  "supportability_status": "not_certified",
+  "target_route": "POST /api/v1/rebalance/idea-action-intake",
+  "route_existence_proven": true,
+  "downstream_execution_proven": false,
+  "supported_feature_promoted": false,
+  "certification_blockers": [
+    "rebalance_execution_authority_remains_lotus_manage",
+    "action_register_persistence_not_certified",
+    "oms_execution_not_certified",
+    "client_publication_authority_blocked"
+  ],
+  "non_proof_boundaries": [
+    "Proves only a live route foundation for lotus-idea conversion-intent handoff into lotus-manage.",
+    "Does not grant suitability, mandate, rebalance, order, OMS, fill, settlement, or client-communication authority.",
+    "Does not create orders, action-register records, execution instructions, fills, settlement records, or client messages.",
+    "Does not promote a supported feature, client-ready workflow, data-product certification, or downstream execution proof."
+  ],
+  "evidence_refs": [
+    "src/api/routers/rebalance_runs_idea_action_intake_routes.py",
+    "src/core/rebalance_runs/idea_action_intake.py",
+    "tests/unit/dpm/api/test_idea_action_intake_api.py"
+  ]
+}

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-06-23T05:41:22.171929+00:00",
+  "generatedAt": "2026-06-27T05:08:45.423395+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -88,6 +88,20 @@
       ]
     },
     {
+      "semanticId": "lotus.action_authority",
+      "canonicalTerm": "action_authority",
+      "preferredName": "action_authority",
+      "description": "Management action authority retained by lotus-manage.",
+      "example": "sample_action_authority",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.action_id",
       "canonicalTerm": "action_id",
       "preferredName": "action_id",
@@ -127,6 +141,20 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.action_register_created",
+      "canonicalTerm": "action_register_created",
+      "preferredName": "action_register_created",
+      "description": "False until a later certified management action realization slice persists one.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
       ]
     },
     {
@@ -2124,6 +2152,22 @@
       ]
     },
     {
+      "semanticId": "lotus.certification_blockers",
+      "canonicalTerm": "certification_blockers",
+      "preferredName": "certification_blockers",
+      "description": "Remaining blockers before this route can support certified realization.",
+      "example": [
+        "sample_certification_blockers_item"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.changed_fields",
       "canonicalTerm": "changed_fields",
       "preferredName": "changed_fields",
@@ -2282,6 +2326,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.client_publication_authorized",
+      "canonicalTerm": "client_publication_authorized",
+      "preferredName": "client_publication_authorized",
+      "description": "False; this route does not authorize client communication or publication.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
       ]
     },
     {
@@ -2556,7 +2614,7 @@
       "semanticId": "lotus.content_hash",
       "canonicalTerm": "content_hash",
       "preferredName": "content_hash",
-      "description": "Canonical source-owned evidence hash when available.",
+      "description": "Optional source-owned content hash for replay and lineage checks.",
       "example": "content_hash_example",
       "type": "object",
       "locations": [
@@ -2685,6 +2743,20 @@
       "preferredName": "controlled_assignment_task_endpoint",
       "description": "Endpoint family for explicit controlled assignment-task state changes.",
       "example": "sample_controlled_assignment_task_endpoint",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.conversion_intent_id",
+      "canonicalTerm": "conversion_intent_id",
+      "preferredName": "conversion_intent_id",
+      "description": "lotus-idea conversion intent identifier used for idempotent handoff tracking.",
+      "example": "CONVERSION_INTENT_001",
       "type": "string",
       "locations": [
         "body"
@@ -4452,7 +4524,7 @@
       "semanticId": "lotus.evidence_refs",
       "canonicalTerm": "evidence_refs",
       "preferredName": "evidence_refs",
-      "description": "dpm mandate dimension score field: evidence refs.",
+      "description": "Implementation and contract evidence references for the route foundation.",
       "example": [
         "sample_evidence_refs_item"
       ],
@@ -6205,6 +6277,20 @@
       ]
     },
     {
+      "semanticId": "lotus.idea_candidate_id",
+      "canonicalTerm": "idea_candidate_id",
+      "preferredName": "idea_candidate_id",
+      "description": "lotus-idea candidate identifier; Manage does not infer portfolio facts from it.",
+      "example": "IDEA_CANDIDATE_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.idempotency_history",
       "canonicalTerm": "idempotency_history",
       "preferredName": "idempotency_history",
@@ -6651,6 +6737,34 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.intake_id",
+      "canonicalTerm": "intake_id",
+      "preferredName": "intake_id",
+      "description": "Deterministic source-safe intake identifier derived from source handoff fields.",
+      "example": "INTAKE_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.intake_status",
+      "canonicalTerm": "intake_status",
+      "preferredName": "intake_status",
+      "description": "Bounded route-foundation status; not a management action or execution status.",
+      "example": "READY",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -9203,6 +9317,20 @@
       ]
     },
     {
+      "semanticId": "lotus.order_created",
+      "canonicalTerm": "order_created",
+      "preferredName": "order_created",
+      "description": "False; no order, OMS instruction, fill, or settlement evidence is created.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
       "semanticId": "lotus.order_intents",
       "canonicalTerm": "order_intents",
       "preferredName": "order_intents",
@@ -10692,6 +10820,20 @@
       ]
     },
     {
+      "semanticId": "lotus.rebalance_execution_authority_granted",
+      "canonicalTerm": "rebalance_execution_authority_granted",
+      "preferredName": "rebalance_execution_authority_granted",
+      "description": "False; this route does not approve, create, route, or execute rebalance orders.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
       "semanticId": "lotus.rebalance_run_id",
       "canonicalTerm": "rebalance_run_id",
       "preferredName": "rebalance_run_id",
@@ -10706,6 +10848,20 @@
       "observedTypes": [
         "string",
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.received_at",
+      "canonicalTerm": "received_at",
+      "preferredName": "received_at",
+      "description": "UTC timestamp when the handoff envelope was acknowledged.",
+      "example": "sample_received_at",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -12006,6 +12162,20 @@
       ]
     },
     {
+      "semanticId": "lotus.route_existence_proven",
+      "canonicalTerm": "route_existence_proven",
+      "preferredName": "route_existence_proven",
+      "description": "True because this route exists and is covered by contract tests.",
+      "example": true,
+      "type": "boolean",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
       "semanticId": "lotus.rule_id",
       "canonicalTerm": "rule_id",
       "preferredName": "rule_id",
@@ -12940,6 +13110,20 @@
       ]
     },
     {
+      "semanticId": "lotus.source_authority",
+      "canonicalTerm": "source_authority",
+      "preferredName": "source_authority",
+      "description": "Source authority for candidate and conversion intent evidence.",
+      "example": "sample_source_authority",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.source_batch_fingerprint",
       "canonicalTerm": "source_batch_fingerprint",
       "preferredName": "source_batch_fingerprint",
@@ -13078,15 +13262,15 @@
       "semanticId": "lotus.source_id",
       "canonicalTerm": "source_id",
       "preferredName": "source_id",
-      "description": "Source-owned risk evidence identifier or request fingerprint.",
+      "description": "Source-owned identifier; no portfolio, account, or client identifier required.",
       "example": "SOURCE_001",
-      "type": "object",
+      "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
-        "object",
-        "string"
+        "string",
+        "object"
       ]
     },
     {
@@ -13198,6 +13382,20 @@
       ]
     },
     {
+      "semanticId": "lotus.source_product",
+      "canonicalTerm": "source_product",
+      "preferredName": "source_product",
+      "description": "Source product represented by the handoff.",
+      "example": "sample_source_product",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.source_product_name",
       "canonicalTerm": "source_product_name",
       "preferredName": "source_product_name",
@@ -13303,7 +13501,7 @@
       "semanticId": "lotus.source_refs",
       "canonicalTerm": "source_refs",
       "preferredName": "source_refs",
-      "description": "Source records referenced by this section.",
+      "description": "Source-safe idea evidence references supplied by lotus-idea.",
       "example": [
         "source_refs_item_example"
       ],
@@ -13454,8 +13652,8 @@
       "semanticId": "lotus.source_type",
       "canonicalTerm": "source_type",
       "preferredName": "source_type",
-      "description": "Source object used to generate the proof pack.",
-      "example": "REBALANCE_RUN",
+      "description": "Source-owned evidence type or product name.",
+      "example": "sample_source_type",
       "type": "string",
       "locations": [
         "body",
@@ -14141,15 +14339,15 @@
       "semanticId": "lotus.supportability_status",
       "canonicalTerm": "supportability_status",
       "preferredName": "supportability_status",
-      "description": "Bounded method-level supportability posture.",
+      "description": "Certification posture for this route foundation.",
       "example": "READY",
-      "type": "ConstructionMethodStatus",
+      "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
-        "ConstructionMethodStatus",
-        "string"
+        "string",
+        "ConstructionMethodStatus"
       ]
     },
     {
@@ -14414,6 +14612,20 @@
       ],
       "observedTypes": [
         "TargetMethod"
+      ]
+    },
+    {
+      "semanticId": "lotus.target_product",
+      "canonicalTerm": "target_product",
+      "preferredName": "target_product",
+      "description": "Manage-owned product that future certified realization may update.",
+      "example": "sample_target_product",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -16803,6 +17015,18 @@
       "allowedValues": [],
       "semanticId": "lotus.idempotency_key",
       "attributeRef": "#/attributeCatalog/lotus.idempotency_key"
+    },
+    {
+      "name": "x_correlation_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": false,
+      "type": "object",
+      "description": "Optional source-safe correlation id supplied by lotus-idea.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_correlation_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_correlation_id"
     },
     {
       "name": "x_policy_pack_id",
@@ -50121,6 +50345,229 @@
           },
           {
             "name": "decisions[].correlation_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.correlation_id",
+            "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "lotus_manage_run_supportability",
+      "method": "POST",
+      "path": "/api/v1/rebalance/idea-action-intake",
+      "operationId": "accept_idea_action_intake_api_v1_rebalance_idea_action_intake_post",
+      "summary": "Accept lotus-idea Action Intake Foundation",
+      "request": {
+        "fields": [
+          {
+            "name": "x-correlation-id",
+            "location": "header",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.x_correlation_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_correlation_id"
+          },
+          {
+            "name": "source_system",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "#/attributeCatalog/lotus.source_system"
+          },
+          {
+            "name": "source_product",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_product",
+            "attributeRef": "#/attributeCatalog/lotus.source_product"
+          },
+          {
+            "name": "idea_candidate_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.idea_candidate_id",
+            "attributeRef": "#/attributeCatalog/lotus.idea_candidate_id"
+          },
+          {
+            "name": "conversion_intent_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.conversion_intent_id",
+            "attributeRef": "#/attributeCatalog/lotus.conversion_intent_id"
+          },
+          {
+            "name": "intent_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.intent_type",
+            "attributeRef": "#/attributeCatalog/lotus.intent_type"
+          },
+          {
+            "name": "source_refs",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.source_refs",
+            "attributeRef": "#/attributeCatalog/lotus.source_refs"
+          },
+          {
+            "name": "source_refs[].source_system",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_system",
+            "attributeRef": "#/attributeCatalog/lotus.source_system"
+          },
+          {
+            "name": "source_refs[].source_type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_type",
+            "attributeRef": "#/attributeCatalog/lotus.source_type"
+          },
+          {
+            "name": "source_refs[].source_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_id",
+            "attributeRef": "#/attributeCatalog/lotus.source_id"
+          },
+          {
+            "name": "source_refs[].content_hash",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.content_hash",
+            "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "intake_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.intake_id",
+            "attributeRef": "#/attributeCatalog/lotus.intake_id"
+          },
+          {
+            "name": "intake_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.intake_status",
+            "attributeRef": "#/attributeCatalog/lotus.intake_status"
+          },
+          {
+            "name": "supportability_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.supportability_status",
+            "attributeRef": "#/attributeCatalog/lotus.supportability_status"
+          },
+          {
+            "name": "source_authority",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_authority",
+            "attributeRef": "#/attributeCatalog/lotus.source_authority"
+          },
+          {
+            "name": "action_authority",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.action_authority",
+            "attributeRef": "#/attributeCatalog/lotus.action_authority"
+          },
+          {
+            "name": "target_product",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.target_product",
+            "attributeRef": "#/attributeCatalog/lotus.target_product"
+          },
+          {
+            "name": "route_existence_proven",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.route_existence_proven",
+            "attributeRef": "#/attributeCatalog/lotus.route_existence_proven"
+          },
+          {
+            "name": "action_register_created",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.action_register_created",
+            "attributeRef": "#/attributeCatalog/lotus.action_register_created"
+          },
+          {
+            "name": "rebalance_execution_authority_granted",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.rebalance_execution_authority_granted",
+            "attributeRef": "#/attributeCatalog/lotus.rebalance_execution_authority_granted"
+          },
+          {
+            "name": "order_created",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.order_created",
+            "attributeRef": "#/attributeCatalog/lotus.order_created"
+          },
+          {
+            "name": "client_publication_authorized",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.client_publication_authorized",
+            "attributeRef": "#/attributeCatalog/lotus.client_publication_authorized"
+          },
+          {
+            "name": "certification_blockers",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.certification_blockers",
+            "attributeRef": "#/attributeCatalog/lotus.certification_blockers"
+          },
+          {
+            "name": "evidence_refs",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.evidence_refs",
+            "attributeRef": "#/attributeCatalog/lotus.evidence_refs"
+          },
+          {
+            "name": "received_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.received_at",
+            "attributeRef": "#/attributeCatalog/lotus.received_at"
+          },
+          {
+            "name": "correlation_id",
             "location": "body",
             "required": true,
             "type": "string",

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -15,6 +15,9 @@ explicitly excluded.
 
 ## Explicitly unsupported in `lotus-manage`
 
+- The `lotus-idea` action-intake route foundation is not a supported feature. It acknowledges
+  source-safe conversion-intent handoff evidence only and does not create action-register records,
+  approve rebalances, create orders, authorize client publication, or prove downstream execution.
 - OMS execution instructions, best execution claims, and settlement lifecycle.
 - Client-ready communication, consent collection, or messaging.
 - External treasury advisory, order routing, or execution confirmation.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-27T05:09:57+00:00`
+- Generated at: `2026-06-27T05:32:38+00:00`
 
-- Report source snapshot: `c387c08f+worktree`
+- Report source snapshot: `6694033b+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,7 +11,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 882 |
-| Total Python LOC | 186034 |
+| Total Python LOC | 186046 |
 | Test functions | 2758 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-23T05:37:12+00:00`
+- Generated at: `2026-06-27T05:09:57+00:00`
 
-- Report source snapshot: `4477ed3e+worktree`
+- Report source snapshot: `c387c08f+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -10,9 +10,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 878 |
-| Total Python LOC | 185594 |
-| Test functions | 2752 |
+| Python files | 882 |
+| Total Python LOC | 186034 |
+| Test functions | 2758 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 
@@ -20,7 +20,7 @@
 
 | Metric | Value |
 | --- | --- |
-| Operations | 135 |
+| Operations | 136 |
 | Missing summary | 0 |
 | Missing description | 0 |
 | Missing tags | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-27T05:09:57+00:00`
+- Generated at: `2026-06-27T05:32:38+00:00`
 
-- Report source snapshot: `c387c08f+worktree`
+- Report source snapshot: `6694033b+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-23T05:37:12+00:00`
+- Generated at: `2026-06-27T05:09:57+00:00`
 
-- Report source snapshot: `4477ed3e+worktree`
+- Report source snapshot: `c387c08f+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-27T05:09:57+00:00`
+- Generated at: `2026-06-27T05:32:38+00:00`
 
-- Report source snapshot: `c387c08f+worktree`
+- Report source snapshot: `6694033b+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-23T05:37:12+00:00`
+- Generated at: `2026-06-27T05:09:57+00:00`
 
-- Report source snapshot: `4477ed3e+worktree`
+- Report source snapshot: `c387c08f+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-27T05:09:57+00:00`
+- Generated at: `2026-06-27T05:32:38+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `c387c08f+worktree`
+- Report source snapshot: `6694033b+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 878 | 882 | +4 |
-| Total Python LOC | 185594 | 186034 | +440 |
+| Total Python LOC | 185594 | 186046 | +452 |
 | Test functions | 2752 | 2758 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-23T05:37:12+00:00`
+- Generated at: `2026-06-27T05:09:57+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `4477ed3e+worktree`
+- Report source snapshot: `c387c08f+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 878 | 878 | +0 |
-| Total Python LOC | 185555 | 185594 | +39 |
-| Test functions | 2750 | 2752 | +2 |
+| Python files | 878 | 882 | +4 |
+| Total Python LOC | 185594 | 186034 | +440 |
+| Test functions | 2752 | 2758 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -22,7 +22,7 @@
 
 | Metric | Current |
 | --- | --- |
-| Operations | 135 |
+| Operations | 136 |
 | Missing summary | 0 |
 | Missing description | 0 |
 | Missing tags | 0 |

--- a/src/api/routers/rebalance_runs.py
+++ b/src/api/routers/rebalance_runs.py
@@ -152,6 +152,7 @@ _ROUTE_MODULES: tuple[str, ...] = (
     "src.api.routers.rebalance_runs_workflow_state_routes",
     "src.api.routers.rebalance_runs_workflow_action_routes",
     "src.api.routers.rebalance_runs_workflow_history_routes",
+    "src.api.routers.rebalance_runs_idea_action_intake_routes",
 )
 
 register_route_modules(_ROUTE_MODULES)

--- a/src/api/routers/rebalance_runs_idea_action_intake_routes.py
+++ b/src/api/routers/rebalance_runs_idea_action_intake_routes.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Header, Request, status
+
+from src.api.routers import rebalance_runs as shared
+from src.core.rebalance_runs import (
+    IDEA_ACTION_INTAKE_ERROR_EXAMPLE,
+    IDEA_ACTION_INTAKE_REQUEST_EXAMPLE,
+    IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE,
+    IdeaActionIntakeRequest,
+    IdeaActionIntakeResponse,
+    acknowledge_idea_action_intake,
+)
+
+
+_IDEA_ACTION_INTAKE_DESCRIPTION = (
+    "Accepts a source-safe lotus-idea conversion-intent handoff for management-side review. "
+    "This route proves only a Manage-owned route foundation for future action-register "
+    "realization. It does not grant rebalance authority, create an action register row, create "
+    "orders, route OMS instructions, contact clients, authorize publication, or promote a "
+    "supported feature."
+)
+
+
+@shared.router.post(
+    "/rebalance/idea-action-intake",
+    response_model=IdeaActionIntakeResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Accept lotus-idea Action Intake Foundation",
+    description=_IDEA_ACTION_INTAKE_DESCRIPTION,
+    responses={
+        202: {
+            "description": (
+                "Source-safe route-foundation acknowledgement. This is not execution or "
+                "action-register creation proof."
+            ),
+            "content": {"application/json": {"example": IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE}},
+        },
+        422: {
+            "description": "Invalid payload or unsupported query parameters were supplied.",
+            "content": {"application/json": {"example": IDEA_ACTION_INTAKE_ERROR_EXAMPLE}},
+        },
+    },
+    openapi_extra={
+        "requestBody": {
+            "content": {"application/json": {"example": IDEA_ACTION_INTAKE_REQUEST_EXAMPLE}}
+        }
+    },
+)
+def accept_idea_action_intake(
+    request: Request,
+    payload: IdeaActionIntakeRequest,
+    x_correlation_id: Annotated[
+        str | None,
+        Header(
+            description="Optional source-safe correlation id supplied by lotus-idea.",
+            examples=["corr-idea-action-001"],
+        ),
+    ] = None,
+) -> IdeaActionIntakeResponse:
+    shared._assert_support_apis_enabled()
+    shared._reject_unexpected_query_params(request, allowed_params=set())
+    return acknowledge_idea_action_intake(
+        payload,
+        correlation_id=x_correlation_id or "corr-idea-action-intake",
+    )

--- a/src/core/rebalance_runs/__init__.py
+++ b/src/core/rebalance_runs/__init__.py
@@ -18,6 +18,7 @@ from src.core.rebalance_runs.models import (
     DpmWorkflowDecisionListResponse,
 )
 from src.core.rebalance_runs.idea_action_intake import (
+    IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS,
     IDEA_ACTION_INTAKE_ERROR_EXAMPLE,
     IDEA_ACTION_INTAKE_REQUEST_EXAMPLE,
     IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE,
@@ -51,6 +52,7 @@ __all__ = [
     "DpmSupportabilitySummaryResponse",
     "DpmWorkflowDecisionListResponse",
     "IDEA_ACTION_INTAKE_ERROR_EXAMPLE",
+    "IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS",
     "IDEA_ACTION_INTAKE_REQUEST_EXAMPLE",
     "IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE",
     "IdeaActionIntakeRequest",

--- a/src/core/rebalance_runs/__init__.py
+++ b/src/core/rebalance_runs/__init__.py
@@ -17,6 +17,14 @@ from src.core.rebalance_runs.models import (
     DpmSupportabilitySummaryResponse,
     DpmWorkflowDecisionListResponse,
 )
+from src.core.rebalance_runs.idea_action_intake import (
+    IDEA_ACTION_INTAKE_ERROR_EXAMPLE,
+    IDEA_ACTION_INTAKE_REQUEST_EXAMPLE,
+    IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE,
+    IdeaActionIntakeRequest,
+    IdeaActionIntakeResponse,
+    acknowledge_idea_action_intake,
+)
 from src.core.rebalance_runs.repository import DpmRunRepository, DpmRunRepositoryConflictError
 from src.core.rebalance_runs.service import (
     DpmAsyncOperationConflictError,
@@ -42,6 +50,12 @@ __all__ = [
     "DpmRunWorkflowActionRequest",
     "DpmSupportabilitySummaryResponse",
     "DpmWorkflowDecisionListResponse",
+    "IDEA_ACTION_INTAKE_ERROR_EXAMPLE",
+    "IDEA_ACTION_INTAKE_REQUEST_EXAMPLE",
+    "IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE",
+    "IdeaActionIntakeRequest",
+    "IdeaActionIntakeResponse",
+    "acknowledge_idea_action_intake",
     "DpmRunWorkflowHistoryResponse",
     "DpmRunWorkflowResponse",
     "DpmAsyncOperationConflictError",

--- a/src/core/rebalance_runs/idea_action_intake.py
+++ b/src/core/rebalance_runs/idea_action_intake.py
@@ -10,6 +10,12 @@ from pydantic import BaseModel, Field
 IdeaActionIntakeStatus = Literal["ROUTE_FOUNDATION_ACCEPTED_NOT_CERTIFIED"]
 IdeaActionIntakeSupportabilityStatus = Literal["not_certified"]
 IdeaActionIntentType = Literal["REVIEW_FOR_REBALANCE", "CREATE_MANAGEMENT_ACTION_DRAFT"]
+IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS = [
+    "rebalance_execution_authority_remains_lotus_manage",
+    "action_register_persistence_not_certified",
+    "oms_execution_not_certified",
+    "client_publication_authority_blocked",
+]
 
 IDEA_ACTION_INTAKE_REQUEST_EXAMPLE: dict[str, Any] = {
     "source_system": "lotus-idea",
@@ -39,7 +45,7 @@ IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE: dict[str, Any] = {
     "rebalance_execution_authority_granted": False,
     "order_created": False,
     "client_publication_authorized": False,
-    "certification_blockers": ["rebalance_execution_authority_remains_lotus_manage"],
+    "certification_blockers": IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS,
     "evidence_refs": [
         "contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json",
         "src/api/routers/rebalance_runs_idea_action_intake_routes.py",
@@ -159,7 +165,7 @@ class IdeaActionIntakeResponse(BaseModel):
     )
     certification_blockers: list[str] = Field(
         description="Remaining blockers before this route can support certified realization.",
-        examples=[["rebalance_execution_authority_remains_lotus_manage"]],
+        examples=[IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS],
     )
     evidence_refs: list[str] = Field(
         description="Implementation and contract evidence references for the route foundation.",
@@ -198,7 +204,7 @@ def acknowledge_idea_action_intake(
         rebalance_execution_authority_granted=False,
         order_created=False,
         client_publication_authorized=False,
-        certification_blockers=["rebalance_execution_authority_remains_lotus_manage"],
+        certification_blockers=list(IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS),
         evidence_refs=[
             "contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json",
             "src/api/routers/rebalance_runs_idea_action_intake_routes.py",

--- a/src/core/rebalance_runs/idea_action_intake.py
+++ b/src/core/rebalance_runs/idea_action_intake.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+IdeaActionIntakeStatus = Literal["ROUTE_FOUNDATION_ACCEPTED_NOT_CERTIFIED"]
+IdeaActionIntakeSupportabilityStatus = Literal["not_certified"]
+IdeaActionIntentType = Literal["REVIEW_FOR_REBALANCE", "CREATE_MANAGEMENT_ACTION_DRAFT"]
+
+IDEA_ACTION_INTAKE_REQUEST_EXAMPLE: dict[str, Any] = {
+    "source_system": "lotus-idea",
+    "source_product": "lotus-idea:IdeaCandidate:v1",
+    "idea_candidate_id": "idea_candidate_001",
+    "conversion_intent_id": "conversion_intent_001",
+    "intent_type": "REVIEW_FOR_REBALANCE",
+    "source_refs": [
+        {
+            "source_system": "lotus-idea",
+            "source_type": "IdeaCandidate",
+            "source_id": "idea_candidate_001",
+            "content_hash": "sha256:abc123",
+        }
+    ],
+}
+
+IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE: dict[str, Any] = {
+    "intake_id": "iai_7a1d2b3c4d5e",
+    "intake_status": "ROUTE_FOUNDATION_ACCEPTED_NOT_CERTIFIED",
+    "supportability_status": "not_certified",
+    "source_authority": "lotus-idea",
+    "action_authority": "lotus-manage",
+    "target_product": "lotus-manage:PortfolioActionRegister:v1",
+    "route_existence_proven": True,
+    "action_register_created": False,
+    "rebalance_execution_authority_granted": False,
+    "order_created": False,
+    "client_publication_authorized": False,
+    "certification_blockers": ["rebalance_execution_authority_remains_lotus_manage"],
+    "evidence_refs": [
+        "contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json",
+        "src/api/routers/rebalance_runs_idea_action_intake_routes.py",
+        "src/core/rebalance_runs/idea_action_intake.py",
+    ],
+    "received_at": "2026-06-21T10:10:00+00:00",
+    "correlation_id": "corr-idea-action-001",
+}
+
+IDEA_ACTION_INTAKE_ERROR_EXAMPLE: dict[str, Any] = {
+    "detail": "UNSUPPORTED_QUERY_PARAMETER: dry_run not supported for this endpoint"
+}
+
+
+class IdeaActionSourceRef(BaseModel):
+    source_system: Literal["lotus-idea"] = Field(
+        description="Source system that owns the referenced idea evidence.",
+        examples=["lotus-idea"],
+    )
+    source_type: str = Field(
+        min_length=1,
+        description="Source-owned evidence type or product name.",
+        examples=["IdeaCandidate"],
+    )
+    source_id: str = Field(
+        min_length=1,
+        description="Source-owned identifier; no portfolio, account, or client identifier required.",
+        examples=["idea_candidate_001"],
+    )
+    content_hash: str | None = Field(
+        default=None,
+        description="Optional source-owned content hash for replay and lineage checks.",
+        examples=["sha256:abc123"],
+    )
+
+
+class IdeaActionIntakeRequest(BaseModel):
+    model_config = {"json_schema_extra": {"example": IDEA_ACTION_INTAKE_REQUEST_EXAMPLE}}
+
+    source_system: Literal["lotus-idea"] = Field(
+        description="Producer system submitting the reviewed opportunity handoff.",
+        examples=["lotus-idea"],
+    )
+    source_product: Literal["lotus-idea:IdeaCandidate:v1"] = Field(
+        description="Source product represented by the handoff.",
+        examples=["lotus-idea:IdeaCandidate:v1"],
+    )
+    idea_candidate_id: str = Field(
+        min_length=1,
+        description="lotus-idea candidate identifier; Manage does not infer portfolio facts from it.",
+        examples=["idea_candidate_001"],
+    )
+    conversion_intent_id: str = Field(
+        min_length=1,
+        description="lotus-idea conversion intent identifier used for idempotent handoff tracking.",
+        examples=["conversion_intent_001"],
+    )
+    intent_type: IdeaActionIntentType = Field(
+        description=(
+            "Requested management-side intake posture. This route records only the handoff "
+            "foundation and does not create an action register row or execution order."
+        ),
+        examples=["REVIEW_FOR_REBALANCE"],
+    )
+    source_refs: list[IdeaActionSourceRef] = Field(
+        min_length=1,
+        description="Source-safe idea evidence references supplied by lotus-idea.",
+    )
+
+
+class IdeaActionIntakeResponse(BaseModel):
+    model_config = {"json_schema_extra": {"example": IDEA_ACTION_INTAKE_RESPONSE_EXAMPLE}}
+
+    intake_id: str = Field(
+        description="Deterministic source-safe intake identifier derived from source handoff fields.",
+        examples=["iai_7a1d2b3c4d5e"],
+    )
+    intake_status: IdeaActionIntakeStatus = Field(
+        description="Bounded route-foundation status; not a management action or execution status.",
+        examples=["ROUTE_FOUNDATION_ACCEPTED_NOT_CERTIFIED"],
+    )
+    supportability_status: IdeaActionIntakeSupportabilityStatus = Field(
+        description="Certification posture for this route foundation.",
+        examples=["not_certified"],
+    )
+    source_authority: Literal["lotus-idea"] = Field(
+        description="Source authority for candidate and conversion intent evidence.",
+        examples=["lotus-idea"],
+    )
+    action_authority: Literal["lotus-manage"] = Field(
+        description="Management action authority retained by lotus-manage.",
+        examples=["lotus-manage"],
+    )
+    target_product: Literal["lotus-manage:PortfolioActionRegister:v1"] = Field(
+        description="Manage-owned product that future certified realization may update.",
+        examples=["lotus-manage:PortfolioActionRegister:v1"],
+    )
+    route_existence_proven: bool = Field(
+        description="True because this route exists and is covered by contract tests.",
+        examples=[True],
+    )
+    action_register_created: bool = Field(
+        description="False until a later certified management action realization slice persists one.",
+        examples=[False],
+    )
+    rebalance_execution_authority_granted: bool = Field(
+        description="False; this route does not approve, create, route, or execute rebalance orders.",
+        examples=[False],
+    )
+    order_created: bool = Field(
+        description="False; no order, OMS instruction, fill, or settlement evidence is created.",
+        examples=[False],
+    )
+    client_publication_authorized: bool = Field(
+        description="False; this route does not authorize client communication or publication.",
+        examples=[False],
+    )
+    certification_blockers: list[str] = Field(
+        description="Remaining blockers before this route can support certified realization.",
+        examples=[["rebalance_execution_authority_remains_lotus_manage"]],
+    )
+    evidence_refs: list[str] = Field(
+        description="Implementation and contract evidence references for the route foundation.",
+    )
+    received_at: str = Field(
+        description="UTC timestamp when the handoff envelope was acknowledged.",
+        examples=["2026-06-21T10:10:00+00:00"],
+    )
+    correlation_id: str = Field(
+        description="Caller or generated correlation id for source-safe operational tracing.",
+        examples=["corr-idea-action-001"],
+    )
+
+
+def acknowledge_idea_action_intake(
+    request: IdeaActionIntakeRequest,
+    *,
+    correlation_id: str,
+    received_at: datetime | None = None,
+) -> IdeaActionIntakeResponse:
+    timestamp = received_at or datetime.now(timezone.utc)
+    intake_id = _intake_id(
+        idea_candidate_id=request.idea_candidate_id,
+        conversion_intent_id=request.conversion_intent_id,
+        intent_type=request.intent_type,
+    )
+    return IdeaActionIntakeResponse(
+        intake_id=intake_id,
+        intake_status="ROUTE_FOUNDATION_ACCEPTED_NOT_CERTIFIED",
+        supportability_status="not_certified",
+        source_authority="lotus-idea",
+        action_authority="lotus-manage",
+        target_product="lotus-manage:PortfolioActionRegister:v1",
+        route_existence_proven=True,
+        action_register_created=False,
+        rebalance_execution_authority_granted=False,
+        order_created=False,
+        client_publication_authorized=False,
+        certification_blockers=["rebalance_execution_authority_remains_lotus_manage"],
+        evidence_refs=[
+            "contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json",
+            "src/api/routers/rebalance_runs_idea_action_intake_routes.py",
+            "src/core/rebalance_runs/idea_action_intake.py",
+        ],
+        received_at=timestamp.isoformat(),
+        correlation_id=correlation_id,
+    )
+
+
+def _intake_id(*, idea_candidate_id: str, conversion_intent_id: str, intent_type: str) -> str:
+    digest = sha256(
+        f"{idea_candidate_id}|{conversion_intent_id}|{intent_type}".encode()
+    ).hexdigest()
+    return f"iai_{digest[:12]}"

--- a/tests/unit/dpm/api/test_idea_action_intake_api.py
+++ b/tests/unit/dpm/api/test_idea_action_intake_api.py
@@ -1,7 +1,11 @@
 from fastapi.testclient import TestClient
 
 from src.api.main import app
-from src.core.rebalance_runs import IdeaActionIntakeRequest, acknowledge_idea_action_intake
+from src.core.rebalance_runs import (
+    IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS,
+    IdeaActionIntakeRequest,
+    acknowledge_idea_action_intake,
+)
 
 
 def _payload() -> dict[str, object]:
@@ -43,7 +47,7 @@ def test_idea_action_intake_route_returns_source_safe_non_execution_posture() ->
     assert body["rebalance_execution_authority_granted"] is False
     assert body["order_created"] is False
     assert body["client_publication_authorized"] is False
-    assert body["certification_blockers"] == ["rebalance_execution_authority_remains_lotus_manage"]
+    assert body["certification_blockers"] == IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS
     assert body["correlation_id"] == "corr-idea-action-001"
 
 

--- a/tests/unit/dpm/api/test_idea_action_intake_api.py
+++ b/tests/unit/dpm/api/test_idea_action_intake_api.py
@@ -1,0 +1,83 @@
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+from src.core.rebalance_runs import IdeaActionIntakeRequest, acknowledge_idea_action_intake
+
+
+def _payload() -> dict[str, object]:
+    return {
+        "source_system": "lotus-idea",
+        "source_product": "lotus-idea:IdeaCandidate:v1",
+        "idea_candidate_id": "idea_candidate_001",
+        "conversion_intent_id": "conversion_intent_001",
+        "intent_type": "REVIEW_FOR_REBALANCE",
+        "source_refs": [
+            {
+                "source_system": "lotus-idea",
+                "source_type": "IdeaCandidate",
+                "source_id": "idea_candidate_001",
+                "content_hash": "sha256:abc123",
+            }
+        ],
+    }
+
+
+def test_idea_action_intake_route_returns_source_safe_non_execution_posture() -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/rebalance/idea-action-intake",
+            json=_payload(),
+            headers={"X-Correlation-Id": "corr-idea-action-001"},
+        )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["intake_id"].startswith("iai_")
+    assert body["intake_status"] == "ROUTE_FOUNDATION_ACCEPTED_NOT_CERTIFIED"
+    assert body["supportability_status"] == "not_certified"
+    assert body["source_authority"] == "lotus-idea"
+    assert body["action_authority"] == "lotus-manage"
+    assert body["target_product"] == "lotus-manage:PortfolioActionRegister:v1"
+    assert body["route_existence_proven"] is True
+    assert body["action_register_created"] is False
+    assert body["rebalance_execution_authority_granted"] is False
+    assert body["order_created"] is False
+    assert body["client_publication_authorized"] is False
+    assert body["certification_blockers"] == ["rebalance_execution_authority_remains_lotus_manage"]
+    assert body["correlation_id"] == "corr-idea-action-001"
+
+
+def test_idea_action_intake_rejects_query_parameters() -> None:
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/rebalance/idea-action-intake?dry_run=true",
+            json=_payload(),
+        )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == (
+        "UNSUPPORTED_QUERY_PARAMETER: dry_run not supported for this endpoint"
+    )
+
+
+def test_idea_action_intake_domain_acknowledgement_is_deterministic() -> None:
+    request = IdeaActionIntakeRequest.model_validate(_payload())
+
+    first = acknowledge_idea_action_intake(request, correlation_id="corr-a")
+    second = acknowledge_idea_action_intake(request, correlation_id="corr-b")
+
+    assert first.intake_id == second.intake_id
+    assert first.action_register_created is False
+    assert first.rebalance_execution_authority_granted is False
+    assert first.order_created is False
+    assert first.client_publication_authorized is False
+
+
+def test_idea_action_intake_route_is_documented_in_openapi() -> None:
+    with TestClient(app) as client:
+        openapi = client.get("/openapi.json").json()
+
+    operation = openapi["paths"]["/api/v1/rebalance/idea-action-intake"]["post"]
+    assert operation["summary"] == "Accept lotus-idea Action Intake Foundation"
+    assert "does not grant rebalance authority" in operation["description"]
+    assert "202" in operation["responses"]

--- a/tests/unit/dpm/contracts/test_idea_action_intake_contract.py
+++ b/tests/unit/dpm/contracts/test_idea_action_intake_contract.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+CONTRACT_PATH = (
+    ROOT / "contracts" / "idea-action-intake" / ("lotus-manage-idea-action-intake.v1.json")
+)
+
+
+def _contract() -> dict:
+    return json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def test_idea_action_intake_contract_preserves_manage_authority_boundary() -> None:
+    contract = _contract()
+
+    assert contract["schema_version"] == "lotus-manage.idea-action-intake.v1"
+    assert contract["repository"] == "lotus-manage"
+    assert contract["approved_producer_repository"] == "lotus-idea"
+    assert contract["approved_producer_product"] == "lotus-idea:IdeaCandidate:v1"
+    assert contract["owned_product"] == "lotus-manage:PortfolioActionRegister:v1"
+    assert contract["source_authority"] == "lotus-manage"
+    assert contract["target_route"] == "POST /api/v1/rebalance/idea-action-intake"
+    assert contract["lifecycle_status"] == "implemented"
+    assert contract["supportability_status"] == "not_certified"
+    assert contract["route_existence_proven"] is True
+    assert contract["downstream_execution_proven"] is False
+    assert contract["supported_feature_promoted"] is False
+
+
+def test_idea_action_intake_contract_keeps_non_proof_boundaries_and_blockers() -> None:
+    contract = _contract()
+    boundaries = " ".join(contract["non_proof_boundaries"])
+
+    assert "Proves only a live route foundation" in boundaries
+    assert "Does not grant suitability" in boundaries
+    assert "Does not create orders" in boundaries
+    assert "Does not promote a supported feature" in boundaries
+    assert (
+        "rebalance_execution_authority_remains_lotus_manage" in (contract["certification_blockers"])
+    )
+    assert "manage_live_contract_proof_missing" not in contract["certification_blockers"]
+    assert {
+        "src/api/routers/rebalance_runs_idea_action_intake_routes.py",
+        "src/core/rebalance_runs/idea_action_intake.py",
+        "tests/unit/dpm/api/test_idea_action_intake_api.py",
+    }.issubset(set(contract["evidence_refs"]))

--- a/tests/unit/dpm/contracts/test_idea_action_intake_contract.py
+++ b/tests/unit/dpm/contracts/test_idea_action_intake_contract.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from src.core.rebalance_runs import IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS
+
 
 ROOT = Path(__file__).resolve().parents[4]
 CONTRACT_PATH = (
@@ -39,9 +41,7 @@ def test_idea_action_intake_contract_keeps_non_proof_boundaries_and_blockers() -
     assert "Does not grant suitability" in boundaries
     assert "Does not create orders" in boundaries
     assert "Does not promote a supported feature" in boundaries
-    assert (
-        "rebalance_execution_authority_remains_lotus_manage" in (contract["certification_blockers"])
-    )
+    assert contract["certification_blockers"] == IDEA_ACTION_INTAKE_CERTIFICATION_BLOCKERS
     assert "manage_live_contract_proof_missing" not in contract["certification_blockers"]
     assert {
         "src/api/routers/rebalance_runs_idea_action_intake_routes.py",

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -276,10 +276,18 @@ def test_manage_product_declaration_publishes_manage_owned_products() -> None:
     assert product["serving_plane"] == "query_control_plane_service"
     assert product["current_routes"] == [
         "/api/v1/rebalance/supportability/summary",
+        "/api/v1/rebalance/idea-action-intake",
         "/api/v1/rebalance/runs/{rebalance_run_id}/artifact",
         "/api/v1/rebalance/runs/{rebalance_run_id}/workflow",
         "/api/v1/rebalance/workflow/decisions",
     ]
+    freshness_description = product["freshness_policy"]["max_allowed_age_description"]
+    assert "not-certified route foundation" in freshness_description
+    assert "does not create action-register records" in freshness_description
+    assert "grant rebalance authority" in freshness_description
+    assert "create orders" in freshness_description
+    assert "authorize client publication" in freshness_description
+    assert "promote a supported feature" in freshness_description
     assert product["lineage_policy"]["lineage_required"] is True
     assert product["lineage_policy"]["lineage_bundle_class_ref"] == "customer_lineage_summary"
 

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -729,7 +729,7 @@ python -m pytest tests/unit/dpm/api/test_api_rebalance.py::test_dpm_supportabili
 LOTUS_MANAGE_BASE_URL=http://127.0.0.1:8001 make live-api-validate
 ```
 
-## Certified endpoint: Idea action-intake route foundation
+## Documented not-certified route foundation: Idea action intake
 
 Route:
 
@@ -753,7 +753,18 @@ Functional coverage:
 - returns `rebalance_execution_authority_granted=false`,
 - returns `order_created=false`,
 - returns `client_publication_authorized=false`,
+- returns all remaining certification blockers:
+  `rebalance_execution_authority_remains_lotus_manage`,
+  `action_register_persistence_not_certified`, `oms_execution_not_certified`, and
+  `client_publication_authority_blocked`,
 - rejects unsupported query parameters.
+
+Certification posture:
+
+- `supportability_status=not_certified`.
+- This route is documented for OpenAPI and route-existence traceability only. It must not be
+  represented as certified endpoint support until a later realization slice persists
+  action-register records and clears all certification blockers.
 
 Downstream consumers:
 

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -729,6 +729,48 @@ python -m pytest tests/unit/dpm/api/test_api_rebalance.py::test_dpm_supportabili
 LOTUS_MANAGE_BASE_URL=http://127.0.0.1:8001 make live-api-validate
 ```
 
+## Certified endpoint: Idea action-intake route foundation
+
+Route:
+
+- `POST /api/v1/rebalance/idea-action-intake`
+
+Purpose:
+
+Source-safe handoff acknowledgement for `lotus-idea` conversion intents that may later become
+Manage-owned action-register work. This is route-existence proof for cross-repo readiness, not
+action-register persistence, rebalance approval, order creation, OMS routing, client contact,
+client publication, or supported-feature promotion.
+
+Functional coverage:
+
+- accepts only `lotus-idea:IdeaCandidate:v1` handoff envelopes,
+- requires at least one source-safe `source_refs` entry,
+- returns deterministic `intake_id` values from the source handoff identity,
+- returns `ROUTE_FOUNDATION_ACCEPTED_NOT_CERTIFIED`,
+- preserves `source_authority=lotus-idea` and `action_authority=lotus-manage`,
+- returns `action_register_created=false`,
+- returns `rebalance_execution_authority_granted=false`,
+- returns `order_created=false`,
+- returns `client_publication_authorized=false`,
+- rejects unsupported query parameters.
+
+Downstream consumers:
+
+- `lotus-idea` consumes the contract as Manage route-foundation evidence for RFC-0002 downstream
+  realization readiness.
+- Gateway and Workbench must not treat this route as a product-surface or client-demo support claim
+  until a later certified realization slice persists action-register records and clears downstream
+  blockers.
+
+Evidence commands:
+
+```bash
+python -m pytest tests/unit/dpm/api/test_idea_action_intake_api.py tests/unit/dpm/contracts/test_idea_action_intake_contract.py tests/unit/test_domain_data_product_contracts.py -q
+python -m pytest tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py::test_openapi_json_requests_and_responses_have_examples tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py::test_openapi_error_responses_have_json_examples -q
+make domain-product-validate
+```
+
 ## Certified endpoint: deterministic run artifact
 
 Route:

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -11,6 +11,9 @@
 - `lotus-advise`
   owner of advisor-led proposal simulation, proposal artifacts, and proposal lifecycle workflows;
   `lotus-manage` must not reintroduce those concerns
+- `lotus-idea`
+  source authority for opportunity candidates and conversion intents that may be handed to Manage
+  through a not-certified action-intake route foundation
 
 ## Boundary rules
 
@@ -22,6 +25,9 @@
 5. advisory proposal workflows should be integrated through `lotus-advise`
 6. risk-aware construction must consume `lotus-risk` authority or source-backed authority context;
    `lotus-manage` must not recalculate risk methodology locally
+7. `lotus-idea` action-intake handoff proves route existence only; it must not be treated as
+   action-register persistence, rebalance approval, order creation, client publication, or
+   supported-feature proof
 
 ## Core Sourcing Target
 
@@ -118,6 +124,9 @@ Strategic downstream consumption should use:
 11. `GET /api/v1/dpm/command-center` bounded command-center summary
 12. `/api/v1/construction/alternative-sets/*` construction alternative generate/read/selection
     routes
+13. `POST /api/v1/rebalance/idea-action-intake` for source-safe `lotus-idea` conversion-intent
+    handoff acknowledgement. This is a not-certified route foundation, not execution or
+    action-register creation proof.
 
 ## Construction Alternatives Upstream Authority
 

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -14,13 +14,19 @@
   evidence for opportunity intelligence and conversion orchestration; it does not own rebalance
   execution, PM operating controls, model-portfolio decisions, order routing, or OMS execution.
 - Supportability discovery: direct Idea consumers may call
-  `/api/v1/integration/capabilities?consumer_system=lotus-idea&tenant_id=<tenant>` before
-  consuming action-register evidence.
+   `/api/v1/integration/capabilities?consumer_system=lotus-idea&tenant_id=<tenant>` before
+   consuming action-register evidence.
+- Idea action-intake route foundation: `POST /api/v1/rebalance/idea-action-intake` accepts
+  source-safe `lotus-idea` conversion-intent handoff evidence and returns a not-certified
+  acknowledgement. It is route-existence proof only; it does not create action-register records,
+  approve rebalances, create orders, route OMS instructions, contact clients, authorize
+  publication, or promote a supported feature.
 - Implemented route families:
-  - `/api/v1/rebalance/supportability/summary`
-  - `/api/v1/rebalance/runs/{rebalance_run_id}/artifact`
-  - `/api/v1/rebalance/runs/{rebalance_run_id}/workflow`
-  - `/api/v1/rebalance/workflow/decisions`
+   - `/api/v1/rebalance/supportability/summary`
+   - `/api/v1/rebalance/idea-action-intake`
+   - `/api/v1/rebalance/runs/{rebalance_run_id}/artifact`
+   - `/api/v1/rebalance/runs/{rebalance_run_id}/workflow`
+   - `/api/v1/rebalance/workflow/decisions`
 - Source declaration: `contracts/domain-data-products/lotus-manage-products.v1.json`
 - Trust telemetry: `contracts/trust-telemetry/portfolio-action-register.telemetry.v1.json`
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -14,6 +14,11 @@ capabilities listed below, but full front-office product claims require the gove
 `lotus-gateway` and `lotus-workbench` realization path to be implemented, validated, merged, and
 published.
 
+Current non-promotion boundary: `POST /api/v1/rebalance/idea-action-intake` exists only as a
+not-certified route foundation for `lotus-idea` conversion-intent handoff evidence. It is not a
+supported feature and does not create action-register records, approve rebalances, create orders,
+authorize client publication, or prove downstream execution.
+
 ```mermaid
 flowchart LR
     Core[lotus-core<br/>portfolio, mandate, tax-lot, tax profile/rule, cashflow, market-data sources]


### PR DESCRIPTION
## Summary

- Adds a source-safe, not-certified `POST /api/v1/rebalance/idea-action-intake` route foundation for `lotus-idea` conversion-intent handoff into Manage.
- Adds the repo-owned contract `contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json` consumed by `lotus-idea` downstream proof.
- Updates the `PortfolioActionRegister` domain data-product declaration, API vocabulary inventory, README, repo context, supported-features boundary, wiki source, and generated quality reports.

## Boundary

This proves Manage route existence only. It does not create action-register records, grant suitability or rebalance authority, create orders, route OMS instructions, contact clients, authorize publication, prove downstream execution, certify the data product, or promote a supported feature.

## Evidence

- `git fetch origin --prune; git branch -r --no-merged origin/main`: no unmerged remote branches reported for `lotus-manage`.
- `git diff --check`: passed.
- `python -m pytest tests/unit/dpm/api/test_idea_action_intake_api.py tests/unit/dpm/contracts/test_idea_action_intake_contract.py tests/unit/test_domain_data_product_contracts.py -q`: `13 passed in 6.20s`.
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -AllowUnpublishedSourceChanges -Repository lotus-manage`: passed with 4 intentional unpublished wiki source changes pending post-merge publication.
- `make check`: passed, including ruff, format, monetary-float, no-alias, mypy, OpenAPI quality, API vocabulary no-drift, service/router boundaries, domain/trust/observability contracts, import-linter, radon, duplicate implementation, deptry, vulture, workflow policy, current engineering health reports, and `2982 passed in 44.70s`.

## Non-Degradation

- API contract posture is explicit and example-backed.
- Domain authority remains in `lotus-manage`; `lotus-idea` remains source authority for candidate/intent evidence.
- Supported-feature docs explicitly block overclaiming.
- Quality reports were regenerated and verified current by `make check`.

## Wiki

Repo-local `wiki/` source changed. Publish after merge with:

```powershell
..\lotus-platform\automation\Sync-RepoWikis.ps1 -Publish -Repository lotus-manage
```