### PR TITLE
ci: assert exact merged sha in releasability dispatch

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -24,6 +24,8 @@ env:
   PYTHONUNBUFFERED: "1"
   PYTHON_VERSION: "3.12"
   COVERAGE_FAIL_UNDER: "99"
+  LOTUS_RELEASE_GIT_REF: ${{ inputs.expected_sha && 'main' || github.ref_name }}
+  LOTUS_QUALITY_REF_NAME: ${{ inputs.expected_sha && 'main' || github.ref_name }}
 
 jobs:
   exact-revision-assertion:
@@ -185,7 +187,7 @@ jobs:
       - name: Build Docker image and write evidence
         env:
           GIT_SHA: ${{ github.sha }}
-          GIT_BRANCH: ${{ github.ref_name }}
+          GIT_BRANCH: ${{ env.LOTUS_RELEASE_GIT_REF }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           CI_PIPELINE_ID: ${{ github.run_id }}
         run: make docker-image-evidence

--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -2,6 +2,15 @@ name: Main Releasability Gate
 
 on:
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: "Optional merged pull-request SHA that this run must validate."
+        required: false
+        type: string
+      triggering_pr:
+        description: "Optional pull request number that dispatched this mainline validation."
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,8 +26,32 @@ env:
   COVERAGE_FAIL_UNDER: "99"
 
 jobs:
+  exact-revision-assertion:
+    name: Main Releasability / Exact Revision Assertion
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Assert expected merged PR SHA
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          TRIGGERING_PR: ${{ inputs.triggering_pr }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          if [ -z "$EXPECTED_SHA" ]; then
+            echo "No expected_sha input supplied; treating this as an operator-dispatched main releasability run."
+            exit 0
+          fi
+          if [ "$actual_sha" != "$EXPECTED_SHA" ]; then
+            echo "::error::Main releasability checkout SHA $actual_sha does not match expected merged PR SHA $EXPECTED_SHA for PR ${TRIGGERING_PR:-unknown}."
+            exit 1
+          fi
+          echo "Validated exact merged PR SHA $EXPECTED_SHA for PR ${TRIGGERING_PR:-unknown}."
+
   workflow-lint:
     name: Main Releasability / Workflow Lint
+    needs: [exact-revision-assertion]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -26,6 +59,7 @@ jobs:
 
   lint-typecheck-security:
     name: Main Releasability / Lint Typecheck Security
+    needs: [exact-revision-assertion]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -23,9 +23,15 @@ jobs:
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           if [ -z "$MERGE_COMMIT_SHA" ]; then
             echo "::error::pull_request.merge_commit_sha is required for exact-main releasability dispatch"
             exit 1
+          fi
+          current_main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"
+          if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then
+            echo "::notice::Skipping stale main releasability dispatch for PR $PR_NUMBER. main is $current_main_sha, merged PR SHA is $MERGE_COMMIT_SHA."
+            exit 0
           fi
           gh workflow run main-releasability.yml \
             --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -20,4 +20,15 @@ jobs:
       - name: Dispatch main releasability gate
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref main
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -z "$MERGE_COMMIT_SHA" ]; then
+            echo "::error::pull_request.merge_commit_sha is required for exact-main releasability dispatch"
+            exit 1
+          fi
+          gh workflow run main-releasability.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f expected_sha="$MERGE_COMMIT_SHA" \
+            -f triggering_pr="$PR_NUMBER"

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
 
 jobs:
   dispatch-main-releasability:
@@ -28,13 +28,22 @@ jobs:
             echo "::error::pull_request.merge_commit_sha is required for exact-main releasability dispatch"
             exit 1
           fi
-          current_main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"
-          if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then
-            echo "::notice::Skipping stale main releasability dispatch for PR $PR_NUMBER. main is $current_main_sha, merged PR SHA is $MERGE_COMMIT_SHA."
-            exit 0
+
+          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"
+          existing_ref_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null || true
+          )"
+          if [ -n "$existing_ref_sha" ] && [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then
+            echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"
+            exit 1
+          fi
+          if [ -z "$existing_ref_sha" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$dispatch_ref" \
+              -f sha="$MERGE_COMMIT_SHA" >/dev/null
           fi
           gh workflow run main-releasability.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref main \
+            --ref "$dispatch_ref" \
             -f expected_sha="$MERGE_COMMIT_SHA" \
             -f triggering_pr="$PR_NUMBER"

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T11:25:57+00:00`
+- Generated at: `2026-08-20T11:50:29+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `d0e639ba+worktree`
+- Report source snapshot: `73589cd9+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205680 |
-| Test functions | 2959 |
+| Total Python LOC | 205709 |
+| Test functions | 2960 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T11:13:26+00:00`
+- Generated at: `2026-08-20T11:25:57+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `ff195bbe`
+- Report source snapshot: `d0e639ba+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205609 |
-| Test functions | 2958 |
+| Total Python LOC | 205680 |
+| Test functions | 2959 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-15T02:12:59+00:00`
+- Generated at: `2026-08-20T10:09:39+00:00`
 
-- Baseline source snapshot: `a6bc609f379b8efadb226c9a2084d7c97b2e26e7`
+- Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `a6bc609f+worktree`
+- Report source snapshot: `0976feac`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205488 |
+| Total Python LOC | 205514 |
 | Test functions | 2957 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T10:09:39+00:00`
+- Generated at: `2026-08-20T11:13:26+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `0976feac`
+- Report source snapshot: `ff195bbe`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205514 |
-| Test functions | 2957 |
+| Total Python LOC | 205609 |
+| Test functions | 2958 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T11:13:26+00:00`
+- Generated at: `2026-08-20T11:25:57+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `ff195bbe`
+- Report source snapshot: `d0e639ba+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T10:09:39+00:00`
+- Generated at: `2026-08-20T11:13:26+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `0976feac`
+- Report source snapshot: `ff195bbe`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T11:25:57+00:00`
+- Generated at: `2026-08-20T11:50:29+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `d0e639ba+worktree`
+- Report source snapshot: `73589cd9+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-15T02:12:59+00:00`
+- Generated at: `2026-08-20T10:09:39+00:00`
 
-- Baseline source snapshot: `a6bc609f379b8efadb226c9a2084d7c97b2e26e7`
+- Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `a6bc609f+worktree`
+- Report source snapshot: `0976feac`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T11:13:26+00:00`
+- Generated at: `2026-08-20T11:25:57+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `ff195bbe`
+- Report source snapshot: `d0e639ba+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T10:09:39+00:00`
+- Generated at: `2026-08-20T11:13:26+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `0976feac`
+- Report source snapshot: `ff195bbe`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-15T02:12:59+00:00`
+- Generated at: `2026-08-20T10:09:39+00:00`
 
-- Baseline source snapshot: `a6bc609f379b8efadb226c9a2084d7c97b2e26e7`
+- Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `a6bc609f+worktree`
+- Report source snapshot: `0976feac`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T11:25:57+00:00`
+- Generated at: `2026-08-20T11:50:29+00:00`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `d0e639ba+worktree`
+- Report source snapshot: `73589cd9+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T10:09:39+00:00`
+- Generated at: `2026-08-20T11:13:26+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `0976feac`
+- Report source snapshot: `ff195bbe`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205488 | 205514 | +26 |
-| Test functions | 2957 | 2957 | +0 |
+| Total Python LOC | 205488 | 205609 | +121 |
+| Test functions | 2957 | 2958 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T11:25:57+00:00`
+- Generated at: `2026-08-20T11:50:29+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `d0e639ba+worktree`
+- Report source snapshot: `73589cd9+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205488 | 205680 | +192 |
-| Test functions | 2957 | 2959 | +2 |
+| Total Python LOC | 205488 | 205709 | +221 |
+| Test functions | 2957 | 2960 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T11:13:26+00:00`
+- Generated at: `2026-08-20T11:25:57+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `ff195bbe`
+- Report source snapshot: `d0e639ba+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205488 | 205609 | +121 |
-| Test functions | 2957 | 2958 | +1 |
+| Total Python LOC | 205488 | 205680 | +192 |
+| Test functions | 2957 | 2959 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-15T02:12:59+00:00`
+- Generated at: `2026-08-20T10:09:39+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `a6bc609f379b8efadb226c9a2084d7c97b2e26e7`
+- Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
 
-- Report source snapshot: `a6bc609f+worktree`
+- Report source snapshot: `0976feac`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205379 | 205488 | +109 |
-| Test functions | 2955 | 2957 | +2 |
+| Total Python LOC | 205488 | 205514 | +26 |
+| Test functions | 2957 | 2957 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -18,6 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 DEFAULT_BASE_REF = "origin/main"
+MAINLINE_REF_NAMES = {"main", "master"}
 QUALITY_DIR = REPO_ROOT / "quality"
 DEFAULT_OUTPUT = QUALITY_DIR / "refactor_health_report.md"
 DEFAULT_BASELINE_OUTPUT = QUALITY_DIR / "baseline_report.md"
@@ -125,6 +126,9 @@ def _git_resolved_ref(ref: str) -> str:
 
 
 def _current_ref_name() -> str:
+    quality_ref_name = os.environ.get("LOTUS_QUALITY_REF_NAME")
+    if quality_ref_name in MAINLINE_REF_NAMES:
+        return quality_ref_name
     env_ref_name = os.environ.get("GITHUB_REF_NAME")
     if env_ref_name:
         return env_ref_name
@@ -132,7 +136,10 @@ def _current_ref_name() -> str:
 
 
 def _is_github_mainline_ref(ref_name: str) -> bool:
-    return bool(os.environ.get("GITHUB_REF_NAME")) and ref_name in {"main", "master"}
+    return (
+        bool(os.environ.get("GITHUB_REF_NAME") or os.environ.get("LOTUS_QUALITY_REF_NAME"))
+        and ref_name in MAINLINE_REF_NAMES
+    )
 
 
 def _recorded_quality_baseline_ref() -> str | None:
@@ -150,7 +157,7 @@ def _recorded_quality_baseline_ref() -> str | None:
 
 def _base_ref_for_quality_check() -> tuple[str, str]:
     ref_name = _current_ref_name()
-    if ref_name in {"main", "master"} and _git_ref_exists("HEAD^"):
+    if ref_name in MAINLINE_REF_NAMES and _git_ref_exists("HEAD^"):
         if _is_github_mainline_ref(ref_name):
             return _recorded_quality_baseline_ref() or "HEAD^", DEFAULT_BASE_REF
         if _git_status_porcelain().strip():

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -21,7 +21,7 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
     "feature-lane.yml": {"contents": "read"},
     "pr-merge-gate.yml": {"contents": "read"},
     "main-releasability.yml": {"contents": "read"},
-    "merged-pr-main-releasability.yml": {"actions": "write", "contents": "read"},
+    "merged-pr-main-releasability.yml": {"actions": "write", "contents": "write"},
     "quality-baseline.yml": {"contents": "read"},
     "demo-certification.yml": {"contents": "read"},
     "pr-auto-merge.yml": {"contents": "read"},
@@ -96,6 +96,17 @@ def _top_level_permissions(text: str) -> dict[str, str] | None:
             permissions[key.strip()] = value.strip().split("#", 1)[0].strip()
         return permissions
     return None
+
+
+def _step_block(text: str, step_name: str) -> str:
+    start = text.find(f"- name: {step_name}")
+    if start == -1:
+        return ""
+    next_step = text.find("\n      - name:", start + 1)
+    next_uses = text.find("\n      - uses:", start + 1)
+    candidates = [index for index in (next_step, next_uses) if index != -1]
+    end = min(candidates) if candidates else len(text)
+    return text[start:end]
 
 
 def permission_violations(workflow_path: Path) -> list[str]:
@@ -305,16 +316,18 @@ def merged_pr_main_releasability_dispatch_violations(
             "github.event.pull_request.merge_commit_sha": (
                 "dispatcher must bind dispatch evidence to the merged PR SHA"
             ),
-            'gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha': (
-                "dispatcher must resolve current main before dispatching"
+            'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"': (
+                "dispatcher must create an immutable dispatch ref for the merged PR SHA"
             ),
-            'if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then': (
-                "dispatcher must skip stale pull-request close events after main advances"
+            'gh api "repos/$GITHUB_REPOSITORY/git/refs"': (
+                "dispatcher must create the immutable dispatch ref before workflow dispatch"
             ),
             "gh workflow run main-releasability.yml": (
                 "dispatcher must start the governed main releasability workflow"
             ),
-            "--ref main": "dispatcher must dispatch against main",
+            '--ref "$dispatch_ref"': (
+                "dispatcher must dispatch against the immutable merged-PR ref"
+            ),
             "-f expected_sha=": (
                 "dispatcher must pass the merged PR SHA as an expected mainline SHA"
             ),
@@ -331,12 +344,13 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{main_releasability.as_posix()}: main releasability must keep manual "
                 "workflow_dispatch support"
             )
+        assertion_step = _step_block(main_text, "Assert expected merged PR SHA")
         required_assertion_tokens = {
             "expected_sha:": trigger_section,
-            'actual_sha="$(git rev-parse HEAD)"': main_text,
-            'if [ "$actual_sha" != "$EXPECTED_SHA" ]; then': main_text,
-            "does not match expected merged PR SHA": main_text,
-            "exit 1": main_text,
+            'actual_sha="$(git rev-parse HEAD)"': assertion_step,
+            'if [ "$actual_sha" != "$EXPECTED_SHA" ]; then': assertion_step,
+            "does not match expected merged PR SHA": assertion_step,
+            "exit 1": assertion_step,
         }
         missing_assertion_tokens = [
             token

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -302,10 +302,16 @@ def merged_pr_main_releasability_dispatch_violations(
             "types: [closed]": "dispatcher must be limited to closed pull request events",
             "github.event.pull_request.merged == true": "dispatcher must require a merged PR",
             "github.event.pull_request.base.ref == 'main'": "dispatcher must target main merges only",
+            "github.event.pull_request.merge_commit_sha": (
+                "dispatcher must bind dispatch evidence to the merged PR SHA"
+            ),
             "gh workflow run main-releasability.yml": (
                 "dispatcher must start the governed main releasability workflow"
             ),
             "--ref main": "dispatcher must dispatch against main",
+            "-f expected_sha=": (
+                "dispatcher must pass the merged PR SHA as an expected mainline SHA"
+            ),
         }
         for token, reason in required_tokens.items():
             if token not in dispatcher_text:
@@ -318,6 +324,11 @@ def merged_pr_main_releasability_dispatch_violations(
             violations.append(
                 f"{main_releasability.as_posix()}: main releasability must keep manual "
                 "workflow_dispatch support"
+            )
+        if "expected_sha:" not in trigger_section or "git rev-parse HEAD" not in main_text:
+            violations.append(
+                f"{main_releasability.as_posix()}: main releasability must assert "
+                "expected_sha against the checked-out main commit when dispatched by a merged PR"
             )
         if "push:" in trigger_section:
             violations.append(

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -305,6 +305,12 @@ def merged_pr_main_releasability_dispatch_violations(
             "github.event.pull_request.merge_commit_sha": (
                 "dispatcher must bind dispatch evidence to the merged PR SHA"
             ),
+            'gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha': (
+                "dispatcher must resolve current main before dispatching"
+            ),
+            'if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then': (
+                "dispatcher must skip stale pull-request close events after main advances"
+            ),
             "gh workflow run main-releasability.yml": (
                 "dispatcher must start the governed main releasability workflow"
             ),
@@ -325,10 +331,28 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{main_releasability.as_posix()}: main releasability must keep manual "
                 "workflow_dispatch support"
             )
-        if "expected_sha:" not in trigger_section or "git rev-parse HEAD" not in main_text:
+        required_assertion_tokens = {
+            "expected_sha:": trigger_section,
+            'actual_sha="$(git rev-parse HEAD)"': main_text,
+            'if [ "$actual_sha" != "$EXPECTED_SHA" ]; then': main_text,
+            "does not match expected merged PR SHA": main_text,
+            "exit 1": main_text,
+        }
+        missing_assertion_tokens = [
+            token
+            for token, search_text in required_assertion_tokens.items()
+            if token not in search_text
+        ]
+        if missing_assertion_tokens:
             violations.append(
                 f"{main_releasability.as_posix()}: main releasability must assert "
-                "expected_sha against the checked-out main commit when dispatched by a merged PR"
+                "expected_sha against the checked-out main commit and fail on mismatch when "
+                f"dispatched by a merged PR; missing {', '.join(missing_assertion_tokens)}"
+            )
+        if "${{ inputs.expected_sha || github.sha }}" not in main_text:
+            violations.append(
+                f"{main_releasability.as_posix()}: main releasability concurrency must be "
+                "revision-aware so stale merged-PR dispatches cannot cancel newer validation"
             )
         if "push:" in trigger_section:
             violations.append(

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -285,9 +285,15 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "types: [closed]" in dispatcher_text
     assert "github.event.pull_request.merged == true" in dispatcher_text
     assert "github.event.pull_request.base.ref == 'main'" in dispatcher_text
+    assert "github.event.pull_request.merge_commit_sha" in dispatcher_text
     assert "gh workflow run main-releasability.yml" in dispatcher_text
     assert "--ref main" in dispatcher_text
+    assert '-f expected_sha="$MERGE_COMMIT_SHA"' in dispatcher_text
+    assert '-f triggering_pr="$PR_NUMBER"' in dispatcher_text
     assert "workflow_dispatch:" in main_trigger_section
+    assert "expected_sha:" in main_trigger_section
+    assert "triggering_pr:" in main_trigger_section
+    assert "git rev-parse HEAD" in main_text
     assert "push:" not in main_trigger_section
 
 
@@ -306,7 +312,9 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: P
                 "      github.event.pull_request.merged == true &&",
                 "      github.event.pull_request.base.ref == 'main'",
                 "    steps:",
-                "      - run: gh workflow run main-releasability.yml --ref main",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: gh workflow run main-releasability.yml --ref main -f expected_sha=$MERGE_COMMIT_SHA",
             ]
         ),
         encoding="utf-8",
@@ -318,8 +326,15 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: P
                 "  push:",
                 '    branches: ["main"]',
                 "  workflow_dispatch:",
+                "    inputs:",
+                "      expected_sha:",
+                "        required: false",
                 "concurrency:",
                 "  group: test",
+                "jobs:",
+                "  exact-revision-assertion:",
+                "    steps:",
+                "      - run: git rev-parse HEAD",
             ]
         ),
         encoding="utf-8",

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -286,6 +286,9 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "github.event.pull_request.merged == true" in dispatcher_text
     assert "github.event.pull_request.base.ref == 'main'" in dispatcher_text
     assert "github.event.pull_request.merge_commit_sha" in dispatcher_text
+    assert 'gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha' in dispatcher_text
+    assert 'if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then' in dispatcher_text
+    assert "Skipping stale main releasability dispatch" in dispatcher_text
     assert "gh workflow run main-releasability.yml" in dispatcher_text
     assert "--ref main" in dispatcher_text
     assert '-f expected_sha="$MERGE_COMMIT_SHA"' in dispatcher_text
@@ -293,7 +296,10 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "workflow_dispatch:" in main_trigger_section
     assert "expected_sha:" in main_trigger_section
     assert "triggering_pr:" in main_trigger_section
-    assert "git rev-parse HEAD" in main_text
+    assert "${{ inputs.expected_sha || github.sha }}" in main_text
+    assert 'actual_sha="$(git rev-parse HEAD)"' in main_text
+    assert 'if [ "$actual_sha" != "$EXPECTED_SHA" ]; then' in main_text
+    assert "does not match expected merged PR SHA" in main_text
     assert "push:" not in main_trigger_section
 
 
@@ -314,7 +320,12 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: P
                 "    steps:",
                 "      - env:",
                 "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
-                "        run: gh workflow run main-releasability.yml --ref main -f expected_sha=$MERGE_COMMIT_SHA",
+                "        run: |",
+                '          current_main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"',
+                '          if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                "            exit 0",
+                "          fi",
+                "          gh workflow run main-releasability.yml --ref main -f expected_sha=$MERGE_COMMIT_SHA",
             ]
         ),
         encoding="utf-8",
@@ -330,11 +341,16 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: P
                 "      expected_sha:",
                 "        required: false",
                 "concurrency:",
-                "  group: test",
+                "  group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}",
                 "jobs:",
                 "  exact-revision-assertion:",
                 "    steps:",
-                "      - run: git rev-parse HEAD",
+                "      - run: |",
+                '          actual_sha="$(git rev-parse HEAD)"',
+                '          if [ "$actual_sha" != "$EXPECTED_SHA" ]; then',
+                '            echo "does not match expected merged PR SHA"',
+                "            exit 1",
+                "          fi",
             ]
         ),
         encoding="utf-8",
