### PR TITLE
fix(ci): isolate and repair Docker parity

### DIFF
--- a/Dockerfile.ci-local
+++ b/Dockerfile.ci-local
@@ -5,7 +5,11 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 WORKDIR /workspace
 
+RUN apt-get update \
+    && apt-get install --no-install-recommends --yes git make \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY pyproject.toml README.md ./
 COPY src ./src
 
-RUN python -m pip install --upgrade pip && pip install -e ".[dev]"
+RUN python -m pip install --upgrade pip && pip install -e ".[dev,quality]"

--- a/Dockerfile.ci-local
+++ b/Dockerfile.ci-local
@@ -7,6 +7,7 @@ WORKDIR /workspace
 
 RUN apt-get update \
     && apt-get install --no-install-recommends --yes git make \
+    && git config --system --add safe.directory /workspace \
     && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml README.md ./

--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,13 @@ ci-local: static-quality-gates check-deps
 	COVERAGE_FILE=.coverage.e2e $(MAKE) test-e2e-coverage
 	$(MAKE) coverage-gate
 
+CI_LOCAL_COMPOSE_PROJECT ?= $(shell python scripts/ci_local_compose_project.py)
+
 ci-local-docker:
-	docker compose -f docker-compose.ci-local.yml up --build --abort-on-container-exit --exit-code-from ci-local ci-local
+	docker compose --project-name "$(CI_LOCAL_COMPOSE_PROJECT)" -f docker-compose.ci-local.yml up --build --abort-on-container-exit --exit-code-from ci-local ci-local
 
 ci-local-docker-down:
-	docker compose -f docker-compose.ci-local.yml down -v --remove-orphans
+	docker compose --project-name "$(CI_LOCAL_COMPOSE_PROJECT)" -f docker-compose.ci-local.yml down -v --remove-orphans
 
 check-all: lint typecheck test-all
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1050,6 +1050,10 @@ Use these commands as the primary local contract:
    `make ci-local`
 5. Docker parity
    `make ci-local-docker`
+   The CI-local Docker lifecycle uses a stable checkout-specific project name from
+   `scripts/ci_local_compose_project.py` for both startup and cleanup. Preserve that symmetric
+   identity so CI teardown cannot remove the live product Compose project; orchestrators may set
+   `CI_LOCAL_COMPOSE_PROJECT` to another unique value.
 6. canonical host runtime
    `make run-canonical`
 7. app-level demo certification

--- a/docker-compose.ci-local.yml
+++ b/docker-compose.ci-local.yml
@@ -18,6 +18,15 @@ services:
     working_dir: /workspace
     volumes:
       - ./:/workspace
+      - ../lotus-platform:/lotus-platform:ro
+      - ../lotus-core/contracts/domain-data-products:/lotus-core/contracts/domain-data-products:ro
+      - ../lotus-performance/contracts/domain-data-products:/lotus-performance/contracts/domain-data-products:ro
+      - ../lotus-risk/contracts/domain-data-products:/lotus-risk/contracts/domain-data-products:ro
+      - ../lotus-advise/contracts/domain-data-products:/lotus-advise/contracts/domain-data-products:ro
+      - ../lotus-report/contracts/domain-data-products:/lotus-report/contracts/domain-data-products:ro
+      - ./contracts/domain-data-products:/lotus-manage/contracts/domain-data-products:ro
+      - ../lotus-gateway/contracts/domain-data-products:/lotus-gateway/contracts/domain-data-products:ro
+      - ../lotus-idea/contracts/domain-data-products:/lotus-idea/contracts/domain-data-products:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -19,6 +19,16 @@
 For full repo-native evidence in production-oriented work, run:
 
 - `make ci-local` (unit/integration/e2e with merge-gate coverage and gates)
