### PR TITLE
docs(idea-action): align supported-feature boundary (#660)

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-03T02:30:18+00:00`
+- Generated at: `2026-09-04T22:41:05+00:00`
 
-- Baseline source snapshot: `491470c4bf2f978ac7e1f91cad046e054090a1da`
+- Baseline source snapshot: `1a37eb947c552c7f38445b0bfcb146d86bf9697e`
 
-- Report source snapshot: `bf31e07e+worktree`
+- Report source snapshot: `30bc3f11+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-03T02:30:18+00:00`
+- Generated at: `2026-09-04T22:41:05+00:00`
 
-- Baseline source snapshot: `491470c4bf2f978ac7e1f91cad046e054090a1da`
+- Baseline source snapshot: `1a37eb947c552c7f38445b0bfcb146d86bf9697e`
 
-- Report source snapshot: `bf31e07e+worktree`
+- Report source snapshot: `30bc3f11+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-03T02:30:18+00:00`
+- Generated at: `2026-09-04T22:41:05+00:00`
 
-- Baseline source snapshot: `491470c4bf2f978ac7e1f91cad046e054090a1da`
+- Baseline source snapshot: `1a37eb947c552c7f38445b0bfcb146d86bf9697e`
 
-- Report source snapshot: `bf31e07e+worktree`
+- Report source snapshot: `30bc3f11+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-03T02:30:18+00:00`
+- Generated at: `2026-09-04T22:41:05+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `491470c4bf2f978ac7e1f91cad046e054090a1da`
+- Baseline source snapshot: `1a37eb947c552c7f38445b0bfcb146d86bf9697e`
 
-- Report source snapshot: `bf31e07e+worktree`
+- Report source snapshot: `30bc3f11+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 915 | 915 | +0 |
-| Total Python LOC | 212061 | 212069 | +8 |
+| Total Python LOC | 212069 | 212069 | +0 |
 | Test functions | 3073 | 3073 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -17,8 +17,10 @@ published.
 Current non-promotion boundary: the `lotus-idea` action-intake and outcome-history routes implement
 durable, portfolio-scoped management-review work with append-only, version-fenced owner outcomes.
 They are not yet a supported feature because production IdP claim binding and live consumer
-certification remain outstanding. A Manage review approval does not prove rebalance or order
-execution, suitability, OMS state, or client publication.
+certification remain outstanding. Neither intake nor a Manage review decision grants rebalance
+execution authority, creates an order, or authorizes client publication. A review approval records
+only the management-review outcome; it does not establish suitability, OMS state, execution, fill,
+settlement, or publication.
 
 ```mermaid
 flowchart LR

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -14,10 +14,11 @@ capabilities listed below, but full front-office product claims require the gove
 `lotus-gateway` and `lotus-workbench` realization path to be implemented, validated, merged, and
 published.
 
-Current non-promotion boundary: `POST /api/v1/rebalance/idea-action-intake` exists only as a
-not-certified executable receipt for `lotus-idea` conversion-intent handoff evidence. It is not a
-supported feature and does not create action-register records, approve rebalances, create orders,
-bind production IdP claims, authorize client publication, or prove downstream execution.
+Current non-promotion boundary: the `lotus-idea` action-intake and outcome-history routes implement
+durable, portfolio-scoped management-review work with append-only, version-fenced owner outcomes.
+They are not yet a supported feature because production IdP claim binding and live consumer
+certification remain outstanding. A Manage review approval does not prove rebalance or order
+execution, suitability, OMS state, or client publication.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Outcome
Corrects the remaining repo-authored wiki page that still described the pre-#661 receipt-only behavior. The page now states the durable management-review realization and keeps production IdP, consumer certification, execution, suitability, OMS, and publication boundaries explicit.

## Evidence
- python -m pytest tests/unit/test_documentation_current_state.py -q (29 passed)
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage -AllowUnpublishedSourceChanges (one intentional source delta)

## Wiki
Publish and verify strict parity after merge.

Closes no issue; #660 remains open for the Idea consumer acceptance evidence.