### PR TITLE
Fix Core DPM universe source identity mapping

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1157,6 +1157,12 @@ Most relevant current governance:
     require complete open-lot coverage from `PortfolioTaxLotWindow:v1` and lot-cost FX where
     needed; missing lots, partial lots, closed/depleted-only lots, or missing lot-cost FX must block
     tax-aware output rather than falling back to a normal non-tax-aware sell.
+15. Core `DpmPortfolioUniverseCandidate:v1` campaign-wave sourcing must consume the producer's
+    canonical `content_hash`/`source_digest` identity for page-level campaign source refs.
+    `source_batch_fingerprint` is optional upstream source-batch lineage and must not be required or
+    silently reused as the canonical content hash when Core returns a valid no-batch response. Manage
+    must fail closed on missing, blank, malformed, or conflicting content identity before publishing
+    Core-sourced bulk-review campaign membership as READY.
 
 ## Context Maintenance Rule
 

--- a/contracts/domain-data-products/lotus-manage-consumers.v1.json
+++ b/contracts/domain-data-products/lotus-manage-consumers.v1.json
@@ -559,7 +559,7 @@
         "product_name",
         "product_version",
         "as_of_date",
-        "source_batch_fingerprint",
+        "content_hash",
         "snapshot_id",
         "correlation_id"
       ],

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-07-28T19:57:37.103659+00:00",
+  "generatedAt": "2026-08-08T14:27:20.619115+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -69269,6 +69269,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -69389,6 +69397,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -69451,6 +69467,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -69657,6 +69681,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -69777,6 +69809,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -69839,6 +69879,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -70137,6 +70185,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -70303,6 +70359,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -70489,6 +70553,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -70663,6 +70735,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -70847,6 +70927,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -71088,6 +71176,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -71208,6 +71304,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -71270,6 +71374,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -71568,6 +71680,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -71734,6 +71854,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -71920,6 +72048,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -72094,6 +72230,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -72278,6 +72422,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -72551,6 +72703,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "items[].candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "items[].candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -72671,6 +72831,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "items[].governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "items[].governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -72733,6 +72901,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "items[].source_refs[].selection_basis",
@@ -73031,6 +73207,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "items[].approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "items[].approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -73197,6 +73381,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "items[].assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "items[].assignment_actions[].source_refs[].selection_basis",
@@ -73383,6 +73575,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "items[].assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "items[].assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -73557,6 +73757,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "items[].assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "items[].assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -73741,6 +73949,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "items[].maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "items[].maker_checker_controls[].source_refs[].selection_basis",
@@ -74030,6 +74246,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -74150,6 +74374,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -74212,6 +74444,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -74510,6 +74750,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -74676,6 +74924,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -74862,6 +75118,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -75036,6 +75300,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -75220,6 +75492,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -75493,6 +75773,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -75613,6 +75901,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -75675,6 +75971,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -75973,6 +76277,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -76139,6 +76451,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -76325,6 +76645,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -76499,6 +76827,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -76683,6 +77019,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -83714,6 +84058,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -83902,6 +84254,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -84022,6 +84382,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -84084,6 +84452,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -84382,6 +84758,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -84548,6 +84932,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -84734,6 +85126,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -84908,6 +85308,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -85092,6 +85500,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -85325,6 +85741,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -85528,6 +85952,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -85716,6 +86148,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -85836,6 +86276,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -85898,6 +86346,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -86196,6 +86652,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -86362,6 +86826,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -86548,6 +87020,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -86722,6 +87202,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -86906,6 +87394,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -87163,6 +87659,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_actions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -87398,6 +87902,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -87586,6 +88098,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -87706,6 +88226,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -87768,6 +88296,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -88066,6 +88602,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -88232,6 +88776,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -88418,6 +88970,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -88592,6 +89152,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -88776,6 +89344,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -89057,6 +89633,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -89231,6 +89815,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -89484,6 +90076,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -89672,6 +90272,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -89792,6 +90400,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -89854,6 +90470,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -90152,6 +90776,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -90318,6 +90950,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -90504,6 +91144,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -90678,6 +91326,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -90862,6 +91518,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -91051,6 +91715,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -91239,6 +91911,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "candidates[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "candidates[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -91359,6 +92039,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -91421,6 +92109,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",
@@ -91719,6 +92415,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "approval_decisions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "approval_decisions[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -91885,6 +92589,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_actions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_actions[].source_refs[].selection_basis",
@@ -92071,6 +92783,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "assignment_tasks[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "assignment_tasks[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -92245,6 +92965,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "assignment_tasks[].transitions[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "assignment_tasks[].transitions[].source_refs[].selection_basis",
@@ -92429,6 +93157,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -92692,6 +93428,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "maker_checker_controls[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "maker_checker_controls[].source_refs[].selection_basis",
@@ -95344,6 +96088,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -95502,6 +96254,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -95726,6 +96486,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -96267,6 +97035,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolios[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "portfolios[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -96401,6 +97177,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "tactical_house_view.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "tactical_house_view.source_refs[].selection_basis",
@@ -96611,6 +97395,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "campaign_governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "campaign_governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -96741,6 +97533,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.trigger.source_refs[].selection_basis",
@@ -96901,6 +97701,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -97125,6 +97933,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -97674,6 +98490,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "portfolios[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "portfolios[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -97808,6 +98632,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "tactical_house_view.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "tactical_house_view.source_refs[].selection_basis",
@@ -98018,6 +98850,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "campaign_governance.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "campaign_governance.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -98148,6 +98988,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.trigger.source_refs[].selection_basis",
@@ -98308,6 +99156,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -98532,6 +99388,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -99197,6 +100061,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "items[].aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "items[].aggregate_metrics.source_analytics[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -99420,6 +100292,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -99578,6 +100458,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -99802,6 +100690,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -100715,6 +101611,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "items[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -100939,6 +101843,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "aggregate_metrics.source_analytics[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -101122,6 +102034,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -101280,6 +102200,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -101504,6 +102432,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -104633,6 +105569,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -104791,6 +105735,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -105015,6 +105967,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -105560,6 +106520,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -105718,6 +106686,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -105942,6 +106918,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -106463,6 +107447,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -106621,6 +107613,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -106845,6 +107845,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -107366,6 +108374,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -107524,6 +108540,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -107748,6 +108772,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -108269,6 +109301,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -108427,6 +109467,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -108651,6 +109699,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -109172,6 +110228,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "wave.trigger.source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "wave.trigger.source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -109330,6 +110394,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.items[].source_refs[].selection_basis",
@@ -109554,6 +110626,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "wave.aggregate_metrics.source_analytics[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "wave.aggregate_metrics.source_analytics[].source_refs[].selection_basis",
@@ -110618,6 +111698,14 @@
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
           },
           {
+            "name": "items[].source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
+          },
+          {
             "name": "items[].source_refs[].selection_basis",
             "location": "body",
             "required": false,
@@ -110856,6 +111944,14 @@
             "type": "object",
             "semanticId": "lotus.content_hash",
             "attributeRef": "#/attributeCatalog/lotus.content_hash"
+          },
+          {
+            "name": "source_refs[].source_batch_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.source_batch_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_batch_fingerprint"
           },
           {
             "name": "source_refs[].selection_basis",

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-07-30T10:50:13+00:00`
+- Generated at: `2026-08-08T16:03:10+00:00`
 
-- Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
+- Baseline source snapshot: `5ba2757c1235ce3e28c630afd44257327c91edf3`
 
-- Report source snapshot: `88da9d46+worktree`
+- Report source snapshot: `db3f6218+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 204523 |
-| Test functions | 2939 |
+| Total Python LOC | 205328 |
+| Test functions | 2953 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-07-30T10:50:13+00:00`
+- Generated at: `2026-08-08T16:03:10+00:00`
 
-- Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
+- Baseline source snapshot: `5ba2757c1235ce3e28c630afd44257327c91edf3`
 
-- Report source snapshot: `88da9d46+worktree`
+- Report source snapshot: `db3f6218+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 
@@ -24,7 +24,7 @@
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
 | 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 107 | 396 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
-| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
+| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 78 | 140 |
 | 9 | test_pm_operating_quality_openapi_contract_is_documented | tests/unit/api/test_pm_operating_quality_api.py | 73 | 142 |
@@ -54,7 +54,7 @@
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
 | 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 107 | 396 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
-| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
+| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 78 | 140 |
 | 9 | test_pm_operating_quality_openapi_contract_is_documented | tests/unit/api/test_pm_operating_quality_api.py | 73 | 142 |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-07-30T10:50:13+00:00`
+- Generated at: `2026-08-08T16:03:10+00:00`
 
-- Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
+- Baseline source snapshot: `5ba2757c1235ce3e28c630afd44257327c91edf3`
 
-- Report source snapshot: `88da9d46+worktree`
+- Report source snapshot: `db3f6218+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-07-30T10:50:13+00:00`
+- Generated at: `2026-08-08T16:03:10+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `36ff8eeeb55bfaa9f9a02d91f9788e1518c05a50`
+- Baseline source snapshot: `5ba2757c1235ce3e28c630afd44257327c91edf3`
 
-- Report source snapshot: `88da9d46+worktree`
+- Report source snapshot: `db3f6218+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 204234 | 204523 | +289 |
-| Test functions | 2933 | 2939 | +6 |
+| Total Python LOC | 204523 | 205328 | +805 |
+| Test functions | 2939 | 2953 | +14 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -52,14 +52,14 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 7505 |
-| 2 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
-| 3 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
-| 4 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3283 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 7624 |
+| 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3591 |
+| 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
+| 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 6 | tests/unit/test_documentation_current_state.py | 2774 |
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
-| 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2665 |
+| 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 | 10 | tests/unit/dpm/pm_quality/test_pm_operating_quality.py | 1996 |
 
@@ -121,7 +121,7 @@
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
 | 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 107 | 396 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
-| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 87 | 148 |
+| 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
 | 8 | test_core_resolver_posts_selector_payload_and_correlation_header | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 78 | 140 |
 | 9 | test_pm_operating_quality_openapi_contract_is_documented | tests/unit/api/test_pm_operating_quality_api.py | 73 | 142 |

--- a/src/api/services/wave_core_portfolio_universe_resolution.py
+++ b/src/api/services/wave_core_portfolio_universe_resolution.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
@@ -22,6 +23,7 @@ from src.core.waves import DpmWaveSourceRef
 CoreResolverFactory = Callable[[], Any]
 
 MAX_CORE_DPM_PORTFOLIO_UNIVERSE_PAGES = 10
+_SHA256_IDENTITY_PATTERN = re.compile(r"^sha256:[0-9a-fA-F]{64}$")
 
 
 @dataclass(frozen=True)
@@ -33,6 +35,13 @@ class _PortfolioUniverseResolutionRequest:
     include_inactive_mandates: bool
     campaign_candidate_page_size: int
     correlation_id: str
+
+
+@dataclass(frozen=True)
+class _CandidateSourceRow:
+    candidate: DpmCorePortfolioUniverseCandidate
+    universe_ref: dict[str, object]
+    selection_basis: dict[str, object] | None
 
 
 def _selection_basis_payload(
@@ -61,14 +70,61 @@ def _portfolio_universe_candidate_ref(
 def _portfolio_universe_candidate_page_ref(
     *, page: DpmCorePortfolioUniverseCandidateResponse
 ) -> dict[str, object]:
+    content_hash = _portfolio_universe_candidate_content_hash(page)
     return DpmWaveSourceRef(
         source_system="lotus-core",
         source_type="DpmPortfolioUniverseCandidate",
         source_id=page.snapshot_id or page.page.request_scope_fingerprint,
         source_version=page.product_version,
         supportability_state=page.supportability.state,
-        content_hash=page.source_batch_fingerprint,
+        content_hash=content_hash,
+        source_batch_fingerprint=_clean_optional_text(page.source_batch_fingerprint),
     ).model_dump(mode="json", exclude_none=True)
+
+
+def _portfolio_universe_candidate_content_hash(
+    page: DpmCorePortfolioUniverseCandidateResponse,
+) -> str:
+    content_hash = _clean_optional_text(page.content_hash)
+    source_digest = _clean_optional_text(page.source_digest)
+    if content_hash is not None and source_digest is not None and content_hash != source_digest:
+        raise DpmWaveDependencyFailedError(
+            code="DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_IDENTITY_CONFLICT",
+            message=(
+                "Core DPM portfolio-universe candidates returned conflicting content_hash and "
+                "source_digest identities."
+            ),
+        )
+
+    resolved_hash = content_hash or source_digest
+    if resolved_hash is None:
+        raise DpmWaveDependencyFailedError(
+            code="DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_REQUIRED",
+            message=(
+                "Core DPM portfolio-universe candidates must publish a canonical content_hash "
+                "or source_digest before Manage can publish campaign membership as READY."
+            ),
+        )
+    if not _is_sha256_identity(resolved_hash):
+        raise DpmWaveDependencyFailedError(
+            code="DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_INVALID",
+            message=(
+                "Core DPM portfolio-universe candidates returned a malformed canonical content "
+                "identity."
+            ),
+        )
+    return resolved_hash
+
+
+def _clean_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _is_sha256_identity(value: str) -> bool:
+    return _SHA256_IDENTITY_PATTERN.fullmatch(value) is not None
 
 
 def resolve_core_dpm_portfolio_universe_candidates(
@@ -159,26 +215,31 @@ def _portfolio_payloads_from_candidate_pages(
             ),
         )
 
-    candidates = _candidate_rows(candidate_pages)
-    if not candidates:
+    candidate_rows = _candidate_source_rows(candidate_pages)
+    if not candidate_rows:
         raise DpmWaveDependencyFailedError(
             code="DPM_CORE_PORTFOLIO_UNIVERSE_EMPTY",
             message="Core DPM portfolio-universe discovery returned no candidate portfolios.",
         )
-    first_page = candidate_pages[0]
-    selection_basis = _selection_basis_payload(first_page)
-    universe_ref = _portfolio_universe_candidate_page_ref(page=first_page)
-    return _candidate_portfolio_payloads(
-        candidates=candidates,
-        universe_ref=universe_ref,
-        selection_basis=selection_basis,
-    )
+    return _candidate_portfolio_payloads(candidate_rows=candidate_rows)
 
 
-def _candidate_rows(
+def _candidate_source_rows(
     candidate_pages: list[DpmCorePortfolioUniverseCandidateResponse],
-) -> list[DpmCorePortfolioUniverseCandidate]:
-    return [candidate for page in candidate_pages for candidate in page.candidates]
+) -> list[_CandidateSourceRow]:
+    rows: list[_CandidateSourceRow] = []
+    for page in candidate_pages:
+        universe_ref = _portfolio_universe_candidate_page_ref(page=page)
+        selection_basis = _selection_basis_payload(page)
+        rows.extend(
+            _CandidateSourceRow(
+                candidate=candidate,
+                universe_ref=universe_ref,
+                selection_basis=selection_basis,
+            )
+            for candidate in page.candidates
+        )
+    return rows
 
 
 def _candidate_key(
@@ -193,14 +254,13 @@ def _candidate_key(
 
 def _candidate_portfolio_payloads(
     *,
-    candidates: list[DpmCorePortfolioUniverseCandidate],
-    universe_ref: dict[str, object],
-    selection_basis: dict[str, object] | None,
+    candidate_rows: list[_CandidateSourceRow],
 ) -> list[dict[str, object]]:
     candidate_keys: set[tuple[str, str | None, str | None]] = set()
     portfolios: list[dict[str, object]] = []
 
-    for candidate in candidates:
+    for row in candidate_rows:
+        candidate = row.candidate
         candidate_key = _candidate_key(candidate)
         if candidate_key in candidate_keys:
             raise DpmWaveDependencyFailedError(
@@ -214,9 +274,10 @@ def _candidate_portfolio_payloads(
                 "mandate_id": candidate.mandate_id,
                 "portfolio_type": "DISCRETIONARY",
                 "source_refs": [
-                    universe_ref,
+                    row.universe_ref,
                     _portfolio_universe_candidate_ref(
-                        candidate=candidate, selection_basis=selection_basis
+                        candidate=candidate,
+                        selection_basis=row.selection_basis,
                     ),
                 ],
             }

--- a/src/core/dpm_source_context_core_products.py
+++ b/src/core/dpm_source_context_core_products.py
@@ -2,7 +2,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class DpmCoreModelPortfolioTargetRow(BaseModel):
@@ -458,9 +458,33 @@ class DpmCorePortfolioUniverseCandidateResponse(BaseModel):
     latest_evidence_timestamp: Optional[datetime] = Field(default=None)
     source_batch_fingerprint: Optional[str] = Field(
         default=None,
-        description="Core source-batch fingerprint for replay and evidence tie-out.",
+        description=(
+            "Core upstream source-batch lineage fingerprint when persisted source-batch lineage "
+            "exists. This is distinct from the deterministic product content identity."
+        ),
+    )
+    content_hash: Optional[str] = Field(
+        default=None,
+        description="Core deterministic content identity for this source-data product response.",
+    )
+    source_digest: Optional[str] = Field(
+        default=None,
+        description="Alias for the Core deterministic source-data product content identity.",
     )
     snapshot_id: Optional[str] = Field(
         default=None,
         description="Core snapshot identifier for the resolved candidate page.",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_content_hash_alias(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        content_hash = data.get("content_hash")
+        source_digest = data.get("source_digest")
+        if content_hash is None and source_digest is not None:
+            normalized = dict(data)
+            normalized["content_hash"] = source_digest
+            return normalized
+        return data

--- a/src/core/waves/campaign_assignment_actions.py
+++ b/src/core/waves/campaign_assignment_actions.py
@@ -13,7 +13,7 @@ from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionAssignmentAction,
 )
-from src.core.waves.models import DpmWaveSourceRef
+from src.core.waves.models import DpmWaveSourceRef, dpm_wave_source_ref_hash_payload
 from src.core.waves.campaign_page_validation import validate_page_count
 
 CampaignAssignmentActionType = Literal[
@@ -292,7 +292,7 @@ def _build_action(
         "escalation_tier": escalation_tier,
         "sla_posture": sla_posture,
         "correlation_id": correlation_id,
-        "source_refs": [ref.model_dump(mode="json") for ref in source_refs],
+        "source_refs": [dpm_wave_source_ref_hash_payload(ref) for ref in source_refs],
     }
     content_hash = (
         "sha256:"

--- a/src/core/waves/campaign_assignment_tasks.py
+++ b/src/core/waves/campaign_assignment_tasks.py
@@ -13,7 +13,7 @@ from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinitionAssignmentTask,
     DpmBulkReviewCampaignDefinitionAssignmentTaskTransition,
 )
-from src.core.waves.models import DpmWaveSourceRef
+from src.core.waves.models import DpmWaveSourceRef, dpm_wave_source_ref_hash_payload
 from src.core.waves.campaign_page_validation import (
     validate_count_map_covers,
     validate_page_count,
@@ -742,7 +742,7 @@ def _build_transition(
         "sla_posture": sla_posture,
         "due_at": due_at.isoformat() if due_at else None,
         "correlation_id": correlation_id,
-        "source_refs": [ref.model_dump(mode="json") for ref in source_refs],
+        "source_refs": [dpm_wave_source_ref_hash_payload(ref) for ref in source_refs],
     }
     content_hash = (
         "sha256:"
@@ -777,8 +777,13 @@ def _task_hash(task: DpmBulkReviewCampaignDefinitionAssignmentTask) -> str:
     payload = task.model_dump(mode="json")
     payload["content_hash"] = ""
     payload["opened_at"] = ""
+    payload["source_refs"] = [dpm_wave_source_ref_hash_payload(ref) for ref in task.source_refs]
     for transition in payload["transitions"]:
         transition["transitioned_at"] = ""
+    for transition, transition_model in zip(payload["transitions"], task.transitions, strict=True):
+        transition["source_refs"] = [
+            dpm_wave_source_ref_hash_payload(ref) for ref in transition_model.source_refs
+        ]
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
@@ -903,4 +908,4 @@ def _transition_due_at_replay_match(
 
 
 def _source_ref_payloads(source_refs: list[DpmWaveSourceRef]) -> list[dict[str, object]]:
-    return [ref.model_dump(mode="json") for ref in source_refs]
+    return [dpm_wave_source_ref_hash_payload(ref) for ref in source_refs]

--- a/src/core/waves/campaign_definition_approval_decisions.py
+++ b/src/core/waves/campaign_definition_approval_decisions.py
@@ -12,7 +12,7 @@ from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionApprovalDecision,
 )
-from src.core.waves.models import DpmWaveSourceRef
+from src.core.waves.models import DpmWaveSourceRef, dpm_wave_source_ref_hash_payload
 from src.core.waves.campaign_page_validation import validate_page_count
 
 CampaignApprovalDecisionType = Literal["APPROVED", "REJECTED", "REQUIRES_REMEDIATION"]
@@ -206,7 +206,7 @@ def _build_decision(
         "decided_by": decided_by,
         "decision_reason": decision_reason,
         "correlation_id": correlation_id,
-        "source_refs": [ref.model_dump(mode="json") for ref in source_refs],
+        "source_refs": [dpm_wave_source_ref_hash_payload(ref) for ref in source_refs],
     }
     content_hash = (
         "sha256:"

--- a/src/core/waves/campaign_definition_launch_package.py
+++ b/src/core/waves/campaign_definition_launch_package.py
@@ -10,7 +10,10 @@ from src.core.waves.campaign_definition_readiness import (
     DpmBulkReviewCampaignDefinitionPreviewReadiness,
     build_bulk_review_campaign_definition_preview_readiness,
 )
-from src.core.waves.campaign_definitions import DpmBulkReviewCampaignDefinition
+from src.core.waves.campaign_definitions import (
+    DpmBulkReviewCampaignDefinition,
+    _campaign_definition_hash_payload,
+)
 from src.core.waves.campaign_operating_boundaries import (
     CAMPAIGN_LAUNCH_PACKAGE_OPERATING_BOUNDARIES,
 )
@@ -140,9 +143,7 @@ def _idempotency_key(
 
 
 def _launch_basis_hash(definition: DpmBulkReviewCampaignDefinition) -> str:
-    payload = definition.model_dump(mode="json")
-    payload["content_hash"] = ""
-    payload["created_at"] = ""
+    payload = _campaign_definition_hash_payload(definition, include_hash=False)
     payload["launch_history"] = []
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/src/core/waves/campaign_definitions.py
+++ b/src/core/waves/campaign_definitions.py
@@ -7,7 +7,10 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
-from src.core.waves.models import DpmWaveSourceRef
+from src.core.waves.models import (
+    DpmWaveSourceRef,
+    normalize_dpm_wave_source_ref_collections_for_hash,
+)
 
 CampaignDefinitionStatus = Literal["ACTIVE", "RETIRED", "SUPERSEDED"]
 
@@ -641,6 +644,7 @@ def _campaign_definition_hash_payload(
 ) -> dict[str, object]:
     payload = definition.model_dump(mode="json")
     _normalize_campaign_definition_hash_fields(payload, include_hash=include_hash)
+    normalize_dpm_wave_source_ref_collections_for_hash(payload)
     _drop_empty_campaign_definition_evidence_collections(payload)
     return payload
 

--- a/src/core/waves/campaign_maker_checker_controls.py
+++ b/src/core/waves/campaign_maker_checker_controls.py
@@ -12,7 +12,7 @@ from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinition,
     DpmBulkReviewCampaignDefinitionMakerCheckerControl,
 )
-from src.core.waves.models import DpmWaveSourceRef
+from src.core.waves.models import DpmWaveSourceRef, dpm_wave_source_ref_hash_payload
 from src.core.waves.campaign_page_validation import validate_page_count
 
 CampaignMakerCheckerControlAction = Literal[
@@ -462,7 +462,7 @@ def _build_control(
         "control_outcome": control_outcome,
         "control_reason": control_reason,
         "correlation_id": correlation_id,
-        "source_refs": [ref.model_dump(mode="json") for ref in source_refs],
+        "source_refs": [dpm_wave_source_ref_hash_payload(ref) for ref in source_refs],
     }
     content_hash = (
         "sha256:"

--- a/src/core/waves/handoffs.py
+++ b/src/core/waves/handoffs.py
@@ -21,6 +21,7 @@ from src.core.waves.models import (
     DpmRebalanceWaveItem,
     DpmWaveHandoffRef,
     DpmWaveSourceRef,
+    normalize_dpm_wave_source_ref_collections_for_hash,
 )
 
 WAVE_REPORT_INPUT_CONTRACT_VERSION = "1.0"
@@ -210,6 +211,7 @@ def build_wave_report_input(
             "lotus-manage only owns internal operations handoff evidence."
         )
     wave_payload = wave.model_dump(mode="json")
+    normalize_dpm_wave_source_ref_collections_for_hash(wave_payload)
     wave_content_hash = hash_canonical_payload(wave_payload)
     payload = DpmWaveReportInput(
         contract_version=WAVE_REPORT_INPUT_CONTRACT_VERSION,

--- a/src/core/waves/models.py
+++ b/src/core/waves/models.py
@@ -78,6 +78,14 @@ class DpmWaveSourceRef(BaseModel):
         description="Canonical content hash when available.",
         examples=["sha256:manifest-example"],
     )
+    source_batch_fingerprint: str | None = Field(
+        default=None,
+        description=(
+            "Optional upstream source-batch lineage fingerprint. This must remain distinct from "
+            "content_hash because not every source product has persisted batch lineage."
+        ),
+        examples=["sha256:source-batch-example"],
+    )
     selection_basis: dict[str, object] | None = Field(
         default=None,
         description=(
@@ -91,6 +99,42 @@ class DpmWaveSourceRef(BaseModel):
             }
         ],
     )
+
+
+def dpm_wave_source_ref_hash_payload(ref: DpmWaveSourceRef) -> dict[str, object]:
+    payload = ref.model_dump(mode="json")
+    if payload.get("source_batch_fingerprint") is None:
+        payload.pop("source_batch_fingerprint", None)
+    return payload
+
+
+def normalize_dpm_wave_source_ref_collections_for_hash(payload: object) -> None:
+    """Preserve legacy hashes by omitting absent batch lineage only on source refs.
+
+    Source-owned selection metadata is intentionally unrestricted. Do not recursively remove
+    ``source_batch_fingerprint`` from arbitrary nested dictionaries because the same field name can
+    be legitimate producer metadata inside ``selection_basis``.
+    """
+    if isinstance(payload, list):
+        for item in payload:
+            normalize_dpm_wave_source_ref_collections_for_hash(item)
+        return
+
+    if not isinstance(payload, dict):
+        return
+
+    _normalize_dpm_wave_source_ref_collection_for_hash(payload.get("source_refs"))
+    for value in payload.values():
+        normalize_dpm_wave_source_ref_collections_for_hash(value)
+
+
+def _normalize_dpm_wave_source_ref_collection_for_hash(source_refs: object) -> None:
+    if not isinstance(source_refs, list):
+        return
+
+    for source_ref in source_refs:
+        if isinstance(source_ref, dict) and source_ref.get("source_batch_fingerprint") is None:
+            source_ref.pop("source_batch_fingerprint", None)
 
 
 class DpmWaveTrigger(BaseModel):

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -82,6 +82,11 @@ from src.core.waves import (
 
 MANDATE_ID = "MANDATE_PB_SG_GLOBAL_BAL_001"
 PORTFOLIO_ID = "PB_SG_GLOBAL_BAL_001"
+DPM_PORTFOLIO_UNIVERSE_CONTENT_HASH = "sha256:" + ("1" * 64)
+DPM_PORTFOLIO_UNIVERSE_CURRENT_CONTENT_HASH = "sha256:" + ("2" * 64)
+DPM_PORTFOLIO_UNIVERSE_CONFLICT_HASH = "sha256:" + ("3" * 64)
+DPM_PORTFOLIO_UNIVERSE_PAGE_1_HASH = "sha256:" + ("4" * 64)
+DPM_PORTFOLIO_UNIVERSE_PAGE_2_HASH = "sha256:" + ("5" * 64)
 
 
 def _error_reason_code(response: Any) -> str:
@@ -484,7 +489,9 @@ def _dpm_portfolio_universe_candidate_payload(
     supportability_state: str = "READY",
     page_truncated: bool = False,
     next_page_token: str | None = None,
-    source_batch_fingerprint: str = "sha256:dpm-portfolio-universe",
+    source_batch_fingerprint: str | None = None,
+    content_hash: str | None = DPM_PORTFOLIO_UNIVERSE_CONTENT_HASH,
+    source_digest: str | None = DPM_PORTFOLIO_UNIVERSE_CONTENT_HASH,
     snapshot_id: str = "dpm_portfolio_universe:sha256:dpm-portfolio-universe",
     candidates: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
@@ -563,6 +570,8 @@ def _dpm_portfolio_universe_candidate_payload(
         "data_quality_status": "ACCEPTED",
         "latest_evidence_timestamp": "2026-05-10T09:00:00Z",
         "source_batch_fingerprint": source_batch_fingerprint,
+        "content_hash": content_hash,
+        "source_digest": source_digest,
         "snapshot_id": snapshot_id,
     }
 
@@ -1838,6 +1847,11 @@ def test_bulk_review_campaign_preview_can_resolve_core_portfolio_universe_candid
         "DPM_PORTFOLIO_UNIVERSE_CANDIDATE",
         "MANDATE_DIGITAL_TWIN",
     }
+    page_ref = next(
+        ref for ref in item["source_refs"] if ref["source_type"] == "DpmPortfolioUniverseCandidate"
+    )
+    assert page_ref["content_hash"] == DPM_PORTFOLIO_UNIVERSE_CONTENT_HASH
+    assert page_ref["source_batch_fingerprint"] is None
     candidate_ref = next(
         ref
         for ref in item["source_refs"]
@@ -1906,8 +1920,17 @@ def test_bulk_review_campaign_preview_exhausts_core_portfolio_universe_candidate
             _dpm_portfolio_universe_candidate_payload(
                 page_truncated=True,
                 next_page_token="page-2",
+                content_hash=DPM_PORTFOLIO_UNIVERSE_PAGE_1_HASH,
+                source_digest=DPM_PORTFOLIO_UNIVERSE_PAGE_1_HASH,
+                snapshot_id="dpm_portfolio_universe:page-1",
             ),
-            _dpm_portfolio_universe_candidate_payload(candidates=[second_candidate]),
+            _dpm_portfolio_universe_candidate_payload(
+                candidates=[second_candidate],
+                content_hash=DPM_PORTFOLIO_UNIVERSE_PAGE_2_HASH,
+                source_digest=DPM_PORTFOLIO_UNIVERSE_PAGE_2_HASH,
+                source_batch_fingerprint="sha256:dpm-portfolio-universe-page-2-batch",
+                snapshot_id="dpm_portfolio_universe:page-2",
+            ),
         ]
     )
     monkeypatch.setattr(waves_router, "build_core_resolver_client", lambda: resolver)
@@ -1929,6 +1952,27 @@ def test_bulk_review_campaign_preview_exhausts_core_portfolio_universe_candidate
     assert all(
         "DpmPortfolioUniverseCandidate" in {ref["source_type"] for ref in item["source_refs"]}
         for item in payload["wave"]["items"]
+    )
+    page_refs_by_portfolio = {
+        item["portfolio_id"]: next(
+            ref
+            for ref in item["source_refs"]
+            if ref["source_type"] == "DpmPortfolioUniverseCandidate"
+        )
+        for item in payload["wave"]["items"]
+    }
+    assert page_refs_by_portfolio[PORTFOLIO_ID]["source_id"] == "dpm_portfolio_universe:page-1"
+    assert page_refs_by_portfolio[PORTFOLIO_ID]["content_hash"] == (
+        DPM_PORTFOLIO_UNIVERSE_PAGE_1_HASH
+    )
+    assert page_refs_by_portfolio[second_portfolio_id]["source_id"] == (
+        "dpm_portfolio_universe:page-2"
+    )
+    assert page_refs_by_portfolio[second_portfolio_id]["content_hash"] == (
+        DPM_PORTFOLIO_UNIVERSE_PAGE_2_HASH
+    )
+    assert page_refs_by_portfolio[second_portfolio_id]["source_batch_fingerprint"] == (
+        "sha256:dpm-portfolio-universe-page-2-batch"
     )
 
 
@@ -1953,7 +1997,82 @@ def test_bulk_review_campaign_create_persists_core_portfolio_universe_candidates
     assert payload["durable"] is True
     assert payload["wave"]["trigger"]["trigger_type"] == "BULK_REVIEW_CAMPAIGN"
     assert payload["wave"]["aggregate_metrics"]["state_counts"] == {"CANDIDATE": 1}
-    assert wave_repository.get_wave(wave_id=payload["wave"]["wave_id"]) is not None
+    persisted_wave = wave_repository.get_wave(wave_id=payload["wave"]["wave_id"])
+    assert persisted_wave is not None
+    page_ref = next(
+        ref
+        for ref in persisted_wave.items[0].source_refs
+        if ref.source_type == "DpmPortfolioUniverseCandidate"
+    )
+    assert page_ref.content_hash == DPM_PORTFOLIO_UNIVERSE_CONTENT_HASH
+    assert page_ref.source_batch_fingerprint is None
+
+
+def test_bulk_review_campaign_preview_preserves_core_universe_batch_lineage(
+    monkeypatch,
+) -> None:
+    mandate_repository = InMemoryDpmMandateRepository()
+    mandate_repository.save_mandate_snapshot(_twin())
+    resolver = _DpmPortfolioUniverseResolver(
+        _dpm_portfolio_universe_candidate_payload(
+            content_hash=DPM_PORTFOLIO_UNIVERSE_CURRENT_CONTENT_HASH,
+            source_digest=DPM_PORTFOLIO_UNIVERSE_CURRENT_CONTENT_HASH,
+            source_batch_fingerprint="sha256:dpm-portfolio-universe-source-batch",
+        )
+    )
+    monkeypatch.setattr(waves_router, "build_core_resolver_client", lambda: resolver)
+
+    with _client(mandate_repository, InMemoryDpmWaveRepository()) as client:
+        response = client.post(
+            "/api/v1/rebalance/waves/preview",
+            json=_core_universe_bulk_review_campaign_request(),
+        )
+
+    assert response.status_code == 200
+    item = response.json()["wave"]["items"][0]
+    page_ref = next(
+        ref for ref in item["source_refs"] if ref["source_type"] == "DpmPortfolioUniverseCandidate"
+    )
+    assert page_ref["content_hash"] == DPM_PORTFOLIO_UNIVERSE_CURRENT_CONTENT_HASH
+    assert page_ref["source_batch_fingerprint"] == "sha256:dpm-portfolio-universe-source-batch"
+
+
+@pytest.mark.parametrize(
+    ("content_hash", "source_digest", "expected_code"),
+    [
+        (None, None, "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_REQUIRED"),
+        (
+            DPM_PORTFOLIO_UNIVERSE_CONTENT_HASH,
+            DPM_PORTFOLIO_UNIVERSE_CONFLICT_HASH,
+            "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_IDENTITY_CONFLICT",
+        ),
+        ("malformed-content-identity", None, "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_INVALID"),
+        ("sha256:x", None, "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_INVALID"),
+    ],
+)
+def test_bulk_review_campaign_preview_fails_closed_for_invalid_core_universe_content_identity(
+    monkeypatch,
+    content_hash: str | None,
+    source_digest: str | None,
+    expected_code: str,
+) -> None:
+    resolver = _DpmPortfolioUniverseResolver(
+        _dpm_portfolio_universe_candidate_payload(
+            content_hash=content_hash,
+            source_digest=source_digest,
+            source_batch_fingerprint="sha256:dpm-portfolio-universe-source-batch",
+        )
+    )
+    monkeypatch.setattr(waves_router, "build_core_resolver_client", lambda: resolver)
+
+    with _client(InMemoryDpmMandateRepository(), InMemoryDpmWaveRepository()) as client:
+        response = client.post(
+            "/api/v1/rebalance/waves/preview",
+            json=_core_universe_bulk_review_campaign_request(),
+        )
+
+    assert response.status_code == 424
+    assert _error_reason_code(response) == expected_code
 
 
 def test_bulk_review_campaign_preview_fails_closed_for_duplicate_core_universe_candidates(

--- a/tests/unit/dpm/infrastructure/test_core_sourcing_client.py
+++ b/tests/unit/dpm/infrastructure/test_core_sourcing_client.py
@@ -345,7 +345,9 @@ def _dpm_portfolio_universe_candidate_payload() -> dict:
         },
         "data_quality_status": "ACCEPTED",
         "latest_evidence_timestamp": "2026-05-10T09:00:00Z",
-        "source_batch_fingerprint": "sha256:dpm-portfolio-universe",
+        "source_batch_fingerprint": None,
+        "content_hash": "sha256:dpm-portfolio-universe-content",
+        "source_digest": "sha256:dpm-portfolio-universe-content",
         "snapshot_id": "dpm_portfolio_universe:sha256:dpm-portfolio-universe",
     }
 
@@ -1720,6 +1722,9 @@ def test_core_resolver_fetches_dpm_portfolio_universe_candidates_source_product(
     assert response.selection_basis.basis_type == "EFFECTIVE_DISCRETIONARY_MANDATE_BINDING"
     assert response.selection_basis.source_table == "portfolio_mandate_bindings"
     assert "relationship householding" in response.selection_basis.downstream_boundary
+    assert response.source_batch_fingerprint is None
+    assert response.content_hash == "sha256:dpm-portfolio-universe-content"
+    assert response.source_digest == "sha256:dpm-portfolio-universe-content"
 
 
 def test_core_resolver_fetches_cio_model_change_affected_cohort_source_product():

--- a/tests/unit/dpm/waves/test_campaign_definition_repository.py
+++ b/tests/unit/dpm/waves/test_campaign_definition_repository.py
@@ -31,6 +31,7 @@ from src.core.waves.campaign_definition_launch_execution import (
     DpmBulkReviewCampaignDefinitionLaunchBlocked,
     build_bulk_review_campaign_definition_launch_command,
 )
+from src.core.waves.campaign_definition_launch_package import _launch_basis_hash
 from src.core.waves.campaign_definition_approval_decisions import (
     _append_approval_decision,
     _approval_decision_input,
@@ -41,15 +42,20 @@ from src.core.waves.campaign_definition_approval_decisions import (
     record_bulk_review_campaign_definition_approval_decision,
 )
 from src.core.waves.campaign_assignment_actions import (
+    _build_action,
     build_bulk_review_campaign_definition_assignment_action_page,
     record_bulk_review_campaign_definition_assignment_action,
 )
 from src.core.waves.campaign_assignment_tasks import (
+    _build_task,
+    _build_transition,
+    _task_hash,
     build_bulk_review_campaign_definition_assignment_task_page,
     open_bulk_review_campaign_definition_assignment_task,
     transition_bulk_review_campaign_definition_assignment_task,
 )
 from src.core.waves.campaign_maker_checker_controls import (
+    _build_control,
     build_bulk_review_campaign_definition_maker_checker_control_page,
     record_bulk_review_campaign_definition_maker_checker_control,
 )
@@ -58,6 +64,7 @@ from src.core.waves.campaign_definitions import (
     DpmBulkReviewCampaignDefinitionCandidate,
     DpmBulkReviewCampaignDefinitionGovernance,
     _apply_campaign_definition_content_hash,
+    _campaign_definition_hash_payload,
     _has_eligible_portfolio_type,
     _validate_campaign_definition_structure,
     _validate_lifecycle_fields_absent,
@@ -274,6 +281,307 @@ def test_campaign_definition_hash_preserves_legacy_empty_evidence_collections(
 
     assert getattr(reloaded, collection_field) == []
     assert bulk_review_campaign_definition_hash(reloaded) == definition.content_hash
+
+
+def test_campaign_definition_hash_preserves_absent_source_batch_lineage() -> None:
+    definition = _definition()
+    hash_payload = _campaign_definition_hash_payload(definition, include_hash=False)
+    candidate_source_ref = hash_payload["candidates"][0]["source_refs"][0]
+
+    assert "source_batch_fingerprint" not in candidate_source_ref
+    assert bulk_review_campaign_definition_hash(definition) == definition.content_hash
+
+    source_ref_with_batch = DpmWaveSourceRef(
+        source_system="lotus-core",
+        source_type="HoldingsAsOf",
+        source_id="holdings-asof-pb-sg-global-bal-001",
+        source_batch_fingerprint="sha256:holdings-source-batch",
+    )
+    definition_with_batch = DpmBulkReviewCampaignDefinition.model_validate(
+        {
+            **definition.model_dump(mode="python"),
+            "content_hash": "",
+            "candidates": [
+                {
+                    **definition.candidates[0].model_dump(mode="python"),
+                    "source_refs": [source_ref_with_batch],
+                }
+            ],
+        }
+    )
+    batch_hash_payload = _campaign_definition_hash_payload(
+        definition_with_batch, include_hash=False
+    )
+    batch_source_ref = batch_hash_payload["candidates"][0]["source_refs"][0]
+
+    assert batch_source_ref["source_batch_fingerprint"] == "sha256:holdings-source-batch"
+    assert bulk_review_campaign_definition_hash(definition_with_batch) != definition.content_hash
+
+
+def test_campaign_definition_hash_preserves_source_owned_selection_basis_metadata() -> None:
+    definition = _definition()
+    source_ref_with_source_owned_metadata = DpmWaveSourceRef(
+        source_system="lotus-core",
+        source_type="HoldingsAsOf",
+        source_id="holdings-asof-pb-sg-global-bal-001",
+        selection_basis={
+            "basis_type": "SOURCE_OWNED_CANDIDATE_SELECTION",
+            "source_batch_fingerprint": None,
+        },
+    )
+    definition_with_metadata = DpmBulkReviewCampaignDefinition.model_validate(
+        {
+            **definition.model_dump(mode="python"),
+            "content_hash": "",
+            "candidates": [
+                {
+                    **definition.candidates[0].model_dump(mode="python"),
+                    "source_refs": [source_ref_with_source_owned_metadata],
+                }
+            ],
+        }
+    )
+
+    hash_payload = _campaign_definition_hash_payload(definition_with_metadata, include_hash=False)
+    candidate_source_ref = hash_payload["candidates"][0]["source_refs"][0]
+
+    assert "source_batch_fingerprint" not in candidate_source_ref
+    assert candidate_source_ref["selection_basis"]["source_batch_fingerprint"] is None
+
+
+def test_campaign_launch_basis_hash_preserves_absent_source_batch_lineage() -> None:
+    definition = _definition()
+    source_ref = definition.candidates[0].source_refs[0]
+    explicit_none_ref = DpmWaveSourceRef.model_validate(source_ref.model_dump(mode="json"))
+    explicit_none_definition = definition.model_copy(
+        deep=True,
+        update={
+            "candidates": [
+                definition.candidates[0].model_copy(
+                    deep=True,
+                    update={"source_refs": [explicit_none_ref]},
+                )
+            ]
+        },
+    )
+    batch_ref = source_ref.model_copy(
+        update={"source_batch_fingerprint": "sha256:holdings-source-batch"}
+    )
+    batch_definition = definition.model_copy(
+        deep=True,
+        update={
+            "candidates": [
+                definition.candidates[0].model_copy(
+                    deep=True,
+                    update={"source_refs": [batch_ref]},
+                )
+            ]
+        },
+    )
+
+    assert _launch_basis_hash(definition) == _launch_basis_hash(explicit_none_definition)
+    assert _launch_basis_hash(batch_definition) != _launch_basis_hash(definition)
+
+
+def test_campaign_workflow_evidence_hashes_preserve_absent_source_batch_lineage() -> None:
+    definition = _definition()
+    source_ref = DpmWaveSourceRef(
+        source_system="lotus-core",
+        source_type="DpmPortfolioUniverseCandidate",
+        source_id="dpm-universe-page-001",
+        content_hash="sha256:" + ("1" * 64),
+    )
+    explicit_none_ref = DpmWaveSourceRef.model_validate(source_ref.model_dump(mode="json"))
+    batch_ref = source_ref.model_copy(
+        update={"source_batch_fingerprint": "sha256:dpm-universe-source-batch"}
+    )
+
+    base_decision = _build_decision(
+        definition=definition,
+        decision_type="APPROVED",
+        decision_ref="BRC-APPROVAL-2026-05-001",
+        decided_by="cio_ops_committee",
+        decision_reason="Approved for bounded DPM campaign launch.",
+        correlation_id="corr-campaign-approval-decision-001",
+        source_refs=[source_ref],
+    )
+    explicit_none_decision = _build_decision(
+        definition=definition,
+        decision_type="APPROVED",
+        decision_ref="BRC-APPROVAL-2026-05-001",
+        decided_by="cio_ops_committee",
+        decision_reason="Approved for bounded DPM campaign launch.",
+        correlation_id="corr-campaign-approval-decision-001",
+        source_refs=[explicit_none_ref],
+    )
+    batch_decision = _build_decision(
+        definition=definition,
+        decision_type="APPROVED",
+        decision_ref="BRC-APPROVAL-2026-05-001",
+        decided_by="cio_ops_committee",
+        decision_reason="Approved for bounded DPM campaign launch.",
+        correlation_id="corr-campaign-approval-decision-001",
+        source_refs=[batch_ref],
+    )
+
+    assert explicit_none_decision.content_hash == base_decision.content_hash
+    assert batch_decision.content_hash != base_decision.content_hash
+
+    base_action = _build_action(
+        definition=definition,
+        action_type="ASSIGNED",
+        action_ref="BRC-ASSIGN-2026-05-001",
+        recorded_by="campaign_owner",
+        action_reason="Assign portfolios for review.",
+        assigned_actor_ids=["rm_sg_001"],
+        escalation_tier="NONE",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-action-001",
+        source_refs=[source_ref],
+    )
+    explicit_none_action = _build_action(
+        definition=definition,
+        action_type="ASSIGNED",
+        action_ref="BRC-ASSIGN-2026-05-001",
+        recorded_by="campaign_owner",
+        action_reason="Assign portfolios for review.",
+        assigned_actor_ids=["rm_sg_001"],
+        escalation_tier="NONE",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-action-001",
+        source_refs=[explicit_none_ref],
+    )
+    batch_action = _build_action(
+        definition=definition,
+        action_type="ASSIGNED",
+        action_ref="BRC-ASSIGN-2026-05-001",
+        recorded_by="campaign_owner",
+        action_reason="Assign portfolios for review.",
+        assigned_actor_ids=["rm_sg_001"],
+        escalation_tier="NONE",
+        sla_posture="ON_TRACK",
+        correlation_id="corr-campaign-assignment-action-001",
+        source_refs=[batch_ref],
+    )
+
+    assert explicit_none_action.content_hash == base_action.content_hash
+    assert batch_action.content_hash != base_action.content_hash
+
+    base_transition = _build_transition(
+        definition=definition,
+        task_id="brc_assignment_task_001",
+        transition_type="OPENED",
+        transition_ref="BRC-TASK-001:opened",
+        transitioned_by="campaign_owner",
+        from_status=None,
+        to_status="OPEN",
+        transition_reason="Open review task.",
+        assigned_actor_ids=["rm_sg_001"],
+        escalation_tier="NONE",
+        sla_posture="ON_TRACK",
+        due_at=None,
+        correlation_id="corr-campaign-assignment-task-001",
+        source_refs=[source_ref],
+    )
+    explicit_none_transition = _build_transition(
+        definition=definition,
+        task_id="brc_assignment_task_001",
+        transition_type="OPENED",
+        transition_ref="BRC-TASK-001:opened",
+        transitioned_by="campaign_owner",
+        from_status=None,
+        to_status="OPEN",
+        transition_reason="Open review task.",
+        assigned_actor_ids=["rm_sg_001"],
+        escalation_tier="NONE",
+        sla_posture="ON_TRACK",
+        due_at=None,
+        correlation_id="corr-campaign-assignment-task-001",
+        source_refs=[explicit_none_ref],
+    )
+    batch_transition = _build_transition(
+        definition=definition,
+        task_id="brc_assignment_task_001",
+        transition_type="OPENED",
+        transition_ref="BRC-TASK-001:opened",
+        transitioned_by="campaign_owner",
+        from_status=None,
+        to_status="OPEN",
+        transition_reason="Open review task.",
+        assigned_actor_ids=["rm_sg_001"],
+        escalation_tier="NONE",
+        sla_posture="ON_TRACK",
+        due_at=None,
+        correlation_id="corr-campaign-assignment-task-001",
+        source_refs=[batch_ref],
+    )
+
+    assert explicit_none_transition.content_hash == base_transition.content_hash
+    assert batch_transition.content_hash != base_transition.content_hash
+
+    base_task = _build_task(
+        definition=definition,
+        task_ref="BRC-TASK-001",
+        task_type="ASSIGNMENT",
+        opened_by="campaign_owner",
+        task_reason="Open review task.",
+        assigned_actor_ids=["rm_sg_001"],
+        escalation_tier="NONE",
+        sla_posture="ON_TRACK",
+        due_at=None,
+        correlation_id="corr-campaign-assignment-task-001",
+        source_refs=[source_ref],
+    )
+    explicit_none_task = base_task.model_copy(
+        update={"source_refs": [explicit_none_ref], "content_hash": ""}
+    )
+    batch_task = base_task.model_copy(update={"source_refs": [batch_ref], "content_hash": ""})
+
+    assert _task_hash(explicit_none_task) == base_task.content_hash
+    assert _task_hash(batch_task) != base_task.content_hash
+
+    base_control = _build_control(
+        definition=definition,
+        control_action="SUBMITTED_FOR_REVIEW",
+        control_ref="BRC-MC-001",
+        recorded_by="campaign_owner",
+        submitter_actor_id="campaign_owner",
+        reviewer_actor_id=None,
+        required_reviewer_role="cio_approver",
+        control_outcome="PENDING",
+        control_reason="Submit campaign for maker-checker review.",
+        correlation_id="corr-campaign-maker-checker-001",
+        source_refs=[source_ref],
+    )
+    explicit_none_control = _build_control(
+        definition=definition,
+        control_action="SUBMITTED_FOR_REVIEW",
+        control_ref="BRC-MC-001",
+        recorded_by="campaign_owner",
+        submitter_actor_id="campaign_owner",
+        reviewer_actor_id=None,
+        required_reviewer_role="cio_approver",
+        control_outcome="PENDING",
+        control_reason="Submit campaign for maker-checker review.",
+        correlation_id="corr-campaign-maker-checker-001",
+        source_refs=[explicit_none_ref],
+    )
+    batch_control = _build_control(
+        definition=definition,
+        control_action="SUBMITTED_FOR_REVIEW",
+        control_ref="BRC-MC-001",
+        recorded_by="campaign_owner",
+        submitter_actor_id="campaign_owner",
+        reviewer_actor_id=None,
+        required_reviewer_role="cio_approver",
+        control_outcome="PENDING",
+        control_reason="Submit campaign for maker-checker review.",
+        correlation_id="corr-campaign-maker-checker-001",
+        source_refs=[batch_ref],
+    )
+
+    assert explicit_none_control.content_hash == base_control.content_hash
+    assert batch_control.content_hash != base_control.content_hash
 
 
 def test_campaign_definition_retired_and_superseded_validation_edges() -> None:

--- a/tests/unit/dpm/waves/test_source_analytics.py
+++ b/tests/unit/dpm/waves/test_source_analytics.py
@@ -262,6 +262,7 @@ def test_source_analytics_from_alternative_uses_enrichment_fallbacks() -> None:
                 "source_version": None,
                 "supportability_state": "DEGRADED",
                 "content_hash": None,
+                "source_batch_fingerprint": None,
                 "selection_basis": None,
             }
         ],

--- a/tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py
+++ b/tests/unit/dpm/waves/test_wave_core_portfolio_universe_resolution_service.py
@@ -5,6 +5,7 @@ from datetime import date
 import pytest
 
 from src.api.services.wave_core_portfolio_universe_resolution import (
+    _CandidateSourceRow,
     _PortfolioUniverseResolutionRequest,
     _candidate_portfolio_payloads,
     _portfolio_universe_candidate_page_ref,
@@ -27,6 +28,17 @@ from src.infrastructure.core_sourcing import (
     DpmCoreResolverError,
     DpmCoreResolverUnavailableError,
 )
+
+PORTFOLIO_UNIVERSE_CONTENT_HASH = "sha256:" + ("1" * 64)
+CORE_CANDIDATE_PAGE_HASH = "sha256:" + ("2" * 64)
+CORE_CONTENT_HASH = "sha256:" + ("3" * 64)
+CORE_SOURCE_DIGEST_HASH = "sha256:" + ("4" * 64)
+CORE_CONFLICTING_CONTENT_HASH = "sha256:" + ("5" * 64)
+FIRST_PAGE_CONTENT_HASH = "sha256:" + ("6" * 64)
+SECOND_PAGE_CONTENT_HASH = "sha256:" + ("7" * 64)
+SECOND_PAGE_CONFLICTING_HASH = "sha256:" + ("8" * 64)
+SOURCE_BATCH_FINGERPRINT = "sha256:core-source-batch"
+SECOND_PAGE_BATCH_FINGERPRINT = "sha256:second-page-batch"
 
 
 def _candidate_row(
@@ -61,6 +73,10 @@ def _candidate_page(
     next_page_token: str | None = None,
     returned_candidate_count: int = 1,
     candidates: list[dict[str, object]] | None = None,
+    content_hash: str | None = PORTFOLIO_UNIVERSE_CONTENT_HASH,
+    source_digest: str | None = PORTFOLIO_UNIVERSE_CONTENT_HASH,
+    source_batch_fingerprint: str | None = None,
+    snapshot_id: str = "snapshot-001",
 ) -> DpmCorePortfolioUniverseCandidateResponse:
     resolved_candidates = (
         [DpmCorePortfolioUniverseCandidate.model_validate(candidate) for candidate in candidates]
@@ -111,8 +127,10 @@ def _candidate_page(
             downstream_boundary="Candidate membership is not execution authority.",
         ),
         lineage={},
-        source_batch_fingerprint="sha256:portfolio-universe",
-        snapshot_id="snapshot-001",
+        source_batch_fingerprint=source_batch_fingerprint,
+        content_hash=content_hash,
+        source_digest=source_digest,
+        snapshot_id=snapshot_id,
         data_quality_status="ACCEPTED",
         latest_evidence_timestamp="2026-05-10T09:00:00Z",
     )
@@ -217,9 +235,13 @@ def test_candidate_portfolio_payloads_preserve_page_and_candidate_source_refs() 
     candidate = page.candidates[0]
 
     payloads = _candidate_portfolio_payloads(
-        candidates=[candidate],
-        universe_ref=_portfolio_universe_candidate_page_ref(page=page),
-        selection_basis=_selection_basis_payload(page),
+        candidate_rows=[
+            _CandidateSourceRow(
+                candidate=candidate,
+                universe_ref=_portfolio_universe_candidate_page_ref(page=page),
+                selection_basis=_selection_basis_payload(page),
+            )
+        ],
     )
 
     assert len(payloads) == 1
@@ -233,7 +255,7 @@ def test_candidate_portfolio_payloads_preserve_page_and_candidate_source_refs() 
         "source_type": "DpmPortfolioUniverseCandidate",
         "source_id": "snapshot-001",
         "source_version": "v1",
-        "content_hash": "sha256:portfolio-universe",
+        "content_hash": PORTFOLIO_UNIVERSE_CONTENT_HASH,
         "supportability_state": "READY",
     }
     assert candidate_ref["source_type"] == "DPM_PORTFOLIO_UNIVERSE_CANDIDATE"
@@ -245,6 +267,170 @@ def test_candidate_portfolio_payloads_preserve_page_and_candidate_source_refs() 
         "included_when": [],
         "downstream_boundary": "Candidate membership is not execution authority.",
     }
+
+
+def test_candidate_page_ref_accepts_no_batch_core_content_identity() -> None:
+    page_ref = _portfolio_universe_candidate_page_ref(
+        page=_candidate_page(
+            content_hash=CORE_CANDIDATE_PAGE_HASH,
+            source_digest=CORE_CANDIDATE_PAGE_HASH,
+            source_batch_fingerprint=None,
+        )
+    )
+
+    assert page_ref["content_hash"] == CORE_CANDIDATE_PAGE_HASH
+    assert "source_batch_fingerprint" not in page_ref
+
+
+def test_candidate_page_ref_preserves_batch_lineage_without_using_it_as_content_hash() -> None:
+    page_ref = _portfolio_universe_candidate_page_ref(
+        page=_candidate_page(
+            content_hash=CORE_CONTENT_HASH,
+            source_digest=CORE_CONTENT_HASH,
+            source_batch_fingerprint=SOURCE_BATCH_FINGERPRINT,
+        )
+    )
+
+    assert page_ref["content_hash"] == CORE_CONTENT_HASH
+    assert page_ref["source_batch_fingerprint"] == SOURCE_BATCH_FINGERPRINT
+
+
+def test_candidate_page_ref_accepts_source_digest_alias_when_content_hash_absent() -> None:
+    page = _candidate_page(
+        content_hash=None,
+        source_digest=CORE_SOURCE_DIGEST_HASH,
+        source_batch_fingerprint=None,
+    )
+    page_ref = _portfolio_universe_candidate_page_ref(page=page)
+
+    assert page.content_hash == CORE_SOURCE_DIGEST_HASH
+    assert page_ref["content_hash"] == CORE_SOURCE_DIGEST_HASH
+
+
+def test_candidate_page_ref_rejects_conflicting_core_content_identities() -> None:
+    with pytest.raises(DpmWaveDependencyFailedError) as exc_info:
+        _portfolio_universe_candidate_page_ref(
+            page=_candidate_page(
+                content_hash=CORE_CONTENT_HASH,
+                source_digest=CORE_CONFLICTING_CONTENT_HASH,
+            )
+        )
+
+    assert exc_info.value.code == "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_IDENTITY_CONFLICT"
+
+
+@pytest.mark.parametrize(
+    ("content_hash", "source_digest", "expected_code"),
+    [
+        (None, None, "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_REQUIRED"),
+        ("", " ", "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_REQUIRED"),
+        ("not-a-sha256-digest", None, "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_INVALID"),
+        (None, "not-a-sha256-digest", "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_INVALID"),
+        ("sha256:x", None, "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_INVALID"),
+        ("sha256:not-hex", None, "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_INVALID"),
+        (None, "sha256:" + ("a" * 63), "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_HASH_INVALID"),
+    ],
+)
+def test_candidate_page_ref_rejects_missing_or_malformed_core_content_identity(
+    content_hash: str | None,
+    source_digest: str | None,
+    expected_code: str,
+) -> None:
+    with pytest.raises(DpmWaveDependencyFailedError) as exc_info:
+        _portfolio_universe_candidate_page_ref(
+            page=_candidate_page(content_hash=content_hash, source_digest=source_digest)
+        )
+
+    assert exc_info.value.code == expected_code
+
+
+def test_resolve_core_dpm_portfolio_universe_candidates_validates_later_page_identity() -> None:
+    first_page = _candidate_page(
+        next_page_token="page-2",
+        returned_candidate_count=1,
+        content_hash=FIRST_PAGE_CONTENT_HASH,
+        source_digest=FIRST_PAGE_CONTENT_HASH,
+        snapshot_id="snapshot-page-1",
+    )
+    second_page = _candidate_page(
+        next_page_token=None,
+        returned_candidate_count=1,
+        content_hash=SECOND_PAGE_CONTENT_HASH,
+        source_digest=SECOND_PAGE_CONFLICTING_HASH,
+        snapshot_id="snapshot-page-2",
+        candidates=[
+            _candidate_row(
+                portfolio_id="PB_SG_GLOBAL_BAL_002",
+                mandate_id="MANDATE_PB_SG_GLOBAL_BAL_002",
+                binding_version=4,
+                source_record_id="mandate-binding-002",
+            )
+        ],
+    )
+
+    with pytest.raises(DpmWaveDependencyFailedError) as exc_info:
+        _resolve(pages=[first_page, second_page], campaign_candidate_page_size=1)
+
+    assert exc_info.value.code == "DPM_CORE_PORTFOLIO_UNIVERSE_CONTENT_IDENTITY_CONFLICT"
+
+
+def test_resolve_core_dpm_portfolio_universe_candidates_preserves_page_specific_refs() -> None:
+    first_page = _candidate_page(
+        next_page_token="page-2",
+        returned_candidate_count=1,
+        content_hash=FIRST_PAGE_CONTENT_HASH,
+        source_digest=FIRST_PAGE_CONTENT_HASH,
+        snapshot_id="snapshot-page-1",
+    )
+    second_page = _candidate_page(
+        next_page_token=None,
+        returned_candidate_count=1,
+        content_hash=SECOND_PAGE_CONTENT_HASH,
+        source_digest=SECOND_PAGE_CONTENT_HASH,
+        source_batch_fingerprint=SECOND_PAGE_BATCH_FINGERPRINT,
+        snapshot_id="snapshot-page-2",
+        candidates=[
+            _candidate_row(
+                portfolio_id="PB_SG_GLOBAL_BAL_002",
+                mandate_id="MANDATE_PB_SG_GLOBAL_BAL_002",
+                binding_version=4,
+                source_record_id="mandate-binding-002",
+            )
+        ],
+    )
+
+    payloads, _resolver = _resolve(
+        pages=[first_page, second_page],
+        campaign_candidate_page_size=1,
+    )
+
+    page_refs = [
+        next(
+            ref
+            for ref in payload["source_refs"]
+            if ref["source_type"] == "DpmPortfolioUniverseCandidate"
+        )
+        for payload in payloads
+    ]
+    assert page_refs == [
+        {
+            "source_system": "lotus-core",
+            "source_type": "DpmPortfolioUniverseCandidate",
+            "source_id": "snapshot-page-1",
+            "source_version": "v1",
+            "supportability_state": "READY",
+            "content_hash": FIRST_PAGE_CONTENT_HASH,
+        },
+        {
+            "source_system": "lotus-core",
+            "source_type": "DpmPortfolioUniverseCandidate",
+            "source_id": "snapshot-page-2",
+            "source_version": "v1",
+            "supportability_state": "READY",
+            "content_hash": SECOND_PAGE_CONTENT_HASH,
+            "source_batch_fingerprint": SECOND_PAGE_BATCH_FINGERPRINT,
+        },
+    ]
 
 
 def test_resolve_core_dpm_portfolio_universe_candidates_rejects_duplicate_candidates() -> None:

--- a/tests/unit/dpm/waves/test_wave_report_input.py
+++ b/tests/unit/dpm/waves/test_wave_report_input.py
@@ -5,10 +5,12 @@ import pytest
 from src.api.services.wave_errors import DpmWaveValidationError
 from src.api.services.wave_report_input import build_report_input_for_wave
 from src.api.services.wave_aggregate_metrics import aggregate_wave_items
+from src.core.common.canonical import hash_canonical_payload
 from src.core.waves import (
     DpmRebalanceWave,
     DpmRebalanceWaveItem,
     DpmWaveHandoffRef,
+    DpmWaveSourceRef,
     DpmWaveTrigger,
 )
 
@@ -25,7 +27,11 @@ def _item() -> DpmRebalanceWaveItem:
     )
 
 
-def _wave(*, handoff_refs: list[DpmWaveHandoffRef] | None = None) -> DpmRebalanceWave:
+def _wave(
+    *,
+    handoff_refs: list[DpmWaveHandoffRef] | None = None,
+    trigger_source_refs: list[DpmWaveSourceRef] | None = None,
+) -> DpmRebalanceWave:
     items = [_item()]
     return DpmRebalanceWave(
         wave_id="dwv_report_input",
@@ -34,6 +40,7 @@ def _wave(*, handoff_refs: list[DpmWaveHandoffRef] | None = None) -> DpmRebalanc
             trigger_type="EXPLICIT_PORTFOLIO_LIST",
             trigger_id="manual-report",
             rationale="Build report input for a governed wave.",
+            source_refs=trigger_source_refs or [],
         ),
         as_of_date="2026-05-03",
         created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
@@ -61,6 +68,39 @@ def test_build_report_input_for_wave_assembles_supportability_and_proof_pack_pos
         == "DPM_WAVE_EXTERNAL_EXECUTION_BOUNDARY"
     )
     assert report_input.portfolio_memory_context is None
+
+
+def test_build_report_input_preserves_legacy_wave_content_hash_for_absent_batch_lineage() -> None:
+    source_ref = DpmWaveSourceRef(
+        source_system="lotus-core",
+        source_type="DpmPortfolioUniverseCandidate",
+        source_id="candidate-page-001",
+        content_hash="sha256:" + ("1" * 64),
+    )
+    wave = _wave(trigger_source_refs=[source_ref])
+    legacy_wave_payload = wave.model_dump(mode="json")
+    legacy_wave_payload["trigger"]["source_refs"][0].pop("source_batch_fingerprint")
+
+    report_input = build_report_input_for_wave(
+        wave=wave,
+        wave_repository=object(),  # type: ignore[arg-type]
+    )
+
+    assert report_input.wave_content_hash == hash_canonical_payload(legacy_wave_payload)
+
+    batch_wave = _wave(
+        trigger_source_refs=[
+            source_ref.model_copy(
+                update={"source_batch_fingerprint": "sha256:source-batch-20260503"}
+            )
+        ]
+    )
+    batch_report_input = build_report_input_for_wave(
+        wave=batch_wave,
+        wave_repository=object(),  # type: ignore[arg-type]
+    )
+
+    assert batch_report_input.wave_content_hash != report_input.wave_content_hash
 
 
 def test_build_report_input_for_wave_maps_external_execution_boundary_error() -> None:

--- a/tests/unit/test_domain_data_product_contracts.py
+++ b/tests/unit/test_domain_data_product_contracts.py
@@ -154,6 +154,11 @@ def test_manage_consumer_declaration_tracks_current_core_inputs() -> None:
     assert by_name["DpmPortfolioUniverseCandidate"]["producer_repository"] == "lotus-core"
     assert by_name["DpmPortfolioUniverseCandidate"]["consumption_mode"] == "stateful_core_sourcing"
     assert by_name["DpmPortfolioUniverseCandidate"]["failure_posture"] == "fail_closed"
+    assert "content_hash" in by_name["DpmPortfolioUniverseCandidate"]["required_trust_metadata"]
+    assert (
+        "source_batch_fingerprint"
+        not in by_name["DpmPortfolioUniverseCandidate"]["required_trust_metadata"]
+    )
     assert (
         "relationship householding" in by_name["DpmPortfolioUniverseCandidate"]["business_purpose"]
     )


### PR DESCRIPTION
## Summary

This PR updates Manage's Core DPM portfolio-universe anti-corruption adapter to consume Core's canonical `content_hash` / `source_digest` identity for `DpmPortfolioUniverseCandidate:v1` page source refs. It keeps `source_batch_fingerprint` as optional lineage instead of overloading it as content identity.

Issue: sgajbi/lotus-manage#629

## Implementation

- Adds `content_hash` and `source_digest` fields to the Manage model for Core `DpmPortfolioUniverseCandidate:v1` responses.
- Resolves page source-ref content identity from `content_hash` or matching `source_digest`.
- Fails closed for missing, blank, malformed, or conflicting Core content identity.
- Adds optional `source_batch_fingerprint` lineage to `DpmWaveSourceRef` and regenerates the API vocabulary artifact.
- Updates focused service, Core sourcing client, API preview/create, and source analytics shape tests.
- Updates repository engineering context so future Manage work preserves the Core source identity boundary.

## Validation

- `python -m pytest tests\\unit\\dpm\\waves\\test_wave_core_portfolio_universe_resolution_service.py tests\\unit\\dpm\\infrastructure\\test_core_sourcing_client.py -q` -> 55 passed
- `python -m pytest tests\\unit\\dpm\\api\\test_waves_api.py -q -k "core_portfolio_universe or core_universe"` -> 14 passed, 134 deselected
- `python scripts\\openapi_quality_gate.py` -> passed
- `python scripts\\api_vocabulary_inventory.py --validate-only` -> passed
- `make check` -> 3257 passed, static gates passed

## Documentation / wiki decision

Repository context and API vocabulary were updated because the consumer-contract truth changed. No repo-local wiki source change is needed for this developer-facing source-contract adapter fix.

## Issue-loop note

Keep sgajbi/lotus-manage#629 open until PR merge, exact-main validation, wiki/no-wiki evidence, branch cleanup, and QA closure evidence are posted.