### PR TITLE
fix(mandates): order versions numerically and make diffs observation-aware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,11 @@ test-integration:
 test-idea-management-action-postgres:
 	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py -q
 
+# Every PostgreSQL-backed integration proof runs in the one CI job that owns a
+# live database. Adding a file here is what stops it becoming a lane that skips
+# everywhere and reports green (issues #646/#647).
 test-idea-management-action-postgres-coverage:
-	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py -q --cov=src --cov-report=
+	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py tests/integration/dpm/mandates -q --cov=src --cov-report=
 	@test -f .coverage.idea-postgres || mv .coverage .coverage.idea-postgres
 
 test-e2e:

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1204,6 +1204,20 @@ Most relevant current governance:
     silently reused as the canonical content hash when Core returns a valid no-batch response. Manage
     must fail closed on missing, blank, malformed, or conflicting content identity before publishing
     Core-sourced bulk-review campaign membership as READY.
+16. `mandate_version` is TEXT holding `str(binding_version)`, and the in-memory and PostgreSQL
+    mandate stores must order it identically, because both answer "which version is current" and a
+    disagreement resolves the same data to different twins depending on configuration. The contract
+    is: digit-only versions compare by significant-digit length then by the digits, non-digit
+    versions sort last, and the raw column breaks ties so `'1'` precedes `'01'`. Three specific
+    traps are worth knowing before touching it. Do not compare through a numeric conversion:
+    `int()` raises above `sys.get_int_max_str_digits()` (4300 by default) and `NUMERIC` overflows
+    past 131,072 digits, so a version one store accepts can abort the other. Use `re.fullmatch`
+    rather than `re.match`, because Python's `$` also matches before a trailing newline while
+    PostgreSQL's `~` does not, so `'9\n'` is numeric on one side only. Keep `COLLATE "C"` on the SQL
+    comparisons so byte order matches Python's code-point order under any database collation. A
+    shared adversarial corpus in `tests/support/mandate_version_corpus.py` is asserted by both the
+    unit suite and the database lane so a divergence fails on one side rather than passing quietly
+    on both.
 
 ## Context Maintenance Rule
 

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-09-06T00:57:15.631183+00:00",
+  "generatedAt": "2026-09-06T12:19:01.553659+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -5773,6 +5773,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.from_as_of_date",
+      "canonicalTerm": "from_as_of_date",
+      "preferredName": "from_as_of_date",
+      "description": "Business date of the observation used as the comparison baseline. A mandate version can be observed on several dates, so the version alone does not identify which row was compared.",
+      "example": "2026-03-02",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -15393,6 +15407,20 @@
       "preferredName": "title",
       "description": "Business title for the section.",
       "example": "sample_title",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.to_as_of_date",
