### PR TITLE
ci: add manage merged-pr releasability dispatcher

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -1,8 +1,6 @@
 name: Main Releasability Gate
 
 on:
-  push:
-    branches: [ "main" ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -1,0 +1,23 @@
+name: Merged PR Main Releasability Dispatch
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch-main-releasability:
+    name: Dispatch Main Releasability
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Dispatch main releasability gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1103,6 +1103,13 @@ Important validation expectations:
     uses `LOTUS_AUTOMERGE_TOKEN`, queues `gh pr merge --auto --rebase --delete-branch`, skips
     cleanly with a warning when the token is absent, and is protected by `make workflow-policy-gate`.
     The helper must not authenticate with `GITHUB_TOKEN` or queue merge commits.
+11. Exact-main releasability follows the governed merged-PR dispatcher posture:
+    `.github/workflows/merged-pr-main-releasability.yml` listens for merged `main` pull requests
+    and dispatches `.github/workflows/main-releasability.yml` against `main`. The main
+    releasability workflow keeps manual `workflow_dispatch` support but must not also carry a
+    direct `push` trigger, because that creates duplicate automatic proof runs for the same merged
+    SHA. `make workflow-policy-gate` enforces both the dispatcher contract and the duplicate-trigger
+    prohibition.
 
 ## Standards And RFCs That Govern This Repository
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-08T17:06:48+00:00`
+- Generated at: `2026-08-15T02:12:59+00:00`
 
-- Baseline source snapshot: `4638650e5544900f571303c4767c520f1f28f610`
+- Baseline source snapshot: `a6bc609f379b8efadb226c9a2084d7c97b2e26e7`
 
-- Report source snapshot: `480ec307+worktree`
+- Report source snapshot: `a6bc609f+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205379 |
-| Test functions | 2955 |
+| Total Python LOC | 205488 |
+| Test functions | 2957 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-08T17:06:48+00:00`
+- Generated at: `2026-08-15T02:12:59+00:00`
 
-- Baseline source snapshot: `4638650e5544900f571303c4767c520f1f28f610`
+- Baseline source snapshot: `a6bc609f379b8efadb226c9a2084d7c97b2e26e7`
 
-- Report source snapshot: `480ec307+worktree`
+- Report source snapshot: `a6bc609f+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-08T17:06:48+00:00`
+- Generated at: `2026-08-15T02:12:59+00:00`
 
-- Baseline source snapshot: `4638650e5544900f571303c4767c520f1f28f610`
+- Baseline source snapshot: `a6bc609f379b8efadb226c9a2084d7c97b2e26e7`
 
-- Report source snapshot: `480ec307+worktree`
+- Report source snapshot: `a6bc609f+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-08T17:06:48+00:00`
+- Generated at: `2026-08-15T02:12:59+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `4638650e5544900f571303c4767c520f1f28f610`
+- Baseline source snapshot: `a6bc609f379b8efadb226c9a2084d7c97b2e26e7`
 
-- Report source snapshot: `480ec307+worktree`
+- Report source snapshot: `a6bc609f+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205328 | 205379 | +51 |
-| Test functions | 2953 | 2955 | +2 |
+| Total Python LOC | 205379 | 205488 | +109 |
+| Test functions | 2955 | 2957 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -38,7 +38,7 @@
 | Rank | File | Lines |
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 7624 |
-| 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3591 |
+| 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -21,6 +21,7 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
     "feature-lane.yml": {"contents": "read"},
     "pr-merge-gate.yml": {"contents": "read"},
     "main-releasability.yml": {"contents": "read"},
+    "merged-pr-main-releasability.yml": {"actions": "write", "contents": "read"},
     "quality-baseline.yml": {"contents": "read"},
     "demo-certification.yml": {"contents": "read"},
     "pr-auto-merge.yml": {"contents": "read"},
@@ -282,6 +283,51 @@ def auto_merge_workflow_violations(workflow_path: Path) -> list[str]:
     return violations
 
 
+def merged_pr_main_releasability_dispatch_violations(
+    workflow_dir: Path = WORKFLOW_DIR,
+) -> list[str]:
+    main_releasability = workflow_dir / "main-releasability.yml"
+    dispatcher = workflow_dir / "merged-pr-main-releasability.yml"
+    violations: list[str] = []
+
+    if not dispatcher.exists():
+        violations.append(
+            f"{dispatcher.as_posix()}: merged PR dispatcher is required so main releasability "
+            "runs for the exact post-merge main SHA"
+        )
+    else:
+        dispatcher_text = dispatcher.read_text(encoding="utf-8")
+        required_tokens = {
+            "pull_request_target:": "dispatcher must run from pull_request_target close events",
+            "types: [closed]": "dispatcher must be limited to closed pull request events",
+            "github.event.pull_request.merged == true": "dispatcher must require a merged PR",
+            "github.event.pull_request.base.ref == 'main'": "dispatcher must target main merges only",
+            "gh workflow run main-releasability.yml": (
+                "dispatcher must start the governed main releasability workflow"
+            ),
+            "--ref main": "dispatcher must dispatch against main",
+        }
+        for token, reason in required_tokens.items():
+            if token not in dispatcher_text:
+                violations.append(f"{dispatcher.as_posix()}: {reason}")
+
+    if main_releasability.exists():
+        main_text = main_releasability.read_text(encoding="utf-8")
+        trigger_section = main_text.split("\nconcurrency:", maxsplit=1)[0]
+        if "workflow_dispatch:" not in trigger_section:
+            violations.append(
+                f"{main_releasability.as_posix()}: main releasability must keep manual "
+                "workflow_dispatch support"
+            )
+        if "push:" in trigger_section:
+            violations.append(
+                f"{main_releasability.as_posix()}: direct push trigger must not coexist with "
+                "merged-pr-main-releasability.yml because it creates duplicate automatic "
+                "mainline proof runs"
+            )
+    return violations
+
+
 def pr_template_policy_violations(template_path: Path = PR_TEMPLATE_PATH) -> list[str]:
     if not template_path.exists():
         return [f"{template_path.as_posix()}: PR template is missing"]
@@ -308,6 +354,7 @@ def evaluate_workflow_policy(workflow_dir: Path = WORKFLOW_DIR) -> list[str]:
         violations.extend(coverage_gate_violations(workflow_path))
         violations.extend(docker_image_evidence_violations(workflow_path))
         violations.extend(auto_merge_workflow_violations(workflow_path))
+    violations.extend(merged_pr_main_releasability_dispatch_violations(workflow_dir))
     violations.extend(pr_template_policy_violations())
     return violations
 

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -8,6 +8,7 @@ from scripts.workflow_policy_gate import (
     coverage_gate_violations,
     docker_image_evidence_violations,
     evaluate_workflow_policy,
+    merged_pr_main_releasability_dispatch_violations,
     permission_violations,
     pr_template_policy_violations,
     quality_report_gate_violations,
@@ -28,6 +29,8 @@ ARTIFACT_WORKFLOWS = [
     Path(".github/workflows/quality-baseline.yml"),
     Path(".github/workflows/demo-certification.yml"),
 ]
+
+MERGED_PR_DISPATCHER = Path(".github/workflows/merged-pr-main-releasability.yml")
 
 QUALITY_GATE_NAMES = [
     "Architecture Gate",
@@ -270,6 +273,65 @@ def test_pr_auto_merge_uses_governed_rebase_actor() -> None:
     assert "timeout-minutes: 10" in workflow_text
     assert "github.token" not in workflow_text
     assert "--auto --merge" not in workflow_text
+
+
+def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
+    dispatcher_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
+    main_text = Path(".github/workflows/main-releasability.yml").read_text(encoding="utf-8")
+    main_trigger_section = main_text.split("\nconcurrency:", maxsplit=1)[0]
+
+    assert merged_pr_main_releasability_dispatch_violations() == []
+    assert "pull_request_target:" in dispatcher_text
+    assert "types: [closed]" in dispatcher_text
+    assert "github.event.pull_request.merged == true" in dispatcher_text
+    assert "github.event.pull_request.base.ref == 'main'" in dispatcher_text
+    assert "gh workflow run main-releasability.yml" in dispatcher_text
+    assert "--ref main" in dispatcher_text
+    assert "workflow_dispatch:" in main_trigger_section
+    assert "push:" not in main_trigger_section
+
+
+def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - run: gh workflow run main-releasability.yml --ref main",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (workflow_dir / "main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  push:",
+                '    branches: ["main"]',
+                "  workflow_dispatch:",
+                "concurrency:",
+                "  group: test",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert (
+        f"{(workflow_dir / 'main-releasability.yml').as_posix()}: direct push trigger must not "
+        "coexist with merged-pr-main-releasability.yml because it creates duplicate automatic "
+        "mainline proof runs"
+    ) in violations
 
 
 def test_pr_template_policy_gate_passes_current_template() -> None:


### PR DESCRIPTION
## Summary
- Adds the governed merged-PR Main Releasability dispatcher for `lotus-manage`.
- Removes the direct `push` trigger from `main-releasability.yml` so the dispatcher owns the automatic exact-main proof path without duplicate runs.
- Extends `workflow-policy-gate` and unit coverage to fail on missing dispatcher or duplicate direct-push trigger reintroduction.
- Refreshes quality reports after the workflow-policy/test surface changed.

## Issue tracking
- Closes #632 after merge, exact-main validation, and platform exception-register cleanup.
- Related platform umbrella: sgajbi/lotus-platform#520. The platform exception remains until this PR is merged and main-validated, then a platform cleanup PR can remove the `lotus-manage` exception.

## Validation
- `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q` => 29 passed
- `make workflow-policy-gate` => passed
- `python -m ruff check scripts/workflow_policy_gate.py tests/unit/test_ci_workflow_gate_enforcement.py` => passed
- `python -m ruff format --check scripts/workflow_policy_gate.py tests/unit/test_ci_workflow_gate_enforcement.py` => passed
- `python automation/validate_auto_merge_releasability.py --require-local-repos` from `lotus-platform` => passed; `lotus-manage` reported `status=aligned`, `violations=[]`
- `make check` => 3259 passed, 13 skipped

## Stranded truth reconciliation
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` returned no unmerged remote branches in `lotus-manage`.

## Docs/wiki/guidance decision
No README, docs, context, supported-features, or repo-authored wiki source changed. No wiki publication is required. The repeatable guard belongs in the repo-native workflow-policy gate and is implemented there in this PR.
