### PR TITLE
Sync AGENTS wiki-check guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,10 +116,14 @@ When documentation, RFC, context, runbook, or operator-facing truth changes:
 
 1. update the repo-local `wiki/` source in the same PR when wiki truth changed,
 2. record an explicit no-wiki-change decision when no wiki update is needed,
-3. run `lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository <repo-name>` before merge,
+3. before merge, run
+   `lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository <repo-name> -AllowUnpublishedSourceChanges`
+   when the branch intentionally changes repo-local `wiki/` source,
 4. after merge to `main`, publish with
    `lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository <repo-name>`,
-5. use `-AllRepositories` only for platform-wide audits or coordinated publication sweeps.
+5. after publishing, run strict parity verification with
+   `lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository <repo-name>`,
+6. use `-AllRepositories` only for platform-wide audits or coordinated publication sweeps.
 
 Repo-local `wiki/` is the authored source of truth. The separate GitHub `*.wiki.git` repository is
 only the publication target and must not receive hand-edited truth that is absent from repo source.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,6 @@ python C:\Users\Sandeep\projects\lotus-platform\codex\skills\lotus-readme-wiki-g
 powershell -NoProfile -ExecutionPolicy Bypass -File C:\Users\Sandeep\projects\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage
 ```
 
+When the branch intentionally changes repo-local `wiki/` source, run the same wiki check with
+`-AllowUnpublishedSourceChanges` before merge, then publish after merge and rerun the strict
+`-CheckOnly` command.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-07-13T14:57:16+00:00`
+- Generated at: `2026-07-14T05:28:30+00:00`
 
-- Baseline source snapshot: `a47d377f6b29bd475ca60bd51ff2f21a29fa556b`
+- Baseline source snapshot: `db977c8eeb63e2b6c02e3a88976c3910fce084f8`
 
-- Report source snapshot: `0688f59e+worktree`
+- Report source snapshot: `db977c8e`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-07-13T14:57:16+00:00`
+- Generated at: `2026-07-14T05:28:30+00:00`
 
-- Baseline source snapshot: `a47d377f6b29bd475ca60bd51ff2f21a29fa556b`
+- Baseline source snapshot: `db977c8eeb63e2b6c02e3a88976c3910fce084f8`
 
-- Report source snapshot: `0688f59e+worktree`
+- Report source snapshot: `db977c8e`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Reported top functions | 10 | 10 | +0 |
-| Highest complexity | 1063 | 1066 | +3 |
+| Highest complexity | 1066 | 1066 | +0 |
 
 ### Most Complex Current Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-07-13T14:57:16+00:00`
+- Generated at: `2026-07-14T05:28:30+00:00`
 
-- Baseline source snapshot: `a47d377f6b29bd475ca60bd51ff2f21a29fa556b`
+- Baseline source snapshot: `db977c8eeb63e2b6c02e3a88976c3910fce084f8`
 
-- Report source snapshot: `0688f59e+worktree`
+- Report source snapshot: `db977c8e`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-07-13T14:57:16+00:00`
+- Generated at: `2026-07-14T05:28:30+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `a47d377f6b29bd475ca60bd51ff2f21a29fa556b`
+- Baseline source snapshot: `db977c8eeb63e2b6c02e3a88976c3910fce084f8`
 
-- Report source snapshot: `0688f59e+worktree`
+- Report source snapshot: `db977c8e`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 894 | 897 | +3 |
-| Total Python LOC | 193019 | 203017 | +9998 |
-| Test functions | 2822 | 2919 | +97 |
+| Python files | 897 | 897 | +0 |
+| Total Python LOC | 203017 | 203017 | +0 |
+| Test functions | 2919 | 2919 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,16 +37,16 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 7324 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 7505 |
 | 2 | tests/unit/dpm/api/test_api_rebalance.py | 3323 |
 | 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
-| 4 | tests/unit/dpm/waves/test_campaign_discovery.py | 3214 |
-| 5 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3122 |
-| 6 | tests/unit/test_documentation_current_state.py | 2771 |
-| 7 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2665 |
-| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2649 |
-| 9 | tests/unit/core/test_risk_realized_outcome_sources.py | 1811 |
-| 10 | tests/unit/api/test_pm_operating_quality_api.py | 1745 |
+| 4 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3283 |
+| 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
+| 6 | tests/unit/test_documentation_current_state.py | 2774 |
+| 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
+| 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2665 |
+| 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
+| 10 | tests/unit/dpm/pm_quality/test_pm_operating_quality.py | 1996 |
 
 ### current branch
 
