### PR TITLE
Stabilize quality report baselines for open branches

### DIFF
--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -71,12 +71,27 @@ jobs:
         run: make dead-code-gate
       - name: Workflow Policy Gate
         run: make workflow-policy-gate
-      - name: Quality Report Freshness Gate
-        run: make quality-report-gate
       - name: Test Family Inventory Gate
         run: make test-family-inventory
       - name: Security Audit
         run: make security-audit
+
+  quality-report:
+    name: PR Merge Gate / Quality Report (PR Head)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+      - name: Install
+        run: make install-ci
+      - name: Quality Report Freshness Gate
+        run: make quality-report-gate
 
   test-suites:
     name: PR Merge Gate / Tests (${{ matrix.suite }})

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1094,7 +1094,10 @@ Important validation expectations:
    findings unrelated to the RFC-0002 temporal-evidence change. Checked-in quality reports pin
    clean branch validation to their recorded immutable baseline SHA;
    do not replace that behavior with moving `origin/main` comparison or normalize away absolute
-   measurements. Dirty worktrees and missing recorded refs retain the safe `origin/main` fallback.
+   measurements. The PR merge gate validates static and test integration on GitHub's merge result,
+   while a separate blocking job checks report freshness on the immutable pull-request head; this
+   prevents unrelated base-branch changes from making branch-owned evidence stale. Dirty worktrees
+   and missing recorded refs retain the safe `origin/main` fallback.
 4. PR-grade validation includes coverage-backed full test execution,
 5. `make static-quality-gates` includes `make test-family-inventory`, which blocks loss of the
    measured API/runtime, contract/governance, observability/security, domain/lifecycle/methodology,

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1091,7 +1091,10 @@ Important validation expectations:
    and static-analysis tool versions should retain bounded upper ranges until a branch intentionally
    absorbs and fixes the new rule family. PR #625 pins Ruff below the next minor family after CI
    resolved `ruff 0.16.0` and surfaced repository-wide pre-existing Linux executable-bit/import
-   findings unrelated to the RFC-0002 temporal-evidence change,
+   findings unrelated to the RFC-0002 temporal-evidence change. Checked-in quality reports pin
+   clean branch validation to their recorded immutable baseline SHA;
+   do not replace that behavior with moving `origin/main` comparison or normalize away absolute
+   measurements. Dirty worktrees and missing recorded refs retain the safe `origin/main` fallback.
 4. PR-grade validation includes coverage-backed full test execution,
 5. `make static-quality-gates` includes `make test-family-inventory`, which blocks loss of the
    measured API/runtime, contract/governance, observability/security, domain/lifecycle/methodology,

--- a/quality/README.md
+++ b/quality/README.md
@@ -6,7 +6,7 @@ repo-native quality gates.
 | File family | Purpose | Owner command |
 | --- | --- | --- |
 | `*_rules.md` | Human-readable governance rules for API and architecture quality. | Keep aligned with Make targets and CI. |
-| `*_report.md` | Generated or refreshed quality reports. | `make quality-report-gate` |
+| `*_report.md` | Generated or refreshed quality reports; their recorded baseline keeps clean branch checks stable when `origin/main` advances. | `make quality-report-gate` |
 | `duplicate_*` | Duplicate implementation inventory and baseline. | `make duplicate-implementation-gate` |
 | `test_family_inventory_baseline.json` | Baseline floors for semantic test proof-family breadth and uncategorized-test exceptions. | `make test-family-inventory` |
 | `quality_scorecard.md` | Current repository quality scorecard. | `make static-quality-gates` or the focused owning gate. |

--- a/quality/README.md
+++ b/quality/README.md
@@ -6,7 +6,7 @@ repo-native quality gates.
 | File family | Purpose | Owner command |
 | --- | --- | --- |
 | `*_rules.md` | Human-readable governance rules for API and architecture quality. | Keep aligned with Make targets and CI. |
