### PR TITLE
feat(idea-intake): expose owner request fingerprint (#668)

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -56,8 +56,9 @@ Current repository posture:
    scoped `PENDING_REVIEW` action plus append-only Manage-owned outcome history. Review decisions
    are fenced by `source_event_version`, and exact replays retain the same action identity. The
    read-only `GET /api/v1/rebalance/idea-action-intakes/outcomes/by-conversion-intent?conversion_intent_id={conversion_intent_id}&portfolio_id={portfolio_id}`
-   route recovers current owner history by the exact trusted tenant, legal-entity, portfolio, and
-   conversion-intent scope after an upstream response-loss window; it rejects portfolio scope
+   route recovers current owner history and its persisted owner request fingerprint by the exact
+   trusted tenant, legal-entity, portfolio, and conversion-intent scope after an upstream
+   response-loss window; it rejects portfolio scope
    before repository I/O and never repeats the intake command. This
    proves management-review state only: it does not grant rebalance authority, create orders,
    prove execution, route OMS instructions, contact clients, authorize publication, bind

--- a/contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json
+++ b/contracts/idea-action-intake/lotus-manage-idea-action-intake.v1.json
@@ -13,6 +13,7 @@
   "durable_management_action_proven": true,
   "management_review_outcome_history_proven": true,
   "conversion_intent_owner_recovery_proven": true,
+  "outcome_history_request_fingerprint_proven": true,
   "downstream_execution_proven": false,
   "supported_feature_promoted": false,
   "receipt_outcomes": [
@@ -36,7 +37,7 @@
   ],
   "non_proof_boundaries": [
     "Proves a live executable action-intake receipt and one durable, portfolio-scoped PENDING_REVIEW management action for an accepted REVIEW_FOR_REBALANCE intent, including replay, rejection, conflict, restart, and append-only review-history behavior.",
-    "The exact conversion-intent outcome lookup is read-only, returns current Manage-owned history within trusted tenant, legal-entity, and portfolio scope, and never creates or repeats management work.",
+    "The exact conversion-intent outcome lookup is read-only, returns current Manage-owned history and the persisted owner request fingerprint within trusted tenant, legal-entity, and portfolio scope, and never creates or repeats management work.",
     "Does not grant suitability, mandate, rebalance, order, OMS, fill, settlement, or client-communication authority.",
     "An APPROVED management-review outcome does not prove rebalance execution, create orders or execution instructions, or prove fills, settlement, suitability, or client publication.",
     "Does not promote a supported feature, client-ready workflow, data-product certification, or downstream execution proof."

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-09-06T00:39:40.052075+00:00",
+  "generatedAt": "2026-09-06T00:57:15.631183+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -52099,6 +52099,14 @@
             "attributeRef": "#/attributeCatalog/lotus.conversion_intent_id"
           },
           {
+            "name": "request_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.request_fingerprint"
+          },
+          {
             "name": "status",
             "location": "body",
             "required": true,
@@ -52418,6 +52426,14 @@
             "attributeRef": "#/attributeCatalog/lotus.conversion_intent_id"
           },
           {
+            "name": "request_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.request_fingerprint"
+          },
+          {
             "name": "status",
             "location": "body",
             "required": true,
@@ -52719,6 +52735,14 @@
             "type": "string",
             "semanticId": "lotus.conversion_intent_id",
             "attributeRef": "#/attributeCatalog/lotus.conversion_intent_id"
+          },
+          {
+            "name": "request_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.request_fingerprint"
           },
           {
             "name": "status",

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-06T00:40:52+00:00`
+- Generated at: `2026-09-06T00:58:06+00:00`
 
-- Baseline source snapshot: `b2486f4778dadd24deaff983742941d6aec16c95`
+- Baseline source snapshot: `10d9c77193254242ddf10bd84a34514b98a7f204`
 
-- Report source snapshot: `e5c6398a`
+- Report source snapshot: `2bf7eb69`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 915 |
-| Total Python LOC | 212591 |
+| Total Python LOC | 212602 |
 | Test functions | 3081 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-06T00:40:52+00:00`
+- Generated at: `2026-09-06T00:58:06+00:00`
 
-- Baseline source snapshot: `b2486f4778dadd24deaff983742941d6aec16c95`
+- Baseline source snapshot: `10d9c77193254242ddf10bd84a34514b98a7f204`
 
-- Report source snapshot: `e5c6398a`
+- Report source snapshot: `2bf7eb69`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-06T00:40:52+00:00`
+- Generated at: `2026-09-06T00:58:06+00:00`
 
-- Baseline source snapshot: `b2486f4778dadd24deaff983742941d6aec16c95`
+- Baseline source snapshot: `10d9c77193254242ddf10bd84a34514b98a7f204`
 
-- Report source snapshot: `e5c6398a`
+- Report source snapshot: `2bf7eb69`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-06T00:40:52+00:00`
+- Generated at: `2026-09-06T00:58:06+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `b2486f4778dadd24deaff983742941d6aec16c95`
+- Baseline source snapshot: `10d9c77193254242ddf10bd84a34514b98a7f204`
 
-- Report source snapshot: `e5c6398a`
+- Report source snapshot: `2bf7eb69`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 915 | 915 | +0 |
-| Total Python LOC | 212069 | 212591 | +522 |
-| Test functions | 3073 | 3081 | +8 |
+| Total Python LOC | 212591 | 212602 | +11 |
+| Test functions | 3081 | 3081 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -39,7 +39,7 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 7624 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
-| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3382 |
+| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3386 |
 | 4 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |

--- a/src/core/rebalance_runs/idea_action_intake.py
+++ b/src/core/rebalance_runs/idea_action_intake.py
@@ -207,6 +207,7 @@ class IdeaManagementActionOutcomeHistoryResponse(BaseModel):
     portfolio_id: str
     idea_candidate_id: str
     conversion_intent_id: str
+    request_fingerprint: str = Field(pattern=r"^sha256:[a-f0-9]{12}$")
     status: DpmWorkflowStatus
     source_event_version: int = Field(ge=1)
     events: tuple[IdeaManagementActionEvent, ...]
@@ -305,6 +306,7 @@ def idea_management_action_history(
         portfolio_id=action.portfolio_id,
         idea_candidate_id=action.idea_candidate_id,
         conversion_intent_id=action.conversion_intent_id,
+        request_fingerprint=action.request_fingerprint,
         status=action.status,
         source_event_version=action.source_event_version,
         events=action.events,

--- a/tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py
+++ b/tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py
@@ -10,6 +10,7 @@ from src.core.rebalance_runs.idea_management_action import (
     create_idea_management_action,
     record_idea_management_review_decision,
 )
+from src.core.rebalance_runs.idea_action_intake import idea_management_action_history
 from src.core.rebalance_runs.idea_management_action_repository import (
     IdeaManagementActionRepositoryConflictError,
 )
@@ -129,6 +130,11 @@ def test_postgres_realization_survives_restart_replays_and_fences_stale_writer()
         conversion_intent_id=original.conversion_intent_id,
     )
     assert recovered_by_conversion == after_restart
+    assert recovered_by_conversion.request_fingerprint == original.request_fingerprint
+    assert (
+        idea_management_action_history(recovered_by_conversion).request_fingerprint
+        == original.request_fingerprint
+    )
     assert (
         restarted_repository.get_by_conversion_intent(
             tenant_id=original.tenant_id,

--- a/tests/unit/dpm/api/test_idea_action_intake_api.py
+++ b/tests/unit/dpm/api/test_idea_action_intake_api.py
@@ -264,6 +264,7 @@ def test_conversion_intent_lookup_recovers_current_owner_history_without_mutatio
     assert recovered.status_code == 200
     assert recovered.json() == approved.json()
     assert replayed.json() == recovered.json()
+    assert recovered.json()["request_fingerprint"] == intake["request_fingerprint"]
     assert recovered.json()["source_event_version"] == 2
     assert [event["event_type"] for event in recovered.json()["events"]] == [
         "INTAKE_ACCEPTED",
@@ -336,6 +337,7 @@ def test_conversion_intent_lookup_recovers_normalized_opaque_intake_identifiers(
     assert recovered.status_code == 200
     assert recovered.json()["conversion_intent_id"] == "vendor/123"
     assert recovered.json()["portfolio_id"] == PORTFOLIO_ID
+    assert recovered.json()["request_fingerprint"] == accepted.json()["request_fingerprint"]
 
 
 def test_conversion_intent_lookup_denies_scope_before_repository_initialization(

--- a/tests/unit/dpm/contracts/test_idea_action_intake_contract.py
+++ b/tests/unit/dpm/contracts/test_idea_action_intake_contract.py
@@ -33,6 +33,7 @@ def test_idea_action_intake_contract_preserves_manage_authority_boundary() -> No
     assert contract["durable_management_action_proven"] is True
     assert contract["management_review_outcome_history_proven"] is True
     assert contract["conversion_intent_owner_recovery_proven"] is True
+    assert contract["outcome_history_request_fingerprint_proven"] is True
     assert contract["conversion_intent_outcome_history_route"] == (
         "GET /api/v1/rebalance/idea-action-intakes/outcomes/by-conversion-intent?"
         "conversion_intent_id={conversion_intent_id}&portfolio_id={portfolio_id}"

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -777,6 +777,9 @@ Route:
 - `POST /api/v1/rebalance/idea-action-intakes/{intake_id}/outcomes`
 - `GET /api/v1/rebalance/idea-action-intakes/outcomes/by-conversion-intent?conversion_intent_id={conversion_intent_id}&portfolio_id={portfolio_id}`
 
+Both history reads return the persisted Manage-owned `request_fingerprint`; recovery consumers
+must not recompute or invent that owner commitment.
+
 Purpose:
 
 Source-safe realization for `lotus-idea` conversion intents. An accepted

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -154,8 +154,9 @@ Strategic downstream consumption should use:
     `POST /api/v1/rebalance/idea-action-intakes/{intake_id}/outcomes` expose and advance
     Manage-owned review history. `GET
     /api/v1/rebalance/idea-action-intakes/outcomes/by-conversion-intent?conversion_intent_id=...&portfolio_id=...`
-    provides exact, read-only recovery of current owner history after an upstream response-loss
-    window; it cannot create or repeat management work. The surface remains not-certified:
+    provides exact, read-only recovery of current owner history and the persisted Manage request
+    fingerprint after an upstream response-loss window; it cannot create or repeat management
+    work, and consumers must not recompute that owner commitment. The surface remains not-certified:
     local/dev trusted headers are
     not production IdP binding, and management review is not execution proof.
 


### PR DESCRIPTION
## Outcome

Expose Manage's persisted request fingerprint on existing Idea action outcome-history reads so an upstream recovery consumer can reconstruct the exact lost acceptance receipt without duplicating or inventing owner canonicalization.

Closes #668. Unblocks sgajbi/lotus-idea#1244 under sgajbi/lotus-idea#673.

## Changes

- adds the existing `request_fingerprint` owner fact to `IdeaManagementActionOutcomeHistoryResponse`;
- returns the same fingerprint through intake-id and exact conversion-intent history reads;
- proves equality with the original receipt, opaque-ID recovery, replay, and PostgreSQL restart persistence;
- updates OpenAPI vocabulary, the intake contract, repository context, and repo-authored wiki;
- preserves the existing route, registry, authorization ordering, append-only history, and non-authority boundaries.

## Validation

- `python -m pytest tests/unit/dpm/api/test_idea_action_intake_api.py tests/unit/dpm/contracts/test_idea_action_intake_contract.py tests/unit/dpm/supportability/test_idea_management_action.py -q` — 42 passed
- Ruff — passed
- OpenAPI quality gate — passed
- API vocabulary validation — passed
- engineering health freshness — passed
- wiki pre-merge check — expected two unpublished branch-source changes

## Boundaries

No management approval, rebalance/order/execution, suitability, publication, production identity, or supported-feature promotion is inferred. Wiki publication and exact-main release evidence remain post-merge gates.