### PR TITLE
test: isolate quality ref environment

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T22:26:23+00:00`
+- Generated at: `2026-08-20T22:39:13+00:00`
 
-- Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
+- Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `48bfede8+worktree`
+- Report source snapshot: `d96f65ea`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208836 |
+| Total Python LOC | 208844 |
 | Test functions | 3015 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T22:50:16+00:00`
+- Generated at: `2026-08-20T22:59:28+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `4251c0ae+worktree`
+- Report source snapshot: `f1b84480+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208918 |
-| Test functions | 3016 |
+| Total Python LOC | 208966 |
+| Test functions | 3017 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T22:39:13+00:00`
+- Generated at: `2026-08-20T22:50:16+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `d96f65ea`
+- Report source snapshot: `4251c0ae+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208844 |
-| Test functions | 3015 |
+| Total Python LOC | 208918 |
+| Test functions | 3016 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T22:59:28+00:00`
+- Generated at: `2026-08-20T23:06:39+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `f1b84480+worktree`
+- Report source snapshot: `16ef00e7+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208966 |
-| Test functions | 3017 |
+| Total Python LOC | 208987 |
+| Test functions | 3018 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-20T22:16:22+00:00`
+- Generated at: `2026-08-20T22:26:23+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `58b9cbe0+worktree`
+- Report source snapshot: `48bfede8+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 901 |
-| Total Python LOC | 208781 |
-| Test functions | 3014 |
+| Total Python LOC | 208836 |
+| Test functions | 3015 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T22:59:28+00:00`
+- Generated at: `2026-08-20T23:06:39+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `f1b84480+worktree`
+- Report source snapshot: `16ef00e7+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T22:16:22+00:00`
+- Generated at: `2026-08-20T22:26:23+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `58b9cbe0+worktree`
+- Report source snapshot: `48bfede8+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T22:50:16+00:00`
+- Generated at: `2026-08-20T22:59:28+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `4251c0ae+worktree`
+- Report source snapshot: `f1b84480+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T22:26:23+00:00`
+- Generated at: `2026-08-20T22:39:13+00:00`
 
-- Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
+- Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `48bfede8+worktree`
+- Report source snapshot: `d96f65ea`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-20T22:39:13+00:00`
+- Generated at: `2026-08-20T22:50:16+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `d96f65ea`
+- Report source snapshot: `4251c0ae+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T22:59:28+00:00`
+- Generated at: `2026-08-20T23:06:39+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `f1b84480+worktree`
+- Report source snapshot: `16ef00e7+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T22:16:22+00:00`
+- Generated at: `2026-08-20T22:26:23+00:00`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `58b9cbe0+worktree`
+- Report source snapshot: `48bfede8+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T22:26:23+00:00`
+- Generated at: `2026-08-20T22:39:13+00:00`
 
-- Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
+- Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `48bfede8+worktree`
+- Report source snapshot: `d96f65ea`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T22:50:16+00:00`
+- Generated at: `2026-08-20T22:59:28+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `4251c0ae+worktree`
+- Report source snapshot: `f1b84480+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-20T22:39:13+00:00`
+- Generated at: `2026-08-20T22:50:16+00:00`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `d96f65ea`
+- Report source snapshot: `4251c0ae+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T22:16:22+00:00`
+- Generated at: `2026-08-20T22:26:23+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
 
-- Report source snapshot: `58b9cbe0+worktree`
+- Report source snapshot: `48bfede8+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208781 | +3072 |
-| Test functions | 2960 | 3014 | +54 |
+| Total Python LOC | 205709 | 208836 | +3127 |
+| Test functions | 2960 | 3015 | +55 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -57,7 +57,7 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3152 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3192 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T22:50:16+00:00`
+- Generated at: `2026-08-20T22:59:28+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `4251c0ae+worktree`
+- Report source snapshot: `f1b84480+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 208781 | 208918 | +137 |
-| Test functions | 3014 | 3016 | +2 |
+| Total Python LOC | 208781 | 208966 | +185 |
+| Test functions | 3014 | 3017 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -56,7 +56,7 @@
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
-| 5 | tests/unit/test_ci_workflow_gate_enforcement.py | 3241 |
+| 5 | tests/unit/test_ci_workflow_gate_enforcement.py | 3262 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T22:26:23+00:00`
+- Generated at: `2026-08-20T22:39:13+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `58cf058954a35c1e73450aabe5d7ae095a20d497`
+- Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `48bfede8+worktree`
+- Report source snapshot: `d96f65ea`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 205709 | 208836 | +3127 |
-| Test functions | 2960 | 3015 | +55 |
+| Total Python LOC | 208781 | 208844 | +63 |
+| Test functions | 3014 | 3015 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -42,11 +42,11 @@
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_documentation_current_state.py | 2774 |
-| 7 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
-| 8 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
-| 9 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
-| 10 | tests/unit/dpm/pm_quality/test_pm_operating_quality.py | 1996 |
+| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3152 |
+| 7 | tests/unit/test_documentation_current_state.py | 2774 |
+| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
+| 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
+| 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
 ### current branch
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T22:59:28+00:00`
+- Generated at: `2026-08-20T23:06:39+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `f1b84480+worktree`
+- Report source snapshot: `16ef00e7+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 208781 | 208966 | +185 |
-| Test functions | 3014 | 3017 | +3 |
+| Total Python LOC | 208781 | 208987 | +206 |
+| Test functions | 3014 | 3018 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -56,7 +56,7 @@
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
-| 5 | tests/unit/test_ci_workflow_gate_enforcement.py | 3262 |
+| 5 | tests/unit/test_ci_workflow_gate_enforcement.py | 3283 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-20T22:39:13+00:00`
+- Generated at: `2026-08-20T22:50:16+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `13138f4f85182bb9d2ba9deda2f76a481424046d`
 
