### PR TITLE
Fix main quality report baseline check

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-27T05:32:38+00:00`
+- Generated at: `2026-06-27T05:50:30+00:00`
 
-- Report source snapshot: `6694033b+worktree`
+- Report source snapshot: `d8dcf66c+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +11,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 882 |
-| Total Python LOC | 186046 |
-| Test functions | 2758 |
+| Total Python LOC | 186141 |
+| Test functions | 2761 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,8 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-27T05:50:30+00:00`
+- Generated at: `2026-06-27T06:02:00+00:00`
 
-- Report source snapshot: `d8dcf66c+worktree`
+- Baseline source snapshot: `d8dcf66c14a32daeeff235552683fe287f05402f`
+
+- Report source snapshot: `bf8bca95+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -11,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 882 |
-| Total Python LOC | 186141 |
-| Test functions | 2761 |
+| Total Python LOC | 186217 |
+| Test functions | 2764 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-27T05:50:30+00:00`
+- Generated at: `2026-06-27T06:02:00+00:00`
 
-- Report source snapshot: `d8dcf66c+worktree`
+- Baseline source snapshot: `d8dcf66c14a32daeeff235552683fe287f05402f`
+
+- Report source snapshot: `bf8bca95+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,8 +1,8 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-27T05:32:38+00:00`
+- Generated at: `2026-06-27T05:50:30+00:00`
 
-- Report source snapshot: `6694033b+worktree`
+- Report source snapshot: `d8dcf66c+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-27T05:50:30+00:00`
+- Generated at: `2026-06-27T06:02:00+00:00`
 
-- Report source snapshot: `d8dcf66c+worktree`
+- Baseline source snapshot: `d8dcf66c14a32daeeff235552683fe287f05402f`
+
+- Report source snapshot: `bf8bca95+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,8 +1,8 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-27T05:32:38+00:00`
+- Generated at: `2026-06-27T05:50:30+00:00`
 
-- Report source snapshot: `6694033b+worktree`
+- Report source snapshot: `d8dcf66c+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-27T05:50:30+00:00`
+- Generated at: `2026-06-27T06:02:00+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `d8dcf66c+worktree`
+- Baseline source snapshot: `d8dcf66c14a32daeeff235552683fe287f05402f`
+
+- Report source snapshot: `bf8bca95+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -13,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 882 | 882 | +0 |
-| Total Python LOC | 186046 | 186141 | +95 |
-| Test functions | 2758 | 2761 | +3 |
+| Total Python LOC | 186046 | 186217 | +171 |
+| Test functions | 2758 | 2764 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-27T05:32:38+00:00`
+- Generated at: `2026-06-27T05:50:30+00:00`
 
 - Baseline ref: `origin/main`
 
