### PR TITLE
ci(idea-action): dotfile coverage uploads need include-hidden-files

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -182,6 +182,9 @@ jobs:
         with:
           name: coverage-data-idea-postgres
           path: .coverage.idea-postgres
+          # Dotfiles are excluded by upload-artifact unless stated - the
+          # matrix uploads say so and this one must match them exactly.
+          include-hidden-files: true
           # A missing coverage file is a broken lane, not a shrug: the silent
           # warning here is exactly how the combined gate read a smaller
           # world and failed wrongly.

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -163,6 +163,9 @@ jobs:
         with:
           name: coverage-data-idea-postgres
           path: .coverage.idea-postgres
+          # Dotfiles are excluded by upload-artifact unless stated - the
+          # matrix uploads say so and this one must match them exactly.
+          include-hidden-files: true
           # A missing coverage file is a broken lane, not a shrug: the silent
           # warning here is exactly how the combined gate read a smaller
           # world and failed wrongly.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-03T00:40:02+00:00`
+- Generated at: `2026-09-03T02:30:18+00:00`
 
-- Baseline source snapshot: `c05fd166ae282a3fc022a714333c691243828493`
+- Baseline source snapshot: `491470c4bf2f978ac7e1f91cad046e054090a1da`
 
-- Report source snapshot: `ae26faf9+worktree`
+- Report source snapshot: `bf31e07e+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 915 |
-| Total Python LOC | 212061 |
+| Total Python LOC | 212069 |
 | Test functions | 3073 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-03T00:40:02+00:00`
+- Generated at: `2026-09-03T02:30:18+00:00`
 
-- Baseline source snapshot: `c05fd166ae282a3fc022a714333c691243828493`
+- Baseline source snapshot: `491470c4bf2f978ac7e1f91cad046e054090a1da`
 
-- Report source snapshot: `ae26faf9+worktree`
+- Report source snapshot: `bf31e07e+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-03T00:40:02+00:00`
+- Generated at: `2026-09-03T02:30:18+00:00`
 
-- Baseline source snapshot: `c05fd166ae282a3fc022a714333c691243828493`
+- Baseline source snapshot: `491470c4bf2f978ac7e1f91cad046e054090a1da`
 
-- Report source snapshot: `ae26faf9+worktree`
+- Report source snapshot: `bf31e07e+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-03T00:40:02+00:00`
+- Generated at: `2026-09-03T02:30:18+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `c05fd166ae282a3fc022a714333c691243828493`
+- Baseline source snapshot: `491470c4bf2f978ac7e1f91cad046e054090a1da`
 
-- Report source snapshot: `ae26faf9+worktree`
+- Report source snapshot: `bf31e07e+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 907 | 915 | +8 |
-| Total Python LOC | 210055 | 212061 | +2006 |
-| Test functions | 3050 | 3073 | +23 |
+| Python files | 915 | 915 | +0 |
+| Total Python LOC | 212061 | 212069 | +8 |
+| Test functions | 3073 | 3073 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/coverage_gate.py
+++ b/scripts/coverage_gate.py
@@ -8,7 +8,15 @@ from pathlib import Path
 import coverage
 from coverage.results import should_fail_under
 
-DEFAULT_COVERAGE_FILES = (".coverage.unit", ".coverage.integration", ".coverage.e2e")
+# Every lane that uploads coverage-data-* must be named here: the gate
+# combines this list, and a lane missing from it is downloaded and silently
+# ignored - the combined total then reads a smaller world than CI proved.
+DEFAULT_COVERAGE_FILES = (
+    ".coverage.unit",
+    ".coverage.integration",
+    ".coverage.e2e",
+    ".coverage.idea-postgres",
+)
 DEFAULT_FAIL_UNDER = 99.0
 REPORT_PRECISION = 2
 


### PR DESCRIPTION
Fix-forward for main releasability: the postgres lane's coverage file existed (`test -f` proved it) and upload-artifact still found nothing — **dotfiles are excluded by default**, and every matrix upload already sets `include-hidden-files: true`. The lane now matches the matrix pattern exactly.

The `if-no-files-found: error` added earlier did its job: this failed **loudly** on main releasability instead of silently shrinking the combined gate's world again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)