### PR TITLE
Fix main quality report CI baseline selection

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-06-27T06:02:00+00:00`
+- Generated at: `2026-06-27T06:14:34+00:00`
 
-- Baseline source snapshot: `d8dcf66c14a32daeeff235552683fe287f05402f`
+- Baseline source snapshot: `380d5f1b70c539fa583f39af8303c4298bdbf291`
 
-- Report source snapshot: `bf8bca95+worktree`
+- Report source snapshot: `380d5f1b+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 882 |
-| Total Python LOC | 186217 |
-| Test functions | 2764 |
+| Total Python LOC | 186245 |
+| Test functions | 2766 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-06-27T06:02:00+00:00`
+- Generated at: `2026-06-27T06:14:34+00:00`
 
-- Baseline source snapshot: `d8dcf66c14a32daeeff235552683fe287f05402f`
+- Baseline source snapshot: `380d5f1b70c539fa583f39af8303c4298bdbf291`
 
-- Report source snapshot: `bf8bca95+worktree`
+- Report source snapshot: `380d5f1b+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-06-27T06:02:00+00:00`
+- Generated at: `2026-06-27T06:14:34+00:00`
 
-- Baseline source snapshot: `d8dcf66c14a32daeeff235552683fe287f05402f`
+- Baseline source snapshot: `380d5f1b70c539fa583f39af8303c4298bdbf291`
 
-- Report source snapshot: `bf8bca95+worktree`
+- Report source snapshot: `380d5f1b+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-06-27T06:02:00+00:00`
+- Generated at: `2026-06-27T06:14:34+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `d8dcf66c14a32daeeff235552683fe287f05402f`
+- Baseline source snapshot: `380d5f1b70c539fa583f39af8303c4298bdbf291`
 
-- Report source snapshot: `bf8bca95+worktree`
+- Report source snapshot: `380d5f1b+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 882 | 882 | +0 |
-| Total Python LOC | 186046 | 186217 | +171 |
-| Test functions | 2758 | 2764 | +6 |
+| Total Python LOC | 186217 | 186245 | +28 |
+| Test functions | 2764 | 2766 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -131,6 +131,10 @@ def _current_ref_name() -> str:
     return _git("rev-parse", "--abbrev-ref", "HEAD").strip()
 
 
+def _is_github_mainline_ref(ref_name: str) -> bool:
+    return bool(os.environ.get("GITHUB_REF_NAME")) and ref_name in {"main", "master"}
+
+
 def _recorded_quality_baseline_ref() -> str | None:
     report_path = QUALITY_DIR / "refactor_health_report.md"
     if not report_path.exists():
@@ -146,11 +150,11 @@ def _recorded_quality_baseline_ref() -> str | None:
 
 def _base_ref_for_quality_check() -> tuple[str, str]:
     ref_name = _current_ref_name()
-    if (
-        ref_name in {"main", "master"}
-        and not _git_status_porcelain().strip()
-        and _git_ref_exists("HEAD^")
-    ):
+    if ref_name in {"main", "master"} and _git_ref_exists("HEAD^"):
+        if _is_github_mainline_ref(ref_name):
+            return _recorded_quality_baseline_ref() or "HEAD^", DEFAULT_BASE_REF
+        if _git_status_porcelain().strip():
+            return DEFAULT_BASE_REF, DEFAULT_BASE_REF
         return _recorded_quality_baseline_ref() or "HEAD^", DEFAULT_BASE_REF
     return DEFAULT_BASE_REF, DEFAULT_BASE_REF
 

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -139,12 +139,7 @@ def test_quality_report_check_uses_origin_main_for_feature_branch(monkeypatch) -
 
 
 def test_quality_report_check_uses_github_ref_name_for_mainline(monkeypatch) -> None:
-    calls: list[tuple[str, ...]] = []
-
     def fake_git(*args: str) -> str:
-        calls.append(args)
-        if args == ("status", "--porcelain"):
-            return ""
         raise AssertionError(args)
 
     monkeypatch.setenv("GITHUB_REF_NAME", "main")
@@ -153,7 +148,6 @@ def test_quality_report_check_uses_github_ref_name_for_mainline(monkeypatch) -> 
     monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: None)
 
     assert ehr._base_ref_for_quality_check() == ("HEAD^", "origin/main")
-    assert calls == [("status", "--porcelain")]
 
 
 def test_quality_report_check_uses_recorded_baseline_for_clean_mainline(
@@ -172,6 +166,36 @@ def test_quality_report_check_uses_recorded_baseline_for_clean_mainline(
     monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: "base1234")
 
     assert ehr._base_ref_for_quality_check() == ("base1234", "origin/main")
+
+
+def test_quality_report_check_uses_recorded_baseline_for_github_mainline_with_workspace_churn(
+    monkeypatch,
+) -> None:
+    def fail_if_status_checked(*args: str) -> str:
+        raise AssertionError(args)
+
+    monkeypatch.setenv("GITHUB_REF_NAME", "main")
+    monkeypatch.setattr(ehr, "_git", fail_if_status_checked)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref in {"HEAD^", "base1234"})
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: "base1234")
+
+    assert ehr._base_ref_for_quality_check() == ("base1234", "origin/main")
+
+
+def test_quality_report_check_uses_origin_main_for_dirty_local_mainline(monkeypatch) -> None:
+    def fake_git(*args: str) -> str:
+        if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return "main\n"
+        if args == ("status", "--porcelain"):
+            return "?? generated.log\n"
+        raise AssertionError(args)
+
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref == "HEAD^")
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: "base1234")
+
+    assert ehr._base_ref_for_quality_check() == ("origin/main", "origin/main")
 
 
 def test_recorded_quality_baseline_ref_reads_checked_in_report(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Fixes mainline quality-report baseline selection for GitHub Actions after rebase-merge history.
- Uses the checked-in recorded baseline on GitHub `main`/`master` even when earlier workflow steps leave generated workspace churn.
- Preserves safer local behavior: dirty local mainline checks compare against `origin/main` instead of masking worktree changes.
- Regenerates checked-in quality evidence from the new baseline.

## Evidence
- `python -m pytest tests/unit/test_engineering_health_report.py -q` -> `18 passed`
- `GITHUB_REF_NAME=main python scripts/engineering_health_report.py --check` -> `Quality reports are current.`
- `git diff --check` -> passed
- `make check` -> `2990 passed in 50.51s`
- Stranded truth: `git branch -r --no-merged origin/main` -> no unmerged remote branches

## Governance
- No wiki change: this fixes CI baseline selection and checked-in quality reports only; no operator-facing wiki truth changed.
- Non-degradation: duplicate-code, complexity, architecture-boundary, security, API-contract, and supportability gates were exercised through `make check`.