### PR TITLE
ci: guard releasability dispatch ref lookup

### DIFF
--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -45,7 +45,6 @@ jobs:
               -f sha="$MERGE_COMMIT_SHA" >/dev/null
           fi
           gh workflow run main-releasability.yml \
-            --repo "$GITHUB_REPOSITORY" \
             --ref "$dispatch_ref" \
             -f expected_sha="$MERGE_COMMIT_SHA" \
             -f triggering_pr="$PR_NUMBER"

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -45,6 +45,7 @@ jobs:
               -f sha="$MERGE_COMMIT_SHA" >/dev/null
           fi
           gh workflow run main-releasability.yml \
+            --repo "$GITHUB_REPOSITORY" \
             --ref "$dispatch_ref" \
             -f expected_sha="$MERGE_COMMIT_SHA" \
             -f triggering_pr="$PR_NUMBER"

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -30,12 +30,14 @@ jobs:
           fi
 
           dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"
-          existing_ref_sha="$(
-            gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null || true
-          )"
-          if [ -n "$existing_ref_sha" ] && [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then
-            echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"
-            exit 1
+          existing_ref_sha=""
+          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then
+            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then
+              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"
+              exit 1
+            fi
+          else
+            existing_ref_sha=""
           fi
           if [ -z "$existing_ref_sha" ]; then
             gh api "repos/$GITHUB_REPOSITORY/git/refs" \

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T18:20:11+00:00`
+- Generated at: `2026-08-20T18:29:55+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `3e70fedd`
+- Report source snapshot: `0172727f+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207767 |
-| Test functions | 2996 |
+| Total Python LOC | 207893 |
+| Test functions | 2998 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T14:55:02+00:00`
+- Generated at: `2026-08-20T15:05:04+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `dc89eb5a+worktree`
+- Report source snapshot: `f5ca0561+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206421 |
-| Test functions | 2974 |
+| Total Python LOC | 206519 |
+| Test functions | 2975 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T15:26:57+00:00`
+- Generated at: `2026-08-20T15:36:12+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `c94aa774+worktree`
+- Report source snapshot: `699a9458+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206628 |
-| Test functions | 2977 |
+| Total Python LOC | 206681 |
+| Test functions | 2978 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T17:33:40+00:00`
+- Generated at: `2026-08-20T17:55:26+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `fd449f18+worktree`
+- Report source snapshot: `7bd5e1d4+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207613 |
-| Test functions | 2993 |
+| Total Python LOC | 207666 |
+| Test functions | 2994 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T16:17:02+00:00`
+- Generated at: `2026-08-20T16:37:32+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `9eac1a77+worktree`
+- Report source snapshot: `bba46d59+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206919 |
-| Test functions | 2982 |
+| Total Python LOC | 207136 |
+| Test functions | 2985 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T15:46:46+00:00`
+- Generated at: `2026-08-20T16:05:03+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5d40fc3d+worktree`
+- Report source snapshot: `56da8f03+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206774 |
-| Test functions | 2980 |
+| Total Python LOC | 206864 |
+| Test functions | 2981 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T20:34:53+00:00`
+- Generated at: `2026-08-20T20:45:26+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `6f62d787+worktree`
+- Report source snapshot: `06d779bb+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208519 |
-| Test functions | 3009 |
+| Total Python LOC | 208594 |
+| Test functions | 3011 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T18:44:41+00:00`
+- Generated at: `2026-08-20T18:55:59+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `8ad5c409+worktree`
+- Report source snapshot: `2071ef65+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207990 |
-| Test functions | 3000 |
+| Total Python LOC | 208060 |
+| Test functions | 3001 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T14:19:12+00:00`
+- Generated at: `2026-08-20T14:30:07+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `90ed3671+worktree`
+- Report source snapshot: `010805fa+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206247 |
-| Test functions | 2970 |
+| Total Python LOC | 206332 |
+| Test functions | 2972 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T20:55:49+00:00`
+- Generated at: `2026-08-20T21:57:56+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `c47f770e+worktree`
+- Report source snapshot: `5164d7b7`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208637 |
-| Test functions | 3012 |
+| Total Python LOC | 208690 |
+| Test functions | 3013 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T19:29:13+00:00`
+- Generated at: `2026-08-20T19:50:00+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `9fde7e10+worktree`
+- Report source snapshot: `e77f72b1+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208145 |
-| Test functions | 3002 |
+| Total Python LOC | 208260 |
+| Test functions | 3004 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T14:08:51+00:00`
+- Generated at: `2026-08-20T14:19:12+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5bec7dde+worktree`
+- Report source snapshot: `90ed3671+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206199 |
-| Test functions | 2969 |
+| Total Python LOC | 206247 |
+| Test functions | 2970 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T18:29:55+00:00`
+- Generated at: `2026-08-20T18:44:41+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `0172727f+worktree`
+- Report source snapshot: `8ad5c409+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207893 |
-| Test functions | 2998 |
+| Total Python LOC | 207990 |
+| Test functions | 3000 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T16:46:34+00:00`
+- Generated at: `2026-08-20T16:59:25+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `40de091a+worktree`
+- Report source snapshot: `68822786+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207248 |
-| Test functions | 2987 |
+| Total Python LOC | 207357 |
+| Test functions | 2989 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T15:05:04+00:00`
+- Generated at: `2026-08-20T15:13:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `f5ca0561+worktree`
+- Report source snapshot: `14ff211c+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206519 |
-| Test functions | 2975 |
+| Total Python LOC | 206567 |
+| Test functions | 2976 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T15:36:12+00:00`
+- Generated at: `2026-08-20T15:46:46+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `699a9458+worktree`
+- Report source snapshot: `5d40fc3d+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206681 |
-| Test functions | 2978 |
+| Total Python LOC | 206774 |
+| Test functions | 2980 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T11:50:29+00:00`
+- Generated at: `2026-08-20T12:37:38+00:00`
 
-- Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
+- Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `73589cd9+worktree`
+- Report source snapshot: `2c324fc8`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205709 |
-| Test functions | 2960 |
+| Total Python LOC | 205762 |
+| Test functions | 2961 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T17:06:14+00:00`
+- Generated at: `2026-08-20T17:13:13+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ef8449c9+worktree`
+- Report source snapshot: `e814fa4f+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207406 |
-| Test functions | 2990 |
+| Total Python LOC | 207458 |
+| Test functions | 2991 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T12:37:38+00:00`
+- Generated at: `2026-08-20T13:06:03+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `2c324fc8`
+- Report source snapshot: `4610629b+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205762 |
-| Test functions | 2961 |
+| Total Python LOC | 205828 |
+| Test functions | 2962 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T20:19:01+00:00`
+- Generated at: `2026-08-20T20:34:53+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `252cb92a+worktree`
+- Report source snapshot: `6f62d787+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208441 |
-| Test functions | 3007 |
+| Total Python LOC | 208519 |
+| Test functions | 3009 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T19:50:00+00:00`
+- Generated at: `2026-08-20T19:58:36+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `e77f72b1+worktree`
+- Report source snapshot: `bce1f9f0+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208260 |
-| Test functions | 3004 |
+| Total Python LOC | 208314 |
+| Test functions | 3005 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T20:09:10+00:00`
+- Generated at: `2026-08-20T20:19:01+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ad2a3cfd+worktree`
+- Report source snapshot: `252cb92a+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208371 |
-| Test functions | 3006 |
+| Total Python LOC | 208441 |
+| Test functions | 3007 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T14:00:40+00:00`
+- Generated at: `2026-08-20T14:08:51+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `14fc4ebc+worktree`
+- Report source snapshot: `5bec7dde+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206160 |
-| Test functions | 2968 |
+| Total Python LOC | 206199 |
+| Test functions | 2969 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T17:55:26+00:00`
+- Generated at: `2026-08-20T18:20:11+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `7bd5e1d4+worktree`
+- Report source snapshot: `3e70fedd`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207666 |
-| Test functions | 2994 |
+| Total Python LOC | 207767 |
+| Test functions | 2996 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T20:45:26+00:00`
+- Generated at: `2026-08-20T20:55:49+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `06d779bb+worktree`
+- Report source snapshot: `c47f770e+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208594 |
-| Test functions | 3011 |
+| Total Python LOC | 208637 |
+| Test functions | 3012 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T16:05:03+00:00`
+- Generated at: `2026-08-20T16:17:02+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `56da8f03+worktree`
+- Report source snapshot: `9eac1a77+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206864 |
-| Test functions | 2981 |
+| Total Python LOC | 206919 |
+| Test functions | 2982 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T16:59:25+00:00`
+- Generated at: `2026-08-20T17:06:14+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `68822786+worktree`
+- Report source snapshot: `ef8449c9+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207357 |
-| Test functions | 2989 |
+| Total Python LOC | 207406 |
+| Test functions | 2990 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T13:52:45+00:00`
+- Generated at: `2026-08-20T14:00:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `7812ef8c+worktree`
+- Report source snapshot: `14fc4ebc+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206076 |
-| Test functions | 2966 |
+| Total Python LOC | 206160 |
+| Test functions | 2968 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T21:57:56+00:00`
+- Generated at: `2026-08-20T22:16:22+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5164d7b7`
+- Report source snapshot: `58b9cbe0+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208690 |
-| Test functions | 3013 |
+| Total Python LOC | 208781 |
+| Test functions | 3014 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T19:58:36+00:00`
+- Generated at: `2026-08-20T20:09:10+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `bce1f9f0+worktree`
+- Report source snapshot: `ad2a3cfd+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208314 |
-| Test functions | 3005 |
+| Total Python LOC | 208371 |
+| Test functions | 3006 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T16:37:32+00:00`
+- Generated at: `2026-08-20T16:46:34+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `bba46d59+worktree`
+- Report source snapshot: `40de091a+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207136 |
-| Test functions | 2985 |
+| Total Python LOC | 207248 |
+| Test functions | 2987 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T14:30:07+00:00`
+- Generated at: `2026-08-20T14:55:02+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `010805fa+worktree`
+- Report source snapshot: `dc89eb5a+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206332 |
-| Test functions | 2972 |
+| Total Python LOC | 206421 |
+| Test functions | 2974 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T18:55:59+00:00`
+- Generated at: `2026-08-20T19:29:13+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `2071ef65+worktree`
+- Report source snapshot: `9fde7e10+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208060 |
-| Test functions | 3001 |
+| Total Python LOC | 208145 |
+| Test functions | 3002 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T13:42:54+00:00`
+- Generated at: `2026-08-20T13:52:45+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `4e9827ec+worktree`
+- Report source snapshot: `7812ef8c+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206023 |
-| Test functions | 2965 |
+| Total Python LOC | 206076 |
+| Test functions | 2966 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T13:15:15+00:00`
+- Generated at: `2026-08-20T13:26:11+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ef0d0b75+worktree`
+- Report source snapshot: `01aeec09+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205865 |
-| Test functions | 2963 |
+| Total Python LOC | 205950 |
+| Test functions | 2964 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T17:13:13+00:00`
+- Generated at: `2026-08-20T17:33:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `e814fa4f+worktree`
+- Report source snapshot: `fd449f18+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 207458 |
-| Test functions | 2991 |
+| Total Python LOC | 207613 |
+| Test functions | 2993 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T15:13:40+00:00`
+- Generated at: `2026-08-20T15:26:57+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `14ff211c+worktree`
+- Report source snapshot: `c94aa774+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 206567 |
-| Test functions | 2976 |
+| Total Python LOC | 206628 |
+| Test functions | 2977 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T13:06:03+00:00`
+- Generated at: `2026-08-20T13:15:15+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `4610629b+worktree`
+- Report source snapshot: `ef0d0b75+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205828 |
-| Test functions | 2962 |
+| Total Python LOC | 205865 |
+| Test functions | 2963 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T13:26:11+00:00`
+- Generated at: `2026-08-20T13:42:54+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `01aeec09+worktree`
+- Report source snapshot: `4e9827ec+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 205950 |
-| Test functions | 2964 |
+| Total Python LOC | 206023 |
+| Test functions | 2965 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T13:06:03+00:00`
+- Generated at: `2026-08-20T13:15:15+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `4610629b+worktree`
+- Report source snapshot: `ef0d0b75+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T15:26:57+00:00`
+- Generated at: `2026-08-20T15:36:12+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `c94aa774+worktree`
+- Report source snapshot: `699a9458+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T15:36:12+00:00`
+- Generated at: `2026-08-20T15:46:46+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `699a9458+worktree`
+- Report source snapshot: `5d40fc3d+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T16:17:02+00:00`
+- Generated at: `2026-08-20T16:37:32+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `9eac1a77+worktree`
+- Report source snapshot: `bba46d59+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T17:06:14+00:00`
+- Generated at: `2026-08-20T17:13:13+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ef8449c9+worktree`
+- Report source snapshot: `e814fa4f+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T13:15:15+00:00`
+- Generated at: `2026-08-20T13:26:11+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ef0d0b75+worktree`
+- Report source snapshot: `01aeec09+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T21:57:56+00:00`
+- Generated at: `2026-08-20T22:16:22+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5164d7b7`
+- Report source snapshot: `58b9cbe0+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T19:58:36+00:00`
+- Generated at: `2026-08-20T20:09:10+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `bce1f9f0+worktree`
+- Report source snapshot: `ad2a3cfd+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T16:46:34+00:00`
+- Generated at: `2026-08-20T16:59:25+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `40de091a+worktree`
+- Report source snapshot: `68822786+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T14:30:07+00:00`
+- Generated at: `2026-08-20T14:55:02+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `010805fa+worktree`
+- Report source snapshot: `dc89eb5a+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T15:05:04+00:00`
+- Generated at: `2026-08-20T15:13:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `f5ca0561+worktree`
+- Report source snapshot: `14ff211c+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T18:20:11+00:00`
+- Generated at: `2026-08-20T18:29:55+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `3e70fedd`
+- Report source snapshot: `0172727f+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T16:05:03+00:00`
+- Generated at: `2026-08-20T16:17:02+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `56da8f03+worktree`
+- Report source snapshot: `9eac1a77+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T15:46:46+00:00`
+- Generated at: `2026-08-20T16:05:03+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5d40fc3d+worktree`
+- Report source snapshot: `56da8f03+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T20:19:01+00:00`
+- Generated at: `2026-08-20T20:34:53+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `252cb92a+worktree`
+- Report source snapshot: `6f62d787+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T14:08:51+00:00`
+- Generated at: `2026-08-20T14:19:12+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5bec7dde+worktree`
+- Report source snapshot: `90ed3671+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T13:52:45+00:00`
+- Generated at: `2026-08-20T14:00:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `7812ef8c+worktree`
+- Report source snapshot: `14fc4ebc+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T19:29:13+00:00`
+- Generated at: `2026-08-20T19:50:00+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `9fde7e10+worktree`
+- Report source snapshot: `e77f72b1+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T20:55:49+00:00`
+- Generated at: `2026-08-20T21:57:56+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `c47f770e+worktree`
+- Report source snapshot: `5164d7b7`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T17:55:26+00:00`
+- Generated at: `2026-08-20T18:20:11+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `7bd5e1d4+worktree`
+- Report source snapshot: `3e70fedd`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T18:44:41+00:00`
+- Generated at: `2026-08-20T18:55:59+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `8ad5c409+worktree`
+- Report source snapshot: `2071ef65+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T11:50:29+00:00`
+- Generated at: `2026-08-20T12:37:38+00:00`
 
-- Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
+- Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `73589cd9+worktree`
+- Report source snapshot: `2c324fc8`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T20:09:10+00:00`
+- Generated at: `2026-08-20T20:19:01+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ad2a3cfd+worktree`
+- Report source snapshot: `252cb92a+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T15:13:40+00:00`
+- Generated at: `2026-08-20T15:26:57+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `14ff211c+worktree`
+- Report source snapshot: `c94aa774+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T14:19:12+00:00`
+- Generated at: `2026-08-20T14:30:07+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `90ed3671+worktree`
+- Report source snapshot: `010805fa+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T17:33:40+00:00`
+- Generated at: `2026-08-20T17:55:26+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `fd449f18+worktree`
+- Report source snapshot: `7bd5e1d4+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T19:50:00+00:00`
+- Generated at: `2026-08-20T19:58:36+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `e77f72b1+worktree`
+- Report source snapshot: `bce1f9f0+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T13:26:11+00:00`
+- Generated at: `2026-08-20T13:42:54+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `01aeec09+worktree`
+- Report source snapshot: `4e9827ec+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T18:29:55+00:00`
+- Generated at: `2026-08-20T18:44:41+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `0172727f+worktree`
+- Report source snapshot: `8ad5c409+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T14:00:40+00:00`
+- Generated at: `2026-08-20T14:08:51+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `14fc4ebc+worktree`
+- Report source snapshot: `5bec7dde+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T16:59:25+00:00`
+- Generated at: `2026-08-20T17:06:14+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `68822786+worktree`
+- Report source snapshot: `ef8449c9+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T20:34:53+00:00`
+- Generated at: `2026-08-20T20:45:26+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `6f62d787+worktree`
+- Report source snapshot: `06d779bb+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T14:55:02+00:00`
+- Generated at: `2026-08-20T15:05:04+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `dc89eb5a+worktree`
+- Report source snapshot: `f5ca0561+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T16:37:32+00:00`
+- Generated at: `2026-08-20T16:46:34+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `bba46d59+worktree`
+- Report source snapshot: `40de091a+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T12:37:38+00:00`
+- Generated at: `2026-08-20T13:06:03+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `2c324fc8`
+- Report source snapshot: `4610629b+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T17:13:13+00:00`
+- Generated at: `2026-08-20T17:33:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `e814fa4f+worktree`
+- Report source snapshot: `fd449f18+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T20:45:26+00:00`
+- Generated at: `2026-08-20T20:55:49+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `06d779bb+worktree`
+- Report source snapshot: `c47f770e+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T18:55:59+00:00`
+- Generated at: `2026-08-20T19:29:13+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `2071ef65+worktree`
+- Report source snapshot: `9fde7e10+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T13:42:54+00:00`
+- Generated at: `2026-08-20T13:52:45+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `4e9827ec+worktree`
+- Report source snapshot: `7812ef8c+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T16:17:02+00:00`
+- Generated at: `2026-08-20T16:37:32+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `9eac1a77+worktree`
+- Report source snapshot: `bba46d59+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T14:19:12+00:00`
+- Generated at: `2026-08-20T14:30:07+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `90ed3671+worktree`
+- Report source snapshot: `010805fa+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T17:33:40+00:00`
+- Generated at: `2026-08-20T17:55:26+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `fd449f18+worktree`
+- Report source snapshot: `7bd5e1d4+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T17:13:13+00:00`
+- Generated at: `2026-08-20T17:33:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `e814fa4f+worktree`
+- Report source snapshot: `fd449f18+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T20:34:53+00:00`
+- Generated at: `2026-08-20T20:45:26+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `6f62d787+worktree`
+- Report source snapshot: `06d779bb+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T17:06:14+00:00`
+- Generated at: `2026-08-20T17:13:13+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ef8449c9+worktree`
+- Report source snapshot: `e814fa4f+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T18:44:41+00:00`
+- Generated at: `2026-08-20T18:55:59+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `8ad5c409+worktree`
+- Report source snapshot: `2071ef65+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T15:46:46+00:00`
+- Generated at: `2026-08-20T16:05:03+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5d40fc3d+worktree`
+- Report source snapshot: `56da8f03+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T13:52:45+00:00`
+- Generated at: `2026-08-20T14:00:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `7812ef8c+worktree`
+- Report source snapshot: `14fc4ebc+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T12:37:38+00:00`
+- Generated at: `2026-08-20T13:06:03+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `2c324fc8`
+- Report source snapshot: `4610629b+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T16:37:32+00:00`
+- Generated at: `2026-08-20T16:46:34+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `bba46d59+worktree`
+- Report source snapshot: `40de091a+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T15:36:12+00:00`
+- Generated at: `2026-08-20T15:46:46+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `699a9458+worktree`
+- Report source snapshot: `5d40fc3d+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T15:05:04+00:00`
+- Generated at: `2026-08-20T15:13:40+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `f5ca0561+worktree`
+- Report source snapshot: `14ff211c+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T14:08:51+00:00`
+- Generated at: `2026-08-20T14:19:12+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5bec7dde+worktree`
+- Report source snapshot: `90ed3671+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T16:46:34+00:00`
+- Generated at: `2026-08-20T16:59:25+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `40de091a+worktree`
+- Report source snapshot: `68822786+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T20:45:26+00:00`
+- Generated at: `2026-08-20T20:55:49+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `06d779bb+worktree`
+- Report source snapshot: `c47f770e+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T13:06:03+00:00`
+- Generated at: `2026-08-20T13:15:15+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `4610629b+worktree`
+- Report source snapshot: `ef0d0b75+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T16:05:03+00:00`
+- Generated at: `2026-08-20T16:17:02+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `56da8f03+worktree`
+- Report source snapshot: `9eac1a77+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T19:50:00+00:00`
+- Generated at: `2026-08-20T19:58:36+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `e77f72b1+worktree`
+- Report source snapshot: `bce1f9f0+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T15:13:40+00:00`
+- Generated at: `2026-08-20T15:26:57+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `14ff211c+worktree`
+- Report source snapshot: `c94aa774+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T20:55:49+00:00`
+- Generated at: `2026-08-20T21:57:56+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `c47f770e+worktree`
+- Report source snapshot: `5164d7b7`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T14:00:40+00:00`
+- Generated at: `2026-08-20T14:08:51+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `14fc4ebc+worktree`
+- Report source snapshot: `5bec7dde+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T14:55:02+00:00`
+- Generated at: `2026-08-20T15:05:04+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `dc89eb5a+worktree`
+- Report source snapshot: `f5ca0561+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T14:30:07+00:00`
+- Generated at: `2026-08-20T14:55:02+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `010805fa+worktree`
+- Report source snapshot: `dc89eb5a+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T13:26:11+00:00`
+- Generated at: `2026-08-20T13:42:54+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `01aeec09+worktree`
+- Report source snapshot: `4e9827ec+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T15:26:57+00:00`
+- Generated at: `2026-08-20T15:36:12+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `c94aa774+worktree`
+- Report source snapshot: `699a9458+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T16:59:25+00:00`
+- Generated at: `2026-08-20T17:06:14+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `68822786+worktree`
+- Report source snapshot: `ef8449c9+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T20:09:10+00:00`
+- Generated at: `2026-08-20T20:19:01+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ad2a3cfd+worktree`
+- Report source snapshot: `252cb92a+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T21:57:56+00:00`
+- Generated at: `2026-08-20T22:16:22+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5164d7b7`
+- Report source snapshot: `58b9cbe0+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T19:58:36+00:00`
+- Generated at: `2026-08-20T20:09:10+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `bce1f9f0+worktree`
+- Report source snapshot: `ad2a3cfd+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T17:55:26+00:00`
+- Generated at: `2026-08-20T18:20:11+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `7bd5e1d4+worktree`
+- Report source snapshot: `3e70fedd`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T19:29:13+00:00`
+- Generated at: `2026-08-20T19:50:00+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `9fde7e10+worktree`
+- Report source snapshot: `e77f72b1+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T18:29:55+00:00`
+- Generated at: `2026-08-20T18:44:41+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `0172727f+worktree`
+- Report source snapshot: `8ad5c409+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T20:19:01+00:00`
+- Generated at: `2026-08-20T20:34:53+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `252cb92a+worktree`
+- Report source snapshot: `6f62d787+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T13:42:54+00:00`
+- Generated at: `2026-08-20T13:52:45+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `4e9827ec+worktree`
+- Report source snapshot: `7812ef8c+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T18:55:59+00:00`
+- Generated at: `2026-08-20T19:29:13+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `2071ef65+worktree`
+- Report source snapshot: `9fde7e10+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T18:20:11+00:00`
+- Generated at: `2026-08-20T18:29:55+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `3e70fedd`
+- Report source snapshot: `0172727f+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T13:15:15+00:00`
+- Generated at: `2026-08-20T13:26:11+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ef0d0b75+worktree`
+- Report source snapshot: `01aeec09+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T11:50:29+00:00`
+- Generated at: `2026-08-20T12:37:38+00:00`
 
-- Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
+- Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `73589cd9+worktree`
+- Report source snapshot: `2c324fc8`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T18:55:59+00:00`
+- Generated at: `2026-08-20T19:29:13+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `2071ef65+worktree`
+- Report source snapshot: `9fde7e10+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208060 | +2351 |
-| Test functions | 2960 | 3001 | +41 |
+| Total Python LOC | 205709 | 208145 | +2436 |
+| Test functions | 2960 | 3002 | +42 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -59,8 +59,8 @@
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 6 | tests/unit/test_documentation_current_state.py | 2774 |
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
-| 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
-| 9 | tests/unit/test_ci_workflow_gate_enforcement.py | 2628 |
+| 8 | tests/unit/test_ci_workflow_gate_enforcement.py | 2682 |
+| 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
 ## Largest Functions

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T17:33:40+00:00`
+- Generated at: `2026-08-20T17:55:26+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `fd449f18+worktree`
+- Report source snapshot: `7bd5e1d4+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207613 | +1904 |
-| Test functions | 2960 | 2993 | +33 |
+| Total Python LOC | 205709 | 207666 | +1957 |
+| Test functions | 2960 | 2994 | +34 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -61,7 +61,7 @@
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
-| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2239 |
+| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2287 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T14:00:40+00:00`
+- Generated at: `2026-08-20T14:08:51+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `14fc4ebc+worktree`
+- Report source snapshot: `5bec7dde+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206160 | +451 |
-| Test functions | 2960 | 2968 | +8 |
+| Total Python LOC | 205709 | 206199 | +490 |
+| Test functions | 2960 | 2969 | +9 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T15:36:12+00:00`
+- Generated at: `2026-08-20T15:46:46+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `699a9458+worktree`
+- Report source snapshot: `5d40fc3d+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206681 | +972 |
-| Test functions | 2960 | 2978 | +18 |
+| Total Python LOC | 205709 | 206774 | +1065 |
+| Test functions | 2960 | 2980 | +20 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T12:37:38+00:00`
+- Generated at: `2026-08-20T13:06:03+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `2c324fc8`
+- Report source snapshot: `4610629b+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 205762 | +53 |
-| Test functions | 2960 | 2961 | +1 |
+| Total Python LOC | 205709 | 205828 | +119 |
+| Test functions | 2960 | 2962 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T21:57:56+00:00`
+- Generated at: `2026-08-20T22:16:22+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5164d7b7`
+- Report source snapshot: `58b9cbe0+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208690 | +2981 |
-| Test functions | 2960 | 3013 | +53 |
+| Total Python LOC | 205709 | 208781 | +3072 |
+| Test functions | 2960 | 3014 | +54 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3120 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3152 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T15:13:40+00:00`
+- Generated at: `2026-08-20T15:26:57+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `14ff211c+worktree`
+- Report source snapshot: `c94aa774+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206567 | +858 |
-| Test functions | 2960 | 2976 | +16 |
+| Total Python LOC | 205709 | 206628 | +919 |
+| Test functions | 2960 | 2977 | +17 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T16:59:25+00:00`
+- Generated at: `2026-08-20T17:06:14+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `68822786+worktree`
+- Report source snapshot: `ef8449c9+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207357 | +1648 |
-| Test functions | 2960 | 2989 | +29 |
+| Total Python LOC | 205709 | 207406 | +1697 |
+| Test functions | 2960 | 2990 | +30 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -61,7 +61,7 @@
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
-| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2072 |
+| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2120 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T17:13:13+00:00`
+- Generated at: `2026-08-20T17:33:40+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `e814fa4f+worktree`
+- Report source snapshot: `fd449f18+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207458 | +1749 |
-| Test functions | 2960 | 2991 | +31 |
+| Total Python LOC | 205709 | 207613 | +1904 |
+| Test functions | 2960 | 2993 | +33 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -61,7 +61,7 @@
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
-| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2168 |
+| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2239 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T15:46:46+00:00`
+- Generated at: `2026-08-20T16:05:03+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5d40fc3d+worktree`
+- Report source snapshot: `56da8f03+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206774 | +1065 |
-| Test functions | 2960 | 2980 | +20 |
+| Total Python LOC | 205709 | 206864 | +1155 |
+| Test functions | 2960 | 2981 | +21 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T15:05:04+00:00`
+- Generated at: `2026-08-20T15:13:40+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `f5ca0561+worktree`
+- Report source snapshot: `14ff211c+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206519 | +810 |
-| Test functions | 2960 | 2975 | +15 |
+| Total Python LOC | 205709 | 206567 | +858 |
+| Test functions | 2960 | 2976 | +16 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T17:55:26+00:00`
+- Generated at: `2026-08-20T18:20:11+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `7bd5e1d4+worktree`
+- Report source snapshot: `3e70fedd`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207666 | +1957 |
-| Test functions | 2960 | 2994 | +34 |
+| Total Python LOC | 205709 | 207767 | +2058 |
+| Test functions | 2960 | 2996 | +36 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -60,8 +60,8 @@
 | 6 | tests/unit/test_documentation_current_state.py | 2774 |
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
-| 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
-| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2287 |
+| 9 | tests/unit/test_ci_workflow_gate_enforcement.py | 2385 |
+| 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T13:52:45+00:00`
+- Generated at: `2026-08-20T14:00:40+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `7812ef8c+worktree`
+- Report source snapshot: `14fc4ebc+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206076 | +367 |
-| Test functions | 2960 | 2966 | +6 |
+| Total Python LOC | 205709 | 206160 | +451 |
+| Test functions | 2960 | 2968 | +8 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T13:42:54+00:00`
+- Generated at: `2026-08-20T13:52:45+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `4e9827ec+worktree`
+- Report source snapshot: `7812ef8c+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206023 | +314 |
-| Test functions | 2960 | 2965 | +5 |
+| Total Python LOC | 205709 | 206076 | +367 |
+| Test functions | 2960 | 2966 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T20:55:49+00:00`
+- Generated at: `2026-08-20T21:57:56+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `c47f770e+worktree`
+- Report source snapshot: `5164d7b7`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208637 | +2928 |
-| Test functions | 2960 | 3012 | +52 |
+| Total Python LOC | 205709 | 208690 | +2981 |
+| Test functions | 2960 | 3013 | +53 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3091 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3120 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T13:26:11+00:00`
+- Generated at: `2026-08-20T13:42:54+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `01aeec09+worktree`
+- Report source snapshot: `4e9827ec+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 205950 | +241 |
-| Test functions | 2960 | 2964 | +4 |
+| Total Python LOC | 205709 | 206023 | +314 |
+| Test functions | 2960 | 2965 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T16:46:34+00:00`
+- Generated at: `2026-08-20T16:59:25+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `40de091a+worktree`
+- Report source snapshot: `68822786+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207248 | +1539 |
-| Test functions | 2960 | 2987 | +27 |
+| Total Python LOC | 205709 | 207357 | +1648 |
+| Test functions | 2960 | 2989 | +29 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -61,7 +61,7 @@
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
-| 10 | tests/unit/dpm/pm_quality/test_pm_operating_quality.py | 1996 |
+| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2072 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T14:55:02+00:00`
+- Generated at: `2026-08-20T15:05:04+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `dc89eb5a+worktree`
+- Report source snapshot: `f5ca0561+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206421 | +712 |
-| Test functions | 2960 | 2974 | +14 |
+| Total Python LOC | 205709 | 206519 | +810 |
+| Test functions | 2960 | 2975 | +15 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T18:44:41+00:00`
+- Generated at: `2026-08-20T18:55:59+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `8ad5c409+worktree`
+- Report source snapshot: `2071ef65+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207990 | +2281 |
-| Test functions | 2960 | 3000 | +40 |
+| Total Python LOC | 205709 | 208060 | +2351 |
+| Test functions | 2960 | 3001 | +41 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -60,7 +60,7 @@
 | 6 | tests/unit/test_documentation_current_state.py | 2774 |
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
-| 9 | tests/unit/test_ci_workflow_gate_enforcement.py | 2579 |
+| 9 | tests/unit/test_ci_workflow_gate_enforcement.py | 2628 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
 ## Largest Functions

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T16:17:02+00:00`
+- Generated at: `2026-08-20T16:37:32+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `9eac1a77+worktree`
+- Report source snapshot: `bba46d59+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206919 | +1210 |
-| Test functions | 2960 | 2982 | +22 |
+| Total Python LOC | 205709 | 207136 | +1427 |
+| Test functions | 2960 | 2985 | +25 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T16:05:03+00:00`
+- Generated at: `2026-08-20T16:17:02+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `56da8f03+worktree`
+- Report source snapshot: `9eac1a77+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206864 | +1155 |
-| Test functions | 2960 | 2981 | +21 |
+| Total Python LOC | 205709 | 206919 | +1210 |
+| Test functions | 2960 | 2982 | +22 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T18:20:11+00:00`
+- Generated at: `2026-08-20T18:29:55+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `3e70fedd`
+- Report source snapshot: `0172727f+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207767 | +2058 |
-| Test functions | 2960 | 2996 | +36 |
+| Total Python LOC | 205709 | 207893 | +2184 |
+| Test functions | 2960 | 2998 | +38 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -60,7 +60,7 @@
 | 6 | tests/unit/test_documentation_current_state.py | 2774 |
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
-| 9 | tests/unit/test_ci_workflow_gate_enforcement.py | 2385 |
+| 9 | tests/unit/test_ci_workflow_gate_enforcement.py | 2483 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
 ## Largest Functions

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T20:09:10+00:00`
+- Generated at: `2026-08-20T20:19:01+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ad2a3cfd+worktree`
+- Report source snapshot: `252cb92a+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208371 | +2662 |
-| Test functions | 2960 | 3006 | +46 |
+| Total Python LOC | 205709 | 208441 | +2732 |
+| Test functions | 2960 | 3007 | +47 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 2881 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 2933 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T19:58:36+00:00`
+- Generated at: `2026-08-20T20:09:10+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `bce1f9f0+worktree`
+- Report source snapshot: `ad2a3cfd+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208314 | +2605 |
-| Test functions | 2960 | 3005 | +45 |
+| Total Python LOC | 205709 | 208371 | +2662 |
+| Test functions | 2960 | 3006 | +46 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 2829 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 2881 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T19:50:00+00:00`
+- Generated at: `2026-08-20T19:58:36+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `e77f72b1+worktree`
+- Report source snapshot: `bce1f9f0+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208260 | +2551 |
-| Test functions | 2960 | 3004 | +44 |
+| Total Python LOC | 205709 | 208314 | +2605 |
+| Test functions | 2960 | 3005 | +45 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 2780 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 2829 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T11:50:29+00:00`
+- Generated at: `2026-08-20T12:37:38+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `c37c75bcb1b1795ae0a3e3b96804aa91e9f6a23d`
+- Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `73589cd9+worktree`
+- Report source snapshot: `2c324fc8`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205488 | 205709 | +221 |
-| Test functions | 2957 | 2960 | +3 |
+| Total Python LOC | 205709 | 205762 | +53 |
+| Test functions | 2960 | 2961 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T17:06:14+00:00`
+- Generated at: `2026-08-20T17:13:13+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ef8449c9+worktree`
+- Report source snapshot: `e814fa4f+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207406 | +1697 |
-| Test functions | 2960 | 2990 | +30 |
+| Total Python LOC | 205709 | 207458 | +1749 |
+| Test functions | 2960 | 2991 | +31 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -61,7 +61,7 @@
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
-| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2120 |
+| 10 | tests/unit/test_ci_workflow_gate_enforcement.py | 2168 |
 
 ## Largest Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T13:06:03+00:00`
+- Generated at: `2026-08-20T13:15:15+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `4610629b+worktree`
+- Report source snapshot: `ef0d0b75+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 205828 | +119 |
-| Test functions | 2960 | 2962 | +2 |
+| Total Python LOC | 205709 | 205865 | +156 |
+| Test functions | 2960 | 2963 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T18:29:55+00:00`
+- Generated at: `2026-08-20T18:44:41+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `0172727f+worktree`
+- Report source snapshot: `8ad5c409+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207893 | +2184 |
-| Test functions | 2960 | 2998 | +38 |
+| Total Python LOC | 205709 | 207990 | +2281 |
+| Test functions | 2960 | 3000 | +40 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -60,7 +60,7 @@
 | 6 | tests/unit/test_documentation_current_state.py | 2774 |
 | 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
-| 9 | tests/unit/test_ci_workflow_gate_enforcement.py | 2483 |
+| 9 | tests/unit/test_ci_workflow_gate_enforcement.py | 2579 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
 ## Largest Functions

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T15:26:57+00:00`
+- Generated at: `2026-08-20T15:36:12+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `c94aa774+worktree`
+- Report source snapshot: `699a9458+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206628 | +919 |
-| Test functions | 2960 | 2977 | +17 |
+| Total Python LOC | 205709 | 206681 | +972 |
+| Test functions | 2960 | 2978 | +18 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T20:19:01+00:00`
+- Generated at: `2026-08-20T20:34:53+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `252cb92a+worktree`
+- Report source snapshot: `6f62d787+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208441 | +2732 |
-| Test functions | 2960 | 3007 | +47 |
+| Total Python LOC | 205709 | 208519 | +2810 |
+| Test functions | 2960 | 3009 | +49 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 2933 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3009 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T14:08:51+00:00`
+- Generated at: `2026-08-20T14:19:12+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `5bec7dde+worktree`
+- Report source snapshot: `90ed3671+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206199 | +490 |
-| Test functions | 2960 | 2969 | +9 |
+| Total Python LOC | 205709 | 206247 | +538 |
+| Test functions | 2960 | 2970 | +10 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T14:19:12+00:00`
+- Generated at: `2026-08-20T14:30:07+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `90ed3671+worktree`
+- Report source snapshot: `010805fa+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206247 | +538 |
-| Test functions | 2960 | 2970 | +10 |
+| Total Python LOC | 205709 | 206332 | +623 |
+| Test functions | 2960 | 2972 | +12 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T20:34:53+00:00`
+- Generated at: `2026-08-20T20:45:26+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `6f62d787+worktree`
+- Report source snapshot: `06d779bb+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208519 | +2810 |
-| Test functions | 2960 | 3009 | +49 |
+| Total Python LOC | 205709 | 208594 | +2885 |
+| Test functions | 2960 | 3011 | +51 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3009 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3062 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T19:29:13+00:00`
+- Generated at: `2026-08-20T19:50:00+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `9fde7e10+worktree`
+- Report source snapshot: `e77f72b1+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208145 | +2436 |
-| Test functions | 2960 | 3002 | +42 |
+| Total Python LOC | 205709 | 208260 | +2551 |
+| Test functions | 2960 | 3004 | +44 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,9 +57,9 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_documentation_current_state.py | 2774 |
-| 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
-| 8 | tests/unit/test_ci_workflow_gate_enforcement.py | 2682 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 2780 |
+| 7 | tests/unit/test_documentation_current_state.py | 2774 |
+| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T20:45:26+00:00`
+- Generated at: `2026-08-20T20:55:49+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `06d779bb+worktree`
+- Report source snapshot: `c47f770e+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208594 | +2885 |
-| Test functions | 2960 | 3011 | +51 |
+| Total Python LOC | 205709 | 208637 | +2928 |
+| Test functions | 2960 | 3012 | +52 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3062 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3091 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T13:15:15+00:00`
+- Generated at: `2026-08-20T13:26:11+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `ef0d0b75+worktree`
+- Report source snapshot: `01aeec09+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 205865 | +156 |
-| Test functions | 2960 | 2963 | +3 |
+| Total Python LOC | 205709 | 205950 | +241 |
+| Test functions | 2960 | 2964 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T16:37:32+00:00`
+- Generated at: `2026-08-20T16:46:34+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `bba46d59+worktree`
+- Report source snapshot: `40de091a+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 207136 | +1427 |
-| Test functions | 2960 | 2985 | +25 |
+| Total Python LOC | 205709 | 207248 | +1539 |
+| Test functions | 2960 | 2987 | +27 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T14:30:07+00:00`
+- Generated at: `2026-08-20T14:55:02+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `010805fa+worktree`
+- Report source snapshot: `dc89eb5a+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 206332 | +623 |
-| Test functions | 2960 | 2972 | +12 |
+| Total Python LOC | 205709 | 206421 | +712 |
+| Test functions | 2960 | 2974 | +14 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -108,6 +108,7 @@ def _opens_nested_shell_scope(stripped_line: str) -> bool:
     return (
         stripped_line == "("
         or stripped_line.startswith("(")
+        or re.search(r"(?:^|[;&|]\s*)\(", stripped_line) is not None
         or stripped_line.startswith(("if ", "for ", "while ", "until ", "case ", "select "))
         or stripped_line.startswith("function ")
         or stripped_line.endswith("() {")
@@ -206,6 +207,13 @@ def _has_failure_masked_outer_brace_group(text: str) -> bool:
                 return True
             brace_depth -= 1
     return False
+
+
+def _has_compound_prefixed_subshell_scope(text: str) -> bool:
+    return any(
+        re.search(r"(?:&&|\|\|)\s*\(", _strip_shell_inline_comment(line.strip())) is not None
+        for line in text.splitlines()
+    )
 
 
 def _strip_shell_inline_comment(stripped_line: str) -> str:
@@ -909,6 +917,12 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{dispatcher.as_posix()}: dispatcher must not wrap the governed "
                 "lookup, creation, and dispatch commands in a brace group whose failure is "
                 "masked by a shell OR fallback"
+            )
+        if _has_compound_prefixed_subshell_scope(dispatch_contract_text):
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must not place the governed lookup, "
+                "creation, and dispatch body behind a compound-prefixed subshell such as "
+                "`false && (...) || true`"
             )
         if not _has_conditionally_guarded_immutable_ref_lookup(dispatch_contract_text):
             violations.append(

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -178,17 +178,13 @@ def _outer_lookup_else_arm_has_unconditional_reset(block: str) -> bool:
     if else_index is None:
         return False
 
-    depth = 1
     for line in lines[else_index + 1 :]:
         stripped = line.strip()
         if stripped == "fi":
-            depth -= 1
-            if depth == 0:
-                break
-        if depth == 1 and stripped == 'existing_ref_sha=""':
-            return True
-        if stripped.startswith("if "):
-            depth += 1
+            break
+        if not stripped or stripped.startswith("#"):
+            continue
+        return stripped == 'existing_ref_sha=""'
     return False
 
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -192,6 +192,22 @@ def _strip_shell_here_document_bodies(text: str) -> str:
     return "\n".join(executable_lines)
 
 
+def _has_failure_masked_outer_brace_group(text: str) -> bool:
+    brace_depth = 0
+    for line in text.splitlines():
+        stripped_line = _strip_shell_inline_comment(line.strip())
+        if not stripped_line:
+            continue
+        if stripped_line == "{":
+            brace_depth += 1
+            continue
+        if stripped_line.startswith("}") and brace_depth:
+            if brace_depth == 1 and "||" in stripped_line:
+                return True
+            brace_depth -= 1
+    return False
+
+
 def _strip_shell_inline_comment(stripped_line: str) -> str:
     in_single_quote = False
     in_double_quote = False
@@ -622,7 +638,7 @@ def _dispatches_after_absent_ref_creation(text: str) -> bool:
             text,
             start_index=-1,
             end_index=dispatch_commands[0][0],
-            protected_variables={"MERGE_COMMIT_SHA"},
+            protected_variables={"GITHUB_REPOSITORY", "MERGE_COMMIT_SHA"},
         )
         and not _has_protected_variable_reassignment_between(
             text,
@@ -888,6 +904,12 @@ def merged_pr_main_releasability_dispatch_violations(
                 search_text = dispatch_contract_text
             if token not in search_text:
                 violations.append(f"{dispatcher.as_posix()}: {reason}")
+        if _has_failure_masked_outer_brace_group(dispatch_contract_text):
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must not wrap the governed "
+                "lookup, creation, and dispatch commands in a brace group whose failure is "
+                "masked by a shell OR fallback"
+            )
         if not _has_conditionally_guarded_immutable_ref_lookup(dispatch_contract_text):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must guard immutable-ref lookup with "

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -205,6 +205,7 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
             or command.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
         )
         and "||" not in command
+        and not command.rstrip().endswith("&")
         and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in command
     )

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -148,8 +148,49 @@ def _step_block(text: str, step_name: str) -> str:
     return text[start:end]
 
 
+def _continued_shell_command(lines: list[str], start_index: int) -> tuple[str, int]:
+    command_parts: list[str] = []
+    index = start_index
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if stripped.endswith("\\"):
+            command_parts.append(stripped[:-1].rstrip())
+            index += 1
+            continue
+        command_parts.append(stripped)
+        break
+    return " ".join(command_parts), index
+
+
 def _contains_immutable_dispatch_ref_lookup(text: str) -> bool:
     return "git/ref/tags/$dispatch_ref" in text or "git/ref/tags/${dispatch_ref}" in text
+
+
+def _immutable_ref_creation_commands(text: str) -> list[str]:
+    lines = text.splitlines()
+    commands: list[str] = []
+    index = 0
+    while index < len(lines):
+        stripped_line = lines[index].strip()
+        if not _is_shell_comment(stripped_line) and (
+            stripped_line == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
+            or stripped_line.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
+        ):
+            command, index = _continued_shell_command(lines, index)
+            commands.append(command)
+        index += 1
+    return commands
+
+
+def _is_exact_immutable_ref_creation_command(command: str) -> bool:
+    return (
+        (
+            command == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
+            or command.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
+        )
+        and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in command
+        and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in command
+    )
 
 
 def _immutable_ref_lookup_blocks(text: str) -> list[str]:
@@ -308,41 +349,49 @@ def _guarded_lookup_success_arms_fail_on_ref_mismatch(text: str) -> bool:
 
 def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
     lines = text.splitlines()
+    creation_commands = _immutable_ref_creation_commands(text)
+    guarded_creation_commands: list[str] = []
     depth = 0
     for index, line in enumerate(lines):
         stripped_line = line.strip()
         if stripped_line == IMMUTABLE_DISPATCH_REF_CREATION_CONDITION and depth == 0:
-            direct_executable_commands: list[str] = []
             creation_depth = 1
-            for follow in lines[index + 1 :]:
+            follow_index = index + 1
+            while follow_index < len(lines):
+                follow = lines[follow_index]
                 stripped_follow = follow.strip()
                 if stripped_follow == "fi" and creation_depth == 1:
                     break
                 if not stripped_follow or _is_shell_comment(stripped_follow):
+                    follow_index += 1
                     continue
-                if creation_depth == 1:
-                    direct_executable_commands.append(stripped_follow)
+                if creation_depth == 1 and (
+                    stripped_follow == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
+                    or stripped_follow.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
+                ):
+                    command, follow_index = _continued_shell_command(lines, follow_index)
+                    guarded_creation_commands.append(command)
+                    follow_index += 1
+                    continue
                 if _opens_nested_shell_scope(stripped_follow):
                     creation_depth += 1
                 if _closes_nested_shell_scope(stripped_follow):
                     creation_depth -= 1
-            creation_text = "\n".join(direct_executable_commands)
-            return (
-                any(
-                    command == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
-                    or command.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
-                    for command in direct_executable_commands
-                )
-                and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in creation_text
-                and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in creation_text
-            )
+                follow_index += 1
         if not stripped_line or _is_shell_comment(stripped_line):
             continue
         if _opens_nested_shell_scope(stripped_line):
             depth += 1
         if _closes_nested_shell_scope(stripped_line):
             depth -= 1
-    return False
+    return (
+        bool(guarded_creation_commands)
+        and len(guarded_creation_commands) == len(creation_commands)
+        and all(
+            _is_exact_immutable_ref_creation_command(command)
+            for command in guarded_creation_commands
+        )
+    )
 
 
 def permission_violations(workflow_path: Path) -> list[str]:
@@ -544,6 +593,13 @@ def merged_pr_main_releasability_dispatch_violations(
         )
     else:
         dispatcher_text = dispatcher.read_text(encoding="utf-8")
+        dispatch_step_text = _step_block(dispatcher_text, "Dispatch main releasability gate")
+        if not dispatch_step_text:
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must keep lookup, conditional ref "
+                "creation, and workflow dispatch in one named run step"
+            )
+        dispatch_contract_text = dispatch_step_text or dispatcher_text
         required_tokens = {
             "pull_request_target:": "dispatcher must run from pull_request_target close events",
             "types: [closed]": "dispatcher must be limited to closed pull request events",
@@ -572,26 +628,37 @@ def merged_pr_main_releasability_dispatch_violations(
             ),
         }
         for token, reason in required_tokens.items():
-            if token not in dispatcher_text:
+            search_text = dispatcher_text
+            if token in {
+                "github.event.pull_request.merge_commit_sha",
+                'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                "Dispatch ref $dispatch_ref points to $existing_ref_sha",
+                'gh api "repos/$GITHUB_REPOSITORY/git/refs"',
+                "gh workflow run main-releasability.yml",
+                '--ref "$dispatch_ref"',
+                "-f expected_sha=",
+            }:
+                search_text = dispatch_contract_text
+            if token not in search_text:
                 violations.append(f"{dispatcher.as_posix()}: {reason}")
-        if not _has_conditionally_guarded_immutable_ref_lookup(dispatcher_text):
+        if not _has_conditionally_guarded_immutable_ref_lookup(dispatch_contract_text):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must guard immutable-ref lookup with "
                 "an if/else reset so a missing ref is treated as absent instead of terminating "
                 "the workflow or capturing an error body as an existing ref SHA"
             )
-        elif not _guarded_lookup_success_arms_fail_on_ref_mismatch(dispatcher_text):
+        elif not _guarded_lookup_success_arms_fail_on_ref_mismatch(dispatch_contract_text):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must fail closed with exit 1 when an "
                 "existing immutable dispatch ref points to a different SHA"
             )
-        if any("||" in block for block in _immutable_ref_lookup_blocks(dispatcher_text)):
+        if any("||" in block for block in _immutable_ref_lookup_blocks(dispatch_contract_text)):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must not mask immutable-ref lookup "
                 "failures with shell OR fallbacks because GitHub 404 response bodies can be "
                 "captured as existing ref SHAs"
             )
-        if not _conditionally_creates_absent_immutable_ref(dispatcher_text):
+        if not _conditionally_creates_absent_immutable_ref(dispatch_contract_text):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must create the immutable dispatch ref only "
                 "inside the empty existing-ref branch with exact ref and SHA fields so reruns do "

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -69,6 +69,20 @@ PR_TEMPLATE_REQUIRED_TOKENS = {
 }
 
 
+def _opens_nested_shell_scope(stripped_line: str) -> bool:
+    return (
+        stripped_line.startswith(("if ", "for ", "while ", "until ", "case "))
+        or stripped_line.startswith("function ")
+        or stripped_line.endswith("() {")
+        or stripped_line.endswith("(){")
+        or stripped_line.endswith(" {")
+    )
+
+
+def _closes_nested_shell_scope(stripped_line: str) -> bool:
+    return stripped_line in {"fi", "done", "esac", "}"}
+
+
 def _workflow_files(workflow_dir: Path = WORKFLOW_DIR) -> list[Path]:
     return sorted(workflow_dir.glob("*.yml")) + sorted(workflow_dir.glob("*.yaml"))
 
@@ -168,9 +182,9 @@ def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
         for follow in lines[index + 1 :]:
             block_lines.append(follow)
             stripped_follow = follow.strip()
-            if stripped_follow.startswith("if "):
+            if _opens_nested_shell_scope(stripped_follow):
                 depth += 1
-            if stripped_follow == "fi":
+            if _closes_nested_shell_scope(stripped_follow):
                 depth -= 1
             if depth == 0:
                 break
@@ -239,9 +253,9 @@ def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
                 continue
             if depth == 1:
                 direct_executable_commands.append(stripped_follow)
-            if stripped_follow.startswith("if "):
+            if _opens_nested_shell_scope(stripped_follow):
                 depth += 1
-            if stripped_follow == "fi":
+            if _closes_nested_shell_scope(stripped_follow):
                 depth -= 1
         return "exit 1" in direct_executable_commands
     return False

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -821,6 +821,11 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{dispatcher.as_posix()}: dispatcher must keep lookup, conditional ref "
                 "creation, and workflow dispatch in one named run step"
             )
+        elif "continue-on-error: true" in dispatch_step_text:
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must not set continue-on-error on "
+                "the governed main releasability dispatch step"
+            )
         dispatch_contract_text = dispatch_step_text or dispatcher_text
         required_tokens = {
             "pull_request_target:": "dispatcher must run from pull_request_target close events",

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -29,6 +29,11 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
 USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?([^\"'\s#]+)", re.MULTILINE)
 VERSION_TAG_PATTERN = re.compile(r"^v\d+(?:\.\d+){0,2}$")
 FULL_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
+IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITION = (
+    'if existing_ref_sha="$(gh api '
+    '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+    '--jq .object.sha 2>/dev/null)"; then'
+)
 PR_TEMPLATE_REQUIRED_TOKENS = {
     "summary": "## Summary",
     "risk": "## Risk / Rollback",
@@ -141,9 +146,7 @@ def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
     blocks: list[str] = []
     for index, line in enumerate(lines):
         stripped_line = line.strip()
-        if "git/ref/tags/$dispatch_ref" not in line or not stripped_line.startswith(
-            'if existing_ref_sha="$(gh api '
-        ):
+        if stripped_line != IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITION:
             continue
 
         block_lines = [line]

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -161,12 +161,43 @@ def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
     return blocks
 
 
+def _outer_lookup_else_arm(block: str) -> str:
+    lines = block.splitlines()
+    else_index: int | None = None
+    depth = 1
+    for index, line in enumerate(lines[1:], start=1):
+        stripped = line.strip()
+        if stripped == "else" and depth == 1:
+            else_index = index
+            break
+        if stripped.startswith("if "):
+            depth += 1
+        if stripped == "fi":
+            depth -= 1
+
+    if else_index is None:
+        return ""
+
+    else_lines: list[str] = []
+    depth = 1
+    for line in lines[else_index + 1 :]:
+        stripped = line.strip()
+        if stripped.startswith("if "):
+            depth += 1
+        if stripped == "fi":
+            depth -= 1
+            if depth == 0:
+                break
+        else_lines.append(line)
+    return "\n".join(else_lines)
+
+
 def _has_conditionally_guarded_immutable_ref_lookup(text: str) -> bool:
     return any(
         "git/ref/tags/$dispatch_ref" in block
         and "\n" in block
         and "else" in block
-        and 'existing_ref_sha=""' in block
+        and 'existing_ref_sha=""' in _outer_lookup_else_arm(block)
         and block.strip().endswith("fi")
         for block in _immutable_ref_lookup_guard_blocks(text)
     )

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -136,6 +136,42 @@ def _immutable_ref_lookup_blocks(text: str) -> list[str]:
     return blocks
 
 
+def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
+    lines = text.splitlines()
+    blocks: list[str] = []
+    for index, line in enumerate(lines):
+        stripped_line = line.strip()
+        if "git/ref/tags/$dispatch_ref" not in line or not stripped_line.startswith(
+            'if existing_ref_sha="$(gh api '
+        ):
+            continue
+
+        block_lines = [line]
+        depth = 1
+        for follow in lines[index + 1 :]:
+            block_lines.append(follow)
+            stripped_follow = follow.strip()
+            if stripped_follow.startswith("if "):
+                depth += 1
+            if stripped_follow == "fi":
+                depth -= 1
+            if depth == 0:
+                break
+        blocks.append("\n".join(block_lines))
+    return blocks
+
+
+def _has_conditionally_guarded_immutable_ref_lookup(text: str) -> bool:
+    return any(
+        "git/ref/tags/$dispatch_ref" in block
+        and "\n" in block
+        and "else" in block
+        and 'existing_ref_sha=""' in block
+        and block.strip().endswith("fi")
+        for block in _immutable_ref_lookup_guard_blocks(text)
+    )
+
+
 def permission_violations(workflow_path: Path) -> list[str]:
     expected = EXPECTED_WORKFLOW_PERMISSIONS.get(workflow_path.name)
     if expected is None:
@@ -346,10 +382,6 @@ def merged_pr_main_releasability_dispatch_violations(
             'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"': (
                 "dispatcher must create an immutable dispatch ref for the merged PR SHA"
             ),
-            'existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref"': (
-                "dispatcher must treat a missing immutable ref as absent without capturing the "
-                "404 response body as a ref SHA"
-            ),
             "Dispatch ref $dispatch_ref points to $existing_ref_sha": (
                 "dispatcher must fail closed if an existing dispatch ref points to a different SHA"
             ),
@@ -369,6 +401,12 @@ def merged_pr_main_releasability_dispatch_violations(
         for token, reason in required_tokens.items():
             if token not in dispatcher_text:
                 violations.append(f"{dispatcher.as_posix()}: {reason}")
+        if not _has_conditionally_guarded_immutable_ref_lookup(dispatcher_text):
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must guard immutable-ref lookup with "
+                "an if/else reset so a missing ref is treated as absent instead of terminating "
+                "the workflow or capturing an error body as an existing ref SHA"
+            )
         if any("||" in block for block in _immutable_ref_lookup_blocks(dispatcher_text)):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must not mask immutable-ref lookup "

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -29,10 +29,17 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
 USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?([^\"'\s#]+)", re.MULTILINE)
 VERSION_TAG_PATTERN = re.compile(r"^v\d+(?:\.\d+){0,2}$")
 FULL_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
-IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITION = (
-    'if existing_ref_sha="$(gh api '
-    '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
-    '--jq .object.sha 2>/dev/null)"; then'
+IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS = (
+    (
+        'if existing_ref_sha="$(gh api '
+        '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+        '--jq .object.sha 2>/dev/null)"; then'
+    ),
+    (
+        'if existing_ref_sha="$(gh api '
+        '"repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" '
+        '--jq .object.sha 2>/dev/null)"; then'
+    ),
 )
 PR_TEMPLATE_REQUIRED_TOKENS = {
     "summary": "## Summary",
@@ -114,11 +121,15 @@ def _step_block(text: str, step_name: str) -> str:
     return text[start:end]
 
 
+def _contains_immutable_dispatch_ref_lookup(text: str) -> bool:
+    return "git/ref/tags/$dispatch_ref" in text or "git/ref/tags/${dispatch_ref}" in text
+
+
 def _immutable_ref_lookup_blocks(text: str) -> list[str]:
     lines = text.splitlines()
     blocks: list[str] = []
     for index, line in enumerate(lines):
-        if "git/ref/tags/$dispatch_ref" not in line:
+        if not _contains_immutable_dispatch_ref_lookup(line):
             continue
 
         block_lines = [line]
@@ -146,7 +157,7 @@ def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
     blocks: list[str] = []
     for index, line in enumerate(lines):
         stripped_line = line.strip()
-        if stripped_line != IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITION:
+        if stripped_line not in IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS:
             continue
 
         block_lines = [line]
@@ -199,7 +210,7 @@ def _outer_lookup_else_arm_has_unconditional_reset(block: str) -> bool:
 
 def _is_conditionally_guarded_immutable_ref_lookup_block(block: str) -> bool:
     return (
-        "git/ref/tags/$dispatch_ref" in block
+        _contains_immutable_dispatch_ref_lookup(block)
         and "\n" in block
         and "else" in block
         and _outer_lookup_else_arm_has_unconditional_reset(block)

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -229,7 +229,7 @@ def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
         if line.strip() != IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION:
             continue
 
-        executable_commands: list[str] = []
+        direct_executable_commands: list[str] = []
         depth = 1
         for follow in then_arm[index + 1 :]:
             stripped_follow = follow.strip()
@@ -237,12 +237,13 @@ def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
                 break
             if not stripped_follow or stripped_follow.startswith("#"):
                 continue
-            executable_commands.append(stripped_follow)
+            if depth == 1:
+                direct_executable_commands.append(stripped_follow)
             if stripped_follow.startswith("if "):
                 depth += 1
             if stripped_follow == "fi":
                 depth -= 1
-        return "exit 1" in executable_commands
+        return "exit 1" in direct_executable_commands
     return False
 
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -207,10 +207,15 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
         )
         and "||" not in command
         and not command.rstrip().endswith("&")
+        and not _has_disallowed_immutable_ref_creation_shell_control(command)
         and not _has_disallowed_immutable_ref_creation_override(command)
         and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in command
     )
+
+
+def _has_disallowed_immutable_ref_creation_shell_control(command: str) -> bool:
+    return ";" in command or "&&" in command
 
 
 def _has_disallowed_immutable_ref_creation_override(command: str) -> bool:

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -449,20 +449,47 @@ def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
     )
 
 
-def _main_releasability_dispatch_command_indices(text: str) -> list[int]:
+def _main_releasability_dispatch_commands(text: str) -> list[tuple[int, str]]:
     lines = text.splitlines()
-    indices: list[int] = []
+    commands: list[tuple[int, str]] = []
     index = 0
+    depth = 0
     while index < len(lines):
         stripped_line = lines[index].strip()
-        if not _is_shell_comment(stripped_line) and (
-            stripped_line == MAIN_RELEASABILITY_DISPATCH_COMMAND
-            or stripped_line.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} ")
+        if (
+            not _is_shell_comment(stripped_line)
+            and depth == 0
+            and (
+                stripped_line == MAIN_RELEASABILITY_DISPATCH_COMMAND
+                or stripped_line.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} ")
+            )
         ):
-            _, index = _continued_shell_command(lines, index)
-            indices.append(index)
+            command, index = _continued_shell_command(lines, index)
+            commands.append((index, command))
+            index += 1
+            continue
+        if stripped_line and not _is_shell_comment(stripped_line):
+            if _opens_nested_shell_scope(stripped_line):
+                depth += 1
+            if _closes_nested_shell_scope(stripped_line):
+                depth -= 1
         index += 1
-    return indices
+    return commands
+
+
+def _is_exact_main_releasability_dispatch_command(command: str) -> bool:
+    return (
+        (
+            command == MAIN_RELEASABILITY_DISPATCH_COMMAND
+            or command.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} ")
+        )
+        and "||" not in command
+        and "&&" not in command
+        and ";" not in command
+        and not command.rstrip().endswith("&")
+        and '--ref "$dispatch_ref"' in command
+        and "-f expected_sha=" in command
+    )
 
 
 def _absent_ref_creation_block_end_index(text: str) -> int | None:
@@ -505,12 +532,13 @@ def _absent_ref_creation_block_end_index(text: str) -> int | None:
 
 
 def _dispatches_after_absent_ref_creation(text: str) -> bool:
-    dispatch_indices = _main_releasability_dispatch_command_indices(text)
+    dispatch_commands = _main_releasability_dispatch_commands(text)
     creation_block_end_index = _absent_ref_creation_block_end_index(text)
     return (
-        len(dispatch_indices) == 1
+        len(dispatch_commands) == 1
         and creation_block_end_index is not None
-        and dispatch_indices[0] > creation_block_end_index
+        and dispatch_commands[0][0] > creation_block_end_index
+        and _is_exact_main_releasability_dispatch_command(dispatch_commands[0][1])
     )
 
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -478,17 +478,18 @@ def _main_releasability_dispatch_commands(text: str) -> list[tuple[int, str]]:
 
 
 def _is_exact_main_releasability_dispatch_command(command: str) -> bool:
+    normalized_command = " ".join(command.split())
     return (
         (
-            command == MAIN_RELEASABILITY_DISPATCH_COMMAND
-            or command.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} ")
+            normalized_command == MAIN_RELEASABILITY_DISPATCH_COMMAND
+            or normalized_command.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} ")
         )
-        and "||" not in command
-        and "&&" not in command
-        and ";" not in command
-        and not command.rstrip().endswith("&")
-        and '--ref "$dispatch_ref"' in command
-        and "-f expected_sha=" in command
+        and "||" not in normalized_command
+        and "&&" not in normalized_command
+        and ";" not in normalized_command
+        and not normalized_command.rstrip().endswith("&")
+        and '--ref "$dispatch_ref"' in normalized_command
+        and '-f expected_sha="$MERGE_COMMIT_SHA"' in normalized_command
     )
 
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -46,6 +46,8 @@ IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION = (
 )
 IMMUTABLE_DISPATCH_REF_CREATION_CONDITION = 'if [ -z "$existing_ref_sha" ]; then'
 IMMUTABLE_DISPATCH_REF_CREATION_COMMAND = 'gh api "repos/$GITHUB_REPOSITORY/git/refs"'
+IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD = '-f ref="refs/tags/$dispatch_ref"'
+IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD = '-f sha="$MERGE_COMMIT_SHA"'
 PR_TEMPLATE_REQUIRED_TOKENS = {
     "summary": "## Summary",
     "risk": "## Risk / Rollback",
@@ -324,10 +326,15 @@ def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
                     creation_depth += 1
                 if _closes_nested_shell_scope(stripped_follow):
                     creation_depth -= 1
-            return any(
-                command == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
-                or command.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
-                for command in direct_executable_commands
+            creation_text = "\n".join(direct_executable_commands)
+            return (
+                any(
+                    command == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
+                    or command.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
+                    for command in direct_executable_commands
+                )
+                and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in creation_text
+                and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in creation_text
             )
         if not stripped_line or _is_shell_comment(stripped_line):
             continue
@@ -587,7 +594,8 @@ def merged_pr_main_releasability_dispatch_violations(
         if not _conditionally_creates_absent_immutable_ref(dispatcher_text):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must create the immutable dispatch ref only "
-                "inside the empty existing-ref branch so reruns do not recreate an existing tag"
+                "inside the empty existing-ref branch with exact ref and SHA fields so reruns do "
+                "not recreate an existing tag or dispatch the wrong revision"
             )
 
     if main_releasability.exists():

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -141,18 +141,34 @@ def _step_block(text: str, step_name: str) -> str:
     start = text.find(f"- name: {step_name}")
     if start == -1:
         return ""
-    next_step = text.find("\n      - name:", start + 1)
-    next_uses = text.find("\n      - uses:", start + 1)
-    candidates = [index for index in (next_step, next_uses) if index != -1]
-    end = min(candidates) if candidates else len(text)
+    next_step = text.find("\n      - ", start + 1)
+    end = next_step if next_step != -1 else len(text)
     return text[start:end]
+
+
+def _strip_shell_inline_comment(stripped_line: str) -> str:
+    in_single_quote = False
+    in_double_quote = False
+    for index, character in enumerate(stripped_line):
+        if character == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+        elif character == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+        elif (
+            character == "#"
+            and not in_single_quote
+            and not in_double_quote
+            and (index == 0 or stripped_line[index - 1].isspace())
+        ):
+            return stripped_line[:index].rstrip()
+    return stripped_line
 
 
 def _continued_shell_command(lines: list[str], start_index: int) -> tuple[str, int]:
     command_parts: list[str] = []
     index = start_index
     while index < len(lines):
-        stripped = lines[index].strip()
+        stripped = _strip_shell_inline_comment(lines[index].strip())
         if stripped.endswith("\\"):
             command_parts.append(stripped[:-1].rstrip())
             index += 1

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
 
 
@@ -49,6 +50,30 @@ IMMUTABLE_DISPATCH_REF_CREATION_COMMAND = 'gh api "repos/$GITHUB_REPOSITORY/git/
 IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD = '-f ref="refs/tags/$dispatch_ref"'
 IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD = '-f sha="$MERGE_COMMIT_SHA"'
 MAIN_RELEASABILITY_DISPATCH_COMMAND = "gh workflow run main-releasability.yml"
+MAIN_RELEASABILITY_DISPATCH_TOKENS = (
+    (
+        "gh",
+        "workflow",
+        "run",
+        "main-releasability.yml",
+        "--ref",
+        "$dispatch_ref",
+        "-f",
+        "expected_sha=$MERGE_COMMIT_SHA",
+    ),
+    (
+        "gh",
+        "workflow",
+        "run",
+        "main-releasability.yml",
+        "--ref",
+        "$dispatch_ref",
+        "-f",
+        "expected_sha=$MERGE_COMMIT_SHA",
+        "-f",
+        "triggering_pr=$PR_NUMBER",
+    ),
+)
 PR_TEMPLATE_REQUIRED_TOKENS = {
     "summary": "## Summary",
     "risk": "## Risk / Rollback",
@@ -479,6 +504,10 @@ def _main_releasability_dispatch_commands(text: str) -> list[tuple[int, str]]:
 
 def _is_exact_main_releasability_dispatch_command(command: str) -> bool:
     normalized_command = " ".join(command.split())
+    try:
+        command_tokens = shlex.split(normalized_command)
+    except ValueError:
+        return False
     return (
         (
             normalized_command == MAIN_RELEASABILITY_DISPATCH_COMMAND
@@ -490,6 +519,7 @@ def _is_exact_main_releasability_dispatch_command(command: str) -> bool:
         and not normalized_command.rstrip().endswith("&")
         and '--ref "$dispatch_ref"' in normalized_command
         and '-f expected_sha="$MERGE_COMMIT_SHA"' in normalized_command
+        and tuple(command_tokens) in MAIN_RELEASABILITY_DISPATCH_TOKENS
     )
 
 
@@ -837,7 +867,8 @@ def merged_pr_main_releasability_dispatch_violations(
         elif not _dispatches_after_absent_ref_creation(dispatch_contract_text):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must run the main releasability dispatch "
-                "only after the absent immutable-ref creation branch has completed"
+                "only after the absent immutable-ref creation branch has completed, using the "
+                "exact same-repository command without repository overrides"
             )
 
     if main_releasability.exists():

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -345,6 +345,8 @@ def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
     condition_depth = 1
     for index, line in enumerate(then_arm):
         stripped_line = line.strip()
+        if condition_depth == 1 and stripped_line.startswith("existing_ref_sha="):
+            return False
         if stripped_line != IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION or condition_depth != 1:
             if _opens_nested_shell_scope(stripped_line):
                 condition_depth += 1
@@ -437,7 +439,8 @@ def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
         if _closes_nested_shell_scope(stripped_line):
             depth -= 1
     return (
-        bool(guarded_creation_commands)
+        len(creation_commands) == 1
+        and len(guarded_creation_commands) == 1
         and len(guarded_creation_commands) == len(creation_commands)
         and all(
             _is_exact_immutable_ref_creation_command(command)

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -30,6 +30,7 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
 USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?([^\"'\s#]+)", re.MULTILINE)
 VERSION_TAG_PATTERN = re.compile(r"^v\d+(?:\.\d+){0,2}$")
 FULL_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
+HERE_DOCUMENT_START_PATTERN = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
 IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS = (
     (
         'if existing_ref_sha="$(gh api '
@@ -174,6 +175,21 @@ def _step_block(text: str, step_name: str) -> str:
     next_step = text.find("\n      - ", start + 1)
     end = next_step if next_step != -1 else len(text)
     return text[start:end]
+
+
+def _strip_shell_here_document_bodies(text: str) -> str:
+    executable_lines: list[str] = []
+    active_delimiter: str | None = None
+    for line in text.splitlines():
+        if active_delimiter is not None:
+            if line.strip() == active_delimiter:
+                active_delimiter = None
+            continue
+        executable_lines.append(line)
+        heredoc_match = HERE_DOCUMENT_START_PATTERN.search(line)
+        if heredoc_match:
+            active_delimiter = heredoc_match.group(2)
+    return "\n".join(executable_lines)
 
 
 def _strip_shell_inline_comment(stripped_line: str) -> str:
@@ -826,7 +842,9 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{dispatcher.as_posix()}: dispatcher must not set continue-on-error on "
                 "the governed main releasability dispatch step"
             )
-        dispatch_contract_text = dispatch_step_text or dispatcher_text
+        dispatch_contract_text = _strip_shell_here_document_bodies(
+            dispatch_step_text or dispatcher_text
+        )
         required_tokens = {
             "pull_request_target:": "dispatcher must run from pull_request_target close events",
             "types: [closed]": "dispatcher must be limited to closed pull request events",

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -319,6 +319,13 @@ def merged_pr_main_releasability_dispatch_violations(
             'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"': (
                 "dispatcher must create an immutable dispatch ref for the merged PR SHA"
             ),
+            'existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref"': (
+                "dispatcher must treat a missing immutable ref as absent without capturing the "
+                "404 response body as a ref SHA"
+            ),
+            "Dispatch ref $dispatch_ref points to $existing_ref_sha": (
+                "dispatcher must fail closed if an existing dispatch ref points to a different SHA"
+            ),
             'gh api "repos/$GITHUB_REPOSITORY/git/refs"': (
                 "dispatcher must create the immutable dispatch ref before workflow dispatch"
             ),
@@ -335,6 +342,12 @@ def merged_pr_main_releasability_dispatch_violations(
         for token, reason in required_tokens.items():
             if token not in dispatcher_text:
                 violations.append(f"{dispatcher.as_posix()}: {reason}")
+        if "git/ref/tags/$dispatch_ref" in dispatcher_text and "|| true" in dispatcher_text:
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must not mask immutable-ref lookup "
+                "failures with `|| true` because GitHub 404 response bodies can be captured as "
+                "existing ref SHAs"
+            )
 
     if main_releasability.exists():
         main_text = main_releasability.read_text(encoding="utf-8")

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -204,6 +204,7 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
             command == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
             or command.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
         )
+        and "||" not in command
         and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in command
     )
@@ -239,9 +240,16 @@ def _immutable_ref_lookup_blocks(text: str) -> list[str]:
 def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
     lines = text.splitlines()
     blocks: list[str] = []
+    outer_depth = 0
     for index, line in enumerate(lines):
         stripped_line = line.strip()
-        if stripped_line not in IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS:
+        if stripped_line not in IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS or outer_depth != 0:
+            if not stripped_line or _is_shell_comment(stripped_line):
+                continue
+            if _opens_nested_shell_scope(stripped_line):
+                outer_depth += 1
+            if _closes_nested_shell_scope(stripped_line):
+                outer_depth -= 1
             continue
 
         block_lines = [line]
@@ -256,6 +264,10 @@ def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
             if depth == 0:
                 break
         blocks.append("\n".join(block_lines))
+        if _opens_nested_shell_scope(stripped_line):
+            outer_depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            outer_depth -= 1
     return blocks
 
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -179,16 +179,16 @@ def _step_block(text: str, step_name: str) -> str:
 
 def _strip_shell_here_document_bodies(text: str) -> str:
     executable_lines: list[str] = []
-    active_delimiter: str | None = None
+    active_delimiters: list[str] = []
     for line in text.splitlines():
-        if active_delimiter is not None:
-            if line.strip() == active_delimiter:
-                active_delimiter = None
+        if active_delimiters:
+            if line.strip() == active_delimiters[0]:
+                active_delimiters.pop(0)
             continue
         executable_lines.append(line)
-        heredoc_match = HERE_DOCUMENT_START_PATTERN.search(line)
-        if heredoc_match:
-            active_delimiter = heredoc_match.group(2)
+        active_delimiters.extend(
+            match.group(2) for match in HERE_DOCUMENT_START_PATTERN.finditer(line)
+        )
     return "\n".join(executable_lines)
 
 
@@ -267,6 +267,8 @@ def _has_disallowed_immutable_ref_creation_override(command: str) -> bool:
     tokens = command.split()
     for index, token in enumerate(tokens):
         if token == "--input" or token.startswith("--input="):
+            return True
+        if token == "--hostname" or token.startswith("--hostname="):
             return True
         if token == "--method":
             return index + 1 >= len(tokens) or tokens[index + 1].upper() != "POST"

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -161,7 +161,7 @@ def _immutable_ref_lookup_guard_blocks(text: str) -> list[str]:
     return blocks
 
 
-def _outer_lookup_else_arm(block: str) -> str:
+def _outer_lookup_else_arm_has_unconditional_reset(block: str) -> bool:
     lines = block.splitlines()
     else_index: int | None = None
     depth = 1
@@ -176,20 +176,20 @@ def _outer_lookup_else_arm(block: str) -> str:
             depth -= 1
 
     if else_index is None:
-        return ""
+        return False
 
-    else_lines: list[str] = []
     depth = 1
     for line in lines[else_index + 1 :]:
         stripped = line.strip()
-        if stripped.startswith("if "):
-            depth += 1
         if stripped == "fi":
             depth -= 1
             if depth == 0:
                 break
-        else_lines.append(line)
-    return "\n".join(else_lines)
+        if depth == 1 and stripped == 'existing_ref_sha=""':
+            return True
+        if stripped.startswith("if "):
+            depth += 1
+    return False
 
 
 def _is_conditionally_guarded_immutable_ref_lookup_block(block: str) -> bool:
@@ -197,7 +197,7 @@ def _is_conditionally_guarded_immutable_ref_lookup_block(block: str) -> bool:
         "git/ref/tags/$dispatch_ref" in block
         and "\n" in block
         and "else" in block
-        and 'existing_ref_sha=""' in _outer_lookup_else_arm(block)
+        and _outer_lookup_else_arm_has_unconditional_reset(block)
         and block.strip().endswith("fi")
     )
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -199,6 +199,7 @@ def _immutable_ref_creation_commands(text: str) -> list[str]:
 
 
 def _is_exact_immutable_ref_creation_command(command: str) -> bool:
+    padded_command = f" {command} "
     return (
         (
             command == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
@@ -206,6 +207,9 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
         )
         and "||" not in command
         and not command.rstrip().endswith("&")
+        and "--method" not in padded_command
+        and " -X" not in padded_command
+        and "--input" not in padded_command
         and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in command
     )

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -369,11 +369,11 @@ def merged_pr_main_releasability_dispatch_violations(
         for token, reason in required_tokens.items():
             if token not in dispatcher_text:
                 violations.append(f"{dispatcher.as_posix()}: {reason}")
-        if any("|| true" in block for block in _immutable_ref_lookup_blocks(dispatcher_text)):
+        if any("||" in block for block in _immutable_ref_lookup_blocks(dispatcher_text)):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must not mask immutable-ref lookup "
-                "failures with `|| true` because GitHub 404 response bodies can be captured as "
-                "existing ref SHAs"
+                "failures with shell OR fallbacks because GitHub 404 response bodies can be "
+                "captured as existing ref SHAs"
             )
 
     if main_releasability.exists():

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -44,6 +44,8 @@ IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS = (
 IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION = (
     'if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then'
 )
+IMMUTABLE_DISPATCH_REF_CREATION_CONDITION = 'if [ -z "$existing_ref_sha" ]; then'
+IMMUTABLE_DISPATCH_REF_CREATION_COMMAND = 'gh api "repos/$GITHUB_REPOSITORY/git/refs"'
 PR_TEMPLATE_REQUIRED_TOKENS = {
     "summary": "## Summary",
     "risk": "## Risk / Rollback",
@@ -302,6 +304,40 @@ def _guarded_lookup_success_arms_fail_on_ref_mismatch(text: str) -> bool:
     )
 
 
+def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
+    lines = text.splitlines()
+    depth = 0
+    for index, line in enumerate(lines):
+        stripped_line = line.strip()
+        if stripped_line == IMMUTABLE_DISPATCH_REF_CREATION_CONDITION and depth == 0:
+            direct_executable_commands: list[str] = []
+            creation_depth = 1
+            for follow in lines[index + 1 :]:
+                stripped_follow = follow.strip()
+                if stripped_follow == "fi" and creation_depth == 1:
+                    break
+                if not stripped_follow or _is_shell_comment(stripped_follow):
+                    continue
+                if creation_depth == 1:
+                    direct_executable_commands.append(stripped_follow)
+                if _opens_nested_shell_scope(stripped_follow):
+                    creation_depth += 1
+                if _closes_nested_shell_scope(stripped_follow):
+                    creation_depth -= 1
+            return any(
+                command == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
+                or command.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
+                for command in direct_executable_commands
+            )
+        if not stripped_line or _is_shell_comment(stripped_line):
+            continue
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
+    return False
+
+
 def permission_violations(workflow_path: Path) -> list[str]:
     expected = EXPECTED_WORKFLOW_PERMISSIONS.get(workflow_path.name)
     if expected is None:
@@ -547,6 +583,11 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{dispatcher.as_posix()}: dispatcher must not mask immutable-ref lookup "
                 "failures with shell OR fallbacks because GitHub 404 response bodies can be "
                 "captured as existing ref SHAs"
+            )
+        if not _conditionally_creates_absent_immutable_ref(dispatcher_text):
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must create the immutable dispatch ref only "
+                "inside the empty existing-ref branch so reruns do not recreate an existing tag"
             )
 
     if main_releasability.exists():

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -588,6 +588,59 @@ def _is_exact_main_releasability_dispatch_command(command: str) -> bool:
     )
 
 
+def _disables_shell_errexit(stripped_line: str) -> bool:
+    try:
+        tokens = shlex.split(stripped_line)
+    except ValueError:
+        return False
+    if not tokens or tokens[0] != "set":
+        return False
+    if "+e" in tokens:
+        return True
+    return any(
+        token.startswith("+") and "e" in token[1:] for token in tokens if token not in {"+o"}
+    ) or any(tokens[index : index + 2] == ["+o", "errexit"] for index in range(len(tokens) - 1))
+
+
+def _dispatch_preserves_step_failure_status(
+    text: str,
+    *,
+    dispatch_command_end_index: int,
+) -> bool:
+    lines = text.splitlines()
+    depth = 0
+    for line in lines[: dispatch_command_end_index + 1]:
+        stripped_line = line.strip()
+        if not stripped_line or _is_shell_comment(stripped_line):
+            continue
+        if depth == 0 and _disables_shell_errexit(stripped_line):
+            return False
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
+
+    for line in lines[dispatch_command_end_index + 1 :]:
+        stripped_line = line.strip()
+        if not stripped_line or _is_shell_comment(stripped_line):
+            continue
+        if depth == 0:
+            return False
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
+    return True
+
+
+def _main_releasability_dispatch_failure_status_is_preserved(text: str) -> bool:
+    dispatch_commands = _main_releasability_dispatch_commands(text)
+    return len(dispatch_commands) == 1 and _dispatch_preserves_step_failure_status(
+        text,
+        dispatch_command_end_index=dispatch_commands[0][0],
+    )
+
+
 def _absent_ref_creation_block_end_index(text: str) -> int | None:
     lines = text.splitlines()
     depth = 0
@@ -976,6 +1029,12 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{dispatcher.as_posix()}: dispatcher must run the main releasability dispatch "
                 "only after the absent immutable-ref creation branch has completed, using the "
                 "exact same-repository command without repository overrides"
+            )
+        elif not _main_releasability_dispatch_failure_status_is_preserved(dispatch_contract_text):
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must preserve the main releasability "
+                "dispatch command failure as the step status; do not disable errexit before "
+                "dispatch or run trailing success commands after dispatch"
             )
 
     if main_releasability.exists():

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -31,6 +31,7 @@ USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?([^\"'\s#]+)", re.MULTILI
 VERSION_TAG_PATTERN = re.compile(r"^v\d+(?:\.\d+){0,2}$")
 FULL_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 HERE_DOCUMENT_START_PATTERN = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+SHELL_TIME_PREFIX_PATTERN = re.compile(r"^time(?:\s+-p)?\s+(.+)$")
 IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS = (
     (
         'if existing_ref_sha="$(gh api '
@@ -105,15 +106,16 @@ PR_TEMPLATE_REQUIRED_TOKENS = {
 
 
 def _opens_nested_shell_scope(stripped_line: str) -> bool:
+    scope_line = _strip_shell_time_prefix(stripped_line)
     return (
-        stripped_line == "("
-        or stripped_line.startswith("(")
-        or re.search(r"(?:^|[;&|]\s*)\(", stripped_line) is not None
-        or stripped_line.startswith(("if ", "for ", "while ", "until ", "case ", "select "))
-        or stripped_line.startswith("function ")
-        or stripped_line.endswith("() {")
-        or stripped_line.endswith("(){")
-        or stripped_line.endswith(" {")
+        scope_line == "("
+        or scope_line.startswith("(")
+        or re.search(r"(?:^|[;&|]\s*)\(", scope_line) is not None
+        or scope_line.startswith(("if ", "for ", "while ", "until ", "case ", "select "))
+        or scope_line.startswith("function ")
+        or scope_line.endswith("() {")
+        or scope_line.endswith("(){")
+        or scope_line.endswith(" {")
     )
 
 
@@ -123,6 +125,11 @@ def _closes_nested_shell_scope(stripped_line: str) -> bool:
 
 def _is_shell_comment(stripped_line: str) -> bool:
     return stripped_line.startswith("#")
+
+
+def _strip_shell_time_prefix(stripped_line: str) -> str:
+    match = SHELL_TIME_PREFIX_PATTERN.match(stripped_line)
+    return match.group(1) if match else stripped_line
 
 
 def _workflow_files(workflow_dir: Path = WORKFLOW_DIR) -> list[Path]:
@@ -214,6 +221,17 @@ def _has_compound_prefixed_subshell_scope(text: str) -> bool:
         re.search(r"(?:&&|\|\|)\s*\(", _strip_shell_inline_comment(line.strip())) is not None
         for line in text.splitlines()
     )
+
+
+def _has_time_prefixed_compound_scope(text: str) -> bool:
+    for line in text.splitlines():
+        stripped_line = _strip_shell_inline_comment(line.strip())
+        if not stripped_line:
+            continue
+        unprefixed_line = _strip_shell_time_prefix(stripped_line)
+        if unprefixed_line != stripped_line and _opens_nested_shell_scope(unprefixed_line):
+            return True
+    return False
 
 
 def _strip_shell_inline_comment(stripped_line: str) -> str:
@@ -923,6 +941,12 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{dispatcher.as_posix()}: dispatcher must not place the governed lookup, "
                 "creation, and dispatch body behind a compound-prefixed subshell such as "
                 "`false && (...) || true`"
+            )
+        if _has_time_prefixed_compound_scope(dispatch_contract_text):
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must not place the governed lookup, "
+                "creation, and dispatch body behind a time-prefixed compound command such as "
+                "`time if ...; then`"
             )
         if not _has_conditionally_guarded_immutable_ref_lookup(dispatch_contract_text):
             violations.append(

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -56,6 +56,8 @@ MAIN_RELEASABILITY_DISPATCH_TOKENS = (
         "workflow",
         "run",
         "main-releasability.yml",
+        "--repo",
+        "$GITHUB_REPOSITORY",
         "--ref",
         "$dispatch_ref",
         "-f",
@@ -66,6 +68,8 @@ MAIN_RELEASABILITY_DISPATCH_TOKENS = (
         "workflow",
         "run",
         "main-releasability.yml",
+        "--repo",
+        "$GITHUB_REPOSITORY",
         "--ref",
         "$dispatch_ref",
         "-f",
@@ -517,6 +521,7 @@ def _is_exact_main_releasability_dispatch_command(command: str) -> bool:
         and "&&" not in normalized_command
         and ";" not in normalized_command
         and not normalized_command.rstrip().endswith("&")
+        and '--repo "$GITHUB_REPOSITORY"' in normalized_command
         and '--ref "$dispatch_ref"' in normalized_command
         and '-f expected_sha="$MERGE_COMMIT_SHA"' in normalized_command
         and tuple(command_tokens) in MAIN_RELEASABILITY_DISPATCH_TOKENS

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -41,6 +41,9 @@ IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS = (
         '--jq .object.sha 2>/dev/null)"; then'
     ),
 )
+IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION = (
+    'if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then'
+)
 PR_TEMPLATE_REQUIRED_TOKENS = {
     "summary": "## Summary",
     "risk": "## Risk / Rollback",
@@ -208,6 +211,41 @@ def _outer_lookup_else_arm_has_unconditional_reset(block: str) -> bool:
     return executable_commands == ['existing_ref_sha=""']
 
 
+def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
+    lines = block.splitlines()
+    then_arm: list[str] = []
+    depth = 1
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "else" and depth == 1:
+            break
+        then_arm.append(line)
+        if stripped.startswith("if "):
+            depth += 1
+        if stripped == "fi":
+            depth -= 1
+
+    for index, line in enumerate(then_arm):
+        if line.strip() != IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION:
+            continue
+
+        executable_commands: list[str] = []
+        depth = 1
+        for follow in then_arm[index + 1 :]:
+            stripped_follow = follow.strip()
+            if stripped_follow == "fi" and depth == 1:
+                break
+            if not stripped_follow or stripped_follow.startswith("#"):
+                continue
+            executable_commands.append(stripped_follow)
+            if stripped_follow.startswith("if "):
+                depth += 1
+            if stripped_follow == "fi":
+                depth -= 1
+        return "exit 1" in executable_commands
+    return False
+
+
 def _is_conditionally_guarded_immutable_ref_lookup_block(block: str) -> bool:
     return (
         _contains_immutable_dispatch_ref_lookup(block)
@@ -227,6 +265,13 @@ def _has_conditionally_guarded_immutable_ref_lookup(text: str) -> bool:
         and all(
             _is_conditionally_guarded_immutable_ref_lookup_block(block) for block in guarded_blocks
         )
+    )
+
+
+def _guarded_lookup_success_arms_fail_on_ref_mismatch(text: str) -> bool:
+    guarded_blocks = _immutable_ref_lookup_guard_blocks(text)
+    return bool(guarded_blocks) and all(
+        _outer_lookup_then_arm_has_mismatch_exit(block) for block in guarded_blocks
     )
 
 
@@ -464,6 +509,11 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{dispatcher.as_posix()}: dispatcher must guard immutable-ref lookup with "
                 "an if/else reset so a missing ref is treated as absent instead of terminating "
                 "the workflow or capturing an error body as an existing ref SHA"
+            )
+        elif not _guarded_lookup_success_arms_fail_on_ref_mismatch(dispatcher_text):
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must fail closed with exit 1 when an "
+                "existing immutable dispatch ref points to a different SHA"
             )
         if any("||" in block for block in _immutable_ref_lookup_blocks(dispatcher_text)):
             violations.append(

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -103,7 +103,7 @@ def _opens_nested_shell_scope(stripped_line: str) -> bool:
     return (
         stripped_line == "("
         or stripped_line.startswith("(")
-        or stripped_line.startswith(("if ", "for ", "while ", "until ", "case "))
+        or stripped_line.startswith(("if ", "for ", "while ", "until ", "case ", "select "))
         or stripped_line.startswith("function ")
         or stripped_line.endswith("() {")
         or stripped_line.endswith("(){")
@@ -562,14 +562,24 @@ def _absent_ref_creation_block_end_index(text: str) -> int | None:
     return None
 
 
-def _has_dispatch_ref_reassignment_between(text: str, *, start_index: int, end_index: int) -> bool:
+def _has_protected_variable_reassignment_between(
+    text: str,
+    *,
+    start_index: int,
+    end_index: int,
+    protected_variables: set[str],
+) -> bool:
     lines = text.splitlines()
     depth = 0
     for line in lines[start_index + 1 : end_index + 1]:
         stripped_line = line.strip()
         if not stripped_line or _is_shell_comment(stripped_line):
             continue
-        if depth == 0 and stripped_line.startswith("dispatch_ref="):
+        if depth == 0 and any(
+            stripped_line.startswith(f"{variable}=")
+            or stripped_line.startswith(f"export {variable}=")
+            for variable in protected_variables
+        ):
             return True
         if _opens_nested_shell_scope(stripped_line):
             depth += 1
@@ -585,10 +595,17 @@ def _dispatches_after_absent_ref_creation(text: str) -> bool:
         len(dispatch_commands) == 1
         and creation_block_end_index is not None
         and dispatch_commands[0][0] > creation_block_end_index
-        and not _has_dispatch_ref_reassignment_between(
+        and not _has_protected_variable_reassignment_between(
+            text,
+            start_index=-1,
+            end_index=dispatch_commands[0][0],
+            protected_variables={"MERGE_COMMIT_SHA"},
+        )
+        and not _has_protected_variable_reassignment_between(
             text,
             start_index=creation_block_end_index,
             end_index=dispatch_commands[0][0],
+            protected_variables={"dispatch_ref"},
         )
         and _is_exact_main_releasability_dispatch_command(dispatch_commands[0][1])
     )

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -71,7 +71,9 @@ PR_TEMPLATE_REQUIRED_TOKENS = {
 
 def _opens_nested_shell_scope(stripped_line: str) -> bool:
     return (
-        stripped_line.startswith(("if ", "for ", "while ", "until ", "case "))
+        stripped_line == "("
+        or stripped_line.startswith("(")
+        or stripped_line.startswith(("if ", "for ", "while ", "until ", "case "))
         or stripped_line.startswith("function ")
         or stripped_line.endswith("() {")
         or stripped_line.endswith("(){")
@@ -80,7 +82,11 @@ def _opens_nested_shell_scope(stripped_line: str) -> bool:
 
 
 def _closes_nested_shell_scope(stripped_line: str) -> bool:
-    return stripped_line in {"fi", "done", "esac", "}"}
+    return stripped_line in {"fi", "done", "esac", "}"} or stripped_line.startswith(")")
+
+
+def _is_shell_comment(stripped_line: str) -> bool:
+    return stripped_line.startswith("#")
 
 
 def _workflow_files(workflow_dir: Path = WORKFLOW_DIR) -> list[Path]:
@@ -146,11 +152,11 @@ def _immutable_ref_lookup_blocks(text: str) -> list[str]:
     lines = text.splitlines()
     blocks: list[str] = []
     for index, line in enumerate(lines):
-        if not _contains_immutable_dispatch_ref_lookup(line):
+        stripped_line = line.strip()
+        if _is_shell_comment(stripped_line) or not _contains_immutable_dispatch_ref_lookup(line):
             continue
 
         block_lines = [line]
-        stripped_line = line.strip()
         if (
             stripped_line == "then"
             or stripped_line.endswith("; then")

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -48,6 +48,7 @@ IMMUTABLE_DISPATCH_REF_CREATION_CONDITION = 'if [ -z "$existing_ref_sha" ]; then
 IMMUTABLE_DISPATCH_REF_CREATION_COMMAND = 'gh api "repos/$GITHUB_REPOSITORY/git/refs"'
 IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD = '-f ref="refs/tags/$dispatch_ref"'
 IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD = '-f sha="$MERGE_COMMIT_SHA"'
+MAIN_RELEASABILITY_DISPATCH_COMMAND = "gh workflow run main-releasability.yml"
 PR_TEMPLATE_REQUIRED_TOKENS = {
     "summary": "## Summary",
     "risk": "## Risk / Rollback",
@@ -199,7 +200,6 @@ def _immutable_ref_creation_commands(text: str) -> list[str]:
 
 
 def _is_exact_immutable_ref_creation_command(command: str) -> bool:
-    padded_command = f" {command} "
     return (
         (
             command == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
@@ -207,12 +207,26 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
         )
         and "||" not in command
         and not command.rstrip().endswith("&")
-        and "--method" not in padded_command
-        and " -X" not in padded_command
-        and "--input" not in padded_command
+        and not _has_disallowed_immutable_ref_creation_override(command)
         and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in command
         and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in command
     )
+
+
+def _has_disallowed_immutable_ref_creation_override(command: str) -> bool:
+    tokens = command.split()
+    for index, token in enumerate(tokens):
+        if token == "--input" or token.startswith("--input="):
+            return True
+        if token == "--method":
+            return index + 1 >= len(tokens) or tokens[index + 1].upper() != "POST"
+        if token.startswith("--method="):
+            return token.partition("=")[2].upper() != "POST"
+        if token == "-X":
+            return index + 1 >= len(tokens) or tokens[index + 1].upper() != "POST"
+        if token.startswith("-X") and len(token) > 2:
+            return token[2:].upper() != "POST"
+    return False
 
 
 def _immutable_ref_lookup_blocks(text: str) -> list[str]:
@@ -424,6 +438,71 @@ def _conditionally_creates_absent_immutable_ref(text: str) -> bool:
             _is_exact_immutable_ref_creation_command(command)
             for command in guarded_creation_commands
         )
+    )
+
+
+def _main_releasability_dispatch_command_indices(text: str) -> list[int]:
+    lines = text.splitlines()
+    indices: list[int] = []
+    index = 0
+    while index < len(lines):
+        stripped_line = lines[index].strip()
+        if not _is_shell_comment(stripped_line) and (
+            stripped_line == MAIN_RELEASABILITY_DISPATCH_COMMAND
+            or stripped_line.startswith(f"{MAIN_RELEASABILITY_DISPATCH_COMMAND} ")
+        ):
+            _, index = _continued_shell_command(lines, index)
+            indices.append(index)
+        index += 1
+    return indices
+
+
+def _absent_ref_creation_block_end_index(text: str) -> int | None:
+    lines = text.splitlines()
+    depth = 0
+    for index, line in enumerate(lines):
+        stripped_line = line.strip()
+        if stripped_line == IMMUTABLE_DISPATCH_REF_CREATION_CONDITION and depth == 0:
+            saw_creation_command = False
+            creation_depth = 1
+            follow_index = index + 1
+            while follow_index < len(lines):
+                follow = lines[follow_index]
+                stripped_follow = follow.strip()
+                if stripped_follow == "fi" and creation_depth == 1:
+                    return follow_index if saw_creation_command else None
+                if not stripped_follow or _is_shell_comment(stripped_follow):
+                    follow_index += 1
+                    continue
+                if creation_depth == 1 and (
+                    stripped_follow == IMMUTABLE_DISPATCH_REF_CREATION_COMMAND
+                    or stripped_follow.startswith(f"{IMMUTABLE_DISPATCH_REF_CREATION_COMMAND} ")
+                ):
+                    command, follow_index = _continued_shell_command(lines, follow_index)
+                    saw_creation_command = _is_exact_immutable_ref_creation_command(command)
+                    follow_index += 1
+                    continue
+                if _opens_nested_shell_scope(stripped_follow):
+                    creation_depth += 1
+                if _closes_nested_shell_scope(stripped_follow):
+                    creation_depth -= 1
+                follow_index += 1
+        if not stripped_line or _is_shell_comment(stripped_line):
+            continue
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
+    return None
+
+
+def _dispatches_after_absent_ref_creation(text: str) -> bool:
+    dispatch_indices = _main_releasability_dispatch_command_indices(text)
+    creation_block_end_index = _absent_ref_creation_block_end_index(text)
+    return (
+        len(dispatch_indices) == 1
+        and creation_block_end_index is not None
+        and dispatch_indices[0] > creation_block_end_index
     )
 
 
@@ -696,6 +775,11 @@ def merged_pr_main_releasability_dispatch_violations(
                 f"{dispatcher.as_posix()}: dispatcher must create the immutable dispatch ref only "
                 "inside the empty existing-ref branch with exact ref and SHA fields so reruns do "
                 "not recreate an existing tag or dispatch the wrong revision"
+            )
+        elif not _dispatches_after_absent_ref_creation(dispatch_contract_text):
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must run the main releasability dispatch "
+                "only after the absent immutable-ref creation branch has completed"
             )
 
     if main_releasability.exists():

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -239,8 +239,14 @@ def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
         if stripped == "fi":
             depth -= 1
 
+    condition_depth = 1
     for index, line in enumerate(then_arm):
-        if line.strip() != IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION:
+        stripped_line = line.strip()
+        if stripped_line != IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION or condition_depth != 1:
+            if _opens_nested_shell_scope(stripped_line):
+                condition_depth += 1
+            if _closes_nested_shell_scope(stripped_line):
+                condition_depth -= 1
             continue
 
         direct_executable_commands: list[str] = []

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -178,14 +178,20 @@ def _outer_lookup_else_arm_has_unconditional_reset(block: str) -> bool:
     if else_index is None:
         return False
 
+    executable_commands: list[str] = []
+    depth = 1
     for line in lines[else_index + 1 :]:
         stripped = line.strip()
-        if stripped == "fi":
+        if stripped == "fi" and depth == 1:
             break
         if not stripped or stripped.startswith("#"):
             continue
-        return stripped == 'existing_ref_sha=""'
-    return False
+        executable_commands.append(stripped)
+        if stripped.startswith("if "):
+            depth += 1
+        if stripped == "fi":
+            depth -= 1
+    return executable_commands == ['existing_ref_sha=""']
 
 
 def _is_conditionally_guarded_immutable_ref_lookup_block(block: str) -> bool:

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -532,6 +532,22 @@ def _absent_ref_creation_block_end_index(text: str) -> int | None:
     return None
 
 
+def _has_dispatch_ref_reassignment_between(text: str, *, start_index: int, end_index: int) -> bool:
+    lines = text.splitlines()
+    depth = 0
+    for line in lines[start_index + 1 : end_index + 1]:
+        stripped_line = line.strip()
+        if not stripped_line or _is_shell_comment(stripped_line):
+            continue
+        if depth == 0 and stripped_line.startswith("dispatch_ref="):
+            return True
+        if _opens_nested_shell_scope(stripped_line):
+            depth += 1
+        if _closes_nested_shell_scope(stripped_line):
+            depth -= 1
+    return False
+
+
 def _dispatches_after_absent_ref_creation(text: str) -> bool:
     dispatch_commands = _main_releasability_dispatch_commands(text)
     creation_block_end_index = _absent_ref_creation_block_end_index(text)
@@ -539,6 +555,11 @@ def _dispatches_after_absent_ref_creation(text: str) -> bool:
         len(dispatch_commands) == 1
         and creation_block_end_index is not None
         and dispatch_commands[0][0] > creation_block_end_index
+        and not _has_dispatch_ref_reassignment_between(
+            text,
+            start_index=creation_block_end_index,
+            end_index=dispatch_commands[0][0],
+        )
         and _is_exact_main_releasability_dispatch_command(dispatch_commands[0][1])
     )
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -192,14 +192,25 @@ def _outer_lookup_else_arm(block: str) -> str:
     return "\n".join(else_lines)
 
 
-def _has_conditionally_guarded_immutable_ref_lookup(text: str) -> bool:
-    return any(
+def _is_conditionally_guarded_immutable_ref_lookup_block(block: str) -> bool:
+    return (
         "git/ref/tags/$dispatch_ref" in block
         and "\n" in block
         and "else" in block
         and 'existing_ref_sha=""' in _outer_lookup_else_arm(block)
         and block.strip().endswith("fi")
-        for block in _immutable_ref_lookup_guard_blocks(text)
+    )
+
+
+def _has_conditionally_guarded_immutable_ref_lookup(text: str) -> bool:
+    lookup_blocks = _immutable_ref_lookup_blocks(text)
+    guarded_blocks = _immutable_ref_lookup_guard_blocks(text)
+    return (
+        bool(lookup_blocks)
+        and len(lookup_blocks) == len(guarded_blocks)
+        and all(
+            _is_conditionally_guarded_immutable_ref_lookup_block(block) for block in guarded_blocks
+        )
     )
 
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -109,6 +109,33 @@ def _step_block(text: str, step_name: str) -> str:
     return text[start:end]
 
 
+def _immutable_ref_lookup_blocks(text: str) -> list[str]:
+    lines = text.splitlines()
+    blocks: list[str] = []
+    for index, line in enumerate(lines):
+        if "git/ref/tags/$dispatch_ref" not in line:
+            continue
+
+        block_lines = [line]
+        stripped_line = line.strip()
+        if (
+            stripped_line == "then"
+            or stripped_line.endswith("; then")
+            or stripped_line.endswith(')"')
+        ):
+            blocks.append("\n".join(block_lines))
+            continue
+        for follow in lines[index + 1 :]:
+            block_lines.append(follow)
+            stripped = follow.strip()
+            if stripped == "then" or stripped.endswith("; then"):
+                break
+            if not follow.rstrip().endswith("\\") and stripped.endswith(')"'):
+                break
+        blocks.append("\n".join(block_lines))
+    return blocks
+
+
 def permission_violations(workflow_path: Path) -> list[str]:
     expected = EXPECTED_WORKFLOW_PERMISSIONS.get(workflow_path.name)
     if expected is None:
@@ -342,7 +369,7 @@ def merged_pr_main_releasability_dispatch_violations(
         for token, reason in required_tokens.items():
             if token not in dispatcher_text:
                 violations.append(f"{dispatcher.as_posix()}: {reason}")
-        if "git/ref/tags/$dispatch_ref" in dispatcher_text and "|| true" in dispatcher_text:
+        if any("|| true" in block for block in _immutable_ref_lookup_blocks(dispatcher_text)):
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must not mask immutable-ref lookup "
                 "failures with `|| true` because GitHub 404 response bodies can be captured as "

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -339,7 +339,10 @@ def test_merged_pr_dispatch_gate_accepts_guarded_braced_lookup(
                 "        run: |",
                 '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
                 '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"; then',
-                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
                 "          else",
                 '            existing_ref_sha=""',
                 "          fi",
@@ -645,6 +648,51 @@ def test_merged_pr_dispatch_gate_rejects_later_braced_unguarded_lookup(
 
     assert any(
         "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_non_failing_ref_mismatch_branch(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              :",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must fail closed with exit 1 when an existing immutable dispatch ref points to a different SHA"
+        in violation
         for violation in violations
     )
 

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -356,6 +356,46 @@ def test_merged_pr_dispatch_gate_accepts_guarded_braced_lookup(
     assert merged_pr_main_releasability_dispatch_violations(workflow_dir) == []
 
 
+def test_merged_pr_dispatch_gate_ignores_commented_ref_lookup(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                "          # Lookup repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref before creating it.",
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert merged_pr_main_releasability_dispatch_violations(workflow_dir) == []
+
+
 def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: Path) -> None:
     workflow_dir = tmp_path / "workflows"
     workflow_dir.mkdir()
@@ -819,6 +859,53 @@ def test_merged_pr_dispatch_gate_rejects_nested_ref_mismatch_condition(
                 "                exit 1",
                 "              fi",
                 "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must fail closed with exit 1 when an existing immutable dispatch ref points to a different SHA"
+        in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_subshell_masked_ref_mismatch_exit(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                "            (",
+                '              if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '                echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "                exit 1",
+                "              fi",
+                "            ) || true",
                 "          else",
                 '            existing_ref_sha=""',
                 "          fi",

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -334,7 +334,8 @@ def test_merged_pr_dispatch_gate_accepts_guarded_braced_lookup(
                 "      github.event.pull_request.merged == true &&",
                 "      github.event.pull_request.base.ref == 'main'",
                 "    steps:",
-                "      - env:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
                 "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
                 "        run: |",
                 '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
@@ -375,7 +376,8 @@ def test_merged_pr_dispatch_gate_ignores_commented_ref_lookup(
                 "      github.event.pull_request.merged == true &&",
                 "      github.event.pull_request.base.ref == 'main'",
                 "    steps:",
-                "      - env:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
                 "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
                 "        run: |",
                 '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
@@ -1005,6 +1007,154 @@ def test_merged_pr_dispatch_gate_rejects_wrong_ref_creation_payload(
                 "          fi",
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$WRONG_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_split_dispatch_run_steps(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                "      - name: Create and dispatch main releasability",
+                "        run: |",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref before workflow dispatch" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_trailing_ref_creation_after_guard(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_binds_payload_fields_to_creation_command(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs"',
+                '            printf "%s" \'-f ref="refs/tags/$dispatch_ref"\'',
+                '            printf "%s" \'-f sha="$MERGE_COMMIT_SHA"\'',
                 "          fi",
                 '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -412,6 +412,58 @@ def test_merged_pr_dispatch_gate_rejects_continue_on_error(
     )
 
 
+def test_merged_pr_dispatch_gate_ignores_here_document_payload(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                "          cat <<'EOF'",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                (
+                    '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" '
+                    '--ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"'
+                ),
+                "          EOF",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "dispatcher must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_repository_override(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -744,6 +744,53 @@ def test_merged_pr_dispatch_gate_rejects_nested_ref_mismatch_exit(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_function_body_ref_mismatch_exit(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              collision_failure() {",
+                "                exit 1",
+                "              }",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must fail closed with exit 1 when an existing immutable dispatch ref points to a different SHA"
+        in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_commented_else_reset(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -2183,6 +2183,35 @@ def test_merged_pr_dispatch_gate_rejects_or_masked_brace_group(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_compound_prefixed_subshell(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    workflow_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
+    workflow_text = workflow_text.replace(
+        "        run: |\n",
+        "        run: |\n          false && (\n",
+        1,
+    ).replace(
+        '            -f triggering_pr="$PR_NUMBER"',
+        '            -f triggering_pr="$PR_NUMBER"\n          ) || true',
+        1,
+    )
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        workflow_text,
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must not place the governed lookup, creation, and dispatch body behind "
+        "a compound-prefixed subshell" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_repository_variable_reassignment(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1363,6 +1363,55 @@ def test_merged_pr_dispatch_gate_rejects_nested_dispatch_command(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_dispatch_ref_reassignment_before_dispatch(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                "          dispatch_ref=main",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_trailing_ref_creation_after_guard(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -359,6 +359,60 @@ def test_merged_pr_dispatch_gate_accepts_guarded_braced_lookup(
     assert merged_pr_main_releasability_dispatch_violations(workflow_dir) == []
 
 
+def test_merged_pr_dispatch_gate_rejects_repository_override(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+
+    for override in ("--repo wrong/other", "-R wrong/other"):
+        (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+            "\n".join(
+                [
+                    "on:",
+                    "  pull_request_target:",
+                    "    types: [closed]",
+                    "jobs:",
+                    "  dispatch:",
+                    "    if: >",
+                    "      github.event.pull_request.merged == true &&",
+                    "      github.event.pull_request.base.ref == 'main'",
+                    "    steps:",
+                    "      - name: Dispatch main releasability gate",
+                    "        env:",
+                    "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                    "        run: |",
+                    '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                    '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"; then',
+                    '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                    '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                    "              exit 1",
+                    "            fi",
+                    "          else",
+                    '            existing_ref_sha=""',
+                    "          fi",
+                    '          if [ -z "$existing_ref_sha" ]; then',
+                    '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                    "          fi",
+                    (
+                        '          gh workflow run main-releasability.yml --ref "$dispatch_ref" '
+                        f'-f expected_sha="$MERGE_COMMIT_SHA" {override}'
+                    ),
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+        assert any(
+            "dispatcher must run the main releasability dispatch only after the absent immutable-ref "
+            "creation branch has completed, using the exact same-repository command without "
+            "repository overrides" in violation
+            for violation in violations
+        )
+
+
 def test_merged_pr_dispatch_gate_ignores_commented_ref_lookup(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1169,6 +1169,104 @@ def test_merged_pr_dispatch_gate_rejects_split_unnamed_run_step(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_masked_dispatch_failure(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA" || true',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_nested_dispatch_command(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                "          if false; then",
+                '            gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_trailing_ref_creation_after_guard(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1313,6 +1313,54 @@ def test_merged_pr_dispatch_gate_rejects_backgrounded_ref_creation(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_chained_ref_creation_command(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" ; exit 0',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_non_post_ref_creation_override(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1217,6 +1217,103 @@ def test_merged_pr_dispatch_gate_rejects_payload_fields_in_inline_comment(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_masked_ref_creation_failure(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" || true',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_function_scoped_lookup_guard(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                "          lookup_dispatch_ref() {",
+                '            if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '              if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '                echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "                exit 1",
+                "              fi",
+                "            else",
+                '              existing_ref_sha=""',
+                "            fi",
+                "          }",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_binds_payload_fields_to_creation_command(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -698,6 +698,48 @@ def test_merged_pr_dispatch_gate_rejects_function_body_else_reset(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_trailing_else_command(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            existing_ref_sha=""',
+                '            gh api "repos/$GITHUB_REPOSITORY/actions/runs?per_page=1" >/dev/null',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1265,6 +1265,54 @@ def test_merged_pr_dispatch_gate_rejects_masked_ref_creation_failure(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_backgrounded_ref_creation(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" &',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_function_scoped_lookup_guard(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -289,9 +289,11 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "contents: write" in dispatcher_text
     assert 'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"' in dispatcher_text
     assert (
-        'existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref"'
+        'if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref"'
         in dispatcher_text
     )
+    assert "else" in dispatcher_text
+    assert 'existing_ref_sha=""' in dispatcher_text
     assert "Dispatch ref $dispatch_ref points to $existing_ref_sha" in dispatcher_text
     assert 'gh api "repos/$GITHUB_REPOSITORY/git/refs"' in dispatcher_text
     assert "gh workflow run main-releasability.yml" in dispatcher_text
@@ -447,7 +449,7 @@ def test_merged_pr_dispatch_gate_rejects_equivalent_masked_dispatch_ref_lookup(
     )
 
 
-def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
+def test_merged_pr_dispatch_gate_rejects_unguarded_dispatch_ref_lookup(
     tmp_path: Path,
 ) -> None:
     workflow_dir = tmp_path / "workflows"
@@ -472,6 +474,47 @@ def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
                 '          echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
                 '          gh api "repos/$GITHUB_REPOSITORY/actions/runs?per_page=1" >/dev/null || true',
             ]
         ),
@@ -482,6 +525,10 @@ def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
 
     assert not any(
         "must not mask immutable-ref lookup failures with shell OR fallbacks" in violation
+        for violation in violations
+    )
+    assert not any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
         for violation in violations
     )
 

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -346,7 +346,9 @@ def test_merged_pr_dispatch_gate_accepts_guarded_braced_lookup(
                 "          else",
                 '            existing_ref_sha=""',
                 "          fi",
-                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
                 '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
@@ -386,7 +388,9 @@ def test_merged_pr_dispatch_gate_ignores_commented_ref_lookup(
                 "          else",
                 '            existing_ref_sha=""',
                 "          fi",
-                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
                 '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
@@ -920,6 +924,51 @@ def test_merged_pr_dispatch_gate_rejects_subshell_masked_ref_mismatch_exit(
 
     assert any(
         "must fail closed with exit 1 when an existing immutable dispatch ref points to a different SHA"
+        in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_unconditional_ref_creation(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch"
         in violation
         for violation in violations
     )

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1361,6 +1361,77 @@ def test_merged_pr_dispatch_gate_rejects_non_post_ref_creation_override(
     )
 
 
+def test_merged_pr_dispatch_gate_allows_explicit_post_ref_creation_method(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        MERGED_PR_DISPATCHER.read_text(encoding="utf-8").replace(
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\',
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" --method POST \\',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert not any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_dispatch_before_ref_creation(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_function_scoped_lookup_guard(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -405,7 +405,44 @@ def test_merged_pr_dispatch_gate_rejects_masked_dispatch_ref_lookup(tmp_path: Pa
     violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
 
     assert any(
-        "must not mask immutable-ref lookup failures with `|| true`" in violation
+        "must not mask immutable-ref lookup failures with shell OR fallbacks" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_equivalent_masked_dispatch_ref_lookup(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null || :)"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must not mask immutable-ref lookup failures with shell OR fallbacks" in violation
         for violation in violations
     )
 
@@ -444,7 +481,7 @@ def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
     violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
 
     assert not any(
-        "must not mask immutable-ref lookup failures with `|| true`" in violation
+        "must not mask immutable-ref lookup failures with shell OR fallbacks" in violation
         for violation in violations
     )
 

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -791,6 +791,53 @@ def test_merged_pr_dispatch_gate_rejects_function_body_ref_mismatch_exit(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_nested_ref_mismatch_condition(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                "            if false; then",
+                '              if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '                echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "                exit 1",
+                "              fi",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must fail closed with exit 1 when an existing immutable dispatch ref points to a different SHA"
+        in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_commented_else_reset(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1313,6 +1313,54 @@ def test_merged_pr_dispatch_gate_rejects_backgrounded_ref_creation(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_non_post_ref_creation_override(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" --method GET -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_function_scoped_lookup_guard(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -360,6 +360,58 @@ def test_merged_pr_dispatch_gate_accepts_guarded_braced_lookup(
     assert merged_pr_main_releasability_dispatch_violations(workflow_dir) == []
 
 
+def test_merged_pr_dispatch_gate_rejects_continue_on_error(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        continue-on-error: true",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                (
+                    '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" '
+                    '--ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"'
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "dispatcher must not set continue-on-error on the governed main releasability dispatch step"
+        in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_repository_override(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -571,6 +571,90 @@ def test_merged_pr_dispatch_gate_rejects_later_unguarded_lookup(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_commented_else_reset(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            # existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_nested_else_reset(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            if [ -n "$dispatch_ref" ]; then',
+                '              existing_ref_sha=""',
+                "            fi",
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -2241,6 +2241,38 @@ def test_merged_pr_dispatch_gate_rejects_time_prefixed_compound_scope(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_masked_dispatch_failure_status(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    workflow_text = (
+        MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
+        .replace(
+            "          gh workflow run main-releasability.yml \\",
+            "          set +e\n          gh workflow run main-releasability.yml \\",
+            1,
+        )
+        .replace(
+            '            -f triggering_pr="$PR_NUMBER"',
+            '            -f triggering_pr="$PR_NUMBER"\n          echo "dispatch attempted"',
+            1,
+        )
+    )
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        workflow_text,
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must preserve the main releasability dispatch command failure as the step status"
+        in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_repository_variable_reassignment(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -655,6 +655,49 @@ def test_merged_pr_dispatch_gate_rejects_nested_else_reset(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_function_body_else_reset(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                "            reset_lookup() {",
+                '              existing_ref_sha=""',
+                "            }",
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -2212,6 +2212,35 @@ def test_merged_pr_dispatch_gate_rejects_compound_prefixed_subshell(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_time_prefixed_compound_scope(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    workflow_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
+    workflow_text = workflow_text.replace(
+        "        run: |\n",
+        "        run: |\n          time if false; then\n",
+        1,
+    ).replace(
+        '            -f triggering_pr="$PR_NUMBER"',
+        '            -f triggering_pr="$PR_NUMBER"\n          fi',
+        1,
+    )
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        workflow_text,
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must not place the governed lookup, creation, and dispatch body behind "
+        "a time-prefixed compound command" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_repository_variable_reassignment(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -297,6 +297,7 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "Dispatch ref $dispatch_ref points to $existing_ref_sha" in dispatcher_text
     assert 'gh api "repos/$GITHUB_REPOSITORY/git/refs"' in dispatcher_text
     assert "gh workflow run main-releasability.yml" in dispatcher_text
+    assert '--repo "$GITHUB_REPOSITORY"' in dispatcher_text
     assert '--ref "$dispatch_ref"' in dispatcher_text
     assert '-f expected_sha="$MERGE_COMMIT_SHA"' in dispatcher_text
     assert '-f triggering_pr="$PR_NUMBER"' in dispatcher_text
@@ -350,7 +351,7 @@ def test_merged_pr_dispatch_gate_accepts_guarded_braced_lookup(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -395,7 +396,7 @@ def test_merged_pr_dispatch_gate_rejects_repository_override(
                     '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                     "          fi",
                     (
-                        '          gh workflow run main-releasability.yml --ref "$dispatch_ref" '
+                        '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" '
                         f'-f expected_sha="$MERGE_COMMIT_SHA" {override}'
                     ),
                 ]
@@ -411,6 +412,54 @@ def test_merged_pr_dispatch_gate_rejects_repository_override(
             "repository overrides" in violation
             for violation in violations
         )
+
+
+def test_merged_pr_dispatch_gate_rejects_missing_repository_pin(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
 
 
 def test_merged_pr_dispatch_gate_ignores_commented_ref_lookup(
@@ -447,7 +496,7 @@ def test_merged_pr_dispatch_gate_ignores_commented_ref_lookup(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -476,7 +525,7 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: P
                 "        run: |",
                 '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
             ]
         ),
         encoding="utf-8",
@@ -537,7 +586,7 @@ def test_merged_pr_dispatch_gate_rejects_masked_dispatch_ref_lookup(tmp_path: Pa
                 '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
                 '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null || true)"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
             ]
         ),
         encoding="utf-8",
@@ -574,7 +623,7 @@ def test_merged_pr_dispatch_gate_rejects_equivalent_masked_dispatch_ref_lookup(
                 '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
                 '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null || :)"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
             ]
         ),
         encoding="utf-8",
@@ -612,7 +661,7 @@ def test_merged_pr_dispatch_gate_rejects_unguarded_dispatch_ref_lookup(
                 '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"',
                 '          echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -654,7 +703,7 @@ def test_merged_pr_dispatch_gate_rejects_lookup_reset_in_success_branch(
                 "          fi",
                 '          echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -696,7 +745,7 @@ def test_merged_pr_dispatch_gate_rejects_later_unguarded_lookup(
                 "          fi",
                 '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -738,7 +787,7 @@ def test_merged_pr_dispatch_gate_rejects_later_braced_unguarded_lookup(
                 "          fi",
                 '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -782,7 +831,7 @@ def test_merged_pr_dispatch_gate_rejects_non_failing_ref_mismatch_branch(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -829,7 +878,7 @@ def test_merged_pr_dispatch_gate_rejects_nested_ref_mismatch_exit(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -876,7 +925,7 @@ def test_merged_pr_dispatch_gate_rejects_function_body_ref_mismatch_exit(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -923,7 +972,7 @@ def test_merged_pr_dispatch_gate_rejects_nested_ref_mismatch_condition(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -972,7 +1021,7 @@ def test_merged_pr_dispatch_gate_rejects_ref_sha_mutation_before_mismatch_check(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1019,7 +1068,7 @@ def test_merged_pr_dispatch_gate_rejects_subshell_masked_ref_mismatch_exit(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1064,7 +1113,7 @@ def test_merged_pr_dispatch_gate_rejects_unconditional_ref_creation(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1111,7 +1160,7 @@ def test_merged_pr_dispatch_gate_rejects_wrong_ref_creation_payload(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$WRONG_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1161,7 +1210,7 @@ def test_merged_pr_dispatch_gate_rejects_split_dispatch_run_steps(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1209,7 +1258,7 @@ def test_merged_pr_dispatch_gate_rejects_split_unnamed_run_step(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1256,7 +1305,7 @@ def test_merged_pr_dispatch_gate_rejects_masked_dispatch_failure(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA" || true',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA" || true',
             ]
         ),
         encoding="utf-8",
@@ -1304,7 +1353,7 @@ def test_merged_pr_dispatch_gate_rejects_wrong_expected_sha_binding(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$WRONG_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$WRONG_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1352,7 +1401,7 @@ def test_merged_pr_dispatch_gate_rejects_empty_expected_sha_binding(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha=',
             ]
         ),
         encoding="utf-8",
@@ -1401,7 +1450,7 @@ def test_merged_pr_dispatch_gate_rejects_nested_dispatch_command(
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
                 "          if false; then",
-                '            gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '            gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
                 "          fi",
             ]
         ),
@@ -1451,7 +1500,7 @@ def test_merged_pr_dispatch_gate_rejects_select_scoped_dispatch_body(
                 '            if [ -z "$existing_ref_sha" ]; then',
                 '              gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "            fi",
-                '            gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '            gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
                 "          done < /dev/null || true",
             ]
         ),
@@ -1500,7 +1549,7 @@ def test_merged_pr_dispatch_gate_rejects_dispatch_ref_reassignment_before_dispat
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
                 "          dispatch_ref=main",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1549,7 +1598,7 @@ def test_merged_pr_dispatch_gate_rejects_merge_sha_reassignment_before_dispatch(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1598,7 +1647,7 @@ def test_merged_pr_dispatch_gate_rejects_trailing_ref_creation_after_guard(
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1647,7 +1696,7 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_guarded_ref_creation(
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1695,7 +1744,7 @@ def test_merged_pr_dispatch_gate_rejects_payload_fields_in_inline_comment(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" # -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1743,7 +1792,7 @@ def test_merged_pr_dispatch_gate_rejects_masked_ref_creation_failure(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" || true',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1791,7 +1840,7 @@ def test_merged_pr_dispatch_gate_rejects_backgrounded_ref_creation(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" &',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1839,7 +1888,7 @@ def test_merged_pr_dispatch_gate_rejects_chained_ref_creation_command(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA" ; exit 0',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1887,7 +1936,7 @@ def test_merged_pr_dispatch_gate_rejects_non_post_ref_creation_override(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" --method GET -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -1955,7 +2004,7 @@ def test_merged_pr_dispatch_gate_rejects_dispatch_before_ref_creation(
                 "          else",
                 '            existing_ref_sha=""',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
@@ -2008,7 +2057,7 @@ def test_merged_pr_dispatch_gate_rejects_function_scoped_lookup_guard(
                 '          if [ -z "$existing_ref_sha" ]; then',
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -2057,7 +2106,7 @@ def test_merged_pr_dispatch_gate_binds_payload_fields_to_creation_command(
                 '            printf "%s" \'-f ref="refs/tags/$dispatch_ref"\'',
                 '            printf "%s" \'-f sha="$MERGE_COMMIT_SHA"\'',
                 "          fi",
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -2099,7 +2148,7 @@ def test_merged_pr_dispatch_gate_rejects_commented_else_reset(
                 '            # existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -2142,7 +2191,7 @@ def test_merged_pr_dispatch_gate_rejects_nested_else_reset(
                 "            fi",
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -2185,7 +2234,7 @@ def test_merged_pr_dispatch_gate_rejects_function_body_else_reset(
                 "            }",
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -2227,7 +2276,7 @@ def test_merged_pr_dispatch_gate_rejects_trailing_else_command(
                 '            gh api "repos/$GITHUB_REPOSITORY/actions/runs?per_page=1" >/dev/null',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -2268,7 +2317,7 @@ def test_merged_pr_dispatch_gate_rejects_lookup_condition_and_false(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -2309,7 +2358,7 @@ def test_merged_pr_dispatch_gate_rejects_lookup_condition_sequence_false(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),
         encoding="utf-8",
@@ -2350,7 +2399,7 @@ def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
                 '          gh api "repos/$GITHUB_REPOSITORY/actions/runs?per_page=1" >/dev/null || true',
             ]
         ),
@@ -2389,7 +2438,7 @@ def test_merged_pr_dispatch_gate_rejects_token_only_revision_assertion(tmp_path:
                 "        run: |",
                 '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
             ]
         ),
         encoding="utf-8",
@@ -2442,7 +2491,7 @@ def test_merged_pr_dispatch_gate_rejects_non_failing_mismatch_branch(tmp_path: P
                 "        run: |",
                 '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
-                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
             ]
         ),
         encoding="utf-8",

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -288,6 +288,11 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "github.event.pull_request.merge_commit_sha" in dispatcher_text
     assert "contents: write" in dispatcher_text
     assert 'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"' in dispatcher_text
+    assert (
+        'existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref"'
+        in dispatcher_text
+    )
+    assert "Dispatch ref $dispatch_ref points to $existing_ref_sha" in dispatcher_text
     assert 'gh api "repos/$GITHUB_REPOSITORY/git/refs"' in dispatcher_text
     assert "gh workflow run main-releasability.yml" in dispatcher_text
     assert '--ref "$dispatch_ref"' in dispatcher_text
@@ -368,6 +373,41 @@ def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: P
         "coexist with merged-pr-main-releasability.yml because it creates duplicate automatic "
         "mainline proof runs"
     ) in violations
+
+
+def test_merged_pr_dispatch_gate_rejects_masked_dispatch_ref_lookup(tmp_path: Path) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null || true)"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=$MERGE_COMMIT_SHA',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must not mask immutable-ref lookup failures with `|| true`" in violation
+        for violation in violations
+    )
 
 
 def test_merged_pr_dispatch_gate_rejects_token_only_revision_assertion(tmp_path: Path) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1217,6 +1217,102 @@ def test_merged_pr_dispatch_gate_rejects_masked_dispatch_failure(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_wrong_expected_sha_binding(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$WRONG_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_empty_expected_sha_binding(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha=',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_nested_dispatch_command(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -464,6 +464,59 @@ def test_merged_pr_dispatch_gate_ignores_here_document_payload(
     )
 
 
+def test_merged_pr_dispatch_gate_strips_multiple_here_document_payloads(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                "          cat <<'EMPTY' <<'POLICY'",
+                "          EMPTY",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                (
+                    '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" '
+                    '--ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"'
+                ),
+                "          POLICY",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "dispatcher must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_repository_override(
     tmp_path: Path,
 ) -> None:
@@ -2072,6 +2125,29 @@ def test_merged_pr_dispatch_gate_allows_explicit_post_ref_creation_method(
     violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
 
     assert not any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_creation_hostname_override(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        MERGED_PR_DISPATCHER.read_text(encoding="utf-8").replace(
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" \\',
+            '            gh api "repos/$GITHUB_REPOSITORY/git/refs" --hostname wrong.example \\',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
         "must create the immutable dispatch ref only inside the empty existing-ref branch "
         "with exact ref and SHA fields" in violation
         for violation in violations

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -884,6 +884,55 @@ def test_merged_pr_dispatch_gate_rejects_nested_ref_mismatch_condition(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_ref_sha_mutation_before_mismatch_check(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            existing_ref_sha="$MERGE_COMMIT_SHA"',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must fail closed with exit 1 when an existing immutable dispatch ref points to a different SHA"
+        in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_subshell_masked_ref_mismatch_exit(
     tmp_path: Path,
 ) -> None:
@@ -1154,6 +1203,55 @@ def test_merged_pr_dispatch_gate_rejects_trailing_ref_creation_after_guard(
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_duplicate_guarded_ref_creation(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
                 '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -410,6 +410,45 @@ def test_merged_pr_dispatch_gate_rejects_masked_dispatch_ref_lookup(tmp_path: Pa
     )
 
 
+def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"',
+                '          echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                '          gh api "repos/$GITHUB_REPOSITORY/actions/runs?per_page=1" >/dev/null || true',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert not any(
+        "must not mask immutable-ref lookup failures with `|| true`" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_token_only_revision_assertion(tmp_path: Path) -> None:
     workflow_dir = tmp_path / "workflows"
     workflow_dir.mkdir()

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -974,6 +974,53 @@ def test_merged_pr_dispatch_gate_rejects_unconditional_ref_creation(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_wrong_ref_creation_payload(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$WRONG_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_commented_else_reset(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -2154,6 +2154,59 @@ def test_merged_pr_dispatch_gate_rejects_creation_hostname_override(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_or_masked_brace_group(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    workflow_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
+    workflow_text = workflow_text.replace(
+        "        run: |\n",
+        "        run: |\n          {\n",
+        1,
+    ).replace(
+        '            -f triggering_pr="$PR_NUMBER"',
+        '            -f triggering_pr="$PR_NUMBER"\n          } || true',
+        1,
+    )
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        workflow_text,
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must not wrap the governed lookup, creation, and dispatch commands in a brace "
+        "group whose failure is masked by a shell OR fallback" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_repository_variable_reassignment(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        MERGED_PR_DISPATCHER.read_text(encoding="utf-8").replace(
+            '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+            '          GITHUB_REPOSITORY="wrong/other"\n'
+            '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_dispatch_before_ref_creation(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -529,6 +529,48 @@ def test_merged_pr_dispatch_gate_rejects_lookup_reset_in_success_branch(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_later_unguarded_lookup(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -317,6 +317,42 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "push:" not in main_trigger_section
 
 
+def test_merged_pr_dispatch_gate_accepts_guarded_braced_lookup(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert merged_pr_main_releasability_dispatch_violations(workflow_dir) == []
+
+
 def test_merged_pr_dispatch_gate_rejects_duplicate_main_push_trigger(tmp_path: Path) -> None:
     workflow_dir = tmp_path / "workflows"
     workflow_dir.mkdir()
@@ -556,6 +592,48 @@ def test_merged_pr_dispatch_gate_rejects_later_unguarded_lookup(
                 '            existing_ref_sha=""',
                 "          fi",
                 '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_later_braced_unguarded_lookup(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/${dispatch_ref}" --jq .object.sha 2>/dev/null)"',
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1072,6 +1072,54 @@ def test_merged_pr_dispatch_gate_rejects_split_dispatch_run_steps(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_split_unnamed_run_step(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                "      - run: |",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref before workflow dispatch" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_trailing_ref_creation_after_guard(
     tmp_path: Path,
 ) -> None:
@@ -1106,6 +1154,54 @@ def test_merged_pr_dispatch_gate_rejects_trailing_ref_creation_after_guard(
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
                 '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must create the immutable dispatch ref only inside the empty existing-ref branch "
+        "with exact ref and SHA fields" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_payload_fields_in_inline_comment(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" # -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
                 '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -740,6 +740,88 @@ def test_merged_pr_dispatch_gate_rejects_trailing_else_command(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_lookup_condition_and_false(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)" && false; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_lookup_condition_sequence_false(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; false; then',
+                '            echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -697,6 +697,53 @@ def test_merged_pr_dispatch_gate_rejects_non_failing_ref_mismatch_branch(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_nested_ref_mismatch_exit(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              if false; then",
+                "                exit 1",
+                "              fi",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must fail closed with exit 1 when an existing immutable dispatch ref points to a different SHA"
+        in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_commented_else_reset(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -487,6 +487,48 @@ def test_merged_pr_dispatch_gate_rejects_unguarded_dispatch_ref_lookup(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_lookup_reset_in_success_branch(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            existing_ref_sha=""',
+                "          else",
+                '            echo "Dispatch ref $dispatch_ref is absent"',
+                "          fi",
+                '          echo "Dispatch ref $dispatch_ref points to $existing_ref_sha"',
+                '          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_allows_unrelated_best_effort_commands(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1417,6 +1417,55 @@ def test_merged_pr_dispatch_gate_rejects_nested_dispatch_command(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_select_scoped_dispatch_body(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                "          select unused in never; do",
+                '            dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '            if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '              if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '                echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "                exit 1",
+                "              fi",
+                "            else",
+                '              existing_ref_sha=""',
+                "            fi",
+                '            if [ -z "$existing_ref_sha" ]; then',
+                '              gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "            fi",
+                '            gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+                "          done < /dev/null || true",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "dispatcher must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_dispatch_ref_reassignment_before_dispatch(
     tmp_path: Path,
 ) -> None:
@@ -1451,6 +1500,55 @@ def test_merged_pr_dispatch_gate_rejects_dispatch_ref_reassignment_before_dispat
                 '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
                 "          fi",
                 "          dispatch_ref=main",
+                '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
+def test_merged_pr_dispatch_gate_rejects_merge_sha_reassignment_before_dispatch(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                "          MERGE_COMMIT_SHA=${{ github.event.pull_request.head.sha }}",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
                 '          gh workflow run main-releasability.yml --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
             ]
         ),


### PR DESCRIPTION
## Summary - Hardens the merged-PR Main Releasability dispatcher policy for RFC-0002 Slice 17 release-evidence integrity. - Requires immutable dispatch-ref lookup before workflow dispatch, guards every lookup path, rejects masked fallback patterns, and verifies absent-ref creation is conditional. - Final review hardening now validates lookup, conditional creation, and workflow dispatch inside one named shell run step; inspects every `git/refs` creation command; binds exact `ref`/`sha` payload fields to the actual creation command; delimits unnamed sibling run steps; and ignores inline shell comments when validating executable payload fields. - Refreshes report-only quality artifacts after the policy-gate implementation changes.  ## Risk / Rollback - Risk is limited to CI policy enforcement. Runtime portfolio-management behavior is not changed. - Rollback: revert the policy-gate commits if the dispatcher contract has to be relaxed, but doing so would reopen the release-evidence race/incorrect-SHA risk captured by #635.  ## Evidence - `python -m ruff format scripts/workflow_policy_gate.py tests/unit/test_ci_workflow_gate_enforcement.py` — passed. - `python -m ruff check scripts/workflow_policy_gate.py tests/unit/test_ci_workflow_gate_enforcement.py` — passed. - `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q` — 58 passed. - `make workflow-policy-gate` — passed. - `python scripts/engineering_health_report.py` — regenerated quality reports. - `make quality-report-gate` — passed. - `make static-quality-gates` — passed, including ruff, format, monetary-float, no-alias, mypy, OpenAPI, vocabulary, service/router boundaries, data-product/trust/observability contract validators, import-linter, complexity reports, duplicate implementation, deptry, vulture, workflow policy, quality report check, and test-family inventory. - `git diff --check` — passed before commit. - Signed branch commit verification: every commit from `origin/main..HEAD` reports `G`.  ## RFC / issue traceability - RFC-0002 Slice 17 dependency: #635. - The PR intentionally remains limited to CI/release-evidence guardrails. It does not claim Manage production IdP/action-register scope binding; #624 remains open for that external auth-dependent scope.  ## Documentation / wiki / context decision - No repo wiki or user-facing product documentation change is required for this CI-enforcement-only fix. - Quality reports were refreshed because the repository treats them as durable scorecard evidence.
### Review-thread hardening update (`ef8449c9`)

Resolved the final two review findings by rejecting failure-masked immutable dispatch-ref creation (`||`) and requiring the lookup guard at executable outer shell scope. Added focused regression tests and reran:

- `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q` (`60 passed`)
- `make workflow-policy-gate`
- `python scripts/engineering_health_report.py`
- `make quality-report-gate`
- `make static-quality-gates`
- `git diff --check`

No wiki/source truth changed; this remains a CI release-governance policy slice.

### Backgrounded creation hardening update (`e814fa4f`)

Resolved the backgrounded immutable-ref creation review finding by rejecting complete creation commands ending with `&`, preventing dispatch races against a tag that may not exist yet.

Local validation:

- `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q` (`61 passed`)
- `make workflow-policy-gate`
- `python scripts/engineering_health_report.py`
- `make quality-report-gate`
- `make static-quality-gates`
- `git diff --check`


### Method override hardening update (`fd449f18`)

Resolved the non-POST immutable-ref creation review finding by rejecting `gh api` method/input overrides such as `--method GET`, `-X`, and `--input`. Added regression coverage for the `--method GET` case.

Local validation:

- `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py -q` (`62 passed`)
- `make workflow-policy-gate`
- `python scripts/engineering_health_report.py`
- `make quality-report-gate`
- `make static-quality-gates`
- `git diff --check`

Same-pattern hardening was ported to lotus-ai and lotus-idea. Platform skill guidance is tracked in sgajbi/lotus-platform#694 / PR #695.
