### PR TITLE
fix(manage): enforce request body limit on received bytes

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1079,7 +1079,11 @@ Important validation expectations:
    addition to Postgres persistence guardrails; PM-quality read/write routes require trusted actor,
    tenant, and role headers, reject body/header actor or tenant mismatches, and persist/list policy,
    score-run, fairness-analysis, review-action, summary-invocation, and portfolio-memory PM-quality
-   source reads under the trusted tenant scope,
+   source reads under the trusted tenant scope. Write-request admission also rejects malformed or
+   negative `Content-Length`, pre-rejects a declared oversized body, and then streams and measures
+   authorized request bytes before replaying the bounded body unchanged to route handling; preserve
+   this received-byte enforcement so missing or under-declared lengths cannot bypass
+   `ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES`,
 3. architecture, complexity, exact duplicate implementation non-regression, dependency-hygiene,
    and dead-code gates are active in Remote Feature Lane, Pull Request Merge Gate, and Main
    Releasability; the separate Quality Baseline workflow remains report-only for expanded trend

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-28T04:29:43+00:00`
+- Generated at: `2026-08-29T01:33:07+00:00`
 
-- Baseline source snapshot: `4faa1b6e9f8aa242daaf8734dc08768dd989305f`
+- Baseline source snapshot: `0f413c505e0846093b45d1a9f4247af00d0d9702`
 
-- Report source snapshot: `6d3b90b0`
+- Report source snapshot: `0f413c50+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 905 |
-| Total Python LOC | 209708 |
-| Test functions | 3039 |
+| Python files | 907 |
+| Total Python LOC | 209897 |
+| Test functions | 3044 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-28T04:29:43+00:00`
+- Generated at: `2026-08-29T01:33:07+00:00`
 
-- Baseline source snapshot: `4faa1b6e9f8aa242daaf8734dc08768dd989305f`
+- Baseline source snapshot: `0f413c505e0846093b45d1a9f4247af00d0d9702`
 
-- Report source snapshot: `6d3b90b0`
+- Report source snapshot: `0f413c50+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-28T04:29:43+00:00`
+- Generated at: `2026-08-29T01:33:07+00:00`
 
-- Baseline source snapshot: `4faa1b6e9f8aa242daaf8734dc08768dd989305f`
+- Baseline source snapshot: `0f413c505e0846093b45d1a9f4247af00d0d9702`
 
-- Report source snapshot: `6d3b90b0`
+- Report source snapshot: `0f413c50+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-28T04:29:43+00:00`
+- Generated at: `2026-08-29T01:33:07+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `4faa1b6e9f8aa242daaf8734dc08768dd989305f`
+- Baseline source snapshot: `0f413c505e0846093b45d1a9f4247af00d0d9702`
 