@@ -69,13 +69,13 @@
 
 | Rank | Function | File | Lines |
 | --- | --- | --- | --- |
-| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1546 |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1549 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 773 |
-| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 383 |
-| 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 376 |
+| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 396 |
+| 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 380 |
 | 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
 | 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
-| 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 328 |
+| 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 334 |
 | 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
 | 9 | test_wave_openapi_pins_campaign_workflow_assignment_and_automation_contracts | tests/unit/dpm/api/test_waves_api.py | 268 |
 | 10 | test_rolling_and_historical_attribution_helper_edges_are_explicit | tests/unit/core/test_risk_realized_outcome_sources.py | 236 |
@@ -101,16 +101,16 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1063 | 1546 |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1066 | 1549 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 274 | 773 |
-| 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 376 |
-| 4 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 230 |
-| 5 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 96 | 383 |
+| 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 107 | 396 |
+| 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 78 | 140 |
-| 9 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 328 |
-| 10 | test_wave_openapi_documents_preview_and_create | tests/unit/dpm/api/test_waves_api.py | 68 | 209 |
+| 9 | test_pm_operating_quality_openapi_contract_is_documented | tests/unit/api/test_pm_operating_quality_api.py | 73 | 142 |
+| 10 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 71 | 334 |
 
 ### current branch
 

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -14,7 +14,7 @@ to `main`.
 | Is the branch locally fit for PR? | `make check`, focused tests, targeted contract validators | Blocking local proof before push or PR updates. |
 | Is the PR mergeable? | Pull Request Merge Gate | Required GitHub checks must be green; solo development does not require a reviewer when CI and conversations are clean. |
 | Is main releasable after merge? | Main Releasability Gate | Post-merge proof must point to the merged `main` SHA when the workflow applies. |
-| Did docs or wiki truth change? | Repo docs tests; `Sync-RepoWikis.ps1 -CheckOnly` before merge; publish after merge | Repo-local `wiki/` is source truth; GitHub wiki is a publication target. |
+| Did docs or wiki truth change? | Repo docs tests; `Sync-RepoWikis.ps1 -CheckOnly -AllowUnpublishedSourceChanges` before merge when the branch intentionally changes `wiki/`; publish after merge; rerun strict `Sync-RepoWikis.ps1 -CheckOnly` after publication | Repo-local `wiki/` is source truth; GitHub wiki is a publication target. |
 | Is live source integration claimed? | `make live-api-validate-core`, `make demo-certify` where applicable | Live proof is required before claiming stateful Core-backed readiness or demo certification. |
 
 ## Lane model


### PR DESCRIPTION
## Summary
- Sync repo-root `AGENTS.md` from `lotus-platform/context/AGENTS-OPERATING-CONTRACT.md`.
- Propagate the governed wiki-check guidance: use `-AllowUnpublishedSourceChanges` before merge when wiki source changes, then strict `-CheckOnly` after publish.
- Refresh generated quality reports required by the repo-native quality-report gate.
- Align repo-authored docs and wiki validation guidance with the updated AGENTS contract.

## Governance
- Refs sgajbi/lotus-platform#524.
- AGENTS change generated with `lotus-platform/automation/Sync-AgentOperatingContract.ps1`; no hand-edited copy.
- Generated report artifacts remain in `quality/`; no new dump folders or ambiguous file names.
- Wiki source changed intentionally in `wiki/Validation-and-CI.md`; publish with `Sync-RepoWikis.ps1 -Publish -Repository lotus-manage` after merge, then rerun strict `-CheckOnly`.

## Validation
- `Sync-AgentOperatingContract.ps1 -AllRepoRoots -CheckOnly` from `lotus-platform` => synchronized 13 targets.
- `python automation/validate_engineering_context_system.py` from `lotus-platform` => passed with no warnings.
- `python scripts/engineering_health_report.py --check` from `lotus-manage` => Quality reports are current.
- `python -m pytest tests\unit\test_documentation_current_state.py -q` => 29 passed.
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage -AllowUnpublishedSourceChanges` => expected `DiffCount 1` because this branch changes repo-local wiki source.