@@ -347,6 +363,61 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: P
         "coexist with merged-pr-main-releasability.yml because it creates duplicate automatic "
         "mainline proof runs"
     ) in violations
+
+
+def test_merged_pr_dispatch_gate_rejects_token_only_revision_assertion(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          current_main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"',
+                '          if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                "            exit 0",
+                "          fi",
+                "          gh workflow run main-releasability.yml --ref main -f expected_sha=$MERGE_COMMIT_SHA",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (workflow_dir / "main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  workflow_dispatch:",
+                "    inputs:",
+                "      expected_sha:",
+                "        required: false",
+                "concurrency:",
+                "  group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}",
+                "jobs:",
+                "  exact-revision-assertion:",
+                "    steps:",
+                "      - run: git rev-parse HEAD",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "main releasability must assert expected_sha against the checked-out main commit and fail on mismatch"
+        in violation
+        for violation in violations
+    )
 
 
 def test_pr_template_policy_gate_passes_current_template() -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -297,9 +297,16 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "expected_sha:" in main_trigger_section
     assert "triggering_pr:" in main_trigger_section
     assert "${{ inputs.expected_sha || github.sha }}" in main_text
+    assert "LOTUS_RELEASE_GIT_REF: ${{ inputs.expected_sha && 'main' || github.ref_name }}" in (
+        main_text
+    )
+    assert "LOTUS_QUALITY_REF_NAME: ${{ inputs.expected_sha && 'main' || github.ref_name }}" in (
+        main_text
+    )
     assert 'actual_sha="$(git rev-parse HEAD)"' in main_text
     assert 'if [ "$actual_sha" != "$EXPECTED_SHA" ]; then' in main_text
     assert "does not match expected merged PR SHA" in main_text
+    assert "GIT_BRANCH: ${{ env.LOTUS_RELEASE_GIT_REF }}" in main_text
     assert "push:" not in main_trigger_section
 
 

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -286,11 +286,11 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "github.event.pull_request.merged == true" in dispatcher_text
     assert "github.event.pull_request.base.ref == 'main'" in dispatcher_text
     assert "github.event.pull_request.merge_commit_sha" in dispatcher_text
-    assert 'gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha' in dispatcher_text
-    assert 'if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then' in dispatcher_text
-    assert "Skipping stale main releasability dispatch" in dispatcher_text
+    assert "contents: write" in dispatcher_text
+    assert 'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"' in dispatcher_text
+    assert 'gh api "repos/$GITHUB_REPOSITORY/git/refs"' in dispatcher_text
     assert "gh workflow run main-releasability.yml" in dispatcher_text
-    assert "--ref main" in dispatcher_text
+    assert '--ref "$dispatch_ref"' in dispatcher_text
     assert '-f expected_sha="$MERGE_COMMIT_SHA"' in dispatcher_text
     assert '-f triggering_pr="$PR_NUMBER"' in dispatcher_text
     assert "workflow_dispatch:" in main_trigger_section
@@ -321,11 +321,9 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: P
                 "      - env:",
                 "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
                 "        run: |",
-                '          current_main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"',
-                '          if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then',
-                "            exit 0",
-                "          fi",
-                "          gh workflow run main-releasability.yml --ref main -f expected_sha=$MERGE_COMMIT_SHA",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
             ]
         ),
         encoding="utf-8",
