### PR TITLE
docs: give the playbook pointer both a filesystem path and a GitHub URL

### DIFF
--- a/docs/architecture/ENTERPRISE_BACKEND_REFACTORING_INSTRUCTIONS.md
+++ b/docs/architecture/ENTERPRISE_BACKEND_REFACTORING_INSTRUCTIONS.md
@@ -1,7 +1,12 @@
 # Enterprise Backend Refactoring Instructions
 
-The canonical Lotus enterprise backend refactoring playbook lives in
-[`../lotus-platform/context/playbooks/ENTERPRISE-BACKEND-REFACTORING-INSTRUCTIONS.md`](../../../lotus-platform/context/playbooks/ENTERPRISE-BACKEND-REFACTORING-INSTRUCTIONS.md).
+The canonical Lotus enterprise backend refactoring playbook lives in the `lotus-platform` sibling
+checkout at `../lotus-platform/context/playbooks/ENTERPRISE-BACKEND-REFACTORING-INSTRUCTIONS.md`,
+and on GitHub at
+[lotus-platform/context/playbooks/ENTERPRISE-BACKEND-REFACTORING-INSTRUCTIONS.md](https://github.com/sgajbi/lotus-platform/blob/main/context/playbooks/ENTERPRISE-BACKEND-REFACTORING-INSTRUCTIONS.md).
+
+Both forms are given deliberately: the filesystem path is what resolves for an agent working in a
+multi-repository workspace, and the URL is what resolves for anyone reading this file on GitHub.
 
 This repository intentionally keeps only this pointer so future agents do not treat a stale local
 copy as authoritative. Follow the central platform playbook together with this repository's

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-28T03:55:53+00:00`
+- Generated at: `2026-08-28T04:29:43+00:00`
 
-- Baseline source snapshot: `6acf2d389f4da2572d35129da8ea3f7a9a50e2e3`
+- Baseline source snapshot: `4faa1b6e9f8aa242daaf8734dc08768dd989305f`
 
-- Report source snapshot: `ea21225d+worktree`
+- Report source snapshot: `6d3b90b0`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-28T03:55:53+00:00`
+- Generated at: `2026-08-28T04:29:43+00:00`
 
-- Baseline source snapshot: `6acf2d389f4da2572d35129da8ea3f7a9a50e2e3`
+- Baseline source snapshot: `4faa1b6e9f8aa242daaf8734dc08768dd989305f`
 
-- Report source snapshot: `ea21225d+worktree`
+- Report source snapshot: `6d3b90b0`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 
@@ -13,7 +13,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Reported top functions | 10 | 10 | +0 |
-| Highest complexity | 1066 | 1068 | +2 |
+| Highest complexity | 1068 | 1068 | +0 |
 
 ### Most Complex Current Functions
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-28T03:55:53+00:00`
+- Generated at: `2026-08-28T04:29:43+00:00`
 
-- Baseline source snapshot: `6acf2d389f4da2572d35129da8ea3f7a9a50e2e3`
+- Baseline source snapshot: `4faa1b6e9f8aa242daaf8734dc08768dd989305f`
 
-- Report source snapshot: `ea21225d+worktree`
+- Report source snapshot: `6d3b90b0`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-28T03:55:53+00:00`
+- Generated at: `2026-08-28T04:29:43+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `6acf2d389f4da2572d35129da8ea3f7a9a50e2e3`
+- Baseline source snapshot: `4faa1b6e9f8aa242daaf8734dc08768dd989305f`
 
-- Report source snapshot: `ea21225d+worktree`
+- Report source snapshot: `6d3b90b0`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 905 | 905 | +0 |
-| Total Python LOC | 209699 | 209708 | +9 |
+| Total Python LOC | 209708 | 209708 | +0 |
 | Test functions | 3039 | 3039 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
@@ -43,7 +43,7 @@
 | 4 | tests/unit/test_ci_workflow_gate_enforcement.py | 3296 |
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2774 |
+| 7 | tests/unit/test_documentation_current_state.py | 2783 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
@@ -69,7 +69,7 @@
 
 | Rank | Function | File | Lines |
 | --- | --- | --- | --- |
-| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1549 |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 774 |
 | 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 396 |
 | 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 380 |
@@ -101,7 +101,7 @@
 
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
-| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1066 | 1549 |
+| 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 774 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
 | 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 107 | 396 |


### PR DESCRIPTION
Documentation only — one file.

A `../../../lotus-platform/...` link resolves in a local sibling checkout but **not on github.com**, where it is interpreted inside this repository's blob hierarchy. The earlier bare `lotus-platform/...` path resolved for neither. Each fix broke the other audience.

The file now carries both forms — the filesystem path in prose for an agent working in a multi-repository workspace, and the canonical GitHub URL as the link for anyone reading on the web — and states why both are present so a future editor does not remove one as redundant. The GitHub path was verified through the API.

Found by review on lotus-performance#493; applied to all six repos carrying this pointer.

## Wiki impact

**No wiki change is needed**, recorded explicitly per the Wiki Publication Rule.

The only file changed is `docs/architecture/ENTERPRISE_BACKEND_REFACTORING_INSTRUCTIONS.md`, which is repository documentation and is not published to the wiki. No `wiki/` page links to it or restates it — checked — so no published operator guidance is affected and nothing needs republishing after merge.