### PR TITLE
docs: make the documented validation commands runnable

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,13 +17,23 @@ nearest durable doc in the same slice.
 Wiki pages are authored in `wiki/`, not in a separate `*.wiki.git` clone. `wiki/` intentionally has
 no local `README.md` because every Markdown file there is publishable wiki source.
 
-Useful validation commands:
+Useful validation commands. Run them from the repository root; the last two invoke
+scripts that live in the `lotus-platform` checkout, so set `$LotusRoot` to the directory
+that contains your Lotus checkouts first. The expansion is quoted so a path containing a
+space still works.
 
 ```powershell
+$LotusRoot = "C:\src\lotus"   # the parent of lotus-manage and lotus-platform
+
 python -m pytest tests\unit\test_documentation_current_state.py -q
-python <lotus-platform>\codex\skills\lotus-readme-wiki-governance\scripts\audit_wiki_quality.py --wiki-dir wiki --changed-page <Page>.md
-powershell -NoProfile -ExecutionPolicy Bypass -File <lotus-platform>\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage
+
+python "$LotusRoot\lotus-platform\codex\skills\lotus-readme-wiki-governance\scripts\audit_wiki_quality.py" --wiki-dir wiki --changed-page Supported-Features.md
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "$LotusRoot\lotus-platform\automation\Sync-RepoWikis.ps1" -CheckOnly -Repository lotus-manage
 ```
+
+`--changed-page` takes the wiki page you actually changed; `Supported-Features.md` is an
+example, not a fixed argument.
 
 When the branch intentionally changes repo-local `wiki/` source, run the same wiki check with
 `-AllowUnpublishedSourceChanges` before merge, then publish after merge and rerun the strict

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-06T10:13:02+00:00`
+- Generated at: `2026-09-06T11:39:42+00:00`
 
-- Baseline source snapshot: `e2e8e2146cfcb0dd9c5221cc73f2c615345454cc`
+- Baseline source snapshot: `017838ea5f9fc4e7e55508c0cf8f96744edb441c`
 
-- Report source snapshot: `cdaf0e18`
+- Report source snapshot: `017838ea+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 915 |
-| Total Python LOC | 212602 |
+| Total Python LOC | 212607 |
 | Test functions | 3081 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-06T10:13:02+00:00`
+- Generated at: `2026-09-06T11:39:42+00:00`
 
-- Baseline source snapshot: `e2e8e2146cfcb0dd9c5221cc73f2c615345454cc`
+- Baseline source snapshot: `017838ea5f9fc4e7e55508c0cf8f96744edb441c`
 
-- Report source snapshot: `cdaf0e18`
+- Report source snapshot: `017838ea+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-06T10:13:02+00:00`
+- Generated at: `2026-09-06T11:39:42+00:00`
 
-- Baseline source snapshot: `e2e8e2146cfcb0dd9c5221cc73f2c615345454cc`
+- Baseline source snapshot: `017838ea5f9fc4e7e55508c0cf8f96744edb441c`
 
-- Report source snapshot: `cdaf0e18`
+- Report source snapshot: `017838ea+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-06T10:13:02+00:00`
+- Generated at: `2026-09-06T11:39:42+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `e2e8e2146cfcb0dd9c5221cc73f2c615345454cc`
+- Baseline source snapshot: `017838ea5f9fc4e7e55508c0cf8f96744edb441c`
 
-- Report source snapshot: `cdaf0e18`
+- Report source snapshot: `017838ea+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 915 | 915 | +0 |
-| Total Python LOC | 212602 | 212602 | +0 |
+| Total Python LOC | 212602 | 212607 | +5 |
 | Test functions | 3081 | 3081 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
@@ -58,7 +58,7 @@
 | 4 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2783 |
+| 7 | tests/unit/test_documentation_current_state.py | 2788 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -111,7 +111,12 @@ def test_local_repository_navigation_readmes_cover_safe_edit_boundaries() -> Non
 
     assert "wiki/` intentionally does not contain a local `README.md`" in root_readme
     assert "wiki/` intentionally has\nno local `README.md`" in docs_readme
-    assert "Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage" in docs_readme
+    # The script path is quoted so a checkout path containing a space survives,
+    # which splits the old contiguous substring. Assert the two halves instead
+    # of loosening to a bare script name: the -CheckOnly flag and the repository
+    # argument are the parts that make this the right documented command.
+    assert 'Sync-RepoWikis.ps1" -CheckOnly -Repository lotus-manage' in docs_readme
+    assert "$LotusRoot" in docs_readme
     assert "make mesh-contract-validate" in contracts_readme
     assert "make observability-contract-validate" in contracts_readme
     assert "make trust-telemetry-validate" in trust_telemetry_readme


### PR DESCRIPTION
Item 3 of the source-authority directive. **The defect is mine, from #670.**

## What went wrong
Replacing an absolute path with a `<lotus-platform>` placeholder made the path portable and left the command **unrunnable**. The block is fenced `powershell`, PowerShell **reserves `<`**, so the line fails before the interpreter starts. A second placeholder, `<Page>.md`, sat inside the same command as though it were an argument.

**Making a path portable and making a command runnable are different properties, and a placeholder satisfies neither on its own.** This is the third instance of that class across the estate today — after a bare relative path resolving into the wrong checkout, and a commented-out Windows activation line — which is why it is worth naming rather than just fixing.

## The fix
- `$LotusRoot` defined once in its own line, **every expansion quoted**, so a checkout path containing a space survives.
- `--changed-page` gets a real example page, stated to be an example rather than a fixed argument.
- **The working directory is stated**, because two of the three commands invoke scripts that live in the `lotus-platform` checkout while the cwd stays here — the cross-repo case where a bare relative path silently resolves into the wrong repository.

## The pinned assertion
The documentation gate pinned the old unquoted command as a contiguous substring, which the required quoting splits. The assertion now checks **the two halves that carry the meaning** — the `-CheckOnly` flag with its repository argument, and the variable that makes the path portable — rather than loosening to a bare script name. The gate still fails if the command stops being documented.

## Deliberately left alone
The placeholder paths in `RFC36-43-GOLD-PASS-AUDIT-MATRIX.md` and `CODEBASE-REVIEW-LEDGER.md`. Those **record where evidence was written during past runs** — historical records, not instructions. Rewriting them would assert something about the present that is not true.

## Verified
Documentation gate 29/29, `make lint`, quality reports current. The `$LotusRoot` assignment was checked to parse with the PowerShell parser rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)