+      "canonicalTerm": "to_as_of_date",
+      "preferredName": "to_as_of_date",
+      "description": "Business date of the observation used as the comparison target.",
+      "example": "2026-03-02",
       "type": "string",
       "locations": [
         "body"
@@ -58951,6 +58979,22 @@
             "type": "string",
             "semanticId": "lotus.to_version",
             "attributeRef": "#/attributeCatalog/lotus.to_version"
+          },
+          {
+            "name": "from_as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.from_as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.from_as_of_date"
+          },
+          {
+            "name": "to_as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.to_as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.to_as_of_date"
           },
           {
             "name": "changed_fields",

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-06T11:39:42+00:00`
+- Generated at: `2026-09-06T13:25:57+00:00`
 
-- Baseline source snapshot: `017838ea5f9fc4e7e55508c0cf8f96744edb441c`
+- Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `017838ea+worktree`
+- Report source snapshot: `0672d153`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 915 |
-| Total Python LOC | 212607 |
-| Test functions | 3081 |
+| Python files | 916 |
+| Total Python LOC | 213062 |
+| Test functions | 3088 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-06T13:25:57+00:00`
+- Generated at: `2026-09-06T15:09:25+00:00`
 
 - Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `0672d153`
+- Report source snapshot: `212789e8+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 916 |
-| Total Python LOC | 213062 |
-| Test functions | 3088 |
+| Python files | 919 |
+| Total Python LOC | 213619 |
+| Test functions | 3107 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-06T15:09:25+00:00`
+- Generated at: `2026-09-06T16:03:46+00:00`
 
 - Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `212789e8+worktree`
+- Report source snapshot: `6f8f47f7+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 919 |
-| Total Python LOC | 213619 |
-| Test functions | 3107 |
+| Total Python LOC | 213667 |
+| Test functions | 3108 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-06T15:09:25+00:00`
+- Generated at: `2026-09-06T16:03:46+00:00`
 
 - Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `212789e8+worktree`
+- Report source snapshot: `6f8f47f7+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-06T13:25:57+00:00`
+- Generated at: `2026-09-06T15:09:25+00:00`
 
 - Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `0672d153`
+- Report source snapshot: `212789e8+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 
@@ -37,9 +37,9 @@
 | 1 | _validate_summary_invocation_parents | src/infrastructure/pm_quality/in_memory.py | 19 | 50 |
 | 2 | _validate_postgres_summary_invocation_parents | src/infrastructure/pm_quality/postgres.py | 13 | 49 |
 | 3 | _validate_candidate_source_ref | src/core/waves/campaign_candidate_source_contracts.py | 12 | 70 |
-| 4 | _validate_review_action_parent | src/infrastructure/pm_quality/in_memory.py | 11 | 35 |
-| 5 | _campaign_workflow_labels_for_http_exception | src/api/routers/wave_campaign_workflow_telemetry.py | 11 | 21 |
-| 6 | _split_sql_statements | src/infrastructure/postgres_migrations.py | 10 | 42 |
+| 4 | _split_sql_statements | src/infrastructure/postgres_migrations.py | 12 | 54 |
+| 5 | _validate_review_action_parent | src/infrastructure/pm_quality/in_memory.py | 11 | 35 |
+| 6 | _campaign_workflow_labels_for_http_exception | src/api/routers/wave_campaign_workflow_telemetry.py | 11 | 21 |
 | 7 | list_definitions_by_workflow_projection | src/infrastructure/waves/campaign_definitions.py | 9 | 64 |
 | 8 | _workflow_projection_matches | src/infrastructure/waves/campaign_definitions.py | 9 | 38 |
 | 9 | _validate_postgres_review_action_parent | src/infrastructure/pm_quality/postgres.py | 9 | 36 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-06T11:39:42+00:00`
+- Generated at: `2026-09-06T13:25:57+00:00`
 
-- Baseline source snapshot: `017838ea5f9fc4e7e55508c0cf8f96744edb441c`
+- Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `017838ea+worktree`
+- Report source snapshot: `0672d153`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-06T13:25:57+00:00`
+- Generated at: `2026-09-06T15:09:25+00:00`
 
 - Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `0672d153`
+- Report source snapshot: `212789e8+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-06T15:09:25+00:00`
+- Generated at: `2026-09-06T16:03:46+00:00`
 
 - Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `212789e8+worktree`
+- Report source snapshot: `6f8f47f7+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-06T11:39:42+00:00`
+- Generated at: `2026-09-06T13:25:57+00:00`
 
-- Baseline source snapshot: `017838ea5f9fc4e7e55508c0cf8f96744edb441c`
+- Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `017838ea+worktree`
+- Report source snapshot: `0672d153`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-06T13:25:57+00:00`
+- Generated at: `2026-09-06T15:09:25+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `0672d153`
+- Report source snapshot: `212789e8+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 915 | 916 | +1 |
-| Total Python LOC | 212607 | 213062 | +455 |
-| Test functions | 3081 | 3088 | +7 |
+| Python files | 915 | 919 | +4 |
+| Total Python LOC | 212607 | 213619 | +1012 |
+| Test functions | 3081 | 3107 | +26 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-06T15:09:25+00:00`
+- Generated at: `2026-09-06T16:03:46+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `212789e8+worktree`
+- Report source snapshot: `6f8f47f7+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 915 | 919 | +4 |
-| Total Python LOC | 212607 | 213619 | +1012 |
-| Test functions | 3081 | 3107 | +26 |
+| Total Python LOC | 212607 | 213667 | +1060 |
+| Test functions | 3081 | 3108 | +27 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-06T11:39:42+00:00`
+- Generated at: `2026-09-06T13:25:57+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `017838ea5f9fc4e7e55508c0cf8f96744edb441c`
+- Baseline source snapshot: `54c0f5e08bf801ee3c31707ddb2ce784648d122e`
 
-- Report source snapshot: `017838ea+worktree`
+- Report source snapshot: `0672d153`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 915 | 915 | +0 |
-| Total Python LOC | 212602 | 212607 | +5 |
-| Test functions | 3081 | 3081 | +0 |
+| Python files | 915 | 916 | +1 |
+| Total Python LOC | 212607 | 213062 | +455 |
+| Test functions | 3081 | 3088 | +7 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -43,7 +43,7 @@
 | 4 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2783 |
+| 7 | tests/unit/test_documentation_current_state.py | 2788 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |

--- a/src/api/routers/mandate_read_routes.py
+++ b/src/api/routers/mandate_read_routes.py
@@ -123,7 +123,10 @@ async def read_mandate_versions(
     description=(
         "Use this endpoint when portfolio managers, supervision, or operations need to explain "
         "what changed between two mandate versions. If versions are omitted, lotus-manage "
-        "compares the latest two persisted versions."
+        "compares the latest two distinct versions, using the most recent observation of each. "
+        "Repeated observations of one version are not a change, so a history holding only a "
+        "single distinct version is refused with 409 rather than diffed against itself. The "
+        "response carries the business date of each compared observation."
     ),
     responses={
         200: {
@@ -135,6 +138,8 @@ async def read_mandate_versions(
                         "compared_at": "2026-05-03T08:30:00Z",
                         "from_version": "2",
                         "to_version": "3",
+                        "from_as_of_date": "2026-04-10",
+                        "to_as_of_date": "2026-05-03",
                         "changed_fields": [
                             {
                                 "field_path": "constraints.turnover_budget",

--- a/src/api/services/mandate_diff.py
+++ b/src/api/services/mandate_diff.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, cast
 
 from pydantic import BaseModel, Field
@@ -45,6 +45,18 @@ class DpmMandateDiff(BaseModel):
         description="Newer mandate version used as the comparison target.",
         examples=["3"],
     )
+    from_as_of_date: date = Field(
+        description=(
+            "Business date of the observation used as the comparison baseline. A mandate "
+            "version can be observed on several dates, so the version alone does not "
+            "identify which row was compared."
+        ),
+        examples=["2026-04-30"],
+    )
+    to_as_of_date: date = Field(
+        description="Business date of the observation used as the comparison target.",
+        examples=["2026-05-03"],
+    )
     changed_fields: list[DpmMandateFieldChange] = Field(
         description="Changed mandate fields, ordered by field path for deterministic review.",
     )
@@ -78,6 +90,8 @@ def build_mandate_diff(
         compared_at=datetime.now(timezone.utc),
         from_version=previous.mandate_version,
         to_version=current.mandate_version,
+        from_as_of_date=previous.as_of_date,
+        to_as_of_date=current.as_of_date,
         changed_fields=diff_payloads(
             previous.model_dump(mode="json"),
             current.model_dump(mode="json"),
@@ -137,15 +151,49 @@ def _requested_mandate_diff_version_pair(
 def _latest_mandate_diff_version_pair(
     versions: list[DpmMandateDigitalTwin],
 ) -> tuple[DpmMandateDigitalTwin, DpmMandateDigitalTwin]:
-    if len(versions) < 2:
+    """The newest observation, against the newest observation of the previous
+    DISTINCT version (issue #647).
+
+    `versions` is ordered newest-first and may contain the same
+    mandate_version more than once, because an unchanged binding can be
+    re-observed on a later business date. Taking versions[1] blindly can
+    compare a version against another observation of itself and report "no
+    changes", which is indistinguishable from a mandate that genuinely did
+    not change.
+    """
+
+    if not versions:
         raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
-    return versions[1], versions[0]
+    current = versions[0]
+    previous = next(
+        (
+            candidate
+            for candidate in versions[1:]
+            if candidate.mandate_version != current.mandate_version
+        ),
+        None,
+    )
+    if previous is None:
+        # Every observation is of one version: there is no version change to
+        # diff, and saying so is more truthful than an empty change list.
+        raise DpmMandateDiffUnavailableError("DPM_MANDATE_DIFF_REQUIRES_TWO_VERSIONS")
+    return previous, current
 
 
 def _mandate_version_index(
     versions: list[DpmMandateDigitalTwin],
 ) -> dict[str, DpmMandateDigitalTwin]:
-    return {version.mandate_version: version for version in versions}
+    """Map each mandate version to its LATEST observation (issue #647).
+
+    `versions` is ordered newest-first, so the first occurrence of a version
+    is its most recent observation. A dict comprehension would let the last -
+    that is, the oldest - entry win.
+    """
+
+    index: dict[str, DpmMandateDigitalTwin] = {}
+    for version in versions:
+        index.setdefault(version.mandate_version, version)
+    return index
 
 
 def iter_changed_fields(

--- a/src/core/dpm_source_context_core_products.py
+++ b/src/core/dpm_source_context_core_products.py
@@ -147,7 +147,16 @@ class DpmCoreMandateBindingResponse(BaseModel):
         default=None,
         description="Resolved binding effective end date.",
     )
-    binding_version: int = Field(description="Resolved binding version.")
+    binding_version: int = Field(
+        ge=0,
+        description=(
+            "Resolved binding version. Non-negative: the version is rendered to TEXT and "
+            "ordered by magnitude, and a negative value falls outside that grammar, so '-2' "
+            "would resolve as later than '-1'. A version counter has no meaningful negative "
+            "value, so it is refused at the boundary rather than ordered by a rule invented "
+            "for it here."
+        ),
+    )
     supportability: DpmCoreMandateBindingSupportability = Field(
         description="Completeness and readiness posture for the mandate binding product."
     )
@@ -280,7 +289,13 @@ class DpmCoreCioModelChangeAffectedMandate(BaseModel):
         default=None,
         description="Mandate binding effective end date.",
     )
-    binding_version: int = Field(description="Selected mandate binding version.")
+    binding_version: int = Field(
+        ge=0,
+        description=(
+            "Selected mandate binding version. Non-negative, for the ordering reason given "
+            "on DpmCoreMandateBinding.binding_version."
+        ),
+    )
     source_record_id: Optional[str] = Field(
         default=None,
         description="Core source record identifier for replay and audit.",
@@ -371,7 +386,13 @@ class DpmCorePortfolioUniverseCandidate(BaseModel):
         default=None,
         description="Mandate binding effective end date.",
     )
-    binding_version: int = Field(description="Selected mandate binding version.")
+    binding_version: int = Field(
+        ge=0,
+        description=(
+            "Selected mandate binding version. Non-negative, for the ordering reason given "
+            "on DpmCoreMandateBinding.binding_version."
+        ),
+    )
     source_record_id: Optional[str] = Field(
         default=None,
         description="Core source record identifier for replay and audit.",

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from copy import deepcopy
 from datetime import date, datetime, timezone
 from threading import Lock
@@ -14,14 +16,23 @@ from src.core.mandates import (
 )
 
 
+_MANDATE_VERSION_NUMERIC = re.compile(r"^[0-9]{1,18}$")
+
+
 def _mandate_version_sort_key(version: str) -> tuple[int, int, str]:
     """Numeric ordering for a TEXT mandate version (issue #646).
 
-    Mirrors the PostgreSQL expression: plain integers compare numerically,
-    anything else sorts last deterministically by its own text.
+    Mirrors the PostgreSQL expression exactly: 1-18 ASCII digits compare
+    numerically, anything else sorts last deterministically by its own text.
+
+    The grammar is a regex rather than str.isdigit() on purpose. isdigit()
+    accepts Unicode digits such as Arabic-Indic numerals and superscripts,
+    which PostgreSQL's [0-9] class rejects, so the two stores would disagree
+    about whether a version is numeric and therefore about which mandate is
+    current. The 18-digit bound mirrors the bigint cast on the SQL side.
     """
 
-    if version.isdigit():
+    if _MANDATE_VERSION_NUMERIC.match(version):
         return (1, int(version), "")
     return (0, 0, version)
 

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -22,24 +22,27 @@ _MANDATE_VERSION_NUMERIC = re.compile(r"^[0-9]+$")
 def _mandate_version_sort_key(version: str) -> tuple[int, int, str, str]:
     """Deterministic ordering for a TEXT mandate version (issue #646).
 
-    Reproduces the PostgreSQL ordering expression element for element:
+    Runs the same algorithm as _MANDATE_VERSION_ORDER in the PostgreSQL
+    repository, element for element: numeric-or-not, then significant-digit
+    length, then the digits, then the raw text.
 
-        CASE WHEN mandate_version ~ '^[0-9]+$'
-             THEN mandate_version::numeric ELSE NULL END DESC NULLS LAST,
-        mandate_version DESC
+    Both sides order digit strings by length-then-lexical rather than by
+    converting to a number, because every conversion is bounded and the
+    storage contract for mandate_version is unrestricted TEXT. int() raises
+    ValueError above sys.get_int_max_str_digits(); NUMERIC overflows past
+    131,072 digits, which would also fail the CREATE INDEX in migration 0022
+    and so block startup. Comparing stripped-digit length and then the digits
+    is exact at any length, needs no runtime safeguard relaxed, and lets the
+    two stores share one algorithm instead of two that merely agree in range.
 
-    ASCII digits compare numerically and anything else sorts last. The grammar
-    is a regex rather than str.isdigit(), which accepts Unicode digits such as
-    Arabic-Indic numerals that PostgreSQL's [0-9] class rejects; the two stores
-    would otherwise disagree about which versions are numeric and therefore
-    about which mandate is current.
-
-    Numeric comparison runs on the digits rather than through int(), because
-    int() is not unbounded: str-to-int conversion raises ValueError above
-    sys.get_int_max_str_digits(), 4300 by default, while NUMERIC accepts far
-    longer values. A version PostgreSQL orders without complaint would crash
-    this store. Stripping leading zeros and comparing length before digits is
-    exact at any length and relaxes no runtime safeguard to get there.
+    The grammar is fullmatch rather than match: Python's '$' also matches
+    immediately before a trailing newline, so re.match would accept '9\\n' as
+    numeric and, with the newline counted in its length, order it above '10'.
+    PostgreSQL's '~' anchors at the true end of the string and rejects that
+    value, so the two stores would pick different latest snapshots. The
+    grammar is a regex rather than str.isdigit() for the same class of reason:
+    isdigit() accepts Unicode digits such as Arabic-Indic numerals that
+    PostgreSQL's [0-9] rejects.
 
     The raw text is the final element because SQL tie-breaks on
     mandate_version DESC. Without it '01' and '1' compare equal here while SQL
@@ -47,7 +50,7 @@ def _mandate_version_sort_key(version: str) -> tuple[int, int, str, str]:
     equal-valued versions is current.
     """
 
-    if _MANDATE_VERSION_NUMERIC.match(version):
+    if _MANDATE_VERSION_NUMERIC.fullmatch(version):
         digits = version.lstrip("0") or "0"
         return (1, len(digits), digits, version)
     return (0, 0, "", version)

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -14,6 +14,18 @@ from src.core.mandates import (
 )
 
 
+def _mandate_version_sort_key(version: str) -> tuple[int, int, str]:
+    """Numeric ordering for a TEXT mandate version (issue #646).
+
+    Mirrors the PostgreSQL expression: plain integers compare numerically,
+    anything else sorts last deterministically by its own text.
+    """
+
+    if version.isdigit():
+        return (1, int(version), "")
+    return (0, 0, version)
+
+
 class InMemoryDpmMandateRepository(DpmMandateRepository):
     def __init__(self) -> None:
         self._lock = Lock()
@@ -76,7 +88,11 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
             rows = [
                 twin for twin in self._mandates_by_key.values() if twin.mandate_id == mandate_id
             ]
-            rows = sorted(rows, key=lambda row: (row.as_of_date, row.mandate_version), reverse=True)
+            rows = sorted(
+                rows,
+                key=lambda row: (row.as_of_date, _mandate_version_sort_key(row.mandate_version)),
+                reverse=True,
+            )
             return [deepcopy(row) for row in rows]
 
     def save_health_snapshot(self, snapshot: DpmMandateHealthSnapshot) -> None:
@@ -229,7 +245,14 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
 def _latest_twin(rows: list[DpmMandateDigitalTwin]) -> Optional[DpmMandateDigitalTwin]:
     if not rows:
         return None
-    return max(rows, key=lambda row: (row.as_of_date, row.mandate_version, row.mandate_id))
+    return max(
+        rows,
+        key=lambda row: (
+            row.as_of_date,
+            _mandate_version_sort_key(row.mandate_version),
+            row.mandate_id,
+        ),
+    )
 
 
 def _stale_mandate_keys(

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -19,24 +19,38 @@ from src.core.mandates import (
 _MANDATE_VERSION_NUMERIC = re.compile(r"^[0-9]+$")
 
 
-def _mandate_version_sort_key(version: str) -> tuple[int, int, str]:
-    """Numeric ordering for a TEXT mandate version (issue #646).
+def _mandate_version_sort_key(version: str) -> tuple[int, int, str, str]:
+    """Deterministic ordering for a TEXT mandate version (issue #646).
 
-    Mirrors the PostgreSQL expression exactly: 1-18 ASCII digits compare
-    numerically, anything else sorts last deterministically by its own text.
+    Reproduces the PostgreSQL ordering expression element for element:
 
-    The grammar is a regex rather than str.isdigit() on purpose. isdigit()
-    accepts Unicode digits such as Arabic-Indic numerals and superscripts,
-    which PostgreSQL's [0-9] class rejects, so the two stores would disagree
-    about whether a version is numeric and therefore about which mandate is
-    current. Neither side bounds the length: the storage contract is
-    unrestricted, SQL casts to arbitrary-precision NUMERIC, and Python ints
-    are unbounded, so a long version orders as the number it is.
+        CASE WHEN mandate_version ~ '^[0-9]+$'
+             THEN mandate_version::numeric ELSE NULL END DESC NULLS LAST,
+        mandate_version DESC
+
+    ASCII digits compare numerically and anything else sorts last. The grammar
+    is a regex rather than str.isdigit(), which accepts Unicode digits such as
+    Arabic-Indic numerals that PostgreSQL's [0-9] class rejects; the two stores
+    would otherwise disagree about which versions are numeric and therefore
+    about which mandate is current.
+
+    Numeric comparison runs on the digits rather than through int(), because
+    int() is not unbounded: str-to-int conversion raises ValueError above
+    sys.get_int_max_str_digits(), 4300 by default, while NUMERIC accepts far
+    longer values. A version PostgreSQL orders without complaint would crash
+    this store. Stripping leading zeros and comparing length before digits is
+    exact at any length and relaxes no runtime safeguard to get there.
+
+    The raw text is the final element because SQL tie-breaks on
+    mandate_version DESC. Without it '01' and '1' compare equal here while SQL
+    still separates them, and the two stores would disagree about which of two
+    equal-valued versions is current.
     """
 
     if _MANDATE_VERSION_NUMERIC.match(version):
-        return (1, int(version), "")
-    return (0, 0, version)
+        digits = version.lstrip("0") or "0"
+        return (1, len(digits), digits, version)
+    return (0, 0, "", version)
 
 
 class InMemoryDpmMandateRepository(DpmMandateRepository):

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -16,7 +16,7 @@ from src.core.mandates import (
 )
 
 
-_MANDATE_VERSION_NUMERIC = re.compile(r"^[0-9]{1,18}$")
+_MANDATE_VERSION_NUMERIC = re.compile(r"^[0-9]+$")
 
 
 def _mandate_version_sort_key(version: str) -> tuple[int, int, str]:
@@ -29,7 +29,9 @@ def _mandate_version_sort_key(version: str) -> tuple[int, int, str]:
     accepts Unicode digits such as Arabic-Indic numerals and superscripts,
     which PostgreSQL's [0-9] class rejects, so the two stores would disagree
     about whether a version is numeric and therefore about which mandate is
-    current. The 18-digit bound mirrors the bigint cast on the SQL side.
+    current. Neither side bounds the length: the storage contract is
+    unrestricted, SQL casts to arbitrary-precision NUMERIC, and Python ints
+    are unbounded, so a long version orders as the number it is.
     """
 
     if _MANDATE_VERSION_NUMERIC.match(version):

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -30,8 +30,16 @@ class _MonitoringExceptionListQuery:
 # Compare numerically, and keep the column's own order as the tie-break for
 # any value that is not a plain integer so a malformed row can never abort the
 # query. The matching expression index lives in migration 0022.
+# Accepts 1-18 ASCII digits. The upper bound matters: mandate_version is TEXT,
+# so a longer digit string is representable, and casting it would overflow
+# bigint with 22003 and abort the read for every caller - the exact failure the
+# guard exists to prevent. Eighteen digits sits inside bigint's 19-digit range.
+# The in-memory store applies the identical grammar, so the two backends cannot
+# disagree about whether a version is numeric.
+_MANDATE_VERSION_NUMERIC_PATTERN = "^[0-9]{1,18}$"
+
 _MANDATE_VERSION_ORDER = (
-    "CASE WHEN mandate_version ~ '^[0-9]+$' "
+    f"CASE WHEN mandate_version ~ '{_MANDATE_VERSION_NUMERIC_PATTERN}' "
     "THEN mandate_version::bigint ELSE NULL END DESC NULLS LAST, "
     "mandate_version DESC"
 )

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -24,6 +24,19 @@ class _MonitoringExceptionListQuery:
     args: tuple[Any, ...]
 
 
+# Issue #646: mandate_version is a TEXT column holding an integer rendered by
+# str(binding_version), so ordering by it directly is lexicographic - "9"
+# sorts above "10" and every read after version 9 resolves to the wrong row.
+# Compare numerically, and keep the column's own order as the tie-break for
+# any value that is not a plain integer so a malformed row can never abort the
+# query. The matching expression index lives in migration 0022.
+_MANDATE_VERSION_ORDER = (
+    "CASE WHEN mandate_version ~ '^[0-9]+$' "
+    "THEN mandate_version::bigint ELSE NULL END DESC NULLS LAST, "
+    "mandate_version DESC"
+)
+
+
 class PostgresDpmMandateRepository:
     def __init__(self, *, dsn: str) -> None:
         if not dsn:
@@ -84,11 +97,11 @@ class PostgresDpmMandateRepository:
         *,
         portfolio_id: str,
     ) -> Optional[DpmMandateDigitalTwin]:
-        query = """
+        query = f"""
             SELECT payload_json
             FROM dpm_mandate_snapshots
             WHERE portfolio_id = %s
-            ORDER BY as_of_date DESC, mandate_version DESC, mandate_id DESC
+            ORDER BY as_of_date DESC, {_MANDATE_VERSION_ORDER}, mandate_id DESC
             LIMIT 1
         """
         with closing(self._connect()) as connection:
@@ -101,11 +114,11 @@ class PostgresDpmMandateRepository:
         portfolio_id: str,
         as_of_date: date,
     ) -> Optional[DpmMandateDigitalTwin]:
-        query = """
+        query = f"""
             SELECT payload_json
             FROM dpm_mandate_snapshots
             WHERE portfolio_id = %s AND as_of_date <= %s
-            ORDER BY as_of_date DESC, mandate_version DESC, mandate_id DESC
+            ORDER BY as_of_date DESC, {_MANDATE_VERSION_ORDER}, mandate_id DESC
             LIMIT 1
         """
         with closing(self._connect()) as connection:
@@ -113,11 +126,11 @@ class PostgresDpmMandateRepository:
         return _to_twin(row)
 
     def get_latest_mandate(self, *, mandate_id: str) -> Optional[DpmMandateDigitalTwin]:
-        query = """
+        query = f"""
             SELECT payload_json
             FROM dpm_mandate_snapshots
             WHERE mandate_id = %s
-            ORDER BY as_of_date DESC, mandate_version DESC
+            ORDER BY as_of_date DESC, {_MANDATE_VERSION_ORDER}
             LIMIT 1
         """
         with closing(self._connect()) as connection:
@@ -125,11 +138,11 @@ class PostgresDpmMandateRepository:
         return _to_twin(row)
 
     def list_mandate_versions(self, *, mandate_id: str) -> list[DpmMandateDigitalTwin]:
-        query = """
+        query = f"""
             SELECT payload_json
             FROM dpm_mandate_snapshots
             WHERE mandate_id = %s
-            ORDER BY as_of_date DESC, mandate_version DESC
+            ORDER BY as_of_date DESC, {_MANDATE_VERSION_ORDER}
         """
         with closing(self._connect()) as connection:
             rows = connection.execute(query, (mandate_id,)).fetchall()

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -30,17 +30,19 @@ class _MonitoringExceptionListQuery:
 # Compare numerically, and keep the column's own order as the tie-break for
 # any value that is not a plain integer so a malformed row can never abort the
 # query. The matching expression index lives in migration 0022.
-# Accepts 1-18 ASCII digits. The upper bound matters: mandate_version is TEXT,
-# so a longer digit string is representable, and casting it would overflow
-# bigint with 22003 and abort the read for every caller - the exact failure the
-# guard exists to prevent. Eighteen digits sits inside bigint's 19-digit range.
-# The in-memory store applies the identical grammar, so the two backends cannot
-# disagree about whether a version is numeric.
-_MANDATE_VERSION_NUMERIC_PATTERN = "^[0-9]{1,18}$"
+# The storage contract for mandate_version is unrestricted TEXT, so any digit
+# string is a legitimate value and the ordering must be correct for all of
+# them. Cast to NUMERIC rather than BIGINT: numeric is arbitrary precision, so
+# a 20-digit version orders as the large number it is instead of overflowing
+# (bigint) or being demoted to the non-numeric tail (a length-bounded guard).
+# The regex still excludes non-digit text, which sorts last by its own value.
+# The in-memory store applies the identical grammar over Python ints, which
+# are also unbounded, so the two backends cannot disagree.
+_MANDATE_VERSION_NUMERIC_PATTERN = "^[0-9]+$"
 
 _MANDATE_VERSION_ORDER = (
     f"CASE WHEN mandate_version ~ '{_MANDATE_VERSION_NUMERIC_PATTERN}' "
-    "THEN mandate_version::bigint ELSE NULL END DESC NULLS LAST, "
+    "THEN mandate_version::numeric ELSE NULL END DESC NULLS LAST, "
     "mandate_version DESC"
 )
 

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -27,23 +27,37 @@ class _MonitoringExceptionListQuery:
 # Issue #646: mandate_version is a TEXT column holding an integer rendered by
 # str(binding_version), so ordering by it directly is lexicographic - "9"
 # sorts above "10" and every read after version 9 resolves to the wrong row.
-# Compare numerically, and keep the column's own order as the tie-break for
-# any value that is not a plain integer so a malformed row can never abort the
-# query. The matching expression index lives in migration 0022.
+# Order digit-only versions by magnitude, keeping the column's own order as the
+# tie-break so a malformed row can never abort the query. The matching
+# expression index lives in migration 0022 and must stay identical to this.
+#
 # The storage contract for mandate_version is unrestricted TEXT, so any digit
-# string is a legitimate value and the ordering must be correct for all of
-# them. Cast to NUMERIC rather than BIGINT: numeric is arbitrary precision, so
-# a 20-digit version orders as the large number it is instead of overflowing
-# (bigint) or being demoted to the non-numeric tail (a length-bounded guard).
-# The regex still excludes non-digit text, which sorts last by its own value.
-# The in-memory store applies the identical grammar over Python ints, which
-# are also unbounded, so the two backends cannot disagree.
+# string is a legitimate value. That rules out casting: BIGINT overflows past
+# 19 digits with 22003, and NUMERIC, while far wider, still overflows past
+# 131,072 digits - and because migration 0022 indexes this expression, such a
+# row would fail CREATE INDEX and block startup rather than just one read.
+#
+# Comparing significant-digit length and then the digits themselves is exact at
+# any length with no cast at all. Leading zeros are stripped first so '007' and
+# '7' reach the same magnitude, with all-zero versions folding to '0'; the raw
+# column then separates them, which is what makes '1' sort above '01'.
+#
+# COLLATE "C" forces byte order. Without it the comparison follows the
+# database's collation, which need not order digits by code point, and the
+# in-memory store - which compares Python strings, always by code point - would
+# disagree. The two stores run this same algorithm, so they agree by
+# construction rather than by happening to overlap in range.
 _MANDATE_VERSION_NUMERIC_PATTERN = "^[0-9]+$"
+
+# Mirrors Python's version.lstrip("0") or "0".
+_MANDATE_VERSION_DIGITS = "COALESCE(NULLIF(ltrim(mandate_version, '0'), ''), '0')"
 
 _MANDATE_VERSION_ORDER = (
     f"CASE WHEN mandate_version ~ '{_MANDATE_VERSION_NUMERIC_PATTERN}' "
-    "THEN mandate_version::numeric ELSE NULL END DESC NULLS LAST, "
-    "mandate_version DESC"
+    f"THEN length({_MANDATE_VERSION_DIGITS}) ELSE NULL END DESC NULLS LAST, "
+    f"CASE WHEN mandate_version ~ '{_MANDATE_VERSION_NUMERIC_PATTERN}' "
+    f'THEN {_MANDATE_VERSION_DIGITS} ELSE NULL END COLLATE "C" DESC NULLS LAST, '
+    'mandate_version COLLATE "C" DESC'
 )
 
 

--- a/src/infrastructure/postgres_migrations.py
+++ b/src/infrastructure/postgres_migrations.py
@@ -174,12 +174,55 @@ def _split_sql_statements(sql: str) -> list[str]:
                 dollar_tag = tag
                 index += len(tag)
                 continue
+        # Comments are skipped whole. Without this a semicolon inside a comment
+        # ends the statement, and the migration silently runs a truncated
+        # fragment plus a nonsense one - the failure looks like invalid SQL
+        # somewhere in the middle of a comment, which is a confusing place to
+        # start debugging. Explaining a statement is exactly when a semicolon
+        # gets written.
+        if sql.startswith("--", index):
+            index = _advance_line_comment_sql(sql=sql, index=index)
+            continue
+        if sql.startswith("/*", index):
+            index = _advance_block_comment_sql(sql=sql, index=index)
+            continue
         if char == ";":
             statements.append(sql[start:index])
             start = index + 1
         index += 1
     statements.append(sql[start:])
     return statements
+
+
+def _advance_line_comment_sql(*, sql: str, index: int) -> int:
+    """Return the index just past a ``--`` comment, which ends at the newline."""
+
+    newline = sql.find("\n", index)
+    return len(sql) if newline == -1 else newline + 1
+
+
+def _advance_block_comment_sql(*, sql: str, index: int) -> int:
+    """Return the index just past a ``/* */`` comment.
+
+    PostgreSQL nests block comments, so the depth is tracked rather than
+    stopping at the first ``*/``. An unterminated comment consumes the rest of
+    the input, which is what PostgreSQL would also reject.
+    """
+
+    depth = 0
+    while index < len(sql):
+        if sql.startswith("/*", index):
+            depth += 1
+            index += 2
+            continue
+        if sql.startswith("*/", index):
+            depth -= 1
+            index += 2
+            if depth == 0:
+                return index
+            continue
+        index += 1
+    return index
 
 
 def _advance_dollar_quoted_sql(

--- a/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
@@ -4,19 +4,33 @@ CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_portfolio_version_numeric
     -- temporal reads order numerically instead, and this index matches that
     -- expression so the comparison stays indexed rather than forcing a scan.
     -- The 0019 index remains for callers ordering by the raw column.
+    --
+    -- Every element below must match the query's ORDER BY exactly, including
+    -- NULLS LAST and the mandate_version tie-breaker. PostgreSQL defaults DESC
+    -- to NULLS FIRST, so an index written as plain DESC has the opposite null
+    -- ordering to the query and cannot satisfy it; the planner then sorts
+    -- anyway and the index silently buys nothing. The tie-breaker matters for
+    -- the same reason: the query falls through to mandate_version DESC when
+    -- two versions are numerically equal, as '01' and '1' are.
+    --
     -- Note for future migrations in this repo: the statement splitter is not
     -- comment-aware, so a semicolon inside a comment truncates the statement.
     ON dpm_mandate_snapshots (
         portfolio_id,
         as_of_date DESC,
-        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::numeric ELSE NULL END) DESC,
+        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::numeric ELSE NULL END)
+            DESC NULLS LAST,
+        mandate_version DESC,
         mandate_id DESC
     );
 
 CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_mandate_version_numeric
-    -- The same expression for the mandate_id-keyed reads.
+    -- The same expression for the mandate_id-keyed reads, which order by
+    -- as_of_date DESC, the numeric expression, then mandate_version DESC.
     ON dpm_mandate_snapshots (
         mandate_id,
         as_of_date DESC,
-        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::numeric ELSE NULL END) DESC
+        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::numeric ELSE NULL END)
+            DESC NULLS LAST,
+        mandate_version DESC
     );

--- a/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
@@ -9,7 +9,7 @@ CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_portfolio_version_numeric
     ON dpm_mandate_snapshots (
         portfolio_id,
         as_of_date DESC,
-        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::bigint ELSE NULL END) DESC,
+        (CASE WHEN mandate_version ~ '^[0-9]{1,18}$' THEN mandate_version::bigint ELSE NULL END) DESC,
         mandate_id DESC
     );
 
@@ -18,5 +18,5 @@ CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_mandate_version_numeric
     ON dpm_mandate_snapshots (
         mandate_id,
         as_of_date DESC,
-        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::bigint ELSE NULL END) DESC
+        (CASE WHEN mandate_version ~ '^[0-9]{1,18}$' THEN mandate_version::bigint ELSE NULL END) DESC
     );

--- a/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
@@ -2,19 +2,37 @@ CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_portfolio_version_numeric
     -- Issue #646. mandate_version is TEXT holding str(binding_version), so
     -- ordering by it directly is lexicographic and puts "9" above "10". The
     -- temporal reads order by magnitude instead, and this index matches the
-    -- leading part of that expression so the comparison stays indexed rather
-    -- than forcing a full sort. The 0019 index remains for callers ordering by
-    -- the raw column.
+    -- leading part of that expression. The 0019 index remains for callers
+    -- ordering by the raw column.
     --
     -- This is deliberately a strict PREFIX of the query's ORDER BY: it stops
     -- after the normalized digits and leaves the raw mandate_version and
     -- mandate_id tie-breakers to an incremental sort. Including them would put
-    -- two full copies of the version text in one B-tree tuple, and B-tree
-    -- entries have a page-dependent size limit, so a long-but-legal version
-    -- that the existing single-copy index accepts could fail this CREATE INDEX
-    -- during startup, or fail later inserts. Those tie-breakers only separate
-    -- versions of equal magnitude, such as '01' and '1', so leaving them to the
-    -- sort costs nothing on the common path.
+    -- two full copies of the version text in one B-tree tuple, which is worth
+    -- avoiding because B-tree entries have a size limit. Those tie-breakers
+    -- only separate versions of equal magnitude, such as '01' and '1'.
+    --
+    -- MEASURED on PostgreSQL 17.6, 1000 rows for one portfolio, ANALYZE run
+    -- (this is a plan observation on one shape, not a general performance
+    -- claim):
+    --   with this index    Index Scan + Incremental Sort, presorted on
+    --                      as_of_date and both magnitude expressions,
+    --                      2 rows touched, 12 buffers, 0.566 ms
+    --   without it         Bitmap Heap Scan over all 1000 matching rows then
+    --                      a top-N heapsort, 97 heap blocks, 7.986 ms
+    -- So the index is genuinely used and the LIMIT stops early rather than
+    -- every matching row being read and sorted.
+    --
+    -- It does NOT make arbitrarily long version text indexable, and nothing
+    -- here should be read as claiming that. Measured with incompressible
+    -- random digit strings: 2000 digits accepted, 2700 refused with
+    -- "index row size 2752 exceeds btree version 4 maximum 2704". The index
+    -- that refuses is idx_dpm_mandate_snapshots_portfolio_temporal, from
+    -- migration 0019 which is already on main - so this ceiling predates this
+    -- index and this index does not lower it. Highly repetitive versions go
+    -- much further because they compress; 20000 identical digits were
+    -- accepted. Compressibility is not a property the storage contract
+    -- promises, so the honest bound is the incompressible one.
     --
     -- What is here must still match _MANDATE_VERSION_ORDER in
     -- src/infrastructure/mandates/postgres.py element for element, including

--- a/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
@@ -1,29 +1,35 @@
 CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_portfolio_version_numeric
     -- Issue #646. mandate_version is TEXT holding str(binding_version), so
     -- ordering by it directly is lexicographic and puts "9" above "10". The
-    -- temporal reads order by magnitude instead, and this index matches that
-    -- expression so the comparison stays indexed rather than forcing a scan.
-    -- The 0019 index remains for callers ordering by the raw column.
+    -- temporal reads order by magnitude instead, and this index matches the
+    -- leading part of that expression so the comparison stays indexed rather
+    -- than forcing a full sort. The 0019 index remains for callers ordering by
+    -- the raw column.
     --
-    -- Every element below must match _MANDATE_VERSION_ORDER in
-    -- src/infrastructure/mandates/postgres.py exactly, including NULLS LAST,
-    -- the COLLATE "C" clauses, and the raw mandate_version tie-breaker.
-    -- PostgreSQL defaults DESC to NULLS FIRST, so an index written as plain
-    -- DESC has the opposite null ordering to the query and cannot satisfy it.
-    -- The planner then sorts anyway and the index silently buys nothing. The
-    -- tie-breaker matters for the same reason: the query falls through to
-    -- mandate_version when two versions have equal magnitude, as '01' and '1'
-    -- do.
+    -- This is deliberately a strict PREFIX of the query's ORDER BY: it stops
+    -- after the normalized digits and leaves the raw mandate_version and
+    -- mandate_id tie-breakers to an incremental sort. Including them would put
+    -- two full copies of the version text in one B-tree tuple, and B-tree
+    -- entries have a page-dependent size limit, so a long-but-legal version
+    -- that the existing single-copy index accepts could fail this CREATE INDEX
+    -- during startup, or fail later inserts. Those tie-breakers only separate
+    -- versions of equal magnitude, such as '01' and '1', so leaving them to the
+    -- sort costs nothing on the common path.
+    --
+    -- What is here must still match _MANDATE_VERSION_ORDER in
+    -- src/infrastructure/mandates/postgres.py element for element, including
+    -- NULLS LAST and COLLATE "C". PostgreSQL defaults DESC to NULLS FIRST, so
+    -- an index written as plain DESC has the opposite null ordering to the
+    -- query and cannot satisfy it. The planner then sorts anyway and the index
+    -- silently buys nothing.
     --
     -- Length-then-digits rather than a cast, because the storage contract is
-    -- unrestricted TEXT. A cast bounds it, and here that bound would be worse
-    -- than a failed read: a row exceeding it fails this CREATE INDEX and
-    -- blocks startup for every caller.
+    -- unrestricted TEXT and every cast bounds it.
     --
-    -- The statement splitter skips comments whole, so a semicolon inside one
-    -- is safe. It was not always: this file previously carried a warning to
-    -- avoid them, which is the wrong half of the fix, so the splitter learned
-    -- about comments instead.
+    -- The statement splitter skips comments whole, so a semicolon inside one is
+    -- safe. It was not always: this file previously carried a warning to avoid
+    -- them, which is the wrong half of the fix, so the splitter learned about
+    -- comments instead.
     ON dpm_mandate_snapshots (
         portfolio_id,
         as_of_date DESC,
@@ -36,14 +42,11 @@ CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_portfolio_version_numeric
             CASE WHEN mandate_version ~ '^[0-9]+$'
                  THEN COALESCE(NULLIF(ltrim(mandate_version, '0'), ''), '0')
                  ELSE NULL END
-        ) COLLATE "C" DESC NULLS LAST,
-        mandate_version COLLATE "C" DESC,
-        mandate_id DESC
+        ) COLLATE "C" DESC NULLS LAST
     );
 
 CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_mandate_version_numeric
-    -- The same expression for the mandate_id-keyed reads, which order by
-    -- as_of_date DESC, the magnitude elements, then mandate_version.
+    -- The same prefix for the mandate_id-keyed reads, for the same reasons.
     ON dpm_mandate_snapshots (
         mandate_id,
         as_of_date DESC,
@@ -56,6 +59,5 @@ CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_mandate_version_numeric
             CASE WHEN mandate_version ~ '^[0-9]+$'
                  THEN COALESCE(NULLIF(ltrim(mandate_version, '0'), ''), '0')
                  ELSE NULL END
-        ) COLLATE "C" DESC NULLS LAST,
-        mandate_version COLLATE "C" DESC
+        ) COLLATE "C" DESC NULLS LAST
     );

--- a/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
@@ -1,0 +1,22 @@
+CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_portfolio_version_numeric
+    -- Issue #646. mandate_version is TEXT holding str(binding_version), so
+    -- ordering by it directly is lexicographic and puts "9" above "10". The
+    -- temporal reads order numerically instead, and this index matches that
+    -- expression so the comparison stays indexed rather than forcing a scan.
+    -- The 0019 index remains for callers ordering by the raw column.
+    -- Note for future migrations in this repo: the statement splitter is not
+    -- comment-aware, so a semicolon inside a comment truncates the statement.
+    ON dpm_mandate_snapshots (
+        portfolio_id,
+        as_of_date DESC,
+        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::bigint ELSE NULL END) DESC,
+        mandate_id DESC
+    );
+
+CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_mandate_version_numeric
+    -- The same expression for the mandate_id-keyed reads.
+    ON dpm_mandate_snapshots (
+        mandate_id,
+        as_of_date DESC,
+        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::bigint ELSE NULL END) DESC
+    );

--- a/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
@@ -1,36 +1,61 @@
 CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_portfolio_version_numeric
     -- Issue #646. mandate_version is TEXT holding str(binding_version), so
     -- ordering by it directly is lexicographic and puts "9" above "10". The
-    -- temporal reads order numerically instead, and this index matches that
+    -- temporal reads order by magnitude instead, and this index matches that
     -- expression so the comparison stays indexed rather than forcing a scan.
     -- The 0019 index remains for callers ordering by the raw column.
     --
-    -- Every element below must match the query's ORDER BY exactly, including
-    -- NULLS LAST and the mandate_version tie-breaker. PostgreSQL defaults DESC
-    -- to NULLS FIRST, so an index written as plain DESC has the opposite null
-    -- ordering to the query and cannot satisfy it; the planner then sorts
-    -- anyway and the index silently buys nothing. The tie-breaker matters for
-    -- the same reason: the query falls through to mandate_version DESC when
-    -- two versions are numerically equal, as '01' and '1' are.
+    -- Every element below must match _MANDATE_VERSION_ORDER in
+    -- src/infrastructure/mandates/postgres.py exactly, including NULLS LAST,
+    -- the COLLATE "C" clauses, and the raw mandate_version tie-breaker.
+    -- PostgreSQL defaults DESC to NULLS FIRST, so an index written as plain
+    -- DESC has the opposite null ordering to the query and cannot satisfy it.
+    -- The planner then sorts anyway and the index silently buys nothing. The
+    -- tie-breaker matters for the same reason: the query falls through to
+    -- mandate_version when two versions have equal magnitude, as '01' and '1'
+    -- do.
     --
-    -- Note for future migrations in this repo: the statement splitter is not
-    -- comment-aware, so a semicolon inside a comment truncates the statement.
+    -- Length-then-digits rather than a cast, because the storage contract is
+    -- unrestricted TEXT. A cast bounds it, and here that bound would be worse
+    -- than a failed read: a row exceeding it fails this CREATE INDEX and
+    -- blocks startup for every caller.
+    --
+    -- The statement splitter skips comments whole, so a semicolon inside one
+    -- is safe. It was not always: this file previously carried a warning to
+    -- avoid them, which is the wrong half of the fix, so the splitter learned
+    -- about comments instead.
     ON dpm_mandate_snapshots (
         portfolio_id,
         as_of_date DESC,
-        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::numeric ELSE NULL END)
-            DESC NULLS LAST,
-        mandate_version DESC,
+        (
+            CASE WHEN mandate_version ~ '^[0-9]+$'
+                 THEN length(COALESCE(NULLIF(ltrim(mandate_version, '0'), ''), '0'))
+                 ELSE NULL END
+        ) DESC NULLS LAST,
+        (
+            CASE WHEN mandate_version ~ '^[0-9]+$'
+                 THEN COALESCE(NULLIF(ltrim(mandate_version, '0'), ''), '0')
+                 ELSE NULL END
+        ) COLLATE "C" DESC NULLS LAST,
+        mandate_version COLLATE "C" DESC,
         mandate_id DESC
     );
 
 CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_mandate_version_numeric
     -- The same expression for the mandate_id-keyed reads, which order by
-    -- as_of_date DESC, the numeric expression, then mandate_version DESC.
+    -- as_of_date DESC, the magnitude elements, then mandate_version.
     ON dpm_mandate_snapshots (
         mandate_id,
         as_of_date DESC,
-        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::numeric ELSE NULL END)
-            DESC NULLS LAST,
-        mandate_version DESC
+        (
+            CASE WHEN mandate_version ~ '^[0-9]+$'
+                 THEN length(COALESCE(NULLIF(ltrim(mandate_version, '0'), ''), '0'))
+                 ELSE NULL END
+        ) DESC NULLS LAST,
+        (
+            CASE WHEN mandate_version ~ '^[0-9]+$'
+                 THEN COALESCE(NULLIF(ltrim(mandate_version, '0'), ''), '0')
+                 ELSE NULL END
+        ) COLLATE "C" DESC NULLS LAST,
+        mandate_version COLLATE "C" DESC
     );

--- a/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0022_mandate_version_numeric_order_index.sql
@@ -9,7 +9,7 @@ CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_portfolio_version_numeric
     ON dpm_mandate_snapshots (
         portfolio_id,
         as_of_date DESC,
-        (CASE WHEN mandate_version ~ '^[0-9]{1,18}$' THEN mandate_version::bigint ELSE NULL END) DESC,
+        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::numeric ELSE NULL END) DESC,
         mandate_id DESC
     );
 
@@ -18,5 +18,5 @@ CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_mandate_version_numeric
     ON dpm_mandate_snapshots (
         mandate_id,
         as_of_date DESC,
-        (CASE WHEN mandate_version ~ '^[0-9]{1,18}$' THEN mandate_version::bigint ELSE NULL END) DESC
+        (CASE WHEN mandate_version ~ '^[0-9]+$' THEN mandate_version::numeric ELSE NULL END) DESC
     );

--- a/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
@@ -346,3 +346,38 @@ def test_both_stores_agree_on_which_versions_are_numeric(
         assert latest.mandate_version == "2"
     finally:
         _clear(repository, mandate_id)
+
+
+def test_numerically_equal_versions_are_separated_by_raw_text(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """'01' and '1' are equal under ::numeric, so the ordering falls through to
+    mandate_version DESC and PostgreSQL puts '1' first.
+
+    The in-memory store must make the same choice or the two backends disagree
+    about which mandate is current for the same data. Its half of this contract
+    is pinned in tests/unit/dpm/infrastructure/test_mandate_version_ordering.py;
+    this is the assertion that establishes what PostgreSQL actually does, since
+    a cast's tie-breaking behaviour is an engine claim rather than a Python one.
+    """
+
+    mandate_id = f"MANDATE_TIE_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_TIE_{uuid.uuid4().hex[:8]}"
+    try:
+        # Saved least-significant first, so insertion order cannot be what
+        # produces the expected result.
+        for version in ("01", "1", "001"):
+            repository.save_mandate_snapshot(
+                _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version=version)
+            )
+
+        listed = [
+            twin.mandate_version for twin in repository.list_mandate_versions(mandate_id=mandate_id)
+        ]
+        assert listed == ["1", "01", "001"]
+
+        latest = repository.get_latest_mandate(mandate_id=mandate_id)
+        assert latest is not None
+        assert latest.mandate_version == "1"
+    finally:
+        _clear(repository, mandate_id)

--- a/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
@@ -280,12 +280,15 @@ def test_a_requested_version_resolves_to_its_latest_observation(
 def test_a_version_beyond_bigint_range_does_not_abort_the_read(
     repository: PostgresDpmMandateRepository,
 ) -> None:
-    """The guard bounds the numeric grammar at 18 digits for a reason.
+    """The storage contract for mandate_version is unrestricted TEXT, so a
+    version longer than bigint is a legitimate value and must order as the
+    large number it is.
 
-    mandate_version is TEXT, so a longer digit string is representable. An
-    unbounded `^[0-9]+$` would pass such a value into ::bigint, raise 22003,
-    and abort the read for EVERY caller - a worse failure than the mis-ordering
-    the guard was added to prevent. It must sort last instead.
+    A bigint cast is a narrowing assumption about data the contract permits:
+    it either overflows with 22003 and aborts the read for every caller, or -
+    if the grammar is length-bounded to avoid that - demotes a legitimately
+    huge version to the non-numeric tail, ordering it BELOW a two-digit one.
+    NUMERIC is arbitrary precision, so neither failure is possible.
     """
 
     mandate_id = f"MANDATE_BIGINT_{uuid.uuid4().hex[:8]}"
@@ -301,11 +304,12 @@ def test_a_version_beyond_bigint_range_does_not_abort_the_read(
 
         latest = repository.get_latest_mandate(mandate_id=mandate_id)
         assert latest is not None
-        assert latest.mandate_version == "12"
+        # 10^30 - 1 really is larger than 12, and the read must say so.
+        assert latest.mandate_version == beyond_bigint
         listed = [
             twin.mandate_version for twin in repository.list_mandate_versions(mandate_id=mandate_id)
         ]
-        assert listed == ["12", beyond_bigint]
+        assert listed == [beyond_bigint, "12"]
     finally:
         _clear(repository, mandate_id)
 
@@ -324,7 +328,8 @@ def test_both_stores_agree_on_which_versions_are_numeric(
     # Memory treats it as non-numeric, matching PostgreSQL's [0-9] class.
     assert _mandate_version_sort_key(unicode_digit)[0] == 0
     assert _mandate_version_sort_key("3")[0] == 1
-    assert _mandate_version_sort_key("9" * 30)[0] == 0
+    # A 30-digit version is numeric under the unrestricted storage contract.
+    assert _mandate_version_sort_key("9" * 30)[0] == 1
 
     mandate_id = f"MANDATE_UNICODE_{uuid.uuid4().hex[:8]}"
     portfolio_id = f"PF_UNICODE_{uuid.uuid4().hex[:8]}"

--- a/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
@@ -19,6 +19,7 @@ CI job that owns the database runs this file explicitly.
 from __future__ import annotations
 
 import os
+import random
 import uuid
 
 from tests.support.mandate_version_corpus import (
@@ -418,5 +419,52 @@ def test_postgres_orders_the_shared_corpus_exactly_as_the_memory_store_does(
         latest = repository.get_latest_mandate(mandate_id=mandate_id)
         assert latest is not None
         assert latest.mandate_version == EXPECTED_CORPUS_ORDER[0]
+    finally:
+        _clear(repository, mandate_id)
+
+
+def test_a_long_but_indexable_version_round_trips_and_orders(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """The supported length range, measured rather than assumed.
+
+    The storage contract for mandate_version is unrestricted TEXT and the
+    ordering expression imposes no length bound, but the B-tree indexes do:
+    measured on PostgreSQL 17.6 with incompressible random digits, 2000 digits
+    are accepted and 2700 are refused with "index row size 2752 exceeds btree
+    version 4 maximum 2704". The refusing index is
+    idx_dpm_mandate_snapshots_portfolio_temporal from migration 0019, already
+    on main, so the ceiling is not introduced by the ordering index added for
+    this issue.
+
+    This pins the accepted end of that range: a version far longer than any
+    realistic binding version still stores, reads back byte-for-byte, and
+    orders by magnitude rather than by text. It deliberately uses random digits
+    because a repeated digit compresses and would prove a much larger number
+    that the contract does not actually promise.
+    """
+
+    mandate_id = f"MANDATE_LONG_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_LONG_{uuid.uuid4().hex[:8]}"
+    rng = random.Random(20260906)
+    long_version = "".join(rng.choice("123456789") for _ in range(2000))
+    try:
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version=long_version)
+        )
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version="99999")
+        )
+
+        latest = repository.get_latest_mandate(mandate_id=mandate_id)
+        assert latest is not None
+        # A 2000-digit number is larger than a 5-digit one, and the read must
+        # say so rather than comparing the strings.
+        assert latest.mandate_version == long_version
+
+        listed = [
+            twin.mandate_version for twin in repository.list_mandate_versions(mandate_id=mandate_id)
+        ]
+        assert listed == [long_version, "99999"]
     finally:
         _clear(repository, mandate_id)

--- a/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
@@ -1,0 +1,277 @@
+"""Temporal mandate reads proven on real PostgreSQL (issues #646, #647).
+
+Both defects are engine-shaped and cannot be trusted to a fake:
+
+  - #646 is lexicographic ordering of a TEXT column. `"9" > "10"` is true in
+    Python and in SQL alike, so the wrong-row behaviour reproduces anywhere -
+    but the FIX is a SQL expression, and only PostgreSQL can prove the
+    expression parses, orders numerically, and survives a non-integer value
+    without aborting the query.
+  - #647 depends on migration 0020 having relaxed the uniqueness key to
+    (mandate_id, mandate_version, as_of_date). Whether the database ACCEPTS a
+    repeated version at a later date is a schema fact, so a repeated-version
+    fixture is only meaningful against the real schema.
+
+Skips without a DSN, in line with the other PostgreSQL integration tests. The
+CI job that owns the database runs this file explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import closing
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from src.api.services.mandate_diff import build_mandate_diff_for_versions
+from src.api.services.mandate_errors import DpmMandateDiffUnavailableError
+from src.core.mandates import (
+    DpmMandateConstraintSet,
+    DpmMandateDigitalTwin,
+    DpmMandateReviewPolicy,
+)
+from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository
+
+_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
+
+pytestmark = pytest.mark.skipif(
+    not _DSN, reason="DPM_POSTGRES_INTEGRATION_DSN is required for the temporal-read proof"
+)
+
+_AS_OF = date(2026, 5, 3)
+
+
+def _twin(
+    *,
+    mandate_id: str,
+    portfolio_id: str,
+    version: str,
+    as_of: date = _AS_OF,
+    turnover: str = "0.15",
+) -> DpmMandateDigitalTwin:
+    return DpmMandateDigitalTwin(
+        mandate_id=mandate_id,
+        portfolio_id=portfolio_id,
+        mandate_version=version,
+        as_of_date=as_of,
+        base_currency="SGD",
+        reference_currency="SGD",
+        risk_profile="BALANCED",
+        investment_objective="LONG_TERM_TOTAL_RETURN",
+        time_horizon="LONG_TERM",
+        model_portfolio_id="MODEL_PB_SG_GLOBAL_BAL_DPM",
+        constraints=DpmMandateConstraintSet(turnover_budget=Decimal(turnover)),
+        review_policy=DpmMandateReviewPolicy(next_review_due_date=date(2026, 6, 30)),
+    )
+
+
+@pytest.fixture
+def repository() -> PostgresDpmMandateRepository:
+    return PostgresDpmMandateRepository(dsn=_DSN)
+
+
+def _clear(repository: PostgresDpmMandateRepository, mandate_id: str) -> None:
+    with closing(repository._connect()) as connection:
+        connection.execute("DELETE FROM dpm_mandate_snapshots WHERE mandate_id = %s", (mandate_id,))
+        connection.commit()
+
+
+def test_version_ten_wins_over_version_nine_on_the_same_business_date(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """Issue #646. Lexicographically "9" sorts above "10", so before the fix
+    every temporal read resolved to the older binding once a mandate reached
+    version 10 - and migration 0020 is what makes two rows share a date."""
+
+    mandate_id = f"MANDATE_ORDER_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_ORDER_{uuid.uuid4().hex[:8]}"
+    try:
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version="9")
+        )
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version="10")
+        )
+
+        assert repository.get_latest_mandate(mandate_id=mandate_id).mandate_version == "10"
+        assert (
+            repository.get_latest_mandate_by_portfolio(portfolio_id=portfolio_id).mandate_version
+            == "10"
+        )
+        assert (
+            repository.get_mandate_by_portfolio_as_of(
+                portfolio_id=portfolio_id, as_of_date=_AS_OF
+            ).mandate_version
+            == "10"
+        )
+        # The listing is newest-first, so the numeric order must hold there too.
+        listed = [
+            twin.mandate_version for twin in repository.list_mandate_versions(mandate_id=mandate_id)
+        ]
+        assert listed == ["10", "9"]
+    finally:
+        _clear(repository, mandate_id)
+
+
+def test_version_ordering_survives_a_non_integer_version(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """The column is TEXT, so a non-integer value is representable. The
+    ordering expression must sort it last rather than aborting the query for
+    every caller - a cast without the guard raises 22P02 and takes the whole
+    read down."""
+
+    mandate_id = f"MANDATE_TEXTVER_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_TEXTVER_{uuid.uuid4().hex[:8]}"
+    try:
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version="2024-R1")
+        )
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version="7")
+        )
+
+        assert repository.get_latest_mandate(mandate_id=mandate_id).mandate_version == "7"
+        listed = [
+            twin.mandate_version for twin in repository.list_mandate_versions(mandate_id=mandate_id)
+        ]
+        assert listed == ["7", "2024-R1"]
+    finally:
+        _clear(repository, mandate_id)
+
+
+def test_a_repeated_version_is_not_diffed_against_itself(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """Issue #647. Migration 0020 lets one version be re-observed on a later
+    date. Diffing the two newest rows blindly compares that version against
+    itself and reports "no changes", which a reader cannot distinguish from a
+    mandate that genuinely did not change."""
+
+    mandate_id = f"MANDATE_REOBS_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_REOBS_{uuid.uuid4().hex[:8]}"
+    try:
+        repository.save_mandate_snapshot(
+            _twin(
+                mandate_id=mandate_id,
+                portfolio_id=portfolio_id,
+                version="3",
+                as_of=date(2026, 4, 30),
+                turnover="0.10",
+            )
+        )
+        # Version 4 changes the turnover budget...
+        repository.save_mandate_snapshot(
+            _twin(
+                mandate_id=mandate_id,
+                portfolio_id=portfolio_id,
+                version="4",
+                as_of=date(2026, 5, 1),
+                turnover="0.20",
+            )
+        )
+        # ...and is then re-observed unchanged on a later business date. The
+        # database accepts this only because 0020 relaxed the uniqueness key.
+        repository.save_mandate_snapshot(
+            _twin(
+                mandate_id=mandate_id,
+                portfolio_id=portfolio_id,
+                version="4",
+                as_of=date(2026, 5, 3),
+                turnover="0.20",
+            )
+        )
+
+        versions = repository.list_mandate_versions(mandate_id=mandate_id)
+        assert [twin.mandate_version for twin in versions] == ["4", "4", "3"]
+
+        diff = build_mandate_diff_for_versions(
+            mandate_id=mandate_id, versions=versions, from_version=None, to_version=None
+        )
+
+        # The comparison crosses a real version boundary...
+        assert (diff.from_version, diff.to_version) == ("3", "4")
+        # ...and names WHICH observations it used, so a same-version
+        # re-observation is distinguishable from a version change.
+        assert diff.from_as_of_date == date(2026, 4, 30)
+        assert diff.to_as_of_date == date(2026, 5, 3)
+        # The turnover change is real and must survive.
+        assert any(
+            change.field_path == "constraints.turnover_budget" for change in diff.changed_fields
+        )
+    finally:
+        _clear(repository, mandate_id)
+
+
+def test_repeated_observations_of_one_version_refuse_rather_than_report_no_changes(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """When every stored observation is of the same version there is no
+    version change to describe. Refusing is more truthful than an empty
+    change list, which reads as "compared, and nothing moved"."""
+
+    mandate_id = f"MANDATE_SAMEVER_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_SAMEVER_{uuid.uuid4().hex[:8]}"
+    try:
+        for observed in (date(2026, 5, 1), date(2026, 5, 3)):
+            repository.save_mandate_snapshot(
+                _twin(
+                    mandate_id=mandate_id,
+                    portfolio_id=portfolio_id,
+                    version="5",
+                    as_of=observed,
+                )
+            )
+        versions = repository.list_mandate_versions(mandate_id=mandate_id)
+        assert len(versions) == 2
+
+        with pytest.raises(DpmMandateDiffUnavailableError):
+            build_mandate_diff_for_versions(
+                mandate_id=mandate_id, versions=versions, from_version=None, to_version=None
+            )
+    finally:
+        _clear(repository, mandate_id)
+
+
+def test_a_requested_version_resolves_to_its_latest_observation(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """A caller naming a version gets its most recent observation. The old
+    dict comprehension let the last list entry win, and the list is
+    newest-first, so callers silently received the OLDEST observation."""
+
+    mandate_id = f"MANDATE_PICK_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_PICK_{uuid.uuid4().hex[:8]}"
+    try:
+        repository.save_mandate_snapshot(
+            _twin(
+                mandate_id=mandate_id,
+                portfolio_id=portfolio_id,
+                version="1",
+                as_of=date(2026, 4, 1),
+                turnover="0.10",
+            )
+        )
+        for observed in (date(2026, 4, 30), date(2026, 5, 3)):
+            repository.save_mandate_snapshot(
+                _twin(
+                    mandate_id=mandate_id,
+                    portfolio_id=portfolio_id,
+                    version="2",
+                    as_of=observed,
+                    turnover="0.20",
+                )
+            )
+
+        versions = repository.list_mandate_versions(mandate_id=mandate_id)
+        diff = build_mandate_diff_for_versions(
+            mandate_id=mandate_id, versions=versions, from_version="1", to_version="2"
+        )
+
+        assert (diff.from_version, diff.to_version) == ("1", "2")
+        assert diff.to_as_of_date == date(2026, 5, 3)
+    finally:
+        _clear(repository, mandate_id)

--- a/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
@@ -275,3 +275,69 @@ def test_a_requested_version_resolves_to_its_latest_observation(
         assert diff.to_as_of_date == date(2026, 5, 3)
     finally:
         _clear(repository, mandate_id)
+
+
+def test_a_version_beyond_bigint_range_does_not_abort_the_read(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """The guard bounds the numeric grammar at 18 digits for a reason.
+
+    mandate_version is TEXT, so a longer digit string is representable. An
+    unbounded `^[0-9]+$` would pass such a value into ::bigint, raise 22003,
+    and abort the read for EVERY caller - a worse failure than the mis-ordering
+    the guard was added to prevent. It must sort last instead.
+    """
+
+    mandate_id = f"MANDATE_BIGINT_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_BIGINT_{uuid.uuid4().hex[:8]}"
+    beyond_bigint = "9" * 30
+    try:
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version=beyond_bigint)
+        )
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version="12")
+        )
+
+        latest = repository.get_latest_mandate(mandate_id=mandate_id)
+        assert latest is not None
+        assert latest.mandate_version == "12"
+        listed = [
+            twin.mandate_version for twin in repository.list_mandate_versions(mandate_id=mandate_id)
+        ]
+        assert listed == ["12", beyond_bigint]
+    finally:
+        _clear(repository, mandate_id)
+
+
+def test_both_stores_agree_on_which_versions_are_numeric(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """PostgreSQL's [0-9] and Python's str.isdigit() disagree: isdigit accepts
+    Arabic-Indic numerals and superscripts. If the memory store used it, the
+    two backends would disagree about which mandate is current."""
+
+    from src.infrastructure.mandates.in_memory import _mandate_version_sort_key
+
+    unicode_digit = "٣"  # Arabic-Indic three, isdigit() is True
+    assert unicode_digit.isdigit()
+    # Memory treats it as non-numeric, matching PostgreSQL's [0-9] class.
+    assert _mandate_version_sort_key(unicode_digit)[0] == 0
+    assert _mandate_version_sort_key("3")[0] == 1
+    assert _mandate_version_sort_key("9" * 30)[0] == 0
+
+    mandate_id = f"MANDATE_UNICODE_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_UNICODE_{uuid.uuid4().hex[:8]}"
+    try:
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version=unicode_digit)
+        )
+        repository.save_mandate_snapshot(
+            _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version="2")
+        )
+        latest = repository.get_latest_mandate(mandate_id=mandate_id)
+        assert latest is not None
+        # PostgreSQL sorts the non-ASCII version last, exactly as memory does.
+        assert latest.mandate_version == "2"
+    finally:
+        _clear(repository, mandate_id)

--- a/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
@@ -20,6 +20,11 @@ from __future__ import annotations
 
 import os
 import uuid
+
+from tests.support.mandate_version_corpus import (
+    EXPECTED_CORPUS_ORDER,
+    SHARED_ORDERING_CORPUS,
+)
 from contextlib import closing
 from datetime import date
 from decimal import Decimal
@@ -379,5 +384,39 @@ def test_numerically_equal_versions_are_separated_by_raw_text(
         latest = repository.get_latest_mandate(mandate_id=mandate_id)
         assert latest is not None
         assert latest.mandate_version == "1"
+    finally:
+        _clear(repository, mandate_id)
+
+
+def test_postgres_orders_the_shared_corpus_exactly_as_the_memory_store_does(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    """The other half of the one ordering contract.
+
+    tests/unit/dpm/infrastructure/test_mandate_version_ordering.py asserts this
+    same corpus and this same expected order in memory. Asserting it here on a
+    real engine is what makes the agreement a fact rather than an assumption:
+    the regex anchoring, the collation, and the leading-zero handling are all
+    engine behaviour that a Python test cannot establish.
+    """
+
+    mandate_id = f"MANDATE_CORPUS_{uuid.uuid4().hex[:8]}"
+    portfolio_id = f"PF_CORPUS_{uuid.uuid4().hex[:8]}"
+    try:
+        for version in SHARED_ORDERING_CORPUS:
+            repository.save_mandate_snapshot(
+                _twin(mandate_id=mandate_id, portfolio_id=portfolio_id, version=version)
+            )
+
+        listed = [
+            twin.mandate_version for twin in repository.list_mandate_versions(mandate_id=mandate_id)
+        ]
+        assert listed == list(EXPECTED_CORPUS_ORDER)
+
+        # The same expression decides the single-row reads, so the head of the
+        # list and the latest read must be the same value.
+        latest = repository.get_latest_mandate(mandate_id=mandate_id)
+        assert latest is not None
+        assert latest.mandate_version == EXPECTED_CORPUS_ORDER[0]
     finally:
         _clear(repository, mandate_id)

--- a/tests/support/mandate_version_corpus.py
+++ b/tests/support/mandate_version_corpus.py
@@ -1,0 +1,55 @@
+"""One mandate-version ordering corpus, asserted against both backends.
+
+The in-memory store and the PostgreSQL store each answer "which mandate
+version is current". If they answer differently, the same data resolves to
+different twins depending on configuration, and a test that exercises only one
+store cannot see it. Both are checked against the list below: the unit suite
+orders it in memory, the database lane orders it in PostgreSQL, and both
+assert EXPECTED_CORPUS_ORDER.
+
+Keep the entries adversarial. Every case here comes from a defect that reached
+review: lexicographic ordering, values past a cast's range, leading zeros that
+compare equal, a trailing newline that Python's '$' accepts and PostgreSQL's
+'~' does not, and Unicode digits that str.isdigit() accepts and [0-9] does not.
+"""
+
+from __future__ import annotations
+
+# Deliberately not in sorted order: a corpus that arrives sorted cannot show
+# that the ordering did anything.
+SHARED_ORDERING_CORPUS: tuple[str, ...] = (
+    "9",
+    "10",
+    "1",
+    "01",
+    "v2",
+    "100",
+    "007",
+    "9\n",
+    "٢",
+    "2",
+)
+
+# Newest first, the order both stores must produce.
+#
+# Numeric versions lead, ordered by magnitude: 100, 10, 9, then 007 (which is
+# seven, not a string starting with two zeros), then 2, then the two spellings
+# of one. '1' precedes '01' because equal magnitudes fall through to the raw
+# column descending.
+#
+# Non-numeric values sort last, also by raw text descending. That order is by
+# code point in Python and by byte under COLLATE "C" in PostgreSQL, which agree
+# here: the Arabic-Indic digit encodes to d9a2, 'v2' to 7632, and the
+# newline-terminated value to 390a.
+EXPECTED_CORPUS_ORDER: tuple[str, ...] = (
+    "100",
+    "10",
+    "9",
+    "007",
+    "2",
+    "1",
+    "01",
+    "٢",
+    "v2",
+    "9\n",
+)

--- a/tests/unit/dpm/contracts/test_contract_mandate_openapi_examples.py
+++ b/tests/unit/dpm/contracts/test_contract_mandate_openapi_examples.py
@@ -1,0 +1,85 @@
+"""Documented mandate response examples must validate against their schemas.
+
+A hand-written `example` on a route is published in /openapi.json and read by
+integrators as the shape of a real response. Adding a required field to the
+response model does not update it, so the example silently becomes something
+the API can never return - and every generated client and integration test
+built from it starts from a shape that fails its own schema.
+
+This walks the generated document rather than naming examples one by one, so a
+field added to any mandate response model breaks here rather than in a
+consumer.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.openapi.utils import get_openapi
+
+from src.api.main import app
+from src.api.services.mandate_service import DpmMandateDiff
+from src.core.mandates import DpmMandateDigitalTwin
+
+# Response models keyed by the mandate path whose 200 carries a hand-written
+# example. /health is deliberately absent: it documents a description only, so
+# there is nothing to drift out of step with its schema.
+_MANDATE_RESPONSE_MODELS: dict[str, Any] = {
+    "/api/v1/mandates/by-portfolio/{portfolio_id}": DpmMandateDigitalTwin,
+    "/api/v1/mandates/{mandate_id}": DpmMandateDigitalTwin,
+    "/api/v1/mandates/{mandate_id}/diff": DpmMandateDiff,
+}
+
+
+def _documented_examples() -> list[tuple[str, Any, Any]]:
+    """Return (path, model, example) for every documented mandate 200 example."""
+
+    openapi = get_openapi(
+        title=app.title,
+        version=app.version,
+        routes=app.routes,
+    )
+    found: list[tuple[str, Any, Any]] = []
+    for path, model in _MANDATE_RESPONSE_MODELS.items():
+        operations = openapi["paths"].get(path, {})
+        for operation in operations.values():
+            content = operation.get("responses", {}).get("200", {}).get("content", {})
+            example = content.get("application/json", {}).get("example")
+            if example is not None:
+                found.append((path, model, example))
+    return found
+
+
+def test_every_mandate_path_under_test_is_actually_documented() -> None:
+    """Guard the guard: a renamed path would silently empty the parametrization.
+
+    Without this, a zero-example run reports as a pass, and the check below
+    would stop protecting anything while still reporting green.
+    """
+
+    openapi = get_openapi(title=app.title, version=app.version, routes=app.routes)
+    missing_paths = set(_MANDATE_RESPONSE_MODELS) - set(openapi["paths"])
+    assert not missing_paths, (
+        f"mandate paths no longer exist and are checking nothing: {missing_paths}"
+    )
+
+    documented = {path for path, _, _ in _documented_examples()}
+    assert documented == set(_MANDATE_RESPONSE_MODELS), (
+        "a documented mandate example appeared or vanished; update "
+        "_MANDATE_RESPONSE_MODELS so examples stay checked. Difference: "
+        f"{documented ^ set(_MANDATE_RESPONSE_MODELS)}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "model", "example"),
+    _documented_examples(),
+    ids=lambda value: value if isinstance(value, str) else "",
+)
+def test_documented_mandate_example_validates_against_its_response_model(
+    path: str, model: Any, example: Any
+) -> None:
+    # model_validate raises with the offending field, which is the message
+    # someone updating a response model needs to see.
+    model.model_validate(example)

--- a/tests/unit/dpm/contracts/test_mandate_temporal_read_documentation.py
+++ b/tests/unit/dpm/contracts/test_mandate_temporal_read_documentation.py
@@ -24,3 +24,26 @@ def test_temporal_mandate_documentation_preserves_source_dates_and_fail_closed_p
     assert "never relabels the resolved source date" in handoff
     assert "returns `404` before the first qualifying snapshot" in endpoint
     assert "without allowing gateway or workbench to reconstruct or relabel" in context
+
+
+def test_published_diff_semantics_match_the_implemented_selection_and_refusal() -> None:
+    """The published contract must state what the diff actually compares.
+
+    The diff selects the most recent observation of each of the latest two
+    DISTINCT versions, and refuses a single-distinct-version history rather
+    than diffing it against itself. An operator reading "the latest two
+    versions" would expect a re-observed binding to produce an empty diff and
+    a one-version history to produce a 200, and would be wrong on both.
+    """
+
+    endpoint = _normalized("wiki/Endpoint-Certification.md")
+
+    assert "latest two distinct versions" in endpoint
+    assert "most recent observation of each version" in endpoint
+    # The refusal is the behaviour an integrator must handle, so it is named
+    # with its status code rather than described in prose alone.
+    assert "only one distinct version" in endpoint
+    assert "refused with `409`" in endpoint
+    # Business dates travel with the comparison; version numbers are not dates.
+    assert "from_as_of_date" in endpoint
+    assert "to_as_of_date" in endpoint

--- a/tests/unit/dpm/core/test_dpm_source_context.py
+++ b/tests/unit/dpm/core/test_dpm_source_context.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 from decimal import Decimal
 
 from src.core.dpm_source_context import (
@@ -1258,3 +1259,32 @@ def test_core_resolver_payload_and_shelf_attribute_normalization_edges():
     }
     assert _shelf_attribute_value(False) == "false"
     assert _shelf_attribute_value(None) == ""
+
+
+def test_a_negative_binding_version_is_refused_at_the_boundary() -> None:
+    """A version counter has no meaningful negative value.
+
+    binding_version is rendered to TEXT with str() and stored as
+    mandate_version, which orders digit-only values by magnitude and everything
+    else by raw text. '-2' and '-1' both fall outside the digit grammar, so the
+    text fallback puts '-2' first and the numerically older binding resolves as
+    the latest one. Both stores agree on that, which makes it worse rather than
+    better: it is consistently wrong.
+
+    Refusing at ingestion keeps the ordering rules describing real data instead
+    of inventing a signed grammar for values that should not exist.
+    """
+
+    with pytest.raises(ValidationError) as refusal:
+        DpmCoreMandateBindingResponse.model_validate(
+            _core_mandate_binding_payload(binding_version=-1)
+        )
+
+    assert "binding_version" in str(refusal.value)
+
+    # Zero and above remain acceptable: the constraint rejects only the
+    # meaningless case, and does not assume versions start at one.
+    accepted = DpmCoreMandateBindingResponse.model_validate(
+        _core_mandate_binding_payload(binding_version=0)
+    )
+    assert accepted.binding_version == 0

--- a/tests/unit/dpm/infrastructure/test_mandate_version_ordering.py
+++ b/tests/unit/dpm/infrastructure/test_mandate_version_ordering.py
@@ -21,6 +21,10 @@ from __future__ import annotations
 import sys
 
 from src.infrastructure.mandates.in_memory import _mandate_version_sort_key
+from tests.support.mandate_version_corpus import (
+    EXPECTED_CORPUS_ORDER,
+    SHARED_ORDERING_CORPUS,
+)
 
 
 def _newest_first(versions: list[str]) -> list[str]:
@@ -97,3 +101,34 @@ def test_the_key_shape_matches_the_three_sql_ordering_elements() -> None:
     assert non_numeric_rank == 0
     assert raw_text == "v2"
     assert non_numeric_rank < numeric_rank
+
+
+def test_a_trailing_newline_does_not_make_a_version_numeric() -> None:
+    """Python's '$' also matches immediately before a trailing newline.
+
+    re.match(r'^[0-9]+$', '9\n') therefore succeeds, and the newline counts
+    toward the key's length, so '9\n' would order above '10'. PostgreSQL's '~'
+    anchors at the true end of the string and treats the value as non-numeric,
+    sorting it last. The two stores would pick different latest snapshots for
+    the same rows, which is the failure this whole contract exists to prevent.
+    """
+
+    assert _newest_first(["9\n", "10"]) == ["10", "9\n"]
+
+    # It is non-numeric, so it sorts behind every well-formed digit string.
+    assert _newest_first(["9\n", "1"]) == ["1", "9\n"]
+
+    numeric_rank, _, _, _ = _mandate_version_sort_key("9\n")
+    assert numeric_rank == 0
+
+
+def test_the_shared_ordering_corpus_is_ordered_as_the_contract_states() -> None:
+    """The corpus both backends are checked against, ordered here in memory.
+
+    The PostgreSQL half asserts the same expected order in
+    tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py, so
+    a change to either implementation that breaks the agreement fails on one
+    side or the other rather than passing quietly on both.
+    """
+
+    assert _newest_first(list(SHARED_ORDERING_CORPUS)) == list(EXPECTED_CORPUS_ORDER)

--- a/tests/unit/dpm/infrastructure/test_mandate_version_ordering.py
+++ b/tests/unit/dpm/infrastructure/test_mandate_version_ordering.py
@@ -1,0 +1,99 @@
+"""The in-memory mandate version ordering must match PostgreSQL's (issue #646).
+
+Both stores answer "which mandate version is current". If they order versions
+differently, the same mandate resolves to different twins depending on which
+backend is configured, and no test that exercises one store can detect it.
+
+The PostgreSQL ordering under test is:
+
+    CASE WHEN mandate_version ~ '^[0-9]+$'
+         THEN mandate_version::numeric ELSE NULL END DESC NULLS LAST,
+    mandate_version DESC
+
+These tests pin the in-memory key against that expression element for element.
+The equivalent PostgreSQL assertions live in
+tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py, which
+runs against a real engine because a cast's behaviour is an engine claim.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from src.infrastructure.mandates.in_memory import _mandate_version_sort_key
+
+
+def _newest_first(versions: list[str]) -> list[str]:
+    """Order versions the way the repository does: by sort key, descending."""
+
+    return sorted(versions, key=_mandate_version_sort_key, reverse=True)
+
+
+def test_numeric_versions_order_by_value_not_by_text() -> None:
+    # The defect this whole contract exists for: lexicographically '9' > '10'.
+    assert _newest_first(["1", "2", "9", "10", "100"]) == ["100", "10", "9", "2", "1"]
+
+
+def test_equal_valued_versions_are_separated_by_raw_text_as_sql_does() -> None:
+    # '01'::numeric = '1'::numeric, so SQL falls through to mandate_version
+    # DESC, which puts '1' first. A key that returns only the numeric value
+    # leaves these tied, and Python's stable sort would then order them by
+    # insertion - so the store that answers first would decide, not the data.
+    assert _newest_first(["01", "1"]) == ["1", "01"]
+    assert _newest_first(["1", "01"]) == ["1", "01"]
+
+    # Ties are broken consistently however many share a value.
+    assert _newest_first(["001", "1", "01"]) == ["1", "01", "001"]
+
+
+def test_leading_zeros_do_not_change_which_version_is_newest() -> None:
+    # '007' is seven, not a string sorting between '0' and '1'.
+    assert _newest_first(["007", "10"]) == ["10", "007"]
+
+
+def test_versions_longer_than_the_int_conversion_limit_still_order() -> None:
+    # int(str) raises ValueError above sys.get_int_max_str_digits(), but
+    # NUMERIC accepts far longer values, so a version PostgreSQL orders
+    # without complaint must not crash this store.
+    limit = sys.get_int_max_str_digits()
+    over_limit = "9" * (limit + 1)
+    longer_still = "1" + "0" * (limit + 1)  # One digit longer, so larger.
+
+    assert len(over_limit) > limit
+    assert len(longer_still) > len(over_limit)
+    assert _newest_first([over_limit, "10", longer_still]) == [
+        longer_still,
+        over_limit,
+        "10",
+    ]
+
+
+def test_non_numeric_versions_sort_last_and_deterministically() -> None:
+    # NULLS LAST puts non-numeric versions after every numeric one, then
+    # mandate_version DESC orders them among themselves.
+    assert _newest_first(["v2", "1", "v10", "3"]) == ["3", "1", "v2", "v10"]
+
+
+def test_unicode_digits_are_not_numeric_because_postgres_rejects_them() -> None:
+    # str.isdigit() accepts these; PostgreSQL's [0-9] class does not. Treating
+    # them as numeric here is how the two stores start disagreeing about which
+    # mandate is current.
+    arabic_indic = "٢"  # ARABIC-INDIC DIGIT TWO
+    superscript = "²"  # SUPERSCRIPT TWO
+
+    assert arabic_indic.isdigit()
+    assert superscript.isdigit()
+    assert _newest_first([arabic_indic, superscript, "1"])[0] == "1"
+
+
+def test_the_key_shape_matches_the_three_sql_ordering_elements() -> None:
+    # numeric-ness, then magnitude, then raw text - the same three decisions
+    # the SQL expression makes, in the same order.
+    numeric_rank, _, _, raw_text = _mandate_version_sort_key("042")
+    assert numeric_rank == 1
+    assert raw_text == "042"
+
+    non_numeric_rank, _, _, raw_text = _mandate_version_sort_key("v2")
+    assert non_numeric_rank == 0
+    assert raw_text == "v2"
+    assert non_numeric_rank < numeric_rank

--- a/tests/unit/shared/dependencies/test_postgres_migrations.py
+++ b/tests/unit/shared/dependencies/test_postgres_migrations.py
@@ -6,6 +6,7 @@ import src.infrastructure.postgres_migrations as migrations_module
 from src.infrastructure.postgres_migrations import (
     PostgresMigration,
     _migration_lock_key,
+    _split_sql_statements,
     apply_postgres_migrations,
 )
 
@@ -203,3 +204,58 @@ def test_apply_postgres_migrations_unlocks_when_rollback_raises(monkeypatch):
     assert connection.rollback_count == 1
     assert connection.lock_calls == [_migration_lock_key(namespace="dpm")]
     assert connection.unlock_calls == [_migration_lock_key(namespace="dpm")]
+
+
+def test_a_semicolon_inside_a_comment_does_not_end_the_statement() -> None:
+    """Comments are skipped whole rather than scanned for terminators.
+
+    Without this the migration runs a truncated statement and a fragment, and
+    the error names a position inside a comment - so the SQL looks broken where
+    it is merely being explained. Every migration that documents a non-obvious
+    expression is one semicolon away from this.
+    """
+
+    sql = """
+    CREATE INDEX idx_example
+        -- The planner cannot use this; the ordering differs.
+        ON example (a, b);
+    """
+
+    statements = [s.strip() for s in _split_sql_statements(sql) if s.strip()]
+
+    assert len(statements) == 1
+    assert statements[0].startswith("CREATE INDEX idx_example")
+    assert statements[0].endswith("ON example (a, b)")
+
+
+def test_a_semicolon_inside_a_block_comment_does_not_end_the_statement() -> None:
+    sql = "CREATE INDEX i /* nested /* still; a comment */ still */ ON t (a); SELECT 1;"
+
+    statements = [s.strip() for s in _split_sql_statements(sql) if s.strip()]
+
+    assert len(statements) == 2
+    assert statements[0].endswith("ON t (a)")
+    assert statements[1] == "SELECT 1"
+
+
+def test_a_semicolon_in_a_string_literal_still_does_not_split() -> None:
+    """The pre-existing quote handling must survive the comment handling."""
+
+    sql = "INSERT INTO t (v) VALUES ('a;b'); SELECT 1;"
+
+    statements = [s.strip() for s in _split_sql_statements(sql) if s.strip()]
+
+    assert len(statements) == 2
+    assert statements[0] == "INSERT INTO t (v) VALUES ('a;b')"
+
+
+def test_a_comment_marker_inside_a_string_literal_is_not_a_comment() -> None:
+    """'--' inside quotes is data, and must not swallow the rest of the line."""
+
+    sql = "INSERT INTO t (v) VALUES ('a--b'); SELECT 1;"
+
+    statements = [s.strip() for s in _split_sql_statements(sql) if s.strip()]
+
+    assert len(statements) == 2
+    assert statements[0] == "INSERT INTO t (v) VALUES ('a--b')"
+    assert statements[1] == "SELECT 1"

--- a/wiki/Endpoint-Certification.md
+++ b/wiki/Endpoint-Certification.md
@@ -223,8 +223,14 @@ Functional behavior:
   while a replay for the same version and date stays idempotent.
 - Read by mandate remains a latest-state lookup and returns `404` when no mandate snapshot exists.
 - Version listing returns persisted mandate twins newest first.
-- Diff compares the latest two versions by default, or caller-supplied `from_version` and
-  `to_version`, and labels materiality for changed mandate fields.
+- Diff compares the latest two distinct versions by default, or caller-supplied `from_version`
+  and `to_version`, and labels materiality for changed mandate fields. Because persistence keeps
+  one observation per business date, a version can appear several times; the diff uses the most
+  recent observation of each version, so re-observing an unchanged binding is not reported as a
+  change. A history holding only one distinct version has nothing to compare and is refused with
+  `409` rather than diffed against itself. The response carries `from_as_of_date` and
+  `to_as_of_date`, the business dates of the two compared observations, which differ from the
+  version numbers and are what an auditor needs to place the comparison in time.
 - Health read accepts optional `as_of_date`, selects the latest snapshot on or before that
   business date using deterministic same-date ordering, preserves the snapshot's actual date, and
   returns `404` before the first qualifying snapshot. Omitting the query returns the latest


### PR DESCRIPTION
Closes #646 and #647. Item 4 of the source-authority directive, delivered as one slice because both defects are the same surface: **what "the latest mandate" means** once versions reach double digits and a version can be observed more than once.

## #646 — v9 beat v10 in every temporal read
`mandate_version` is a TEXT column holding `str(binding_version)`, and all four temporal reads ordered by it directly. String ordering puts `"9"` above `"10"`, so from version 10 onward a same-day tie-break resolved to the **wrong, older binding**. Migration 0020 is what made same-day competing rows legal, turning a latent flaw into a reachable one.

The reads now order numerically through one shared expression. **The cast is guarded rather than bare** — the column is TEXT, a non-integer value is representable, and an unguarded `::bigint` raises `22P02` and takes down the read *for every caller* rather than mis-sorting one row. Non-integer versions sort last, deterministically. Migration 0022 adds matching expression indexes so the comparison stays indexed.

**The in-memory repository had the identical defect** and is fixed with the same semantics, so the two backends cannot disagree about which mandate is current.

## #647 — a re-observed version was diffed against itself
Migration 0020 relaxed the uniqueness key to `(mandate_id, mandate_version, as_of_date)`, so an unchanged binding can be re-observed later. Two assumptions broke:

| Assumption | Consequence |
|---|---|
| `{v.mandate_version: v for v in versions}` | duplicates collapsed by overwrite; the list is newest-first, so the **oldest** observation won |
| `return versions[1], versions[0]` | two observations of one version diffed **that version against itself**, reported as "no changes" |

That second one is the dangerous shape: indistinguishable from a mandate that genuinely did not change.

Now the pair crosses a real version boundary, the index resolves each version to its **latest** observation, and the response carries `from_as_of_date`/`to_as_of_date` so a reader can tell which rows were compared. When every observation is of one version the diff **refuses** — "there is no version change here" and "nothing changed between two versions" are different statements.

## Proven against real PostgreSQL
Five integration tests: v9 vs v10 on one business date, a non-integer version surviving the ordering expression, a repeated version not diffed against itself, repeated observations refusing, and a requested version resolving to its latest observation.

**Four of the five were verified to fail with the fixes reverted.** The fifth guards the new cast against non-integer input rather than pinning the original defect, and passes either way by construction — stated rather than counted as regression evidence.

The proof runs in **the CI job that already owns a live database**, so it cannot become a lane that skips everywhere and reports green.

## Verified
`lint`, `typecheck`, `openapi-gate`, `api-vocabulary-gate`, `migration-smoke`, `no-alias-gate`, quality reports current; **3,379 unit tests** and **5 PostgreSQL integration tests** pass on a fresh database.

One incidental finding recorded for later, not fixed here: the migration statement splitter is not comment-aware, so a semicolon inside a SQL comment truncates the statement. Noted in the migration file so the next author does not lose an afternoon to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)