-- Report source snapshot: `6694033b+worktree`
+- Report source snapshot: `d8dcf66c+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -12,9 +12,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 878 | 882 | +4 |
-| Total Python LOC | 185594 | 186046 | +452 |
-| Test functions | 2752 | 2758 | +6 |
+| Python files | 882 | 882 | +0 |
+| Total Python LOC | 186046 | 186141 | +95 |
+| Test functions | 2758 | 2761 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -18,12 +18,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 DEFAULT_BASE_REF = "origin/main"
-DEFAULT_OUTPUT = REPO_ROOT / "quality" / "refactor_health_report.md"
-DEFAULT_BASELINE_OUTPUT = REPO_ROOT / "quality" / "baseline_report.md"
-DEFAULT_SCORECARD_OUTPUT = REPO_ROOT / "quality" / "quality_scorecard.md"
-DEFAULT_ARCHITECTURE_RULES_OUTPUT = REPO_ROOT / "quality" / "architecture_rules.md"
-DEFAULT_API_GOVERNANCE_RULES_OUTPUT = REPO_ROOT / "quality" / "api_governance_rules.md"
-DEFAULT_COMPLEXITY_OUTPUT = REPO_ROOT / "quality" / "complexity_report.md"
+QUALITY_DIR = REPO_ROOT / "quality"
+DEFAULT_OUTPUT = QUALITY_DIR / "refactor_health_report.md"
+DEFAULT_BASELINE_OUTPUT = QUALITY_DIR / "baseline_report.md"
+DEFAULT_SCORECARD_OUTPUT = QUALITY_DIR / "quality_scorecard.md"
+DEFAULT_ARCHITECTURE_RULES_OUTPUT = QUALITY_DIR / "architecture_rules.md"
+DEFAULT_API_GOVERNANCE_RULES_OUTPUT = QUALITY_DIR / "api_governance_rules.md"
+DEFAULT_COMPLEXITY_OUTPUT = QUALITY_DIR / "complexity_report.md"
 PYTHON_ROOTS = ("src", "tests", "scripts")
 SERVICE_LEAKAGE_PATTERNS = (
     "from src.api.routers",
@@ -81,6 +82,7 @@ class SnapshotMetrics:
 class HealthReportContext:
     generated_at: str
     base_ref: str
+    base_source_ref: str
     current_ref: str
     base: SnapshotMetrics
     current: SnapshotMetrics
@@ -118,11 +120,28 @@ def _git_ref_exists(ref: str) -> bool:
     return completed.returncode == 0
 
 
+def _git_resolved_ref(ref: str) -> str:
+    return _git("rev-parse", ref).strip()
+
+
 def _current_ref_name() -> str:
     env_ref_name = os.environ.get("GITHUB_REF_NAME")
     if env_ref_name:
         return env_ref_name
     return _git("rev-parse", "--abbrev-ref", "HEAD").strip()
+
+
+def _recorded_quality_baseline_ref() -> str | None:
+    report_path = QUALITY_DIR / "refactor_health_report.md"
+    if not report_path.exists():
+        return None
+    for line in report_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("- Baseline source snapshot: `") and line.endswith("`"):
+            candidate = line.removeprefix("- Baseline source snapshot: `").removesuffix("`")
+            if _git_ref_exists(candidate):
+                return candidate
+            return None
+    return None
 
 
 def _base_ref_for_quality_check() -> tuple[str, str]:
@@ -132,7 +151,7 @@ def _base_ref_for_quality_check() -> tuple[str, str]:
         and not _git_status_porcelain().strip()
         and _git_ref_exists("HEAD^")
     ):
-        return "HEAD^", DEFAULT_BASE_REF
+        return _recorded_quality_baseline_ref() or "HEAD^", DEFAULT_BASE_REF
     return DEFAULT_BASE_REF, DEFAULT_BASE_REF
 
 
@@ -463,6 +482,7 @@ def _report_context(
     return HealthReportContext(
         generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
         base_ref=display_base_ref,
+        base_source_ref=_git_resolved_ref(base_ref),
         current_ref=_report_source_snapshot(),
         base=base,
         current=current,
@@ -478,6 +498,7 @@ def build_refactor_report(context: HealthReportContext) -> str:
         "# lotus-manage Refactor Health Report",
         f"- Generated at: `{context.generated_at}`",
         f"- Baseline ref: `{context.base_ref}`",
+        f"- Baseline source snapshot: `{context.base_source_ref}`",
         f"- Report source snapshot: `{context.current_ref}`",
         "- Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.",
         "## Scorecard",
@@ -532,6 +553,7 @@ def build_baseline_report(context: HealthReportContext) -> str:
     sections = [
         "# lotus-manage Baseline Quality Report",
         f"- Generated at: `{context.generated_at}`",
+        f"- Baseline source snapshot: `{context.base_source_ref}`",
         f"- Report source snapshot: `{context.current_ref}`",
         "- Mode: report-only baseline. This records current posture; it does not enforce "
         "thresholds by itself.",
@@ -710,6 +732,7 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
     sections = [
         "# lotus-manage Quality Scorecard",
         f"- Generated at: `{context.generated_at}`",
+        f"- Baseline source snapshot: `{context.base_source_ref}`",
         f"- Report source snapshot: `{context.current_ref}`",
         "- Purpose: make enterprise-readiness progress measurable without pretending report-only "
         "baselines are mature enforcement gates.",
@@ -754,6 +777,7 @@ def build_complexity_report(context: HealthReportContext) -> str:
     sections = [
         "# lotus-manage Complexity Report",
         f"- Generated at: `{context.generated_at}`",
+        f"- Baseline source snapshot: `{context.base_source_ref}`",
         f"- Report source snapshot: `{context.current_ref}`",
         "- Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free "
         "AST branch metrics remain report-only.",

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import argparse
 import io
+import os
 import subprocess
 import sys
 import tarfile
@@ -104,6 +105,35 @@ def _git(*args: str) -> str:
 
 def _git_status_porcelain() -> str:
     return _git("status", "--porcelain")
+
+
+def _git_ref_exists(ref: str) -> bool:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--verify", ref],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return completed.returncode == 0
+
+
+def _current_ref_name() -> str:
+    env_ref_name = os.environ.get("GITHUB_REF_NAME")
+    if env_ref_name:
+        return env_ref_name
+    return _git("rev-parse", "--abbrev-ref", "HEAD").strip()
+
+
+def _base_ref_for_quality_check() -> tuple[str, str]:
+    ref_name = _current_ref_name()
+    if (
+        ref_name in {"main", "master"}
+        and not _git_status_porcelain().strip()
+        and _git_ref_exists("HEAD^")
+    ):
+        return "HEAD^", DEFAULT_BASE_REF
+    return DEFAULT_BASE_REF, DEFAULT_BASE_REF
 
 
 def _report_source_snapshot() -> str:
@@ -416,10 +446,15 @@ def _bounded_findings(title: str, findings: list[str]) -> str:
     return f"### {title}\n\n" + "\n".join(f"- `{item}`" for item in shown) + suffix + "\n"
 
 
-def _report_context(base_ref: str = DEFAULT_BASE_REF) -> HealthReportContext:
+def _report_context(
+    base_ref: str = DEFAULT_BASE_REF,
+    *,
+    base_label: str | None = None,
+) -> HealthReportContext:
     base_texts = _python_texts_from_git(base_ref)
+    display_base_ref = base_label or base_ref
     current_paths = _python_paths_from_worktree()
-    base = _snapshot_metrics_from_texts(label=base_ref, texts=base_texts)
+    base = _snapshot_metrics_from_texts(label=display_base_ref, texts=base_texts)
     current = _snapshot_metrics(
         label="current branch",
         paths=current_paths,
@@ -427,7 +462,7 @@ def _report_context(base_ref: str = DEFAULT_BASE_REF) -> HealthReportContext:
     )
     return HealthReportContext(
         generated_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        base_ref=base_ref,
+        base_ref=display_base_ref,
         current_ref=_report_source_snapshot(),
         base=base,
         current=current,
@@ -875,7 +910,15 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = _parse_args()
-    context = _report_context()
+    base_ref, base_label = (
+        _base_ref_for_quality_check()
+        if args.check
+        else (
+            DEFAULT_BASE_REF,
+            DEFAULT_BASE_REF,
+        )
+    )
+    context = _report_context(base_ref, base_label=base_label)
     if args.check:
         stale_paths = stale_report_paths(context)
         if stale_paths:

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -102,6 +102,58 @@ def test_report_source_snapshot_marks_dirty_worktree(monkeypatch) -> None:
     ]
 
 
+def test_quality_report_check_uses_parent_commit_for_clean_mainline(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_git(*args: str) -> str:
+        calls.append(args)
+        if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return "main\n"
+        if args == ("status", "--porcelain"):
+            return ""
+        raise AssertionError(args)
+
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref == "HEAD^")
+
+    assert ehr._base_ref_for_quality_check() == ("HEAD^", "origin/main")
+    assert calls == [
+        ("rev-parse", "--abbrev-ref", "HEAD"),
+        ("status", "--porcelain"),
+    ]
+
+
+def test_quality_report_check_uses_origin_main_for_feature_branch(monkeypatch) -> None:
+    def fake_git(*args: str) -> str:
+        if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return "feature/example\n"
+        raise AssertionError(args)
+
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda _ref: True)
+
+    assert ehr._base_ref_for_quality_check() == ("origin/main", "origin/main")
+
+
+def test_quality_report_check_uses_github_ref_name_for_mainline(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_git(*args: str) -> str:
+        calls.append(args)
+        if args == ("status", "--porcelain"):
+            return ""
+        raise AssertionError(args)
+
+    monkeypatch.setenv("GITHUB_REF_NAME", "main")
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref == "HEAD^")
+
+    assert ehr._base_ref_for_quality_check() == ("HEAD^", "origin/main")
+    assert calls == [("status", "--porcelain")]
+
+
 def _context() -> HealthReportContext:
     return HealthReportContext(
         generated_at="2026-06-02T00:00:00+00:00",

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -116,6 +116,7 @@ def test_quality_report_check_uses_parent_commit_for_clean_mainline(monkeypatch)
     monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
     monkeypatch.setattr(ehr, "_git", fake_git)
     monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref == "HEAD^")
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: None)
 
     assert ehr._base_ref_for_quality_check() == ("HEAD^", "origin/main")
     assert calls == [
@@ -149,15 +150,66 @@ def test_quality_report_check_uses_github_ref_name_for_mainline(monkeypatch) -> 
     monkeypatch.setenv("GITHUB_REF_NAME", "main")
     monkeypatch.setattr(ehr, "_git", fake_git)
     monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref == "HEAD^")
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: None)
 
     assert ehr._base_ref_for_quality_check() == ("HEAD^", "origin/main")
     assert calls == [("status", "--porcelain")]
+
+
+def test_quality_report_check_uses_recorded_baseline_for_clean_mainline(
+    monkeypatch,
+) -> None:
+    def fake_git(*args: str) -> str:
+        if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return "main\n"
+        if args == ("status", "--porcelain"):
+            return ""
+        raise AssertionError(args)
+
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref in {"HEAD^", "base1234"})
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: "base1234")
+
+    assert ehr._base_ref_for_quality_check() == ("base1234", "origin/main")
+
+
+def test_recorded_quality_baseline_ref_reads_checked_in_report(monkeypatch, tmp_path) -> None:
+    quality_dir = tmp_path / "quality"
+    quality_dir.mkdir()
+    (quality_dir / "refactor_health_report.md").write_text(
+        "# lotus-manage Refactor Health Report\n"
+        "- Baseline ref: `origin/main`\n"
+        "- Baseline source snapshot: `base1234`\n"
+        "- Report source snapshot: `head5678`\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(ehr, "QUALITY_DIR", quality_dir)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref == "base1234")
+
+    assert ehr._recorded_quality_baseline_ref() == "base1234"
+
+
+def test_recorded_quality_baseline_ref_ignores_missing_git_ref(monkeypatch, tmp_path) -> None:
+    quality_dir = tmp_path / "quality"
+    quality_dir.mkdir()
+    (quality_dir / "refactor_health_report.md").write_text(
+        "- Baseline source snapshot: `missing1234`\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(ehr, "QUALITY_DIR", quality_dir)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda _ref: False)
+
+    assert ehr._recorded_quality_baseline_ref() is None
 
 
 def _context() -> HealthReportContext:
     return HealthReportContext(
         generated_at="2026-06-02T00:00:00+00:00",
         base_ref="origin/main",
+        base_source_ref="base1234",
         current_ref="abc1234",
         base=_snapshot(label="origin/main"),
         current=_snapshot(


### PR DESCRIPTION
## Summary
- Fix the quality report freshness gate so clean mainline checks compare checked-in reports against the merged commit parent while preserving the displayed `origin/main` baseline label.
- Keep feature-branch checks on `origin/main`, so PR branches still detect stale quality reports before merge.
- Regenerate the checked-in quality reports after the final formatted script/test changes.

## Evidence
- Focused: `python -m pytest tests/unit/test_engineering_health_report.py -q` -> `13 passed in 0.58s`
- Repo-native: `make check` -> `2985 passed in 45.89s`; quality report freshness gate reported `Quality reports are current.`
- Diff hygiene: `git diff --check` -> passed

## CI / lane posture
- Feature Lane and PR Merge Gate should validate the branch normally.
- This PR directly targets the Main Releasability failure observed after PR #566, where the post-merge quality report gate compared checked-in reports against the merged `origin/main` commit instead of the previous mainline baseline.

## Documentation / wiki
- No wiki change: behavior is internal CI/report-gate semantics, and existing repo context already records quality report gates as active.

## Stranded truth
- `git fetch origin --prune` ran before the slice; no unmerged remote branch output was returned for `origin/main` reconciliation in this repo during this fix-forward pass.