@@ -383,11 +381,9 @@ def test_merged_pr_dispatch_gate_rejects_token_only_revision_assertion(tmp_path:
                 "      - env:",
                 "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
                 "        run: |",
-                '          current_main_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)"',
-                '          if [ "$current_main_sha" != "$MERGE_COMMIT_SHA" ]; then',
-                "            exit 0",
-                "          fi",
-                "          gh workflow run main-releasability.yml --ref main -f expected_sha=$MERGE_COMMIT_SHA",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
             ]
         ),
         encoding="utf-8",
@@ -406,6 +402,67 @@ def test_merged_pr_dispatch_gate_rejects_token_only_revision_assertion(tmp_path:
                 "  exact-revision-assertion:",
                 "    steps:",
                 "      - run: git rev-parse HEAD",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "main releasability must assert expected_sha against the checked-out main commit and fail on mismatch"
+        in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_non_failing_mismatch_branch(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (workflow_dir / "main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  workflow_dispatch:",
+                "    inputs:",
+                "      expected_sha:",
+                "        required: false",
+                "concurrency:",
+                "  group: ${{ github.workflow }}-${{ inputs.expected_sha || github.sha }}",
+                "jobs:",
+                "  exact-revision-assertion:",
+                "    steps:",
+                "      - name: Assert expected merged PR SHA",
+                "        run: |",
+                '          actual_sha="$(git rev-parse HEAD)"',
+                '          if [ "$actual_sha" != "$EXPECTED_SHA" ]; then',
+                '            echo "does not match expected merged PR SHA"',
+                "            exit 0",
+                "          fi",
+                "      - name: Unrelated failure",
+                "        run: exit 1",
             ]
         ),
         encoding="utf-8",

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -150,6 +150,21 @@ def test_quality_report_check_uses_github_ref_name_for_mainline(monkeypatch) -> 
     assert ehr._base_ref_for_quality_check() == ("HEAD^", "origin/main")
 
 
+def test_quality_report_check_preserves_mainline_context_for_exact_sha_dispatch(
+    monkeypatch,
+) -> None:
+    def fake_git(*args: str) -> str:
+        raise AssertionError(args)
+
+    monkeypatch.setenv("GITHUB_REF_NAME", "main-releasability-abc123")
+    monkeypatch.setenv("LOTUS_QUALITY_REF_NAME", "main")
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref in {"HEAD^", "base1234"})
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: "base1234")
+
+    assert ehr._base_ref_for_quality_check() == ("base1234", "origin/main")
+
+
 def test_quality_report_check_uses_recorded_baseline_for_clean_mainline(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Passes the merged PR `merge_commit_sha` into Main Releasability as `expected_sha`.
- Adds an exact-revision assertion so a dispatched run fails if GitHub resolves `main` to a later SHA.
- Extends the repo workflow-policy gate and regression tests for the stronger invariant.

## RFC-0002 / issue traceability
- Related to sgajbi/lotus-platform#691.
- RFC-0002 Slice 17 release evidence hardening.
- Keep sgajbi/lotus-platform#691 open until the platform validator and remaining Workbench rollout posture are merged/validated.

## Validation
- `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q`
- `make workflow-policy-gate`
- `git diff --check`