-| `*_report.md` | Generated or refreshed quality reports; their recorded baseline keeps clean branch checks stable when `origin/main` advances. | `make quality-report-gate` |
+| `*_report.md` | Generated or refreshed quality reports; their recorded baseline keeps clean branch checks stable when `origin/main` advances, and PR freshness is measured on the immutable branch head. | `make quality-report-gate` |
 | `duplicate_*` | Duplicate implementation inventory and baseline. | `make duplicate-implementation-gate` |
 | `test_family_inventory_baseline.json` | Baseline floors for semantic test proof-family breadth and uncategorized-test exceptions. | `make test-family-inventory` |
 | `quality_scorecard.md` | Current repository quality scorecard. | `make static-quality-gates` or the focused owning gate. |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-29T01:33:07+00:00`
+- Generated at: `2026-08-29T02:28:51+00:00`
 
-- Baseline source snapshot: `0f413c505e0846093b45d1a9f4247af00d0d9702`
+- Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0f413c50+worktree`
+- Report source snapshot: `0c33ffd8+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 907 |
-| Total Python LOC | 209897 |
-| Test functions | 3044 |
+| Total Python LOC | 209953 |
+| Test functions | 3047 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-29T02:28:51+00:00`
+- Generated at: `2026-08-29T02:45:38+00:00`
 
 - Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0c33ffd8+worktree`
+- Report source snapshot: `0a392fca+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 907 |
-| Total Python LOC | 209953 |
-| Test functions | 3047 |
+| Total Python LOC | 210018 |
+| Test functions | 3049 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-08-29T02:45:38+00:00`
+- Generated at: `2026-08-29T02:58:25+00:00`
 
 - Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0a392fca+worktree`
+- Report source snapshot: `85165370+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 907 |
-| Total Python LOC | 210018 |
-| Test functions | 3049 |
+| Total Python LOC | 210055 |
+| Test functions | 3050 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -35,6 +35,7 @@ The following commands are active repository gates:
   - `make dead-code-gate` (`python -m vulture src tests --min-confidence 80`)
   - `make workflow-policy-gate` (`python scripts/workflow_policy_gate.py`; blocks unpinned
     action references, unexpected workflow permissions, missing blocking quality-report checks, and
+    PR quality-report checks that do not use the immutable pull-request head, plus
     PR-template evidence drift for local gates, CI lanes, security, stranded truth, wiki decisions,
     guidance decisions, coverage evidence, blocking workflow coverage-gate drift, and raw pytest
     shortcuts in blocking workflows when repo-native Make test targets exist)
@@ -90,7 +91,8 @@ The following commands are active repository gates:
   - matrix unit/integration/e2e tests with coverage upload
   - combined coverage floor (`99`)
   - workflow policy integrity
-  - checked-in quality report freshness
+  - checked-in quality report freshness in a separate blocking job checked out at the immutable PR
+    head; the other PR gates continue to validate GitHub's merge result
   - test-family breadth inventory (`make test-family-inventory`)
   - shared coverage gate script for downloaded unit/integration/e2e coverage artifacts
   - suite tests through `make test-${{ matrix.suite }}-coverage`, preserving

--- a/quality/ci_quality_gates.md
+++ b/quality/ci_quality_gates.md
@@ -39,7 +39,9 @@ The following commands are active repository gates:
     guidance decisions, coverage evidence, blocking workflow coverage-gate drift, and raw pytest
     shortcuts in blocking workflows when repo-native Make test targets exist)
   - `make quality-report-gate` (`python scripts/engineering_health_report.py --check`;
-    ignores volatile report provenance while enforcing measured report content)
+    pins clean checkouts to the immutable baseline SHA recorded in the report, ignores volatile
+    report provenance, and enforces absolute measured content; dirty development worktrees and
+    missing recorded refs safely fall back to `origin/main`)
   - `make test-family-inventory` (`python scripts/test_family_inventory.py --check`;
     blocks loss of measured proof-family breadth and rejects new uncategorized tests against
     `quality/test_family_inventory_baseline.json`)

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-29T02:45:38+00:00`
+- Generated at: `2026-08-29T02:58:25+00:00`
 
 - Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0a392fca+worktree`
+- Report source snapshot: `85165370+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-29T01:33:07+00:00`
+- Generated at: `2026-08-29T02:28:51+00:00`
 
-- Baseline source snapshot: `0f413c505e0846093b45d1a9f4247af00d0d9702`
+- Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0f413c50+worktree`
+- Report source snapshot: `0c33ffd8+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-08-29T02:28:51+00:00`
+- Generated at: `2026-08-29T02:45:38+00:00`
 
 - Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0c33ffd8+worktree`
+- Report source snapshot: `0a392fca+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-29T02:45:38+00:00`
+- Generated at: `2026-08-29T02:58:25+00:00`
 
 - Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0a392fca+worktree`
