### PR TITLE
Fix Core tax-lot identity mapping in stateful sourcing

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-07-30T09:52:45+00:00`
+- Generated at: `2026-07-30T10:01:15+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `6f971186`
+- Report source snapshot: `1fad6f63`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 204236 |
-| Test functions | 2933 |
+| Total Python LOC | 204265 |
+| Test functions | 2934 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-07-30T10:18:32+00:00`
+- Generated at: `2026-07-30T10:37:28+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `7e5f70c3+worktree`
+- Report source snapshot: `268e41d1+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 204329 |
-| Test functions | 2935 |
+| Total Python LOC | 204489 |
+| Test functions | 2938 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-07-30T10:37:28+00:00`
+- Generated at: `2026-07-30T10:50:13+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `268e41d1+worktree`
+- Report source snapshot: `88da9d46+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 204489 |
-| Test functions | 2938 |
+| Total Python LOC | 204523 |
+| Test functions | 2939 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-07-30T10:01:15+00:00`
+- Generated at: `2026-07-30T10:18:32+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `1fad6f63`
+- Report source snapshot: `7e5f70c3+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 204265 |
-| Test functions | 2934 |
+| Total Python LOC | 204329 |
+| Test functions | 2935 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-07-28T20:50:21+00:00`
+- Generated at: `2026-07-30T09:52:45+00:00`
 
-- Baseline source snapshot: `98be0d9e9f7e07f1d790e95e56ab604baca6b8f3`
+- Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `ca40ce6f+worktree`
+- Report source snapshot: `6f971186`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 204234 |
+| Total Python LOC | 204236 |
 | Test functions | 2933 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-07-30T10:37:28+00:00`
+- Generated at: `2026-07-30T10:50:13+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `268e41d1+worktree`
+- Report source snapshot: `88da9d46+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-07-30T09:52:45+00:00`
+- Generated at: `2026-07-30T10:01:15+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `6f971186`
+- Report source snapshot: `1fad6f63`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-07-28T20:50:21+00:00`
+- Generated at: `2026-07-30T09:52:45+00:00`
 
-- Baseline source snapshot: `98be0d9e9f7e07f1d790e95e56ab604baca6b8f3`
+- Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `ca40ce6f+worktree`
+- Report source snapshot: `6f971186`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-07-30T10:01:15+00:00`
+- Generated at: `2026-07-30T10:18:32+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `1fad6f63`
+- Report source snapshot: `7e5f70c3+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-07-30T10:18:32+00:00`
+- Generated at: `2026-07-30T10:37:28+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `7e5f70c3+worktree`
+- Report source snapshot: `268e41d1+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-07-30T10:18:32+00:00`
+- Generated at: `2026-07-30T10:37:28+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `7e5f70c3+worktree`
+- Report source snapshot: `268e41d1+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-07-30T10:01:15+00:00`
+- Generated at: `2026-07-30T10:18:32+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `1fad6f63`
+- Report source snapshot: `7e5f70c3+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-07-30T09:52:45+00:00`
+- Generated at: `2026-07-30T10:01:15+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `6f971186`
+- Report source snapshot: `1fad6f63`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-07-30T10:37:28+00:00`
+- Generated at: `2026-07-30T10:50:13+00:00`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `268e41d1+worktree`
+- Report source snapshot: `88da9d46+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-07-28T20:50:21+00:00`
+- Generated at: `2026-07-30T09:52:45+00:00`
 
-- Baseline source snapshot: `98be0d9e9f7e07f1d790e95e56ab604baca6b8f3`
+- Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `ca40ce6f+worktree`
+- Report source snapshot: `6f971186`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-07-30T10:37:28+00:00`
+- Generated at: `2026-07-30T10:50:13+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `268e41d1+worktree`
+- Report source snapshot: `88da9d46+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 204234 | 204489 | +255 |
-| Test functions | 2933 | 2938 | +5 |
+| Total Python LOC | 204234 | 204523 | +289 |
+| Test functions | 2933 | 2939 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-07-28T20:50:21+00:00`
+- Generated at: `2026-07-30T09:52:45+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `98be0d9e9f7e07f1d790e95e56ab604baca6b8f3`
+- Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `ca40ce6f+worktree`
+- Report source snapshot: `6f971186`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 203984 | 204234 | +250 |
-| Test functions | 2931 | 2933 | +2 |
+| Total Python LOC | 204234 | 204236 | +2 |
+| Test functions | 2933 | 2933 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-07-30T10:18:32+00:00`
+- Generated at: `2026-07-30T10:37:28+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `7e5f70c3+worktree`
+- Report source snapshot: `268e41d1+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 204234 | 204329 | +95 |
-| Test functions | 2933 | 2935 | +2 |
+| Total Python LOC | 204234 | 204489 | +255 |
+| Test functions | 2933 | 2938 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-07-30T09:52:45+00:00`
+- Generated at: `2026-07-30T10:01:15+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `6f971186`
+- Report source snapshot: `1fad6f63`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 204234 | 204236 | +2 |
-| Test functions | 2933 | 2933 | +0 |
+| Total Python LOC | 204234 | 204265 | +31 |
+| Test functions | 2933 | 2934 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-07-30T10:01:15+00:00`
+- Generated at: `2026-07-30T10:18:32+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
 
-- Report source snapshot: `1fad6f63`
+- Report source snapshot: `7e5f70c3+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 204234 | 204265 | +31 |
-| Test functions | 2933 | 2934 | +1 |
+| Total Python LOC | 204234 | 204329 | +95 |
+| Test functions | 2933 | 2935 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/core/dpm_source_context.py
+++ b/src/core/dpm_source_context.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
 from typing import Any, Literal, Optional