-- Report source snapshot: `6d3b90b0`
+- Report source snapshot: `0f413c50+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 905 | 905 | +0 |
-| Total Python LOC | 209708 | 209708 | +0 |
-| Test functions | 3039 | 3039 | +0 |
+| Python files | 905 | 907 | +2 |
+| Total Python LOC | 209708 | 209897 | +189 |
+| Test functions | 3039 | 3044 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/src/api/enterprise_readiness.py
+++ b/src/api/enterprise_readiness.py
@@ -8,6 +8,12 @@ from typing import Any, Awaitable, Callable
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
 
+from src.api.request_body_limit import (
+    declared_content_length,
+    read_limited_body,
+    replay_body_for_downstream,
+)
+
 logger = logging.getLogger("enterprise_readiness")
 MiddlewareNext = Callable[[Request], Awaitable[Response]]
 MiddlewareCallable = Callable[[Request, MiddlewareNext], Awaitable[Response]]
@@ -253,20 +259,6 @@ def emit_audit_event(
     )
 
 
-def _request_content_length(request: Request) -> int:
-    try:
-        return int(request.headers.get("content-length", "0"))
-    except ValueError:
-        return 0
-
-
-def _write_payload_too_large(request: Request, *, max_write_payload_bytes: int) -> bool:
-    return (
-        request.method in _WRITE_METHODS
-        and _request_content_length(request) > max_write_payload_bytes
-    )
-
-
 def _audit_identity_from_request(request: Request) -> _AuditIdentity:
     return _AuditIdentity(
         actor_id=request.headers.get("X-Actor-Id", "unknown"),
@@ -325,11 +317,14 @@ def _emit_write_audit_if_needed(request: Request, response: Response) -> None:
 def build_enterprise_audit_middleware() -> MiddlewareCallable:
     async def middleware(request: Request, call_next: MiddlewareNext) -> Response:
         max_write_payload_bytes = _env_int("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", 1_048_576)
-        if _write_payload_too_large(
-            request,
-            max_write_payload_bytes=max_write_payload_bytes,
-        ):
-            return JSONResponse(status_code=413, content={"detail": "payload_too_large"})
+        method_is_write = request.method in _WRITE_METHODS
+        if method_is_write:
+            try:
+                content_length = declared_content_length(request)
+            except ValueError:
+                return JSONResponse(status_code=400, content={"detail": "invalid_content_length"})
+            if content_length is not None and content_length > max_write_payload_bytes:
+                return JSONResponse(status_code=413, content={"detail": "payload_too_large"})
 
         authorized, reason = authorize_write_request(
             request.method, request.url.path, dict(request.headers)
@@ -337,6 +332,12 @@ def build_enterprise_audit_middleware() -> MiddlewareCallable:
         if not authorized:
             _emit_denied_write_audit(request, reason=reason)
             return _authorization_denied_response(reason)
+
+        if method_is_write:
+            body = await read_limited_body(request, max_bytes=max_write_payload_bytes)
+            if body is None:
+                return JSONResponse(status_code=413, content={"detail": "payload_too_large"})
+            replay_body_for_downstream(request, body)
 
         response = await call_next(request)
         _attach_policy_version_header(response)

--- a/src/api/request_body_limit.py
+++ b/src/api/request_body_limit.py
@@ -1,0 +1,43 @@
+from typing import Any
+
+from fastapi import Request
+
+
+def declared_content_length(request: Request) -> int | None:
+    raw_content_length = request.headers.get("content-length")
+    if raw_content_length is None:
+        return None
+    try:
+        declared_length = int(raw_content_length)
+    except ValueError as exc:
+        raise ValueError("invalid_content_length") from exc
+    if declared_length < 0:
+        raise ValueError("invalid_content_length")
+    return declared_length
+
+
+async def read_limited_body(request: Request, *, max_bytes: int) -> bytes | None:
+    chunks: list[bytes] = []
+    received_bytes = 0
+    async for chunk in request.stream():
+        if not chunk:
+            continue
+        received_bytes += len(chunk)
+        if received_bytes > max_bytes:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def replay_body_for_downstream(request: Request, body: bytes) -> None:
+    sent = False
+
+    async def receive() -> dict[str, Any]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    setattr(request, "_body", body)
+    setattr(request, "_receive", receive)

--- a/tests/unit/api/test_enterprise_readiness_hardening.py
+++ b/tests/unit/api/test_enterprise_readiness_hardening.py
@@ -9,7 +9,6 @@ from src.api.enterprise_readiness import (
     _authorization_denied_response,
     _has_service_identity,
     _missing_capability_reason,
-    _request_content_length,
     _missing_required_headers,
     _missing_required_headers_reason,
     _missing_service_identity_reason,
@@ -18,7 +17,6 @@ from src.api.enterprise_readiness import (
     _provided_capabilities,
     _secret_rotation_issue,
     _write_authorization_failure_reason,
-    _write_payload_too_large,
     _write_authorization_required,
     authorize_write_request,
     build_enterprise_audit_middleware,
@@ -250,7 +248,7 @@ def test_enterprise_middleware_blocks_oversized_payload(monkeypatch) -> None:
     assert response.json() == {"detail": "payload_too_large"}
 
 
-def test_enterprise_middleware_treats_invalid_content_length_as_zero(monkeypatch) -> None:
+def test_enterprise_middleware_rejects_invalid_content_length(monkeypatch) -> None:
     monkeypatch.setenv("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", "5")
     client = TestClient(_enterprise_app())
 
@@ -266,7 +264,8 @@ def test_enterprise_middleware_treats_invalid_content_length_as_zero(monkeypatch
         },
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 400
+    assert response.json() == {"detail": "invalid_content_length"}
 
 
 def test_enterprise_middleware_helpers_parse_size_and_audit_identity(monkeypatch) -> None:
@@ -280,17 +279,11 @@ def test_enterprise_middleware_helpers_parse_size_and_audit_identity(monkeypatch
             "X-Correlation-Id": "corr",
         }
     )
-    invalid_length_request = _request(headers={"content-length": "not-a-number"})
-
     identity = _audit_identity_from_request(request)
     response = Response()
     denied_response = _authorization_denied_response("missing_service_identity")
     _attach_policy_version_header(response)
 
-    assert _request_content_length(request) == 6
-    assert _request_content_length(invalid_length_request) == 0
-    assert _write_payload_too_large(request, max_write_payload_bytes=5)
-    assert not _write_payload_too_large(request, max_write_payload_bytes=6)
     assert identity.actor_id == "actor"
     assert identity.tenant_id == "tenant"
     assert identity.role == "operator"

--- a/tests/unit/api/test_request_body_limit.py
+++ b/tests/unit/api/test_request_body_limit.py
@@ -1,0 +1,152 @@
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from fastapi import Request, Response
+
+from src.api.enterprise_readiness import build_enterprise_audit_middleware
+
+
+def _streaming_request(
+    *,
+    chunks: list[bytes],
+    content_length: str | None = None,
+    method: str = "POST",
+) -> Request:
+    headers = [] if content_length is None else [(b"content-length", content_length.encode())]
+    chunk_iterator: AsyncIterator[bytes] = _chunks(chunks)
+
+    async def receive() -> dict[str, Any]:
+        try:
+            chunk = await anext(chunk_iterator)
+        except StopAsyncIteration:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        return {"type": "http.request", "body": chunk, "more_body": True}
+
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": "/write",
+            "headers": headers,
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+        },
+        receive=receive,
+    )
+
+
+async def _chunks(chunks: list[bytes]) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        yield chunk
+
+
+@pytest.mark.asyncio
+async def test_middleware_measures_streamed_body_without_content_length(monkeypatch) -> None:
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_AUTHZ", "false")
+    monkeypatch.setenv("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", "5")
+    middleware = build_enterprise_audit_middleware()
+    request = _streaming_request(chunks=[b"abc", b"def"])
+
+    async def downstream(_request: Request) -> Response:
+        raise AssertionError("An oversized body must not reach route handling.")
+
+    response = await middleware(request, downstream)
+
+    assert response.status_code == 413
+    assert bytes(response.body) == b'{"detail":"payload_too_large"}'
+
+
+@pytest.mark.asyncio
+async def test_middleware_measures_underdeclared_body(monkeypatch) -> None:
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_AUTHZ", "false")
+    monkeypatch.setenv("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", "5")
+    middleware = build_enterprise_audit_middleware()
+    request = _streaming_request(chunks=[b"abc", b"def"], content_length="2")
+
+    async def downstream(_request: Request) -> Response:
+        raise AssertionError("An under-declared oversized body must not reach route handling.")
+
+    response = await middleware(request, downstream)
+
+    assert response.status_code == 413
+    assert bytes(response.body) == b'{"detail":"payload_too_large"}'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_length", ["not-a-number", "-1"])
+async def test_middleware_rejects_invalid_content_length(monkeypatch, content_length: str) -> None:
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_AUTHZ", "false")
+    middleware = build_enterprise_audit_middleware()
+    request = _streaming_request(chunks=[b"{}"], content_length=content_length)
+
+    async def downstream(_request: Request) -> Response:
+        raise AssertionError("An invalid declaration must not reach route handling.")
+
+    response = await middleware(request, downstream)
+
+    assert response.status_code == 400
+    assert bytes(response.body) == b'{"detail":"invalid_content_length"}'
+
+
+@pytest.mark.asyncio
+async def test_middleware_replays_accepted_body_unchanged(monkeypatch) -> None:
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_AUTHZ", "false")
+    monkeypatch.setenv("ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES", "32")
+    middleware = build_enterprise_audit_middleware()
+    request = _streaming_request(chunks=[b'{"status":', b'"ready"}'])
+    received_body = b""
+    replay_messages: list[dict[str, Any]] = []
+
+    async def downstream(replayed_request: Request) -> Response:
+        nonlocal received_body
+        received_body = await replayed_request.body()
+        replay_messages.extend([await replayed_request.receive(), await replayed_request.receive()])
+        return Response(status_code=204)
+
+    response = await middleware(request, downstream)
+
+    assert response.status_code == 204
+    assert received_body == b'{"status":"ready"}'
+    assert replay_messages == [
+        {
+            "type": "http.request",
+            "body": b'{"status":"ready"}',
+            "more_body": False,
+        },
+        {"type": "http.request", "body": b"", "more_body": False},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_middleware_does_not_buffer_unauthorized_write(monkeypatch) -> None:
+    monkeypatch.setenv("ENTERPRISE_ENFORCE_AUTHZ", "true")
+    middleware = build_enterprise_audit_middleware()
+    body_read = False
+
+    async def receive() -> dict[str, Any]:
+        nonlocal body_read
+        body_read = True
+        return {"type": "http.request", "body": b"secret", "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/write",
+            "headers": [],
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+        },
+        receive=receive,
+    )
+
+    async def downstream(_request: Request) -> Response:
+        raise AssertionError("An unauthorized write must not reach route handling.")
+
+    response = await middleware(request, downstream)
+
+    assert response.status_code == 403
+    assert body_read is False

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -222,7 +222,7 @@ reach the port.
 
 | control | mechanism |
 |---|---|
-| write payload size | `ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES`, compared against a **declared** `Content-Length` on write methods — see the gap below |
+| write payload size | `ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES`, enforced against bytes actually received for every write method |
 | runtime configuration validation | `validate_enterprise_runtime_config()` collects issues — policy version, secret rotation, authorization key material — and raises `enterprise_runtime_config_invalid` **only when `ENTERPRISE_ENFORCE_RUNTIME_CONFIG` is enabled**, default `"false"` |
 | policy version | `ENTERPRISE_POLICY_VERSION` |
 | key material and rotation | `ENTERPRISE_PRIMARY_KEY_ID`, `ENTERPRISE_SECRET_ROTATION_DAYS` |
@@ -238,19 +238,18 @@ discards it without logging, and with authorization off the key-material check i
 `LOCAL` deployment with both toggles unset therefore gets neither enforcement nor a warning. The
 `PRODUCTION` profile is what turns that silence into a startup failure.
 
-### Gap: the payload cap needs a well-formed declared length
+### Bounded write-body handling
 
-`_request_content_length()` reads `Content-Length` and returns `0` when the header is absent **or
-unparseable**. The middleware never measures the received body, so a write that omits the header —
-chunked transfer encoding, for instance — or sends a malformed one is compared against zero and
-passes whatever its actual size. There is no proxy or server-level body limit elsewhere in the repo
-to catch it.
+The service treats `Content-Length` as an early-rejection hint, not as the source of truth for body
+size. A declared length above the configured cap is rejected before the body is read. Missing
+declarations, including chunked transfers, are accepted only after the middleware streams and
+measures the received bytes. A declaration below the cap does not bypass that measurement, so an
+under-declared body is still rejected with `413 payload_too_large`.
 
-This is the same control implemented three ways across the estate, and this is the weakest:
-`lotus-report` streams and enforces the cap when no length is declared; `lotus-render` is also
-header-only but treats a malformed header as oversized, failing closed; `lotus-manage` fails open in
-both cases. Tracked as [#653](https://github.com/sgajbi/lotus-manage/issues/653), and as
-[lotus-render#84](https://github.com/sgajbi/lotus-render/issues/84) for the sibling.
+Malformed and negative declarations are rejected with `400 invalid_content_length`. An authorized,
+bounded body is replayed unchanged to route handling. Authorization runs before streaming when the
+declaration is otherwise valid, so the service does not buffer an unauthorized caller's body.
+Ingress limits remain defense in depth rather than a substitute for this service boundary.
 
 Sensitive fields — `password`, `secret`, `token` and their siblings — are redacted from audit
 records rather than logged.


### PR DESCRIPTION
## Root cause and estate decision

Manage treated a missing or malformed `Content-Length` as zero and compared only that caller-controlled declaration to `ENTERPRISE_MAX_WRITE_PAYLOAD_BYTES`. Missing, malformed, negative, and under-declared requests could therefore bypass the received-byte cap.

This PR implements Option 1 selected jointly for Manage #653 and Render #84 while keeping this PR Manage-only:

- missing `Content-Length`: stream and measure the received body;
- malformed or negative declaration: reject with `400 invalid_content_length`;
- declared oversized body: reject before reading with `413 payload_too_large`;
- declared in-range body: still measure received bytes, preventing under-declaration bypass;
- accepted body: replay the identical bounded bytes to route handling.

Authorization remains ahead of body streaming for an otherwise valid declaration, so an unauthorized write is not buffered. Ingress limits remain defense in depth.

## Architecture and compatibility

The bounded stream/replay concern is extracted into `src/api/request_body_limit.py`, reducing the already-large enterprise middleware and keeping domain routers free of transport policy. Existing valid clients, including chunked callers, remain compatible. The malformed/negative response is an intentional fail-closed contract correction.

## Regression and quality proof

Failing first: **4 failed, 2 passed**. Missing and under-declared oversized bodies reached route handling; malformed and negative lengths were accepted.

Final:

- focused middleware and enterprise tests: 20 passed
- request-body limit module: 100% covered
- `make ci`: passed
  - 3,607 tests passed
  - combined coverage 99.02%
  - lint, formatting, mypy, OpenAPI, vocabulary and contract gates passed
  - architecture, complexity, duplicate implementation, dependency hygiene and dead-code gates passed
  - no known vulnerabilities
- quality reports refreshed because current #651 gate requires source-linked generated evidence
- wiki pre-merge check: one intentional authored-source difference; publish after merge

Repository context and security-governance documentation now state the received-byte control truth. No product feature catalogue change is required: this is a cross-cutting request-admission control, not a new business capability.

Closes #653