+- `make ci-local-docker` followed by `make ci-local-docker-down` for Docker parity. Both commands
+  derive the same stable, checkout-specific Compose project identity from the absolute repository
+  path. `CI_LOCAL_COMPOSE_PROJECT` may override it when an orchestrator supplies a unique identity.
+  Cleanup is therefore limited to CI-owned containers, networks, and volumes and must not stop or
+  remove the live product Compose project. The purpose-built CI image includes GNU Make because its
+  bounded entrypoint executes the repo-native `make ci-local` target, and mounts the sibling
+  `lotus-platform` tree plus the eight manifest-declared repositories' domain-data-product
+  declaration directories read-only for governed validators and generated contract evidence.
+  Keep those sibling repositories available at the standard workspace paths before running Docker
+  parity; no service source tree outside `lotus-manage` is writable inside the CI container.
 - `make mesh-contract-validate`
 
 ## Incident triage

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -24,7 +24,8 @@ For full repo-native evidence in production-oriented work, run:
   path. `CI_LOCAL_COMPOSE_PROJECT` may override it when an orchestrator supplies a unique identity.
   Cleanup is therefore limited to CI-owned containers, networks, and volumes and must not stop or
   remove the live product Compose project. The purpose-built CI image includes GNU Make because its
-  bounded entrypoint executes the repo-native `make ci-local` target, and mounts the sibling
+  bounded entrypoint executes the repo-native `make ci-local` target, trusts only the `/workspace`
+  bind mount for the Git-backed quality gates on Linux hosts, and mounts the sibling
   `lotus-platform` tree plus the eight manifest-declared repositories' domain-data-product
   declaration directories read-only for governed validators and generated contract evidence.
   Keep those sibling repositories available at the standard workspace paths before running Docker

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-26T15:34:51+00:00`
+- Generated at: `2026-08-26T16:16:19+00:00`
 
 - Baseline source snapshot: `0f4ab7ffea4209135e33b6353910d7fe79ee6a6b`
 
-- Report source snapshot: `0f4ab7ff+worktree`
+- Report source snapshot: `1d337d83+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 905 |
-| Total Python LOC | 209698 |
+| Total Python LOC | 209699 |
 | Test functions | 3039 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-26T10:21:47+00:00`
+- Generated at: `2026-08-26T15:34:51+00:00`
 
-- Baseline source snapshot: `ccf35bd848128a683954ed9132ec8a4699af13dd`
+- Baseline source snapshot: `0f4ab7ffea4209135e33b6353910d7fe79ee6a6b`
 
-- Report source snapshot: `c0c897b8`
+- Report source snapshot: `0f4ab7ff+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 904 |
-| Total Python LOC | 209623 |
-| Test functions | 3037 |
+| Python files | 905 |
+| Total Python LOC | 209698 |
+| Test functions | 3039 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-26T10:21:47+00:00`
+- Generated at: `2026-08-26T15:34:51+00:00`
 
-- Baseline source snapshot: `ccf35bd848128a683954ed9132ec8a4699af13dd`
+- Baseline source snapshot: `0f4ab7ffea4209135e33b6353910d7fe79ee6a6b`
 
-- Report source snapshot: `c0c897b8`
+- Report source snapshot: `0f4ab7ff+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-26T15:34:51+00:00`
+- Generated at: `2026-08-26T16:16:19+00:00`
 
 - Baseline source snapshot: `0f4ab7ffea4209135e33b6353910d7fe79ee6a6b`
 
-- Report source snapshot: `0f4ab7ff+worktree`
+- Report source snapshot: `1d337d83+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-26T15:34:51+00:00`
+- Generated at: `2026-08-26T16:16:19+00:00`
 
 - Baseline source snapshot: `0f4ab7ffea4209135e33b6353910d7fe79ee6a6b`
 
-- Report source snapshot: `0f4ab7ff+worktree`
+- Report source snapshot: `1d337d83+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-26T10:21:47+00:00`
+- Generated at: `2026-08-26T15:34:51+00:00`
 
-- Baseline source snapshot: `ccf35bd848128a683954ed9132ec8a4699af13dd`
+- Baseline source snapshot: `0f4ab7ffea4209135e33b6353910d7fe79ee6a6b`
 
-- Report source snapshot: `c0c897b8`
+- Report source snapshot: `0f4ab7ff+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-26T15:34:51+00:00`
+- Generated at: `2026-08-26T16:16:19+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `0f4ab7ffea4209135e33b6353910d7fe79ee6a6b`
 