@@ -537,18 +538,18 @@ def build_portfolio_snapshot_with_core_tax_lots(
     if response.portfolio_id != portfolio_snapshot.portfolio_id:
         raise DpmCoreContextIncompleteError("DPM_CORE_TAX_LOT_PORTFOLIO_MISMATCH")
 
-    lots_by_instrument = _open_core_tax_lots_by_instrument(
+    tax_lot_index = _index_open_core_tax_lots(
         response=response,
         base_currency=portfolio_snapshot.base_currency,
     )
     _validate_core_tax_lot_coverage(
         portfolio_snapshot=portfolio_snapshot,
-        lots_by_instrument=lots_by_instrument,
+        tax_lot_index=tax_lot_index,
     )
     positions = [
         _portfolio_position_with_tax_lots(
             position=position,
-            lots_by_instrument=lots_by_instrument,
+            tax_lot_index=tax_lot_index,
         )
         for position in portfolio_snapshot.positions
     ]
@@ -560,12 +561,12 @@ def build_portfolio_snapshot_with_core_tax_lots(
 def _validate_core_tax_lot_coverage(
     *,
     portfolio_snapshot: PortfolioSnapshot,
-    lots_by_instrument: dict[str, list[TaxLot]],
+    tax_lot_index: "_CoreTaxLotIndex",
 ) -> None:
     for position in portfolio_snapshot.positions:
         if position.quantity <= Decimal("0"):
             continue
-        lots = lots_by_instrument.get(position.instrument_id, [])
+        lots = tax_lot_index.for_position(position.instrument_id)
         if not lots:
             raise DpmCoreContextIncompleteError("DPM_CORE_TAX_LOTS_INCOMPLETE")
         lot_quantity = sum((lot.quantity for lot in lots), Decimal("0"))
@@ -573,22 +574,35 @@ def _validate_core_tax_lot_coverage(
             raise DpmCoreContextIncompleteError("DPM_CORE_TAX_LOT_QUANTITY_MISMATCH")
 
 
-def _open_core_tax_lots_by_instrument(
+@dataclass(frozen=True)
+class _CoreTaxLotIndex:
+    by_security_id: dict[str, list[TaxLot]]
+    by_instrument_id: dict[str, list[TaxLot]]
+
+    def for_position(self, position_identity: str) -> list[TaxLot]:
+        security_lots = self.by_security_id.get(position_identity)
+        if security_lots is not None:
+            return security_lots
+        return self.by_instrument_id.get(position_identity, [])
+
+
+def _index_open_core_tax_lots(
     *,
     response: DpmCorePortfolioTaxLotWindowResponse,
     base_currency: str,
-) -> dict[str, list[TaxLot]]:
-    lots_by_instrument: dict[str, list[TaxLot]] = {}
+) -> _CoreTaxLotIndex:
+    lots_by_security_id: dict[str, list[TaxLot]] = {}
+    lots_by_instrument_id: dict[str, list[TaxLot]] = {}
     for lot in response.lots:
         if lot.tax_lot_status != "OPEN" or lot.open_quantity <= Decimal("0"):
             continue
         engine_lot = _core_tax_lot_to_engine_lot(lot=lot, base_currency=base_currency)
-        # Core snapshots normally key positions by security_id, but the accepted legacy shape
-        # falls back to instrument_id when security_id is absent. Index both distinct identities
-        # without duplicating a lot when the source uses the same value for both.
-        for identity in dict.fromkeys((lot.security_id, lot.instrument_id)):
-            lots_by_instrument.setdefault(identity, []).append(engine_lot)
-    return lots_by_instrument
+        lots_by_security_id.setdefault(lot.security_id, []).append(engine_lot)
+        lots_by_instrument_id.setdefault(lot.instrument_id, []).append(engine_lot)
+    return _CoreTaxLotIndex(
+        by_security_id=lots_by_security_id,
+        by_instrument_id=lots_by_instrument_id,
+    )
 
 
 def _core_tax_lot_to_engine_lot(
@@ -612,10 +626,10 @@ def _core_tax_lot_to_engine_lot(
 def _portfolio_position_with_tax_lots(
     *,
     position: Position,
-    lots_by_instrument: dict[str, list[TaxLot]],
+    tax_lot_index: _CoreTaxLotIndex,
 ) -> Position:
     position_payload = position.model_dump(mode="python")
-    position_payload["lots"] = lots_by_instrument.get(position.instrument_id, [])
+    position_payload["lots"] = tax_lot_index.for_position(position.instrument_id)
     return type(position).model_validate(position_payload)
 
 

--- a/src/core/dpm_source_context.py
+++ b/src/core/dpm_source_context.py
@@ -588,15 +588,18 @@ class _CoreTaxLotIndex:
             return self.by_security_id.get(position_identity, [])
         if identity_namespace == "instrument_id":
             return self.by_instrument_id.get(position_identity, [])
+        security_lots = self.by_security_id.get(position_identity, [])
+        instrument_lots = self.by_instrument_id.get(position_identity, [])
         if (
             position_identity in self.security_identities
             and position_identity in self.instrument_identities
         ):
+            if security_lots == instrument_lots:
+                return security_lots
             raise DpmCoreContextIncompleteError("DPM_CORE_TAX_LOT_IDENTITY_AMBIGUOUS")
-        security_lots = self.by_security_id.get(position_identity)
-        if security_lots is not None:
+        if position_identity in self.security_identities:
             return security_lots
-        return self.by_instrument_id.get(position_identity, [])
+        return instrument_lots
 
 
 def _index_open_core_tax_lots(

--- a/src/core/dpm_source_context.py
+++ b/src/core/dpm_source_context.py
@@ -566,7 +566,7 @@ def _validate_core_tax_lot_coverage(
     for position in portfolio_snapshot.positions:
         if position.quantity <= Decimal("0"):
             continue
-        lots = tax_lot_index.for_position(position.instrument_id)
+        lots = tax_lot_index.for_position(position)
         if not lots:
             raise DpmCoreContextIncompleteError("DPM_CORE_TAX_LOTS_INCOMPLETE")
         lot_quantity = sum((lot.quantity for lot in lots), Decimal("0"))
@@ -578,8 +578,21 @@ def _validate_core_tax_lot_coverage(
 class _CoreTaxLotIndex:
     by_security_id: dict[str, list[TaxLot]]
     by_instrument_id: dict[str, list[TaxLot]]
+    security_identities: set[str]
+    instrument_identities: set[str]
 
-    def for_position(self, position_identity: str) -> list[TaxLot]:
+    def for_position(self, position: Position) -> list[TaxLot]:
+        position_identity = position.instrument_id
+        identity_namespace = getattr(position, "_core_source_identity_namespace", "unknown")
+        if identity_namespace == "security_id":
+            return self.by_security_id.get(position_identity, [])
+        if identity_namespace == "instrument_id":
+            return self.by_instrument_id.get(position_identity, [])
+        if (
+            position_identity in self.security_identities
+            and position_identity in self.instrument_identities
+        ):
+            raise DpmCoreContextIncompleteError("DPM_CORE_TAX_LOT_IDENTITY_AMBIGUOUS")
         security_lots = self.by_security_id.get(position_identity)
         if security_lots is not None:
             return security_lots
@@ -593,7 +606,11 @@ def _index_open_core_tax_lots(
 ) -> _CoreTaxLotIndex:
     lots_by_security_id: dict[str, list[TaxLot]] = {}
     lots_by_instrument_id: dict[str, list[TaxLot]] = {}
+    security_identities: set[str] = set()
+    instrument_identities: set[str] = set()
     for lot in response.lots:
+        security_identities.add(lot.security_id)
+        instrument_identities.add(lot.instrument_id)
         if lot.tax_lot_status != "OPEN" or lot.open_quantity <= Decimal("0"):
             continue
         engine_lot = _core_tax_lot_to_engine_lot(lot=lot, base_currency=base_currency)
@@ -602,6 +619,8 @@ def _index_open_core_tax_lots(
     return _CoreTaxLotIndex(
         by_security_id=lots_by_security_id,
         by_instrument_id=lots_by_instrument_id,
+        security_identities=security_identities,
+        instrument_identities=instrument_identities,
     )
 
 
@@ -629,8 +648,14 @@ def _portfolio_position_with_tax_lots(
     tax_lot_index: _CoreTaxLotIndex,
 ) -> Position:
     position_payload = position.model_dump(mode="python")
-    position_payload["lots"] = tax_lot_index.for_position(position.instrument_id)
-    return type(position).model_validate(position_payload)
+    position_payload["lots"] = tax_lot_index.for_position(position)
+    enriched_position = type(position).model_validate(position_payload)
+    enriched_position._core_source_identity_namespace = getattr(
+        position,
+        "_core_source_identity_namespace",
+        "unknown",
+    )
+    return enriched_position
 
 
 def build_market_data_snapshot_from_core_coverage(

--- a/src/core/dpm_source_context.py
+++ b/src/core/dpm_source_context.py
@@ -582,7 +582,9 @@ def _open_core_tax_lots_by_instrument(
     for lot in response.lots:
         if lot.tax_lot_status != "OPEN" or lot.open_quantity <= Decimal("0"):
             continue
-        lots_by_instrument.setdefault(lot.instrument_id, []).append(
+        # PortfolioSnapshot positions are keyed by Core's security_id. The separate
+        # instrument_id is reference/vendor identity and must not be used for lot attachment.
+        lots_by_instrument.setdefault(lot.security_id, []).append(
             _core_tax_lot_to_engine_lot(lot=lot, base_currency=base_currency)
         )
     return lots_by_instrument

--- a/src/core/dpm_source_context.py
+++ b/src/core/dpm_source_context.py
@@ -582,11 +582,12 @@ def _open_core_tax_lots_by_instrument(
     for lot in response.lots:
         if lot.tax_lot_status != "OPEN" or lot.open_quantity <= Decimal("0"):
             continue
-        # PortfolioSnapshot positions are keyed by Core's security_id. The separate
-        # instrument_id is reference/vendor identity and must not be used for lot attachment.
-        lots_by_instrument.setdefault(lot.security_id, []).append(
-            _core_tax_lot_to_engine_lot(lot=lot, base_currency=base_currency)
-        )
+        engine_lot = _core_tax_lot_to_engine_lot(lot=lot, base_currency=base_currency)
+        # Core snapshots normally key positions by security_id, but the accepted legacy shape
+        # falls back to instrument_id when security_id is absent. Index both distinct identities
+        # without duplicating a lot when the source uses the same value for both.
+        for identity in dict.fromkeys((lot.security_id, lot.instrument_id)):
+            lots_by_instrument.setdefault(identity, []).append(engine_lot)
     return lots_by_instrument
 
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -7,7 +7,14 @@ from decimal import Decimal
 from enum import Enum
 from typing import Annotated, Any, ClassVar, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 
 class ValuationMode(str, Enum):
@@ -85,6 +92,10 @@ class FxRate(BaseModel):
 
 
 class Position(BaseModel):
+    _core_source_identity_namespace: Literal["security_id", "instrument_id", "unknown"] = (
+        PrivateAttr(default="unknown")
+    )
+
     instrument_id: str = Field(description="Unique instrument identifier.", examples=["AAPL"])
     quantity: Decimal = Field(description="Held quantity before simulation.", examples=["100"])
     market_value: Optional[Money] = Field(

--- a/src/infrastructure/core_sourcing/snapshot_mapping.py
+++ b/src/infrastructure/core_sourcing/snapshot_mapping.py
@@ -1,13 +1,14 @@
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal, InvalidOperation
-from typing import Any, Mapping
+from typing import Any, Literal, Mapping
 
 from src.core.models import CashBalance, Money, PortfolioSnapshot, Position
 from src.infrastructure.core_sourcing.errors import DpmCoreResolverError
 
 
 CORE_SNAPSHOT_INCOMPLETE = "DPM_CORE_PORTFOLIO_SNAPSHOT_INCOMPLETE"
+CoreSnapshotIdentityNamespace = Literal["security_id", "instrument_id", "unknown"]
 
 
 @dataclass(frozen=True)
@@ -25,11 +26,21 @@ def core_snapshot_base_currency(payload: Mapping[str, Any]) -> str:
     )
 
 
-def core_snapshot_row_instrument_id(row: Mapping[str, Any]) -> str:
-    return _required_text(
-        row.get("security_id") or row.get("instrument_id"),
-        field="positions_baseline[].instrument_id",
+def core_snapshot_row_identity(row: Mapping[str, Any]) -> tuple[str, CoreSnapshotIdentityNamespace]:
+    if row.get("security_id") is not None:
+        return (
+            _required_text(row.get("security_id"), field="positions_baseline[].security_id"),
+            "security_id",
+        )
+    return (
+        _required_text(row.get("instrument_id"), field="positions_baseline[].instrument_id"),
+        "instrument_id",
     )
+
+
+def core_snapshot_row_instrument_id(row: Mapping[str, Any]) -> str:
+    instrument_id, _namespace = core_snapshot_row_identity(row)
+    return instrument_id
 
 
 def core_snapshot_row_quantity(row: Mapping[str, Any]) -> Decimal:
@@ -67,16 +78,17 @@ def position_core_snapshot_row(
     quantity: Decimal,
     currency: str,
     market_value: Decimal | None,
+    identity_namespace: CoreSnapshotIdentityNamespace = "unknown",
 ) -> CoreSnapshotMappedRow:
-    return CoreSnapshotMappedRow(
-        position=Position(
-            instrument_id=instrument_id,
-            quantity=quantity,
-            market_value=(
-                Money(amount=market_value, currency=currency) if market_value is not None else None
-            ),
-        )
+    position = Position(
+        instrument_id=instrument_id,
+        quantity=quantity,
+        market_value=(
+            Money(amount=market_value, currency=currency) if market_value is not None else None
+        ),
     )
+    position._core_source_identity_namespace = identity_namespace
+    return CoreSnapshotMappedRow(position=position)
 
 
 def held_instrument_ids(portfolio_snapshot: PortfolioSnapshot) -> list[str]:
@@ -88,7 +100,7 @@ def map_core_snapshot_row(
     *,
     base_currency: str,
 ) -> CoreSnapshotMappedRow | None:
-    instrument_id = core_snapshot_row_instrument_id(row)
+    instrument_id, identity_namespace = core_snapshot_row_identity(row)
     if not instrument_id:
         return None
 
@@ -105,6 +117,7 @@ def map_core_snapshot_row(
         quantity=quantity,
         currency=currency,
         market_value=market_value,
+        identity_namespace=identity_namespace,
     )
 
 

--- a/tests/unit/dpm/core/test_dpm_source_context.py
+++ b/tests/unit/dpm/core/test_dpm_source_context.py
@@ -29,6 +29,7 @@ from src.core.dpm_source_context import (
     DpmStatefulInput,
 )
 from src.core.models import PortfolioSnapshot, SimulationScenario
+from src.infrastructure.core_sourcing.snapshot_mapping import portfolio_snapshot_from_core_snapshot
 
 
 def _core_context(*, supportability_state: str = "READY") -> DpmCoreExecutionContext:
@@ -692,19 +693,15 @@ def test_core_tax_lots_preserve_snapshot_instrument_identity_fallback():
     )
 
 
-def test_core_tax_lots_keep_security_and_instrument_identity_namespaces_separate():
+def test_core_tax_lots_reject_ambiguous_identity_without_core_snapshot_provenance():
     portfolio = PortfolioSnapshot.model_validate(
         {
             **_core_context().portfolio_snapshot.model_dump(mode="python"),
             "positions": [
                 {
-                    "instrument_id": "EQ_US_AAPL",
-                    "quantity": "100.0000000000",
-                },
-                {
                     "instrument_id": "AAPL",
-                    "quantity": "50.0000000000",
-                },
+                    "quantity": "100.0000000000",
+                }
             ],
         }
     )
@@ -726,6 +723,51 @@ def test_core_tax_lots_keep_security_and_instrument_identity_namespaces_separate
     payload["supportability"]["returned_lot_count"] = 3
     response = DpmCorePortfolioTaxLotWindowResponse.model_validate(payload)
 
+    with pytest.raises(DpmCoreContextIncompleteError, match="DPM_CORE_TAX_LOT_IDENTITY_AMBIGUOUS"):
+        build_portfolio_snapshot_with_core_tax_lots(
+            portfolio_snapshot=portfolio,
+            response=response,
+        )
+
+
+def test_core_tax_lots_preserve_core_snapshot_fallback_instrument_provenance():
+    portfolio = portfolio_snapshot_from_core_snapshot(
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "as_of_date": "2026-04-10",
+            "snapshot_id": "core-pf-snap-001",
+            "valuation_context": {"portfolio_currency": "SGD"},
+            "sections": {
+                "positions_baseline": [
+                    {
+                        "instrument_id": "AAPL",
+                        "quantity": "100.0000000000",
+                        "market_value_local": "18712",
+                        "currency": "USD",
+                    }
+                ],
+                "portfolio_totals": {"baseline_total_market_value_base": "18712"},
+            },
+        }
+    )
+    payload = _core_tax_lot_payload()
+    payload["lots"].append(
+        {
+            **payload["lots"][0],
+            "security_id": "AAPL",
+            "instrument_id": "OTHER_REFERENCE",
+            "lot_id": "LOT-SECURITY-ID-COLLISION",
+            "open_quantity": "100.0000000000",
+            "original_quantity": "100.0000000000",
+            "cost_basis_base": "7500.0000000000",
+            "cost_basis_local": "7500.0000000000",
+            "source_transaction_id": "TXN-SECURITY-ID-COLLISION",
+        }
+    )
+    payload["supportability"]["requested_security_count"] = 2
+    payload["supportability"]["returned_lot_count"] = 3
+    response = DpmCorePortfolioTaxLotWindowResponse.model_validate(payload)
+
     enriched = build_portfolio_snapshot_with_core_tax_lots(
         portfolio_snapshot=portfolio,
         response=response,
@@ -735,7 +777,56 @@ def test_core_tax_lots_keep_security_and_instrument_identity_namespaces_separate
         "LOT-AAPL-001",
         "LOT-AAPL-002",
     ]
-    assert [lot.lot_id for lot in enriched.positions[1].lots] == ["LOT-SECURITY-ID-COLLISION"]
+    assert "LOT-SECURITY-ID-COLLISION" not in [lot.lot_id for lot in enriched.positions[0].lots]
+
+
+def test_core_tax_lots_do_not_fallback_for_security_position_with_no_open_lots():
+    portfolio = portfolio_snapshot_from_core_snapshot(
+        {
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "as_of_date": "2026-04-10",
+            "snapshot_id": "core-pf-snap-001",
+            "valuation_context": {"portfolio_currency": "SGD"},
+            "sections": {
+                "positions_baseline": [
+                    {
+                        "security_id": "EQ_US_AAPL",
+                        "instrument_id": "AAPL",
+                        "quantity": "100.0000000000",
+                        "market_value_local": "18712",
+                        "currency": "USD",
+                    }
+                ],
+                "portfolio_totals": {"baseline_total_market_value_base": "18712"},
+            },
+        }
+    )
+    payload = _core_tax_lot_payload()
+    payload["lots"][0]["tax_lot_status"] = "CLOSED"
+    payload["lots"][1]["open_quantity"] = "0.0000000000"
+    payload["lots"].append(
+        {
+            **payload["lots"][0],
+            "security_id": "OTHER_SECURITY",
+            "instrument_id": "EQ_US_AAPL",
+            "lot_id": "LOT-INSTRUMENT-ALIAS-COLLISION",
+            "open_quantity": "100.0000000000",
+            "original_quantity": "100.0000000000",
+            "tax_lot_status": "OPEN",
+            "cost_basis_base": "7500.0000000000",
+            "cost_basis_local": "7500.0000000000",
+            "source_transaction_id": "TXN-INSTRUMENT-ALIAS-COLLISION",
+        }
+    )
+    payload["supportability"]["requested_security_count"] = 2
+    payload["supportability"]["returned_lot_count"] = 3
+    response = DpmCorePortfolioTaxLotWindowResponse.model_validate(payload)
+
+    with pytest.raises(DpmCoreContextIncompleteError, match="DPM_CORE_TAX_LOTS_INCOMPLETE"):
+        build_portfolio_snapshot_with_core_tax_lots(
+            portfolio_snapshot=portfolio,
+            response=response,
+        )
 
 
 def test_core_tax_lots_reject_closed_or_depleted_lots_for_positive_position():
@@ -821,6 +912,8 @@ def test_portfolio_position_tax_lot_helper_attaches_grouped_lots_by_instrument()
         tax_lot_index=_CoreTaxLotIndex(
             by_security_id={"EQ_US_AAPL": [tax_lot]},
             by_instrument_id={},
+            security_identities={"EQ_US_AAPL"},
+            instrument_identities={"AAPL"},
         ),
     )
 

--- a/tests/unit/dpm/core/test_dpm_source_context.py
+++ b/tests/unit/dpm/core/test_dpm_source_context.py
@@ -730,6 +730,37 @@ def test_core_tax_lots_reject_ambiguous_identity_without_core_snapshot_provenanc
         )
 
 
+def test_core_tax_lots_accept_identical_security_and_instrument_identity_groups():
+    portfolio = PortfolioSnapshot.model_validate(
+        {
+            **_core_context().portfolio_snapshot.model_dump(mode="python"),
+            "positions": [
+                {
+                    "instrument_id": "EQ_US_AAPL",
+                    "quantity": "100.0000000000",
+                }
+            ],
+        }
+    )
+    payload = _core_tax_lot_payload()
+    for lot in payload["lots"]:
+        lot["instrument_id"] = lot["security_id"]
+    response = DpmCorePortfolioTaxLotWindowResponse.model_validate(payload)
+
+    enriched = build_portfolio_snapshot_with_core_tax_lots(
+        portfolio_snapshot=portfolio,
+        response=response,
+    )
+
+    assert [lot.lot_id for lot in enriched.positions[0].lots] == [
+        "LOT-AAPL-001",
+        "LOT-AAPL-002",
+    ]
+    assert sum((lot.quantity for lot in enriched.positions[0].lots), Decimal("0")) == Decimal(
+        "100.0000000000"
+    )
+
+
 def test_core_tax_lots_preserve_core_snapshot_fallback_instrument_provenance():
     portfolio = portfolio_snapshot_from_core_snapshot(
         {

--- a/tests/unit/dpm/core/test_dpm_source_context.py
+++ b/tests/unit/dpm/core/test_dpm_source_context.py
@@ -9,6 +9,7 @@ from src.core.dpm_source_context import (
     DpmCoreMarketDataCoverageWindowResponse,
     DpmCoreModelPortfolioTargetResponse,
     DpmCorePortfolioTaxLotWindowResponse,
+    _CoreTaxLotIndex,
     _core_coverage_fx_rates,
     _core_coverage_prices,
     _core_tax_lot_to_engine_lot,
@@ -691,6 +692,52 @@ def test_core_tax_lots_preserve_snapshot_instrument_identity_fallback():
     )
 
 
+def test_core_tax_lots_keep_security_and_instrument_identity_namespaces_separate():
+    portfolio = PortfolioSnapshot.model_validate(
+        {
+            **_core_context().portfolio_snapshot.model_dump(mode="python"),
+            "positions": [
+                {
+                    "instrument_id": "EQ_US_AAPL",
+                    "quantity": "100.0000000000",
+                },
+                {
+                    "instrument_id": "AAPL",
+                    "quantity": "50.0000000000",
+                },
+            ],
+        }
+    )
+    payload = _core_tax_lot_payload()
+    payload["lots"].append(
+        {
+            **payload["lots"][0],
+            "security_id": "AAPL",
+            "instrument_id": "OTHER_REFERENCE",
+            "lot_id": "LOT-SECURITY-ID-COLLISION",
+            "open_quantity": "50.0000000000",
+            "original_quantity": "50.0000000000",
+            "cost_basis_base": "7500.0000000000",
+            "cost_basis_local": "7500.0000000000",
+            "source_transaction_id": "TXN-SECURITY-ID-COLLISION",
+        }
+    )
+    payload["supportability"]["requested_security_count"] = 2
+    payload["supportability"]["returned_lot_count"] = 3
+    response = DpmCorePortfolioTaxLotWindowResponse.model_validate(payload)
+
+    enriched = build_portfolio_snapshot_with_core_tax_lots(
+        portfolio_snapshot=portfolio,
+        response=response,
+    )
+
+    assert [lot.lot_id for lot in enriched.positions[0].lots] == [
+        "LOT-AAPL-001",
+        "LOT-AAPL-002",
+    ]
+    assert [lot.lot_id for lot in enriched.positions[1].lots] == ["LOT-SECURITY-ID-COLLISION"]
+
+
 def test_core_tax_lots_reject_closed_or_depleted_lots_for_positive_position():
     portfolio = PortfolioSnapshot.model_validate(
         {
@@ -771,7 +818,10 @@ def test_portfolio_position_tax_lot_helper_attaches_grouped_lots_by_instrument()
 
     position = _portfolio_position_with_tax_lots(
         position=portfolio.positions[0],
-        lots_by_instrument={"EQ_US_AAPL": [tax_lot]},
+        tax_lot_index=_CoreTaxLotIndex(
+            by_security_id={"EQ_US_AAPL": [tax_lot]},
+            by_instrument_id={},
+        ),
     )
 
     assert [lot.lot_id for lot in position.lots] == ["LOT-AAPL-001"]

--- a/tests/unit/dpm/core/test_dpm_source_context.py
+++ b/tests/unit/dpm/core/test_dpm_source_context.py
@@ -576,7 +576,7 @@ def _core_tax_lot_payload(**overrides: object) -> dict:
             {
                 "portfolio_id": "PB_SG_GLOBAL_BAL_001",
                 "security_id": "EQ_US_AAPL",
-                "instrument_id": "EQ_US_AAPL",
+                "instrument_id": "AAPL",
                 "lot_id": "LOT-AAPL-001",
                 "open_quantity": "60.0000000000",
                 "original_quantity": "60.0000000000",
@@ -594,7 +594,7 @@ def _core_tax_lot_payload(**overrides: object) -> dict:
             {
                 "portfolio_id": "PB_SG_GLOBAL_BAL_001",
                 "security_id": "EQ_US_AAPL",
-                "instrument_id": "EQ_US_AAPL",
+                "instrument_id": "AAPL",
                 "lot_id": "LOT-AAPL-002",
                 "open_quantity": "40.0000000000",
                 "original_quantity": "40.0000000000",

--- a/tests/unit/dpm/core/test_dpm_source_context.py
+++ b/tests/unit/dpm/core/test_dpm_source_context.py
@@ -663,6 +663,34 @@ def test_core_tax_lots_attach_to_portfolio_snapshot_for_tax_aware_engine():
     assert enriched.positions[0].lots[1].purchase_date == "2026-03-28"
 
 
+def test_core_tax_lots_preserve_snapshot_instrument_identity_fallback():
+    portfolio = PortfolioSnapshot.model_validate(
+        {
+            **_core_context().portfolio_snapshot.model_dump(mode="python"),
+            "positions": [
+                {
+                    "instrument_id": "AAPL",
+                    "quantity": "100.0000000000",
+                }
+            ],
+        }
+    )
+    response = DpmCorePortfolioTaxLotWindowResponse.model_validate(_core_tax_lot_payload())
+
+    enriched = build_portfolio_snapshot_with_core_tax_lots(
+        portfolio_snapshot=portfolio,
+        response=response,
+    )
+
+    assert [lot.lot_id for lot in enriched.positions[0].lots] == [
+        "LOT-AAPL-001",
+        "LOT-AAPL-002",
+    ]
+    assert sum((lot.quantity for lot in enriched.positions[0].lots), Decimal("0")) == Decimal(
+        "100.0000000000"
+    )
+
+
 def test_core_tax_lots_reject_closed_or_depleted_lots_for_positive_position():
     portfolio = PortfolioSnapshot.model_validate(
         {

--- a/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
+++ b/tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py
@@ -512,6 +512,24 @@ def test_core_snapshot_row_mapper_preserves_position_market_value_currency() -> 
     assert mapped_row.position.market_value is not None
     assert mapped_row.position.market_value.amount == Decimal("1234.56")
     assert mapped_row.position.market_value.currency == "USD"
+    assert mapped_row.position._core_source_identity_namespace == "security_id"
+
+
+def test_core_snapshot_row_mapper_marks_instrument_fallback_identity_namespace() -> None:
+    mapped_row = _map_core_snapshot_row(
+        {
+            "instrument_id": "AAPL",
+            "quantity": "12.5",
+            "currency": "usd",
+            "market_value_local": "1234.56",
+        },
+        base_currency="SGD",
+    )
+
+    assert mapped_row is not None
+    assert mapped_row.position is not None
+    assert mapped_row.position.instrument_id == "AAPL"
+    assert mapped_row.position._core_source_identity_namespace == "instrument_id"
 
 
 def test_core_snapshot_row_currency_normalizes_and_rejects_missing_currency() -> None:


### PR DESCRIPTION
Addresses #626. Keep #626 open after this PR: code, local proof, Feature Lane, and PR Merge Gate are expected on head dd416967, but final governed Platform command-center seed evidence is still pending because manage.dev.lotus is reachable and core.dev.lotus is not resolvable in the current local environment. No production, supported-feature, or Core readiness claim is made.

Review-fix evidence on final head dd416967:
- Preserves Core snapshot identity provenance (`security_id` versus fallback `instrument_id`) as private Position state without changing the public API schema.
- Resolves tax-lot lookup by provenance so security-keyed positions cannot fall through to instrument aliases and fallback-origin positions cannot attach unrelated security-id lots.
- Reserves Core tax-lot security/instrument namespaces before filtering closed/depleted lots so closed/depleted-only security lots still fail closed.
- Treats unproven positions with identical security/instrument lot groups as unambiguous so normal validated snapshots where `security_id == instrument_id` do not fail closed incorrectly.
- Local focused proof: `python -m pytest tests/unit/dpm/core/test_dpm_source_context.py tests/unit/dpm/infrastructure/test_core_sourcing_client.py tests/unit/dpm/infrastructure/test_core_sourcing_client_hardening.py -q` -> 116 passed.
- Local repo-native proof: `make check` -> passed, including 3245 unit tests.