-- Report source snapshot: `d96f65ea`
+- Report source snapshot: `4251c0ae+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 901 | 901 | +0 |
-| Total Python LOC | 208781 | 208844 | +63 |
-| Test functions | 3014 | 3015 | +1 |
+| Total Python LOC | 208781 | 208918 | +137 |
+| Test functions | 3014 | 3016 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -56,8 +56,8 @@
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
-| 5 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 6 | tests/unit/test_ci_workflow_gate_enforcement.py | 3192 |
+| 5 | tests/unit/test_ci_workflow_gate_enforcement.py | 3241 |
+| 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -124,6 +124,32 @@ def _closes_nested_shell_scope(stripped_line: str) -> bool:
     return stripped_line in {"fi", "done", "esac", "}"} or stripped_line.startswith(")")
 
 
+def _opens_isolating_shell_scope(stripped_line: str) -> bool:
+    scope_line = _strip_shell_command_prefixes(stripped_line)
+    return (
+        scope_line == "("
+        or scope_line.startswith("(")
+        or re.search(r"(?:^|[;&|]\s*)\(", scope_line) is not None
+    )
+
+
+def _closes_isolating_shell_scope(stripped_line: str) -> bool:
+    return stripped_line.startswith(")")
+
+
+def _contains_protected_assignment_command(
+    stripped_line: str,
+    *,
+    protected_variables: set[str],
+) -> bool:
+    variable_alternation = "|".join(re.escape(variable) for variable in protected_variables)
+    assignment_pattern = re.compile(
+        rf"(?:^|[;&|]|\bthen\b|\bdo\b)\s*(?:export\s+)?"
+        rf"(?:{variable_alternation})="
+    )
+    return assignment_pattern.search(stripped_line) is not None
+
+
 def _is_shell_comment(stripped_line: str) -> bool:
     return stripped_line.startswith("#")
 
@@ -708,15 +734,14 @@ def _has_protected_variable_reassignment_between(
         stripped_line = line.strip()
         if not stripped_line or _is_shell_comment(stripped_line):
             continue
-        if depth == 0 and any(
-            stripped_line.startswith(f"{variable}=")
-            or stripped_line.startswith(f"export {variable}=")
-            for variable in protected_variables
+        if depth == 0 and _contains_protected_assignment_command(
+            stripped_line,
+            protected_variables=protected_variables,
         ):
             return True
-        if _opens_nested_shell_scope(stripped_line):
+        if _opens_isolating_shell_scope(stripped_line):
             depth += 1
-        if _closes_nested_shell_scope(stripped_line):
+        if _closes_isolating_shell_scope(stripped_line):
             depth -= 1
     return False
 

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -143,11 +143,11 @@ def _without_shell_quoted_regions(stripped_line: str) -> str:
     escaped = False
     for character in stripped_line:
         if escaped:
-            output.append(" " if quote else character)
+            output.append(" ")
             escaped = False
             continue
         if character == "\\" and quote != "'":
-            output.append(" " if quote else character)
+            output.append(" ")
             escaped = True
             continue
         if quote:

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -137,17 +137,44 @@ def _closes_isolating_shell_scope(stripped_line: str) -> bool:
     return stripped_line.startswith(")")
 
 
+def _without_shell_quoted_regions(stripped_line: str) -> str:
+    output: list[str] = []
+    quote: str | None = None
+    escaped = False
+    for character in stripped_line:
+        if escaped:
+            output.append(" " if quote else character)
+            escaped = False
+            continue
+        if character == "\\" and quote != "'":
+            output.append(" " if quote else character)
+            escaped = True
+            continue
+        if quote:
+            if character == quote:
+                quote = None
+            output.append(" ")
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            output.append(" ")
+            continue
+        output.append(character)
+    return "".join(output)
+
+
 def _contains_protected_assignment_command(
     stripped_line: str,
     *,
     protected_variables: set[str],
 ) -> bool:
+    executable_line = _without_shell_quoted_regions(stripped_line)
     variable_alternation = "|".join(re.escape(variable) for variable in protected_variables)
     assignment_pattern = re.compile(
         rf"(?:^|[;&|]|\bthen\b|\bdo\b)\s*(?:export\s+)?"
         rf"(?:{variable_alternation})="
     )
-    return assignment_pattern.search(stripped_line) is not None
+    return assignment_pattern.search(executable_line) is not None
 
 
 def _is_shell_comment(stripped_line: str) -> bool:

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -32,6 +32,7 @@ VERSION_TAG_PATTERN = re.compile(r"^v\d+(?:\.\d+){0,2}$")
 FULL_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 HERE_DOCUMENT_START_PATTERN = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
 SHELL_TIME_PREFIX_PATTERN = re.compile(r"^time(?:\s+-p)?\s+(.+)$")
+SHELL_NEGATION_PREFIX_PATTERN = re.compile(r"^!\s+(.+)$")
 IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS = (
     (
         'if existing_ref_sha="$(gh api '
@@ -106,7 +107,7 @@ PR_TEMPLATE_REQUIRED_TOKENS = {
 
 
 def _opens_nested_shell_scope(stripped_line: str) -> bool:
-    scope_line = _strip_shell_time_prefix(stripped_line)
+    scope_line = _strip_shell_command_prefixes(stripped_line)
     return (
         scope_line == "("
         or scope_line.startswith("(")
@@ -130,6 +131,20 @@ def _is_shell_comment(stripped_line: str) -> bool:
 def _strip_shell_time_prefix(stripped_line: str) -> str:
     match = SHELL_TIME_PREFIX_PATTERN.match(stripped_line)
     return match.group(1) if match else stripped_line
+
+
+def _strip_shell_negation_prefix(stripped_line: str) -> str:
+    match = SHELL_NEGATION_PREFIX_PATTERN.match(stripped_line)
+    return match.group(1) if match else stripped_line
+
+
+def _strip_shell_command_prefixes(stripped_line: str) -> str:
+    previous_line = stripped_line
+    while True:
+        current_line = _strip_shell_negation_prefix(_strip_shell_time_prefix(previous_line))
+        if current_line == previous_line:
+            return current_line
+        previous_line = current_line
 
 
 def _workflow_files(workflow_dir: Path = WORKFLOW_DIR) -> list[Path]:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1791,6 +1791,27 @@ def test_merged_pr_dispatch_gate_ignores_quoted_dispatch_ref_diagnostics(
     assert merged_pr_main_releasability_dispatch_violations(workflow_dir) == []
 
 
+def test_merged_pr_dispatch_gate_ignores_escaped_separator_diagnostics(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    workflow_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8").replace(
+        "          gh workflow run main-releasability.yml \\",
+        "          echo diagnostic \\; dispatch_ref=unchanged\n"
+        "          echo diagnostic \\&\\& MERGE_COMMIT_SHA=unchanged\n"
+        "          echo diagnostic \\|\\| GITHUB_REPOSITORY=unchanged\n"
+        "          gh workflow run main-releasability.yml \\",
+        1,
+    )
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        workflow_text,
+        encoding="utf-8",
+    )
+
+    assert merged_pr_main_releasability_dispatch_violations(workflow_dir) == []
+
+
 def test_merged_pr_dispatch_gate_rejects_merge_sha_reassignment_before_dispatch(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1770,6 +1770,27 @@ def test_merged_pr_dispatch_gate_rejects_negated_conditional_dispatch_ref_reassi
     )
 
 
+def test_merged_pr_dispatch_gate_ignores_quoted_dispatch_ref_diagnostics(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    workflow_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8").replace(
+        "          gh workflow run main-releasability.yml \\",
+        '          echo "diagnostic; dispatch_ref=unchanged"\n'
+        '          echo "diagnostic then MERGE_COMMIT_SHA=unchanged"\n'
+        "          echo 'diagnostic do GITHUB_REPOSITORY=unchanged'\n"
+        "          gh workflow run main-releasability.yml \\",
+        1,
+    )
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        workflow_text,
+        encoding="utf-8",
+    )
+
+    assert merged_pr_main_releasability_dispatch_violations(workflow_dir) == []
+
+
 def test_merged_pr_dispatch_gate_rejects_merge_sha_reassignment_before_dispatch(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -1721,6 +1721,55 @@ def test_merged_pr_dispatch_gate_rejects_dispatch_ref_reassignment_before_dispat
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_negated_conditional_dispatch_ref_reassignment(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        "\n".join(
+            [
+                "on:",
+                "  pull_request_target:",
+                "    types: [closed]",
+                "jobs:",
+                "  dispatch:",
+                "    if: >",
+                "      github.event.pull_request.merged == true &&",
+                "      github.event.pull_request.base.ref == 'main'",
+                "    steps:",
+                "      - name: Dispatch main releasability gate",
+                "        env:",
+                "          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}",
+                "        run: |",
+                '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                '          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then',
+                '            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then',
+                '              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"',
+                "              exit 1",
+                "            fi",
+                "          else",
+                '            existing_ref_sha=""',
+                "          fi",
+                '          if [ -z "$existing_ref_sha" ]; then',
+                '            gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/tags/$dispatch_ref" -f sha="$MERGE_COMMIT_SHA"',
+                "          fi",
+                "          ! if true; then dispatch_ref=main; fi",
+                '          gh workflow run main-releasability.yml --repo "$GITHUB_REPOSITORY" --ref "$dispatch_ref" -f expected_sha="$MERGE_COMMIT_SHA"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must run the main releasability dispatch only after the absent immutable-ref creation "
+        "branch has completed" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_merge_sha_reassignment_before_dispatch(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -2241,6 +2241,46 @@ def test_merged_pr_dispatch_gate_rejects_time_prefixed_compound_scope(
     )
 
 
+def test_merged_pr_dispatch_gate_rejects_negated_lookup_scope(
+    tmp_path: Path,
+) -> None:
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    workflow_text = (
+        MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
+        .replace(
+            (
+                '          if existing_ref_sha="$(gh api '
+                '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+                '--jq .object.sha 2>/dev/null)"; then'
+            ),
+            (
+                "          ! if false; then\n"
+                '          if existing_ref_sha="$(gh api '
+                '"repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" '
+                '--jq .object.sha 2>/dev/null)"; then'
+            ),
+            1,
+        )
+        .replace(
+            '          if [ -z "$existing_ref_sha" ]; then',
+            '          # fi\n          if [ -z "$existing_ref_sha" ]; then',
+            1,
+        )
+    )
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(
+        workflow_text,
+        encoding="utf-8",
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any(
+        "must guard immutable-ref lookup with an if/else reset" in violation
+        for violation in violations
+    )
+
+
 def test_merged_pr_dispatch_gate_rejects_masked_dispatch_failure_status(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -2,6 +2,8 @@ import io
 import tarfile
 from types import SimpleNamespace
 
+import pytest
+
 from scripts import engineering_health_report as ehr
 from scripts.engineering_health_report import (
     ComplexityMetric,
@@ -15,6 +17,12 @@ from scripts.engineering_health_report import (
     build_complexity_report,
     build_quality_scorecard,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_quality_ref_environment(monkeypatch) -> None:
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.delenv("LOTUS_QUALITY_REF_NAME", raising=False)
 
 
 def _tar_bytes(files: dict[str, str]) -> bytes:


### PR DESCRIPTION
## Summary
- Restores the stranded `16797cff` negated release-dispatch scope hardening that PR #636 left off `main`.
- Fixes the main-releasability unit failure from run 32424369641 by making `test_engineering_health_report` hermetic for both GitHub ref environment variables.
- Refreshes generated quality reports against the current main baseline.

## Evidence
- Failed main run: https://github.com/sgajbi/lotus-manage/actions/runs/32424369641
- Local full unit lane: `make test-unit-coverage` -> 3330 passed
- Local targeted lane: `python -m pytest tests/unit/test_ci_workflow_gate_enforcement.py tests/unit/test_engineering_health_report.py -q` -> 105 passed
- Local workflow gate: `make workflow-policy-gate` -> passed
- Local quality gate: `make quality-report-gate` -> current
- Lint/format: `python -m ruff check scripts/workflow_policy_gate.py tests/unit/test_ci_workflow_gate_enforcement.py tests/unit/test_engineering_health_report.py` -> passed; `python -m ruff format --check ...` -> passed
- Whitespace: `git diff --check` -> passed

Fixes #635