### PR TITLE
Sync agent operating contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,29 @@ Before doing substantial work, load context in this order:
 
 Use the smallest correct working set. Do not load broad context blindly if the task is narrow.
 
+## Target Repository Root Rule
+
+Do not assume the inherited shell working directory is the task repository. VS Code multi-root
+workspaces can start Codex in the first workspace folder, even when the user asks for another Lotus
+repository.
+
+Before substantial work:
+
+1. infer the target repository from the user request, active goal, issue, PR, branch, file path, or
+   explicit repo name,
+2. if the target is a Lotus repository and the current working directory is a different Lotus
+   repository, switch command `workdir` to that target repo before reading repo-local context,
+   running tests, inspecting git state, editing files, or creating issues,
+3. use `lotus-platform` only for central context, automation, platform contracts, skill source, and
+   cross-repo governance unless the task explicitly targets `lotus-platform`,
+4. for multi-repo work, state the active repo for each command group and never let one repo's
+   `AGENTS.md` or `REPOSITORY-ENGINEERING-CONTEXT.md` stand in for another repo's local truth,
+5. when delegating or launching background work, pass the exact repository name, absolute repo root,
+   branch, read/write scope, and expected evidence so child agents do not inherit the wrong cwd.
+
+If the inherited cwd conflicts with the named target repo, announce the correction briefly and keep
+all subsequent repo-local commands anchored to the target repo.
+
 ## Mandatory Operating Rules
 
 Always:

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-07-03T04:55:02+00:00`
+- Generated at: `2026-07-04T07:10:44+00:00`
 
-- Baseline source snapshot: `240b23eb6f11a9dca11596e6e240fa8bf2a14d4b`
+- Baseline source snapshot: `a0371c61c3adf06e6e64775fd17ee27f63b27773`
 
-- Report source snapshot: `95ae4d47`
+- Report source snapshot: `be7c2bd5`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-07-03T04:55:02+00:00`
+- Generated at: `2026-07-04T07:10:44+00:00`
 
-- Baseline source snapshot: `240b23eb6f11a9dca11596e6e240fa8bf2a14d4b`
+- Baseline source snapshot: `a0371c61c3adf06e6e64775fd17ee27f63b27773`
 
-- Report source snapshot: `95ae4d47`
+- Report source snapshot: `be7c2bd5`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-07-03T04:55:02+00:00`
+- Generated at: `2026-07-04T07:10:44+00:00`
 
-- Baseline source snapshot: `240b23eb6f11a9dca11596e6e240fa8bf2a14d4b`
+- Baseline source snapshot: `a0371c61c3adf06e6e64775fd17ee27f63b27773`
 
-- Report source snapshot: `95ae4d47`
+- Report source snapshot: `be7c2bd5`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-07-03T04:55:02+00:00`
+- Generated at: `2026-07-04T07:10:44+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `240b23eb6f11a9dca11596e6e240fa8bf2a14d4b`
+- Baseline source snapshot: `a0371c61c3adf06e6e64775fd17ee27f63b27773`
 
-- Report source snapshot: `95ae4d47`
+- Report source snapshot: `be7c2bd5`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 


### PR DESCRIPTION
Syncs repo-root AGENTS.md with the governed Lotus agent operating contract from lotus-platform main after sgajbi/lotus-platform#486. No code changes.

Validation: platform source sync was checked with Sync-AgentOperatingContract.ps1 -AllRepoRoots -IncludeDeployedTarget -CheckOnly before creating these repo sync PRs.