-- Report source snapshot: `0f4ab7ff+worktree`
+- Report source snapshot: `1d337d83+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 904 | 905 | +1 |
-| Total Python LOC | 209623 | 209698 | +75 |
+| Total Python LOC | 209623 | 209699 | +76 |
 | Test functions | 3037 | 3039 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-26T10:21:47+00:00`
+- Generated at: `2026-08-26T15:34:51+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `ccf35bd848128a683954ed9132ec8a4699af13dd`
+- Baseline source snapshot: `0f4ab7ffea4209135e33b6353910d7fe79ee6a6b`
 
-- Report source snapshot: `c0c897b8`
+- Report source snapshot: `0f4ab7ff+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 901 | 904 | +3 |
-| Total Python LOC | 208987 | 209623 | +636 |
-| Test functions | 3018 | 3037 | +19 |
+| Python files | 904 | 905 | +1 |
+| Total Python LOC | 209623 | 209698 | +75 |
+| Test functions | 3037 | 3039 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -40,8 +40,8 @@
 | 1 | tests/unit/dpm/api/test_waves_api.py | 7624 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
-| 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
-| 5 | tests/unit/test_ci_workflow_gate_enforcement.py | 3283 |
+| 4 | tests/unit/test_ci_workflow_gate_enforcement.py | 3296 |
+| 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 7 | tests/unit/test_documentation_current_state.py | 2774 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |

--- a/scripts/ci_local_compose_project.py
+++ b/scripts/ci_local_compose_project.py
@@ -1,0 +1,20 @@
+"""Derive a stable, checkout-specific Docker Compose project name."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+
+def compose_project_name(checkout: Path) -> str:
+    """Return a valid project name that is stable for one checkout path."""
+    resolved = checkout.resolve()
+    checkout_name = re.sub(r"[^a-z0-9_-]+", "-", resolved.name.lower()).strip("-_")
+    checkout_name = checkout_name or "workspace"
+    path_hash = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:10]
+    return f"lotus-manage-ci-local-{checkout_name}-{path_hash}"
+
+
+if __name__ == "__main__":
+    print(compose_project_name(Path.cwd()))

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -71,6 +71,7 @@ def test_ci_local_docker_compose_does_not_publish_internal_postgres_port() -> No
     assert "postgres:17.6" in compose_text
     assert '"5432:5432"' not in compose_text
     assert "apt-get install --no-install-recommends --yes git make" in dockerfile_text
+    assert "git config --system --add safe.directory /workspace" in dockerfile_text
     assert 'pip install -e ".[dev,quality]"' in dockerfile_text
     assert 'command: ["sh", "-lc", "make ci-local"]' in compose_text
     assert "../lotus-platform:/lotus-platform:ro" in compose_text

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from scripts.ci_local_compose_project import compose_project_name
+
 
 def test_local_docker_compose_does_not_publish_internal_postgres_port() -> None:
     compose_text = Path("docker-compose.yml").read_text(encoding="utf-8")
@@ -64,9 +66,62 @@ def test_local_docker_runtime_exposes_stateful_core_sourcing_gates() -> None:
 
 def test_ci_local_docker_compose_does_not_publish_internal_postgres_port() -> None:
     compose_text = Path("docker-compose.ci-local.yml").read_text(encoding="utf-8")
+    dockerfile_text = Path("Dockerfile.ci-local").read_text(encoding="utf-8")
 
     assert "postgres:17.6" in compose_text
     assert '"5432:5432"' not in compose_text
+    assert "apt-get install --no-install-recommends --yes git make" in dockerfile_text
+    assert 'pip install -e ".[dev,quality]"' in dockerfile_text
+    assert 'command: ["sh", "-lc", "make ci-local"]' in compose_text
+    assert "../lotus-platform:/lotus-platform:ro" in compose_text
+    for repository in (
+        "lotus-core",
+        "lotus-performance",
+        "lotus-risk",
+        "lotus-advise",
+        "lotus-report",
+        "lotus-gateway",
+        "lotus-idea",
+    ):
+        assert (
+            f"../{repository}/contracts/domain-data-products:/{repository}/contracts/"
+            "domain-data-products:ro"
+        ) in compose_text
+    assert (
+        "./contracts/domain-data-products:/lotus-manage/contracts/domain-data-products:ro"
+        in compose_text
+    )
+
+
+def test_ci_local_compose_cleanup_uses_an_isolated_project_identity() -> None:
+    makefile_text = Path("Makefile").read_text(encoding="utf-8")
+
+    assert (
+        "CI_LOCAL_COMPOSE_PROJECT ?= $(shell python scripts/ci_local_compose_project.py)"
+        in makefile_text
+    )
+    assert (
+        'docker compose --project-name "$(CI_LOCAL_COMPOSE_PROJECT)" '
+        "-f docker-compose.ci-local.yml "
+        "up --build --abort-on-container-exit --exit-code-from ci-local ci-local"
+    ) in makefile_text
+    assert (
+        'docker compose --project-name "$(CI_LOCAL_COMPOSE_PROJECT)" '
+        "-f docker-compose.ci-local.yml down -v --remove-orphans"
+    ) in makefile_text
+    assert "docker compose -f docker-compose.ci-local.yml down" not in makefile_text
+
+
+def test_ci_local_compose_project_name_is_stable_and_checkout_specific(tmp_path: Path) -> None:
+    first_checkout = tmp_path / "first" / "lotus-manage"
+    second_checkout = tmp_path / "second" / "lotus-manage"
+
+    first_name = compose_project_name(first_checkout)
+
+    assert first_name == compose_project_name(first_checkout)
+    assert first_name != compose_project_name(second_checkout)
+    assert first_name.startswith("lotus-manage-ci-local-lotus-manage-")
+    assert first_name.replace("-", "").isalnum()
 
 
 def test_readme_documents_internal_postgres_port_stays_unpublished() -> None:

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -36,7 +36,10 @@ to `main`.
 - `make ci-local`
   split local validation across unit, integration, and e2e phases
 - `make ci-local-docker`
-  Docker parity for the local CI contract
+  Docker parity for the local CI contract. Startup and cleanup share a stable, checkout-specific
+  Compose project derived by `scripts/ci_local_compose_project.py`; an orchestrator may override it
+  with `CI_LOCAL_COMPOSE_PROJECT`. `make ci-local-docker-down` removes only this CI-owned project
+  and must not remove an active product `lotus-manage` container, network, or volume.
 - `make live-api-validate`
   live API evidence against a running `lotus-manage` instance
 - `make live-api-validate-core`


### PR DESCRIPTION
Closes #638

## Summary
- derive one stable checkout-specific Compose project identity for CI startup and teardown
- make the CI image self-contained for the repo-native gate by installing git, make, and quality dependencies
- mount platform validation assets and only the manifest-declared sibling contract directories read-only
- add regression tests and document the isolation/override contract

## Evidence
- make check: 3341 passed, 13 expected solver skips
- make ci: 3588 passed, 13 expected solver skips; coverage 99.00%; Bandit and pip-audit clean
- make ci-local-docker: 3354 unit + 219 integration + 28 e2e passed; combined coverage 99.02%
- isolated teardown preserved product container a470f3f52b24, network 1d01e7a753d3, and lotus-manage_manage-postgres-data; no CI containers or network remained
- Docker Compose config validation passed
- wiki pre-publication check passed with one intentional source delta

## Wiki
Validation-and-CI source changed. Publish and verify strict parity after merge.