+- Report source snapshot: `85165370+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-29T02:28:51+00:00`
+- Generated at: `2026-08-29T02:45:38+00:00`
 
 - Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0c33ffd8+worktree`
+- Report source snapshot: `0a392fca+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 
@@ -20,8 +20,8 @@
 | OpenAPI 4xx/5xx response markers | Baseline debt | Current missing markers: 1. |
 | Complexity | Active source C gate | `make complexity-gate` blocks Radon C-or-worse source functions; `quality/complexity_report.md` keeps broader source/test metrics report-only. |
 | Duplicate implementation hotspots | Active exact-duplicate non-regression gate | `make duplicate-implementation-gate` blocks newly introduced exact non-trivial Python function-body duplicates; `quality/duplicate_implementation_baseline.json` governs current accepted groups. |
-| Quality report freshness | Active gate | `make quality-report-gate` blocks stale checked-in quality reports, pins clean checkouts to the report's recorded baseline, and ignores volatile report provenance. |
-| Workflow policy | Active gate | `make workflow-policy-gate` blocks unpinned action refs, permission creep, blocking quality-report drift, raw blocking-workflow pytest shortcuts, coverage-gate drift, and PR evidence drift. |
+| Quality report freshness | Active gate | `make quality-report-gate` blocks stale checked-in quality reports, pins clean checkouts to the report's recorded baseline, measures pull requests on the immutable PR head, and ignores volatile report provenance. |
+| Workflow policy | Active gate | `make workflow-policy-gate` blocks unpinned action refs, permission creep, blocking quality-report drift, non-head PR report checks, raw blocking-workflow pytest shortcuts, coverage-gate drift, and PR evidence drift. |
 | Local CI parity | Active gate | `make check`, `make ci`, and `make ci-local` share `make static-quality-gates` so local proof cannot omit active static gates. |
 | Coverage gate parity | Active gate | `scripts/coverage_gate.py` is the shared local and GitHub combined coverage gate. |
 | Test-family proof breadth | Active gate | `make test-family-inventory` checks `quality/test_family_inventory_baseline.json` and blocks loss of API/runtime, contract/governance, observability/security, domain/lifecycle/methodology, and integration/runtime proof-family file counts. |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-08-29T01:33:07+00:00`
+- Generated at: `2026-08-29T02:28:51+00:00`
 
-- Baseline source snapshot: `0f413c505e0846093b45d1a9f4247af00d0d9702`
+- Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0f413c50+worktree`
+- Report source snapshot: `0c33ffd8+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 
@@ -20,7 +20,7 @@
 | OpenAPI 4xx/5xx response markers | Baseline debt | Current missing markers: 1. |
 | Complexity | Active source C gate | `make complexity-gate` blocks Radon C-or-worse source functions; `quality/complexity_report.md` keeps broader source/test metrics report-only. |
 | Duplicate implementation hotspots | Active exact-duplicate non-regression gate | `make duplicate-implementation-gate` blocks newly introduced exact non-trivial Python function-body duplicates; `quality/duplicate_implementation_baseline.json` governs current accepted groups. |
-| Quality report freshness | Active gate | `make quality-report-gate` blocks stale checked-in quality reports while ignoring volatile report provenance. |
+| Quality report freshness | Active gate | `make quality-report-gate` blocks stale checked-in quality reports, pins clean checkouts to the report's recorded baseline, and ignores volatile report provenance. |
 | Workflow policy | Active gate | `make workflow-policy-gate` blocks unpinned action refs, permission creep, blocking quality-report drift, raw blocking-workflow pytest shortcuts, coverage-gate drift, and PR evidence drift. |
 | Local CI parity | Active gate | `make check`, `make ci`, and `make ci-local` share `make static-quality-gates` so local proof cannot omit active static gates. |
 | Coverage gate parity | Active gate | `scripts/coverage_gate.py` is the shared local and GitHub combined coverage gate. |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-29T02:28:51+00:00`
+- Generated at: `2026-08-29T02:45:38+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0c33ffd8+worktree`
+- Report source snapshot: `0a392fca+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 907 | 907 | +0 |
-| Total Python LOC | 209897 | 209953 | +56 |
-| Test functions | 3044 | 3047 | +3 |
+| Total Python LOC | 209897 | 210018 | +121 |
+| Test functions | 3044 | 3049 | +5 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -54,8 +54,8 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 7624 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
-| 3 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
-| 4 | tests/unit/test_ci_workflow_gate_enforcement.py | 3296 |
+| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3352 |
+| 4 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 7 | tests/unit/test_documentation_current_state.py | 2783 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-29T02:45:38+00:00`
+- Generated at: `2026-08-29T02:58:25+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0a392fca+worktree`
+- Report source snapshot: `85165370+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 907 | 907 | +0 |
-| Total Python LOC | 209897 | 210018 | +121 |
-| Test functions | 3044 | 3049 | +5 |
+| Total Python LOC | 209897 | 210055 | +158 |
+| Test functions | 3044 | 3050 | +6 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -54,7 +54,7 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 7624 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
-| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3352 |
+| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3382 |
 | 4 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-08-29T01:33:07+00:00`
+- Generated at: `2026-08-29T02:28:51+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `0f413c505e0846093b45d1a9f4247af00d0d9702`
+- Baseline source snapshot: `0c33ffd896c6fdbecea019547495b0e17423e1cc`
 
-- Report source snapshot: `0f413c50+worktree`
+- Report source snapshot: `0c33ffd8+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 905 | 907 | +2 |
-| Total Python LOC | 209708 | 209897 | +189 |
-| Test functions | 3039 | 3044 | +5 |
+| Python files | 907 | 907 | +0 |
+| Total Python LOC | 209897 | 209953 | +56 |
+| Test functions | 3044 | 3047 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -163,7 +163,9 @@ def _base_ref_for_quality_check() -> tuple[str, str]:
         if _git_status_porcelain().strip():
             return DEFAULT_BASE_REF, DEFAULT_BASE_REF
         return _recorded_quality_baseline_ref() or "HEAD^", DEFAULT_BASE_REF
-    return DEFAULT_BASE_REF, DEFAULT_BASE_REF
+    if _git_status_porcelain().strip():
+        return DEFAULT_BASE_REF, DEFAULT_BASE_REF
+    return _recorded_quality_baseline_ref() or DEFAULT_BASE_REF, DEFAULT_BASE_REF
 
 
 def _report_source_snapshot() -> str:
@@ -688,7 +690,8 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
         [
             "Quality report freshness",
             "Active gate",
-            "`make quality-report-gate` blocks stale checked-in quality reports while ignoring volatile report provenance.",
+            "`make quality-report-gate` blocks stale checked-in quality reports, pins clean "
+            "checkouts to the report's recorded baseline, and ignores volatile report provenance.",
         ],
         [
             "Workflow policy",

--- a/scripts/engineering_health_report.py
+++ b/scripts/engineering_health_report.py
@@ -691,12 +691,13 @@ def build_quality_scorecard(context: HealthReportContext) -> str:
             "Quality report freshness",
             "Active gate",
             "`make quality-report-gate` blocks stale checked-in quality reports, pins clean "
-            "checkouts to the report's recorded baseline, and ignores volatile report provenance.",
+            "checkouts to the report's recorded baseline, measures pull requests on the immutable "
+            "PR head, and ignores volatile report provenance.",
         ],
         [
             "Workflow policy",
             "Active gate",
-            "`make workflow-policy-gate` blocks unpinned action refs, permission creep, blocking quality-report drift, raw blocking-workflow pytest shortcuts, coverage-gate drift, and PR evidence drift.",
+            "`make workflow-policy-gate` blocks unpinned action refs, permission creep, blocking quality-report drift, non-head PR report checks, raw blocking-workflow pytest shortcuts, coverage-gate drift, and PR evidence drift.",
         ],
         [
             "Local CI parity",

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -28,6 +28,7 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
     "pr-auto-merge.yml": {"contents": "read"},
 }
 USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?([^\"'\s#]+)", re.MULTILINE)
+WORKFLOW_JOB_PATTERN = re.compile(r"(?m)^  [A-Za-z0-9_-]+:\s*$")
 VERSION_TAG_PATTERN = re.compile(r"^v\d+(?:\.\d+){0,2}$")
 FULL_SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 HERE_DOCUMENT_START_PATTERN = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
@@ -816,17 +817,23 @@ def quality_report_gate_violations(workflow_path: Path) -> list[str]:
     if "make quality-report-gate" not in text:
         return [f"{workflow_path.as_posix()}: blocking workflow must run make quality-report-gate"]
     start = text.index("make quality-report-gate")
-    checkout_start = text.rfind("uses: actions/checkout@", 0, start)
+    preceding_jobs = list(WORKFLOW_JOB_PATTERN.finditer(text, 0, start))
+    job_start = preceding_jobs[-1].start() if preceding_jobs else start
+    next_job = WORKFLOW_JOB_PATTERN.search(text, start)
+    job_end = next_job.start() if next_job else len(text)
+    job_block = text[job_start:job_end]
+    gate_offset = start - job_start
+    checkout_start = job_block.rfind("uses: actions/checkout@", 0, gate_offset)
     if checkout_start == -1:
         violations.append(
             f"{workflow_path.as_posix()}: quality report gate job must checkout repository first"
         )
     else:
-        checkout_block_end = text.find("\n      - ", checkout_start)
+        checkout_block_end = job_block.find("\n      - ", checkout_start)
         checkout_block = (
-            text[checkout_start:]
+            job_block[checkout_start:]
             if checkout_block_end == -1
-            else text[checkout_start:checkout_block_end]
+            else job_block[checkout_start:checkout_block_end]
         )
         if "fetch-depth: 0" not in checkout_block:
             violations.append(
@@ -841,9 +848,9 @@ def quality_report_gate_violations(workflow_path: Path) -> list[str]:
                 f"{workflow_path.as_posix()}: PR quality report gate must checkout the "
                 "immutable pull-request head so merge-checkout changes cannot stale the report"
             )
-    step_start = text.rfind("\n      - name:", 0, start)
-    step_end = text.find("\n      - name:", start)
-    step_block = text[step_start:] if step_end == -1 else text[step_start:step_end]
+    step_start = job_block.rfind("\n      - name:", 0, gate_offset)
+    step_end = job_block.find("\n      - name:", gate_offset)
+    step_block = job_block[step_start:] if step_end == -1 else job_block[step_start:step_end]
     if "continue-on-error" in step_block:
         violations.append(
             f"{workflow_path.as_posix()}: quality report freshness gate must be blocking, "

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -833,6 +833,14 @@ def quality_report_gate_violations(workflow_path: Path) -> list[str]:
                 f"{workflow_path.as_posix()}: quality report gate job must use "
                 "actions/checkout with fetch-depth: 0 so origin/main is available"
             )
+        if (
+            workflow_path.name == "pr-merge-gate.yml"
+            and "github.event.pull_request.head.sha" not in checkout_block
+        ):
+            violations.append(
+                f"{workflow_path.as_posix()}: PR quality report gate must checkout the "
+                "immutable pull-request head so merge-checkout changes cannot stale the report"
+            )
     step_start = text.rfind("\n      - name:", 0, start)
     step_end = text.find("\n      - name:", start)
     step_block = text[step_start:] if step_end == -1 else text[step_start:step_end]

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -3194,8 +3194,64 @@ def test_workflow_policy_gate_requires_full_history_for_quality_report_gate(
 
     assert quality_report_gate_violations(workflow) == [
         f"{workflow.as_posix()}: quality report gate job must use actions/checkout with "
-        "fetch-depth: 0 so origin/main is available"
+        "fetch-depth: 0 so origin/main is available",
+        f"{workflow.as_posix()}: PR quality report gate must checkout the immutable "
+        "pull-request head so merge-checkout changes cannot stale the report",
     ]
+
+
+def test_workflow_policy_gate_requires_pr_head_for_quality_report_gate(
+    tmp_path: Path,
+) -> None:
+    workflow = tmp_path / "pr-merge-gate.yml"
+    workflow.write_text(
+        "\n".join(
+            [
+                "permissions:",
+                "  contents: read",
+                "jobs:",
+                "  quality-report:",
+                "    steps:",
+                "      - uses: actions/checkout@v6",
+                "        with:",
+                "          fetch-depth: 0",
+                "      - name: Quality Report Freshness Gate",
+                "        run: make quality-report-gate",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert quality_report_gate_violations(workflow) == [
+        f"{workflow.as_posix()}: PR quality report gate must checkout the immutable "
+        "pull-request head so merge-checkout changes cannot stale the report"
+    ]
+
+
+def test_workflow_policy_gate_accepts_blocking_pr_head_quality_report_gate(
+    tmp_path: Path,
+) -> None:
+    workflow = tmp_path / "pr-merge-gate.yml"
+    workflow.write_text(
+        "\n".join(
+            [
+                "permissions:",
+                "  contents: read",
+                "jobs:",
+                "  quality-report:",
+                "    steps:",
+                "      - uses: actions/checkout@v6",
+                "        with:",
+                "          fetch-depth: 0",
+                "          ref: ${{ github.event.pull_request.head.sha || github.sha }}",
+                "      - name: Quality Report Freshness Gate",
+                "        run: make quality-report-gate",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert quality_report_gate_violations(workflow) == []
 
 
 def test_workflow_policy_gate_rejects_ad_hoc_coverage_commands(tmp_path: Path) -> None:

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -3254,6 +3254,36 @@ def test_workflow_policy_gate_accepts_blocking_pr_head_quality_report_gate(
     assert quality_report_gate_violations(workflow) == []
 
 
+def test_workflow_policy_gate_does_not_reuse_checkout_from_preceding_job(
+    tmp_path: Path,
+) -> None:
+    workflow = tmp_path / "pr-merge-gate.yml"
+    workflow.write_text(
+        "\n".join(
+            [
+                "permissions:",
+                "  contents: read",
+                "jobs:",
+                "  merge-validation:",
+                "    steps:",
+                "      - uses: actions/checkout@v6",
+                "        with:",
+                "          fetch-depth: 0",
+                "          ref: ${{ github.event.pull_request.head.sha || github.sha }}",
+                "  quality-report:",
+                "    steps:",
+                "      - name: Quality Report Freshness Gate",
+                "        run: make quality-report-gate",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert quality_report_gate_violations(workflow) == [
+        f"{workflow.as_posix()}: quality report gate job must checkout repository first"
+    ]
+
+
 def test_workflow_policy_gate_rejects_ad_hoc_coverage_commands(tmp_path: Path) -> None:
     workflow = tmp_path / "pr-merge-gate.yml"
     workflow.write_text(

--- a/tests/unit/test_engineering_health_report.py
+++ b/tests/unit/test_engineering_health_report.py
@@ -133,15 +133,68 @@ def test_quality_report_check_uses_parent_commit_for_clean_mainline(monkeypatch)
     ]
 
 
-def test_quality_report_check_uses_origin_main_for_feature_branch(monkeypatch) -> None:
+def test_quality_report_check_uses_recorded_baseline_for_clean_feature_branch(
+    monkeypatch,
+) -> None:
     def fake_git(*args: str) -> str:
         if args == ("rev-parse", "--abbrev-ref", "HEAD"):
             return "feature/example\n"
+        if args == ("status", "--porcelain"):
+            return ""
         raise AssertionError(args)
 
     monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
     monkeypatch.setattr(ehr, "_git", fake_git)
-    monkeypatch.setattr(ehr, "_git_ref_exists", lambda _ref: True)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref == "base1234")
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: "base1234")
+
+    assert ehr._base_ref_for_quality_check() == ("base1234", "origin/main")
+
+
+def test_quality_report_check_uses_recorded_baseline_in_github_feature_lane(
+    monkeypatch,
+) -> None:
+    def fake_git(*args: str) -> str:
+        if args == ("status", "--porcelain"):
+            return ""
+        raise AssertionError(args)
+
+    monkeypatch.setenv("GITHUB_REF_NAME", "feature/example")
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: "base1234")
+
+    assert ehr._base_ref_for_quality_check() == ("base1234", "origin/main")
+
+
+def test_quality_report_check_uses_origin_main_for_dirty_feature_branch(monkeypatch) -> None:
+    def fake_git(*args: str) -> str:
+        if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return "feature/example\n"
+        if args == ("status", "--porcelain"):
+            return " M src/example.py\n"
+        raise AssertionError(args)
+
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_git_ref_exists", lambda ref: ref == "base1234")
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: "base1234")
+
+    assert ehr._base_ref_for_quality_check() == ("origin/main", "origin/main")
+
+
+def test_quality_report_check_falls_back_when_recorded_feature_baseline_is_missing(
+    monkeypatch,
+) -> None:
+    def fake_git(*args: str) -> str:
+        if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+            return "feature/example\n"
+        if args == ("status", "--porcelain"):
+            return ""
+        raise AssertionError(args)
+
+    monkeypatch.delenv("GITHUB_REF_NAME", raising=False)
+    monkeypatch.setattr(ehr, "_git", fake_git)
+    monkeypatch.setattr(ehr, "_recorded_quality_baseline_ref", lambda: None)
 
     assert ehr._base_ref_for_quality_check() == ("origin/main", "origin/main")
 

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -40,6 +40,11 @@ to `main`.
   Compose project derived by `scripts/ci_local_compose_project.py`; an orchestrator may override it
   with `CI_LOCAL_COMPOSE_PROJECT`. `make ci-local-docker-down` removes only this CI-owned project
   and must not remove an active product `lotus-manage` container, network, or volume.
+- `make quality-report-gate`
+  verifies the checked-in quality reports against their immutable recorded baseline and current
+  absolute measurements. A clean feature branch therefore does not become stale merely because
+  `origin/main` advances; dirty development worktrees and unavailable recorded commits fall back
+  to the current upstream baseline.
 - `make live-api-validate`
   live API evidence against a running `lotus-manage` instance
 - `make live-api-validate-core`

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -44,7 +44,9 @@ to `main`.
   verifies the checked-in quality reports against their immutable recorded baseline and current
   absolute measurements. A clean feature branch therefore does not become stale merely because
   `origin/main` advances; dirty development worktrees and unavailable recorded commits fall back
-  to the current upstream baseline.
+  to the current upstream baseline. Pull requests run this check in a separate blocking job on the
+  immutable PR head, while static, contract, security, and test gates continue to validate the
+  merge result.
 - `make live-api-validate`
   live API evidence against a running `lotus-manage` instance
 - `make live-api-validate-core`


### PR DESCRIPTION
## Summary
- keep clean feature-lane quality-report checks pinned to the immutable baseline SHA recorded in the checked-in report
- run PR report freshness on the immutable pull-request head, independently from merge-result integration checks
- retain moving `origin/main` comparison for dirty development worktrees and as the safe fallback when the recorded commit no longer exists
- preserve baseline-relative deltas and every absolute quality measurement instead of normalizing them away
- document the control in repository context, quality guidance, generated scorecards, and the wiki validation guide

## Decision
Selects issue Option 3. The implementation uses the report's existing immutable baseline SHA rather than recomputing merge-base on every run. This prevents unrelated upstream merges from invalidating unchanged open branches while still requiring regeneration after a branch/rebase changes measured code.

A valid review finding identified that GitHub's default PR checkout is a synthetic merge. The corrected design retains static, contract, security, and test proof against that merge result, while a separate blocking job checks the immutable PR head for branch-owned report freshness. `make workflow-policy-gate` now rejects any PR workflow that regresses to a non-head report check and scopes the required checkout to the job that runs the report gate.

## Failing-first proof
- initial focused suite: 1 failure, 19 passed
- failure proved a clean feature branch returned `origin/main` instead of its recorded `base1234`
- review-regression coverage rejects a full-history checkout that omits the immutable PR-head ref
- job-scope regression coverage rejects a report job that attempts to inherit a preceding job's valid checkout

## Validation
- exact head: `f439e9c53bb9cf9c5d01b9b66b421b0b4ed57d25`
- focused report/workflow contracts: 115 passed
- clean branch `make quality-report-gate`: green
- `make workflow-policy-gate`: green
- `make check`: all static/architecture/contract gates and 3,366 unit tests green
- `make ci`: 3,613 tests green, 99.02% coverage, Bandit green, no known dependency vulnerabilities
- wiki check: one expected unpublished source difference; publish after merge

## Compatibility
No product/API/runtime behavior changes. The quality gate remains blocking and continues to compare absolute measurements. Only clean-checkout baseline selection and the PR checkout used for branch-owned freshness proof change.

Closes #651
