### PR TITLE
fix(ci): gate every commit a merged PR puts on main

### DIFF
--- a/.github/workflows/main-gate-coverage-audit.yml
+++ b/.github/workflows/main-gate-coverage-audit.yml
@@ -1,0 +1,35 @@
+name: Main Gate Coverage Audit
+
+on:
+  schedule:
+    - cron: "20 3 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  audit:
+    name: Audit / Every Main Commit Has A Gate Verdict
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # The audit walks main's history; a shallow checkout would silently
+          # audit a window smaller than the one it reports.
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Audit main gate coverage (fail closed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Invoked BARE. Piping this would report the pipe's exit code and leave
+        # the step green while the audit failed on every run - the same
+        # cannot-fail defect the audit itself exists to detect.
+        run: |
+          set -euo pipefail
+          git fetch origin main --quiet
+          python scripts/audit_main_gate_coverage.py --since-days 7 --fail-on-gap

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -9,24 +9,33 @@ permissions:
   contents: write
 
 jobs:
-  dispatch-main-releasability:
-    name: Dispatch Main Releasability
+  # Enumeration is a separate job from dispatch on purpose (issue #659).
+  #
+  # This repository merges by rebase, so a merged PR of N commits puts N commits
+  # on main and every one of them needs its own gate run - a commit that was
+  # never the PR head still becomes the deployed tree on rollback and bisect.
+  #
+  # The dispatch itself must stay a flat lookup / conditional ref creation /
+  # dispatch sequence in one named step, because scripts/workflow_policy_gate.py
+  # validates that structure and a shell `for` loop nests it out of reach of
+  # that control. A matrix gives one un-nested dispatch per revision instead,
+  # and each revision gets its own job log rather than being buried in a loop.
+  enumerate-merged-revisions:
+    name: Enumerate Merged Revisions
     if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    outputs:
+      revisions: ${{ steps.enumerate.outputs.revisions }}
     steps:
       - uses: actions/checkout@v6
         with:
           # Every revision the PR added must be enumerable, not just the head.
           fetch-depth: 0
-      # Step name is load-bearing: scripts/workflow_policy_gate.py locates this
-      # step by name to check the lookup, conditional ref creation and dispatch
-      # all live in one governed run step. Renaming it makes that whole control
-      # silently find nothing - the lifted version of this file carried the
-      # source repository's name and disabled the check on arrival.
-      - name: Dispatch main releasability gate
+      - name: Enumerate every revision the merged PR put on main
+        id: enumerate
         env:
           GH_TOKEN: ${{ github.token }}
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
@@ -43,13 +52,12 @@ jobs:
             exit 1
           fi
 
-          # This enumeration is correct ONLY under rebase-only merging: a squash
-          # lands one commit however many the PR held (the extra dispatches
-          # would name commits from earlier PRs), and a merge commit adds a
-          # second parent (the walk would descend into main's own history).
-          # Gating the wrong trees while reporting success is worse than the
-          # coverage gap this closes, so fail loudly if the repository's merge
-          # methods ever change.
+          # The enumeration is correct ONLY under rebase-only merging: a squash
+          # lands one commit however many the PR held, so the extra revisions
+          # would name commits from earlier PRs; a merge commit adds a second
+          # parent, so the walk would descend into main's own history. Gating
+          # the wrong trees while reporting success is worse than the coverage
+          # gap this closes, so fail loudly if the setting ever changes.
           merge_methods="$(gh api "repos/$GITHUB_REPOSITORY" \
             --jq '[.allow_squash_merge, .allow_merge_commit, .allow_rebase_merge] | @csv')"
           if [ "$merge_methods" != "false,false,true" ]; then
@@ -58,8 +66,8 @@ jobs:
           fi
 
           git fetch origin main --quiet
-          # Judge ancestry against the freshly fetched main, not the event-time
-          # checkout snapshot.
+          # Ancestry is judged against the freshly fetched main, not the
+          # event-time checkout snapshot.
           git checkout --quiet --detach FETCH_HEAD
           revisions="$(git rev-list -n "$COMMIT_COUNT" "$MERGE_COMMIT_SHA" | tac)"
           if [ -z "$revisions" ]; then
@@ -67,49 +75,73 @@ jobs:
             exit 1
           fi
 
-          dispatched=0
+          enumerated=0
           for revision in $revisions; do
             # A revision that is not on the fetched main - for example after a
             # forced move of main between the merge event and this checkout -
             # must never be tagged or gated as main history.
             if ! git merge-base --is-ancestor "$revision" HEAD; then
-              echo "::error::Revision $revision is not an ancestor of main; refusing to dispatch."
+              echo "::error::Revision $revision is not an ancestor of main; refusing to enumerate it."
               exit 1
             fi
-            dispatch_ref="main-releasability-${revision}"
-            existing_ref_sha=""
-            if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then
-              if [ "$existing_ref_sha" != "$revision" ]; then
-                echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $revision"
-                exit 1
-              fi
-            else
-              existing_ref_sha=""
-            fi
-            if [ -z "$existing_ref_sha" ]; then
-              gh api "repos/$GITHUB_REPOSITORY/git/refs" \
-                -f ref="refs/tags/$dispatch_ref" \
-                -f sha="$revision" >/dev/null
-            fi
-            # Inputs are exactly the two this repository's gate declares.
-            # main-releasability.yml here takes expected_sha and triggering_pr
-            # and nothing else; passing an input it does not declare makes the
-            # dispatch 422 and the gate never runs, which would disable this
-            # fix silently rather than loudly.
-            gh workflow run main-releasability.yml \
-              --repo "$GITHUB_REPOSITORY" \
-              --ref "$dispatch_ref" \
-              -f expected_sha="$revision" \
-              -f triggering_pr="$PR_NUMBER"
-            dispatched=$((dispatched + 1))
-            echo "Dispatched main releasability for $revision (PR #$PR_NUMBER)"
+            enumerated=$((enumerated + 1))
           done
 
-          # A merged PR of N commits must produce N dispatches. Asserted rather
-          # than assumed, because the loop silently doing nothing is the exact
-          # shape of the gap being closed.
-          if [ "$dispatched" -ne "$COMMIT_COUNT" ]; then
-            echo "::error::Dispatched $dispatched runs for a $COMMIT_COUNT-commit PR #$PR_NUMBER"
+          # A merged PR of N commits must enumerate N revisions. Asserted rather
+          # than assumed, because producing an empty or short list silently is
+          # the exact shape of the gap being closed.
+          if [ "$enumerated" -ne "$COMMIT_COUNT" ]; then
+            echo "::error::Enumerated $enumerated revisions for a $COMMIT_COUNT-commit PR #$PR_NUMBER"
             exit 1
           fi
-          echo "Dispatched $dispatched of $COMMIT_COUNT merged revisions for PR #$PR_NUMBER"
+
+          payload="$(printf '%s\n' $revisions | jq -R . | jq -sc .)"
+          echo "revisions=$payload" >> "$GITHUB_OUTPUT"
+          echo "Enumerated $enumerated of $COMMIT_COUNT merged revisions for PR #$PR_NUMBER"
+
+  dispatch-main-releasability:
+    name: Dispatch Main Releasability
+    needs: enumerate-merged-revisions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      # Sequential on purpose: two jobs creating dispatch tags at the same time
+      # race on the refs API, and a failed tag creation would drop a revision's
+      # gate run silently. fail-fast off so one revision's failure does not
+      # cancel the gate runs of the others.
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        revision: ${{ fromJson(needs.enumerate-merged-revisions.outputs.revisions) }}
+    steps:
+      # Step name is load-bearing: scripts/workflow_policy_gate.py locates this
+      # step by name to verify the lookup, conditional ref creation and dispatch
+      # all live in one governed run step. Renaming it makes that whole control
+      # silently find nothing.
+      - name: Dispatch main releasability gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          revision: ${{ matrix.revision }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          dispatch_ref="main-releasability-${revision}"
+          existing_ref_sha=""
+          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then
+            if [ "$existing_ref_sha" != "$revision" ]; then
+              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $revision"
+              exit 1
+            fi
+          else
+            existing_ref_sha=""
+          fi
+          if [ -z "$existing_ref_sha" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$dispatch_ref" \
+              -f sha="$revision" >/dev/null
+          fi
+          gh workflow run main-releasability.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$dispatch_ref" \
+            -f expected_sha="$revision" \
+            -f triggering_pr="$PR_NUMBER"

--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -17,10 +17,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@v6
+        with:
+          # Every revision the PR added must be enumerable, not just the head.
+          fetch-depth: 0
+      # Step name is load-bearing: scripts/workflow_policy_gate.py locates this
+      # step by name to check the lookup, conditional ref creation and dispatch
+      # all live in one governed run step. Renaming it makes that whole control
+      # silently find nothing - the lifted version of this file carried the
+      # source repository's name and disabled the check on arrival.
       - name: Dispatch main releasability gate
         env:
           GH_TOKEN: ${{ github.token }}
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          COMMIT_COUNT: ${{ github.event.pull_request.commits }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
@@ -28,24 +38,78 @@ jobs:
             echo "::error::pull_request.merge_commit_sha is required for exact-main releasability dispatch"
             exit 1
           fi
+          if [ -z "$COMMIT_COUNT" ] || [ "$COMMIT_COUNT" -lt 1 ]; then
+            echo "::error::pull_request.commits was '$COMMIT_COUNT'; cannot enumerate merged revisions"
+            exit 1
+          fi
 
-          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"
-          existing_ref_sha=""
-          if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then
-            if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then
-              echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $MERGE_COMMIT_SHA"
+          # This enumeration is correct ONLY under rebase-only merging: a squash
+          # lands one commit however many the PR held (the extra dispatches
+          # would name commits from earlier PRs), and a merge commit adds a
+          # second parent (the walk would descend into main's own history).
+          # Gating the wrong trees while reporting success is worse than the
+          # coverage gap this closes, so fail loudly if the repository's merge
+          # methods ever change.
+          merge_methods="$(gh api "repos/$GITHUB_REPOSITORY" \
+            --jq '[.allow_squash_merge, .allow_merge_commit, .allow_rebase_merge] | @csv')"
+          if [ "$merge_methods" != "false,false,true" ]; then
+            echo "::error::Merge methods changed ($merge_methods); per-commit enumeration assumes rebase-only merging. Update the dispatcher before merging anything."
+            exit 1
+          fi
+
+          git fetch origin main --quiet
+          # Judge ancestry against the freshly fetched main, not the event-time
+          # checkout snapshot.
+          git checkout --quiet --detach FETCH_HEAD
+          revisions="$(git rev-list -n "$COMMIT_COUNT" "$MERGE_COMMIT_SHA" | tac)"
+          if [ -z "$revisions" ]; then
+            echo "::error::No revisions enumerated for merged PR #$PR_NUMBER at $MERGE_COMMIT_SHA"
+            exit 1
+          fi
+
+          dispatched=0
+          for revision in $revisions; do
+            # A revision that is not on the fetched main - for example after a
+            # forced move of main between the merge event and this checkout -
+            # must never be tagged or gated as main history.
+            if ! git merge-base --is-ancestor "$revision" HEAD; then
+              echo "::error::Revision $revision is not an ancestor of main; refusing to dispatch."
               exit 1
             fi
-          else
+            dispatch_ref="main-releasability-${revision}"
             existing_ref_sha=""
+            if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref" --jq .object.sha 2>/dev/null)"; then
+              if [ "$existing_ref_sha" != "$revision" ]; then
+                echo "::error::Dispatch ref $dispatch_ref points to $existing_ref_sha, expected $revision"
+                exit 1
+              fi
+            else
+              existing_ref_sha=""
+            fi
+            if [ -z "$existing_ref_sha" ]; then
+              gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+                -f ref="refs/tags/$dispatch_ref" \
+                -f sha="$revision" >/dev/null
+            fi
+            # Inputs are exactly the two this repository's gate declares.
+            # main-releasability.yml here takes expected_sha and triggering_pr
+            # and nothing else; passing an input it does not declare makes the
+            # dispatch 422 and the gate never runs, which would disable this
+            # fix silently rather than loudly.
+            gh workflow run main-releasability.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --ref "$dispatch_ref" \
+              -f expected_sha="$revision" \
+              -f triggering_pr="$PR_NUMBER"
+            dispatched=$((dispatched + 1))
+            echo "Dispatched main releasability for $revision (PR #$PR_NUMBER)"
+          done
+
+          # A merged PR of N commits must produce N dispatches. Asserted rather
+          # than assumed, because the loop silently doing nothing is the exact
+          # shape of the gap being closed.
+          if [ "$dispatched" -ne "$COMMIT_COUNT" ]; then
+            echo "::error::Dispatched $dispatched runs for a $COMMIT_COUNT-commit PR #$PR_NUMBER"
+            exit 1
           fi
-          if [ -z "$existing_ref_sha" ]; then
-            gh api "repos/$GITHUB_REPOSITORY/git/refs" \
-              -f ref="refs/tags/$dispatch_ref" \
-              -f sha="$MERGE_COMMIT_SHA" >/dev/null
-          fi
-          gh workflow run main-releasability.yml \
-            --repo "$GITHUB_REPOSITORY" \
-            --ref "$dispatch_ref" \
-            -f expected_sha="$MERGE_COMMIT_SHA" \
-            -f triggering_pr="$PR_NUMBER"
+          echo "Dispatched $dispatched of $COMMIT_COUNT merged revisions for PR #$PR_NUMBER"

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1140,13 +1140,43 @@ Important validation expectations:
     uses `LOTUS_AUTOMERGE_TOKEN`, queues `gh pr merge --auto --rebase --delete-branch`, skips
     cleanly with a warning when the token is absent, and is protected by `make workflow-policy-gate`.
     The helper must not authenticate with `GITHUB_TOKEN` or queue merge commits.
-11. Exact-main releasability follows the governed merged-PR dispatcher posture:
-    `.github/workflows/merged-pr-main-releasability.yml` listens for merged `main` pull requests
-    and dispatches `.github/workflows/main-releasability.yml` against `main`. The main
-    releasability workflow keeps manual `workflow_dispatch` support but must not also carry a
-    direct `push` trigger, because that creates duplicate automatic proof runs for the same merged
-    SHA. `make workflow-policy-gate` enforces both the dispatcher contract and the duplicate-trigger
-    prohibition.
+11. Exact-main releasability is **per commit, not per merged pull request**
+    (issue #659). `.github/workflows/merged-pr-main-releasability.yml` listens for merged `main`
+    pull requests and dispatches `.github/workflows/main-releasability.yml` once for **every
+    revision the pull request put on main**, each pinned to its own immutable
+    `main-releasability-<sha>` tag. Dispatching only the head left 38 of 40 recent commits with no
+    verdict at all: this repository merges by rebase, so a merged PR of N commits puts N on main,
+    and a commit that was never the head still becomes the deployed tree on rollback and bisect.
+    A run that is never created is not a failure, so nothing else reports the loss.
+
+    Three constraints govern any future change here:
+
+    - **Rebase-only merging is a prerequisite, not an assumption.** The enumeration is correct only
+      because squash and merge-commit are disabled. The dispatcher asserts
+      `[squash, merge, rebase] == [false, false, true]` and fails loudly if that changes, because
+      gating the wrong trees while reporting success is worse than the gap it closes.
+    - **Enumeration and dispatch are separate jobs on purpose.** The dispatch step must stay a flat
+      lookup / conditional ref creation / dispatch sequence: `scripts/workflow_policy_gate.py`
+      validates that structure, and wrapping it in a shell loop nests it out of that control's
+      reach. A matrix fed from the enumerating job's output gives one un-nested dispatch per
+      revision, runs sequentially so concurrent tag creation cannot race, and keeps the dispatched
+      SHA bound to the merge event.
+    - **One coherent SHA binding.** The ref name, the mismatch check, the created ref SHA and the
+      dispatched `expected_sha` must all use the same variable. A mixed binding checks out one
+      revision and asserts against another; the resulting failure is a *verdict*, which the
+      coverage audit would count as evaluation - falsely reporting coverage.
+
+    `.github/workflows/main-gate-coverage-audit.yml` runs `scripts/audit_main_gate_coverage.py`
+    daily with `--fail-on-gap` and is fail-closed by design: a missing `gh`, an unfetchable run
+    listing, or a cancelled run all fail rather than pass, because only a verdict-bearing run
+    (success or failure) evidences evaluation. Its permissions are read-only - a watchdog able to
+    dispatch could manufacture the coverage it audits.
+
+    The main releasability workflow keeps manual `workflow_dispatch` support but must not also
+    carry a direct `push` trigger, because that creates duplicate automatic proof runs for the same
+    merged SHA. `make workflow-policy-gate` enforces the dispatcher contract, the coherent binding
+    and the duplicate-trigger prohibition; `make test-family-inventory` requires new guard suites to
+    declare their family.
 
 ## Standards And RFCs That Govern This Repository
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-07T08:29:35+00:00`
+- Generated at: `2026-09-07T08:55:38+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `8ae9804b+worktree`
+- Report source snapshot: `55083718+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 928 |
-| Total Python LOC | 216996 |
+| Total Python LOC | 217099 |
 | Test functions | 3148 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-07T09:07:40+00:00`
+- Generated at: `2026-09-07T09:19:22+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `71d08374+worktree`
+- Report source snapshot: `63b3e59a+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 928 |
-| Total Python LOC | 217102 |
-| Test functions | 3148 |
+| Total Python LOC | 217192 |
+| Test functions | 3150 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-07T06:51:46+00:00`
+- Generated at: `2026-09-07T08:29:35+00:00`
 
-- Baseline source snapshot: `d0b56d92005132cf21d97a65e20e75bd13b414e7`
+- Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `70db19b5+worktree`
+- Report source snapshot: `8ae9804b+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 926 |
-| Total Python LOC | 216545 |
-| Test functions | 3138 |
+| Python files | 928 |
+| Total Python LOC | 216996 |
+| Test functions | 3148 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-07T08:55:38+00:00`
+- Generated at: `2026-09-07T09:07:40+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `55083718+worktree`
+- Report source snapshot: `71d08374+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 928 |
-| Total Python LOC | 217099 |
+| Total Python LOC | 217102 |
 | Test functions | 3148 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-07T08:55:38+00:00`
+- Generated at: `2026-09-07T09:07:40+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `55083718+worktree`
+- Report source snapshot: `71d08374+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-07T08:29:35+00:00`
+- Generated at: `2026-09-07T08:55:38+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `8ae9804b+worktree`
+- Report source snapshot: `55083718+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-07T06:51:46+00:00`
+- Generated at: `2026-09-07T08:29:35+00:00`
 
-- Baseline source snapshot: `d0b56d92005132cf21d97a65e20e75bd13b414e7`
+- Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `70db19b5+worktree`
+- Report source snapshot: `8ae9804b+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-07T09:07:40+00:00`
+- Generated at: `2026-09-07T09:19:22+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `71d08374+worktree`
+- Report source snapshot: `63b3e59a+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-07T08:55:38+00:00`
+- Generated at: `2026-09-07T09:07:40+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `55083718+worktree`
+- Report source snapshot: `71d08374+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-07T08:29:35+00:00`
+- Generated at: `2026-09-07T08:55:38+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `8ae9804b+worktree`
+- Report source snapshot: `55083718+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-07T09:07:40+00:00`
+- Generated at: `2026-09-07T09:19:22+00:00`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `71d08374+worktree`
+- Report source snapshot: `63b3e59a+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-07T06:51:46+00:00`
+- Generated at: `2026-09-07T08:29:35+00:00`
 
-- Baseline source snapshot: `d0b56d92005132cf21d97a65e20e75bd13b414e7`
+- Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `70db19b5+worktree`
+- Report source snapshot: `8ae9804b+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-07T06:51:46+00:00`
+- Generated at: `2026-09-07T08:29:35+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `d0b56d92005132cf21d97a65e20e75bd13b414e7`
+- Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `70db19b5+worktree`
+- Report source snapshot: `8ae9804b+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 919 | 926 | +7 |
-| Total Python LOC | 214106 | 216545 | +2439 |
-| Test functions | 3114 | 3138 | +24 |
+| Python files | 926 | 928 | +2 |
+| Total Python LOC | 216545 | 216996 | +451 |
+| Test functions | 3138 | 3148 | +10 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,14 +37,14 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 7624 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 7756 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3386 |
-| 4 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
-| 5 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3289 |
+| 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
+| 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 7 | tests/unit/test_documentation_current_state.py | 2788 |
-| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2689 |
+| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2708 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
@@ -70,8 +70,8 @@
 | Rank | Function | File | Lines |
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1558 |
-| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 774 |
-| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 396 |
+| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 791 |
+| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 410 |
 | 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 380 |
 | 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
 | 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
@@ -102,9 +102,9 @@
 | Rank | Function | File | Complexity | Lines |
 | --- | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
-| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 774 |
+| 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 791 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 107 | 396 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 410 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-07T08:29:35+00:00`
+- Generated at: `2026-09-07T08:55:38+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `8ae9804b+worktree`
+- Report source snapshot: `55083718+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 926 | 928 | +2 |
-| Total Python LOC | 216545 | 216996 | +451 |
+| Total Python LOC | 216545 | 217099 | +554 |
 | Test functions | 3138 | 3148 | +10 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
@@ -54,7 +54,7 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 7756 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
-| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3386 |
+| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3395 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-07T09:07:40+00:00`
+- Generated at: `2026-09-07T09:19:22+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `71d08374+worktree`
+- Report source snapshot: `63b3e59a+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 926 | 928 | +2 |
-| Total Python LOC | 216545 | 217102 | +557 |
-| Test functions | 3138 | 3148 | +10 |
+| Total Python LOC | 216545 | 217192 | +647 |
+| Test functions | 3138 | 3150 | +12 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-07T08:55:38+00:00`
+- Generated at: `2026-09-07T09:07:40+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
 
-- Report source snapshot: `55083718+worktree`
+- Report source snapshot: `71d08374+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 926 | 928 | +2 |
-| Total Python LOC | 216545 | 217099 | +554 |
+| Total Python LOC | 216545 | 217102 | +557 |
 | Test functions | 3138 | 3148 | +10 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/scripts/audit_main_gate_coverage.py
+++ b/scripts/audit_main_gate_coverage.py
@@ -1,0 +1,185 @@
+"""Audit which commits on main the Main Releasability Gate actually evaluated.
+
+The gate is dispatched per merged pull request; this repository merges by
+rebase, so a pull request holding N commits puts N on main and every one of
+them must have a gate run - a commit that was never head becomes the deployed
+tree on rollback and bisect. A run that is never created is not a failure, so
+nothing else reports the loss; this audit does.
+
+Fail-closed by design (a watchdog that can pass while verifying nothing is
+the same liveness defect it exists to catch):
+
+- a missing ``gh`` binary is a failure under ``--fail-on-gap``, never a skip;
+- a commit whose run listing cannot be fetched (rate limit, token scope,
+  transient API failure) is UNKNOWN, and unknown commits fail the audit under
+  ``--fail-on-gap`` - they are unverified, not implicitly fine;
+- only runs that reached a verdict (success or failure) count as evaluation:
+  a run cancelled seconds after dispatch evaluated nothing. In-progress runs
+  count as pending (unknown), not as coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+
+WORKFLOW = "main-releasability.yml"
+_VERDICT_CONCLUSIONS = {"success", "failure"}
+
+
+def _git(*args: str) -> list[str]:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def _run_conclusions(sha: str) -> list[str] | None:
+    """Conclusions of every gate run for one commit, or None when unknowable."""
+
+    completed = subprocess.run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            WORKFLOW,
+            "--commit",
+            sha,
+            "--json",
+            "conclusion,status",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    try:
+        runs = json.loads(completed.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    return [str(run.get("conclusion") or run.get("status") or "") for run in runs]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--since-days",
+        type=int,
+        default=7,
+        help=(
+            "audit every commit on origin/main from the last N days; a time window, "
+            "not a commit count, so a busy day cannot age a commit out unexamined"
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=400,
+        help=(
+            "safety cap on commits examined; reaching it means the window was "
+            "truncated, which is unverified coverage and fails under --fail-on-gap"
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-gap",
+        action="store_true",
+        help=(
+            "exit non-zero when a commit has no verdict-bearing releasability run "
+            "OR when any commit could not be verified (unknown fails closed)"
+        ),
+    )
+    arguments = parser.parse_args()
+
+    if shutil.which("gh") is None:
+        print("gh is not available; cannot ask which commits the gate evaluated.")
+        return 1 if arguments.fail_on_gap else 0
+
+    # Probe one past the cap: a window holding exactly `limit` commits was fully
+    # examined, so only a (limit + 1)th commit proves the span was truncated.
+    # `--since` STOPS traversal at the first commit older than the cutoff, so a
+    # newer-dated ancestor sitting behind an older-dated commit is silently
+    # omitted and its coverage never examined - a green audit for a window it
+    # never walked. `--since-as-filter` visits every commit and filters, so the
+    # claimed window is the audited window regardless of date monotonicity.
+    probed = _git(
+        "log",
+        f"--since-as-filter={arguments.since_days} days ago",
+        f"-{arguments.limit + 1}",
+        "--format=%H %h %s",
+        "origin/main",
+    )
+    # A prefix of the window is not the window: if the cap was exceeded, older
+    # commits inside the requested span went unexamined and their coverage is
+    # unknown, not proven.
+    truncated = len(probed) > arguments.limit
+    commits = probed[: arguments.limit]
+    ungated: list[str] = []
+    unknown: list[str] = []
+    failing: list[str] = []
+    passing = 0
+
+    for entry in commits:
+        sha, short, subject = entry.split(" ", 2)
+        conclusions = _run_conclusions(sha)
+        if conclusions is None:
+            unknown.append(short)
+            print(f"UNKNOWN  {short}  (run listing could not be fetched)")
+            continue
+        verdicts = [conclusion for conclusion in conclusions if conclusion in _VERDICT_CONCLUSIONS]
+        if verdicts:
+            if "success" in verdicts:
+                passing += 1
+            else:
+                failing.append(f"{short}  {subject[:70]}")
+            continue
+        if conclusions:
+            # Runs exist but none reached a verdict (cancelled / in progress):
+            # not proven ungated, but not verified either.
+            unknown.append(short)
+            print(f"UNKNOWN  {short}  (runs exist without a verdict: {sorted(set(conclusions))})")
+            continue
+        ungated.append(f"{short}  {subject[:70]}")
+        print(f"UNGATED  {short}  {subject[:70]}")
+
+    print(
+        f"\naudited {len(commits)} commit(s) on main from the last "
+        f"{arguments.since_days} day(s); "
+        f"{len(ungated)} with no verdict-bearing {WORKFLOW} run; "
+        f"{len(unknown)} unverifiable; "
+        f"{passing} passing, {len(failing)} with a failing verdict."
+    )
+    if truncated:
+        print(
+            f"WINDOW TRUNCATED: the cap of {arguments.limit} commit(s) was reached, so "
+            f"older commits inside the {arguments.since_days}-day window went unexamined. "
+            "A prefix of the window is not the window; raise --limit and run again."
+        )
+    # Coverage is the invariant; the pass/fail split is reported beside it
+    # because they are different claims: a failing verdict is information
+    # (a backfilled historical tree measured against today's environment, or
+    # an intermediate commit that fails its own tests), a missing run is
+    # not. The audit fails only on missing/unverifiable coverage.
+    for entry in failing:
+        print(f"FAILING  {entry}")
+    if ungated:
+        print(
+            "\nBackfill one with:\n"
+            "  gh api repos/OWNER/REPO/git/refs "
+            "-f ref=refs/tags/main-releasability-SHA -f sha=SHA\n"
+            "  gh workflow run main-releasability.yml --ref main-releasability-SHA "
+            "-f expected_sha=SHA -f triggering_pr=backfill\n"
+        )
+    if arguments.fail_on_gap and (ungated or unknown or truncated):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_family_inventory.py
+++ b/scripts/test_family_inventory.py
@@ -32,6 +32,9 @@ CONTRACT_GOVERNANCE_TOKENS = (
     "trust_telemetry",
     "workflow_policy",
     "ci_workflow",
+    # Per-commit main-gate coverage guards (issue #659): CI governance proof,
+    # the same family as the workflow-policy and coverage-gate suites.
+    "main_gate",
     "service_boundary",
     "service_layer_architecture_boundaries",
     "router_infrastructure",

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -26,6 +26,10 @@ EXPECTED_WORKFLOW_PERMISSIONS = {
     "quality-baseline.yml": {"contents": "read"},
     "demo-certification.yml": {"contents": "read"},
     "pr-auto-merge.yml": {"contents": "read"},
+    # Reads history and run listings only; it must never be able to dispatch or
+    # write, because a watchdog that can create the evidence it audits could
+    # report coverage it manufactured (issue #659).
+    "main-gate-coverage-audit.yml": {"actions": "read", "contents": "read"},
 }
 USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses:\s*[\"']?([^\"'\s#]+)", re.MULTILINE)
 WORKFLOW_JOB_PATTERN = re.compile(r"(?m)^  [A-Za-z0-9_-]+:\s*$")
@@ -46,13 +50,23 @@ IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS = (
         '--jq .object.sha 2>/dev/null)"; then'
     ),
 )
-IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION = (
-    'if [ "$existing_ref_sha" != "$MERGE_COMMIT_SHA" ]; then'
+# The dispatcher pins one run per revision the merged PR put on main (issue
+# #659), so the pinned SHA is the loop's `$revision` rather than the PR head.
+# Both forms are accepted here because this gate answers "is the dispatch
+# pinned and immutable" - whether it covers EVERY merged commit is a different
+# claim, owned by tests/unit/test_main_gate_commit_coverage.py. Collapsing the
+# two would let one control's pass be read as the other's.
+IMMUTABLE_DISPATCH_REF_PINNED_SHA_VARIABLES = ("$MERGE_COMMIT_SHA", "$revision")
+IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITIONS = tuple(
+    f'if [ "$existing_ref_sha" != "{variable}" ]; then'
+    for variable in IMMUTABLE_DISPATCH_REF_PINNED_SHA_VARIABLES
 )
 IMMUTABLE_DISPATCH_REF_CREATION_CONDITION = 'if [ -z "$existing_ref_sha" ]; then'
 IMMUTABLE_DISPATCH_REF_CREATION_COMMAND = 'gh api "repos/$GITHUB_REPOSITORY/git/refs"'
 IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD = '-f ref="refs/tags/$dispatch_ref"'
-IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD = '-f sha="$MERGE_COMMIT_SHA"'
+IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELDS = tuple(
+    f'-f sha="{variable}"' for variable in IMMUTABLE_DISPATCH_REF_PINNED_SHA_VARIABLES
+)
 MAIN_RELEASABILITY_DISPATCH_COMMAND = "gh workflow run main-releasability.yml"
 MAIN_RELEASABILITY_DISPATCH_TOKENS = (
     (
@@ -78,6 +92,34 @@ MAIN_RELEASABILITY_DISPATCH_TOKENS = (
         "$dispatch_ref",
         "-f",
         "expected_sha=$MERGE_COMMIT_SHA",
+        "-f",
+        "triggering_pr=$PR_NUMBER",
+    ),
+    # Per-revision dispatch (issue #659): one pinned run for every commit the
+    # merged PR put on main, not only its head.
+    (
+        "gh",
+        "workflow",
+        "run",
+        "main-releasability.yml",
+        "--repo",
+        "$GITHUB_REPOSITORY",
+        "--ref",
+        "$dispatch_ref",
+        "-f",
+        "expected_sha=$revision",
+    ),
+    (
+        "gh",
+        "workflow",
+        "run",
+        "main-releasability.yml",
+        "--repo",
+        "$GITHUB_REPOSITORY",
+        "--ref",
+        "$dispatch_ref",
+        "-f",
+        "expected_sha=$revision",
         "-f",
         "triggering_pr=$PR_NUMBER",
     ),
@@ -366,7 +408,7 @@ def _is_exact_immutable_ref_creation_command(command: str) -> bool:
         and not _has_disallowed_immutable_ref_creation_shell_control(command)
         and not _has_disallowed_immutable_ref_creation_override(command)
         and IMMUTABLE_DISPATCH_REF_CREATION_REF_FIELD in command
-        and IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELD in command
+        and any(field in command for field in IMMUTABLE_DISPATCH_REF_CREATION_SHA_FIELDS)
     )
 
 
@@ -505,7 +547,10 @@ def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
         stripped_line = line.strip()
         if condition_depth == 1 and stripped_line.startswith("existing_ref_sha="):
             return False
-        if stripped_line != IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITION or condition_depth != 1:
+        if (
+            stripped_line not in IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITIONS
+            or condition_depth != 1
+        ):
             if _opens_nested_shell_scope(stripped_line):
                 condition_depth += 1
             if _closes_nested_shell_scope(stripped_line):

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -57,6 +57,38 @@ IMMUTABLE_DISPATCH_REF_LOOKUP_CONDITIONS = (
 # claim, owned by tests/unit/test_main_gate_commit_coverage.py. Collapsing the
 # two would let one control's pass be read as the other's.
 IMMUTABLE_DISPATCH_REF_PINNED_SHA_VARIABLES = ("$MERGE_COMMIT_SHA", "$revision")
+
+
+def _pinned_sha_variable(dispatch_step_text: str) -> str | None:
+    """The one SHA variable this dispatcher pins with, or None if inconsistent.
+
+    Accepting the two variables INDEPENDENTLY at each point would let a mixed
+    dispatcher through: a ref named from `$revision` with `expected_sha` still
+    bound to `$MERGE_COMMIT_SHA` checks out one tree and asserts against
+    another. The gate's exact-revision assertion then fails, and a failure is a
+    verdict - so the coverage audit would count that revision as evaluated when
+    nothing evaluated it. Falsely reported coverage is the defect this whole
+    control exists to prevent, so the mode must be coherent across the ref
+    name, the mismatch check, the creation SHA and the dispatch input.
+    """
+
+    chosen: str | None = None
+    for variable in IMMUTABLE_DISPATCH_REF_PINNED_SHA_VARIABLES:
+        markers = (
+            f'dispatch_ref="main-releasability-${{{variable.lstrip("$")}}}"',
+            f'if [ "$existing_ref_sha" != "{variable}" ]; then',
+            f'-f sha="{variable}"',
+            f'-f expected_sha="{variable}"',
+        )
+        present = [marker for marker in markers if marker in dispatch_step_text]
+        if not present:
+            continue
+        if len(present) != len(markers) or chosen is not None:
+            return None
+        chosen = variable
+    return chosen
+
+
 IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITIONS = tuple(
     f'if [ "$existing_ref_sha" != "{variable}" ]; then'
     for variable in IMMUTABLE_DISPATCH_REF_PINNED_SHA_VARIABLES
@@ -1070,6 +1102,14 @@ def merged_pr_main_releasability_dispatch_violations(
             violations.append(
                 f"{dispatcher.as_posix()}: dispatcher must not set continue-on-error on "
                 "the governed main releasability dispatch step"
+            )
+        if dispatch_step_text and _pinned_sha_variable(dispatch_step_text) is None:
+            violations.append(
+                f"{dispatcher.as_posix()}: dispatcher must pin the ref name, the mismatch "
+                "check, the created ref SHA and the dispatched expected_sha with ONE "
+                "consistent SHA variable; a mixed binding checks out one revision and "
+                "asserts against another, and the resulting failure is a verdict the "
+                "coverage audit would count as evaluation"
             )
         dispatch_contract_text = _strip_shell_here_document_bodies(
             dispatch_step_text or dispatcher_text

--- a/scripts/workflow_policy_gate.py
+++ b/scripts/workflow_policy_gate.py
@@ -547,10 +547,7 @@ def _outer_lookup_then_arm_has_mismatch_exit(block: str) -> bool:
         stripped_line = line.strip()
         if condition_depth == 1 and stripped_line.startswith("existing_ref_sha="):
             return False
-        if (
-            stripped_line not in IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITIONS
-            or condition_depth != 1
-        ):
+        if stripped_line not in IMMUTABLE_DISPATCH_REF_MISMATCH_CONDITIONS or condition_depth != 1:
             if _opens_nested_shell_scope(stripped_line):
                 condition_depth += 1
             if _closes_nested_shell_scope(stripped_line):
@@ -697,7 +694,15 @@ def _is_exact_main_releasability_dispatch_command(command: str) -> bool:
         and not normalized_command.rstrip().endswith("&")
         and '--repo "$GITHUB_REPOSITORY"' in normalized_command
         and '--ref "$dispatch_ref"' in normalized_command
-        and '-f expected_sha="$MERGE_COMMIT_SHA"' in normalized_command
+        # Either the PR-head binding or the per-revision one (issue #659). The
+        # exhaustive token-sequence check below is what actually pins the
+        # command shape; this line only requires that SOME pinned expected_sha
+        # is passed, so a dispatch with no pinning at all still fails here
+        # rather than relying on the tuple comparison alone.
+        and any(
+            f'-f expected_sha="{variable}"' in normalized_command
+            for variable in IMMUTABLE_DISPATCH_REF_PINNED_SHA_VARIABLES
+        )
         and tuple(command_tokens) in MAIN_RELEASABILITY_DISPATCH_TOKENS
     )
 
@@ -1074,12 +1079,21 @@ def merged_pr_main_releasability_dispatch_violations(
             "types: [closed]": "dispatcher must be limited to closed pull request events",
             "github.event.pull_request.merged == true": "dispatcher must require a merged PR",
             "github.event.pull_request.base.ref == 'main'": "dispatcher must target main merges only",
-            "github.event.pull_request.merge_commit_sha": (
-                "dispatcher must bind dispatch evidence to the merged PR SHA"
-            ),
-            'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"': (
-                "dispatcher must create an immutable dispatch ref for the merged PR SHA"
-            ),
+            # Per-commit dispatch (issue #659) binds each run to one revision the
+            # merged PR put on main, rather than to the PR head alone. Either
+            # binding is accepted, but the per-revision form must come from the
+            # enumerating job's output - a bare ${{ matrix.revision }} could be
+            # fed from anywhere, whereas that job is where rebase-only merging
+            # and ancestry against fetched main are asserted. So this stays a
+            # binding to the merge event, one hop further along.
+            (
+                "github.event.pull_request.merge_commit_sha",
+                "needs.enumerate-merged-revisions.outputs.revisions",
+            ): ("dispatcher must bind dispatch evidence to the merged PR SHA"),
+            (
+                'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+                'dispatch_ref="main-releasability-${revision}"',
+            ): ("dispatcher must create an immutable dispatch ref for the dispatched SHA"),
             "Dispatch ref $dispatch_ref points to $existing_ref_sha": (
                 "dispatcher must fail closed if an existing dispatch ref points to a different SHA"
             ),
@@ -1096,19 +1110,36 @@ def merged_pr_main_releasability_dispatch_violations(
                 "dispatcher must pass the merged PR SHA as an expected mainline SHA"
             ),
         }
+        # A key may be one token or a tuple of acceptable alternatives; a tuple
+        # is satisfied by any one of them. Alternatives exist only where the
+        # per-commit dispatch expresses the same guarantee differently, never to
+        # excuse a missing guarantee.
+        step_scoped_tokens = {
+            "github.event.pull_request.merge_commit_sha",
+            "needs.enumerate-merged-revisions.outputs.revisions",
+            'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+            'dispatch_ref="main-releasability-${revision}"',
+            "Dispatch ref $dispatch_ref points to $existing_ref_sha",
+            'gh api "repos/$GITHUB_REPOSITORY/git/refs"',
+            "gh workflow run main-releasability.yml",
+            '--ref "$dispatch_ref"',
+            "-f expected_sha=",
+        }
         for token, reason in required_tokens.items():
-            search_text = dispatcher_text
-            if token in {
-                "github.event.pull_request.merge_commit_sha",
-                'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
-                "Dispatch ref $dispatch_ref points to $existing_ref_sha",
-                'gh api "repos/$GITHUB_REPOSITORY/git/refs"',
-                "gh workflow run main-releasability.yml",
-                '--ref "$dispatch_ref"',
-                "-f expected_sha=",
-            }:
-                search_text = dispatch_contract_text
-            if token not in search_text:
+            alternatives = token if isinstance(token, tuple) else (token,)
+            satisfied = False
+            for alternative in alternatives:
+                search_text = (
+                    dispatch_contract_text if alternative in step_scoped_tokens else dispatcher_text
+                )
+                # The per-revision matrix source is declared on the job, not
+                # inside the governed step, so it is read from the whole file.
+                if alternative == "needs.enumerate-merged-revisions.outputs.revisions":
+                    search_text = dispatcher_text
+                if alternative in search_text:
+                    satisfied = True
+                    break
+            if not satisfied:
                 violations.append(f"{dispatcher.as_posix()}: {reason}")
         if _has_failure_masked_outer_brace_group(dispatch_contract_text):
             violations.append(

--- a/tests/unit/test_ci_workflow_gate_enforcement.py
+++ b/tests/unit/test_ci_workflow_gate_enforcement.py
@@ -304,7 +304,13 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "github.event.pull_request.base.ref == 'main'" in dispatcher_text
     assert "github.event.pull_request.merge_commit_sha" in dispatcher_text
     assert "contents: write" in dispatcher_text
-    assert 'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"' in dispatcher_text
+    # Per-commit dispatch (#659) pins each run to one merged revision; the
+    # PR-head form remains valid for a single-commit PR. Either is a pinned
+    # immutable ref, which is the property this asserts.
+    assert (
+        'dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"' in dispatcher_text
+        or 'dispatch_ref="main-releasability-${revision}"' in dispatcher_text
+    )
     assert (
         'if existing_ref_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$dispatch_ref"'
         in dispatcher_text
@@ -316,7 +322,10 @@ def test_merged_pr_main_releasability_dispatcher_is_governed() -> None:
     assert "gh workflow run main-releasability.yml" in dispatcher_text
     assert '--repo "$GITHUB_REPOSITORY"' in dispatcher_text
     assert '--ref "$dispatch_ref"' in dispatcher_text
-    assert '-f expected_sha="$MERGE_COMMIT_SHA"' in dispatcher_text
+    assert (
+        '-f expected_sha="$MERGE_COMMIT_SHA"' in dispatcher_text
+        or '-f expected_sha="$revision"' in dispatcher_text
+    )
     assert '-f triggering_pr="$PR_NUMBER"' in dispatcher_text
     assert "workflow_dispatch:" in main_trigger_section
     assert "expected_sha:" in main_trigger_section
@@ -2269,8 +2278,8 @@ def test_merged_pr_dispatch_gate_rejects_or_masked_brace_group(
     workflow_dir.mkdir()
     workflow_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
     workflow_text = workflow_text.replace(
-        "        run: |\n",
-        "        run: |\n          {\n",
+        "        run: |\n          set -euo pipefail\n          dispatch_ref=",
+        "        run: |\n          {\n          set -euo pipefail\n          dispatch_ref=",
         1,
     ).replace(
         '            -f triggering_pr="$PR_NUMBER"',
@@ -2298,7 +2307,7 @@ def test_merged_pr_dispatch_gate_rejects_compound_prefixed_subshell(
     workflow_dir.mkdir()
     workflow_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
     workflow_text = workflow_text.replace(
-        "        run: |\n",
+        "        run: |\n          set -euo pipefail\n          dispatch_ref=",
         "        run: |\n          false && (\n",
         1,
     ).replace(
@@ -2327,7 +2336,7 @@ def test_merged_pr_dispatch_gate_rejects_time_prefixed_compound_scope(
     workflow_dir.mkdir()
     workflow_text = MERGED_PR_DISPATCHER.read_text(encoding="utf-8")
     workflow_text = workflow_text.replace(
-        "        run: |\n",
+        "        run: |\n          set -euo pipefail\n          dispatch_ref=",
         "        run: |\n          time if false; then\n",
         1,
     ).replace(
@@ -2428,9 +2437,9 @@ def test_merged_pr_dispatch_gate_rejects_repository_variable_reassignment(
     workflow_dir.mkdir()
     (workflow_dir / "merged-pr-main-releasability.yml").write_text(
         MERGED_PR_DISPATCHER.read_text(encoding="utf-8").replace(
-            '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+            '          dispatch_ref="main-releasability-${revision}"',
             '          GITHUB_REPOSITORY="wrong/other"\n'
-            '          dispatch_ref="main-releasability-${MERGE_COMMIT_SHA}"',
+            '          dispatch_ref="main-releasability-${revision}"',
             1,
         ),
         encoding="utf-8",

--- a/tests/unit/test_main_gate_commit_coverage.py
+++ b/tests/unit/test_main_gate_commit_coverage.py
@@ -252,15 +252,33 @@ def test_the_dispatcher_passes_only_inputs_this_gate_declares() -> None:
     )
 
 
-def test_the_dispatcher_asserts_it_dispatched_one_run_per_commit() -> None:
-    """A loop that silently does nothing is the shape of the gap being closed.
+def test_the_dispatcher_asserts_it_enumerated_one_revision_per_commit() -> None:
+    """A loop that silently produces nothing is the shape of the gap being closed.
 
-    Enumerating revisions and then dispatching none would leave the dispatcher
-    job green with zero coverage created - indistinguishable, from the outside,
-    from the defect this issue reports.
+    Enumerating zero or too few revisions would leave the job green with no
+    coverage created - indistinguishable, from the outside, from the defect this
+    issue reports. The count is asserted against the PR's own commit count.
+
+    Enumeration and dispatch are separate jobs so the dispatch step stays a flat
+    lookup / conditional ref creation / dispatch sequence: workflow_policy_gate
+    validates that structure, and a shell `for` loop around it nests the whole
+    thing out of that control's reach.
     """
 
     dispatcher = (WORKFLOW_ROOT / "merged-pr-main-releasability.yml").read_text(encoding="utf-8")
 
-    assert 'if [ "$dispatched" -ne "$COMMIT_COUNT" ]; then' in dispatcher
-    assert "dispatched=$((dispatched + 1))" in dispatcher
+    assert 'if [ "$enumerated" -ne "$COMMIT_COUNT" ]; then' in dispatcher
+    assert "enumerated=$((enumerated + 1))" in dispatcher
+    # One dispatch job per enumerated revision, fed from the enumerating job so
+    # the dispatched SHA stays bound to the merge event rather than to anything
+    # a later edit could supply.
+    assert "revisions: ${{ steps.enumerate.outputs.revisions }}" in dispatcher
+    assert (
+        "revision: ${{ fromJson(needs.enumerate-merged-revisions.outputs.revisions) }}"
+        in dispatcher
+    )
+    # Sequential: concurrent jobs creating dispatch tags race on the refs API,
+    # and a failed tag creation drops a revision's gate run silently.
+    assert "max-parallel: 1" in dispatcher
+    # One revision failing must not cancel the others' gate runs.
+    assert "fail-fast: false" in dispatcher

--- a/tests/unit/test_main_gate_commit_coverage.py
+++ b/tests/unit/test_main_gate_commit_coverage.py
@@ -282,3 +282,53 @@ def test_the_dispatcher_asserts_it_enumerated_one_revision_per_commit() -> None:
     assert "max-parallel: 1" in dispatcher
     # One revision failing must not cancel the others' gate runs.
     assert "fail-fast: false" in dispatcher
+
+
+def test_a_mixed_sha_binding_is_rejected(tmp_path) -> None:
+    """One coherent pinning mode, not two accepted independently.
+
+    Accepting $MERGE_COMMIT_SHA and $revision at each point separately lets a
+    mixed dispatcher through: a ref named from $revision while expected_sha is
+    still bound to $MERGE_COMMIT_SHA checks out one tree and asserts against
+    another. The gate's exact-revision assertion then fails - and a failure is a
+    VERDICT, so the coverage audit would count that revision as evaluated when
+    nothing evaluated it.
+
+    Falsely reported coverage is the defect this whole change exists to remove,
+    so a permissive checker here would defeat its own purpose.
+    """
+
+    from scripts.workflow_policy_gate import merged_pr_main_releasability_dispatch_violations
+
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    mixed = (WORKFLOW_ROOT / "merged-pr-main-releasability.yml").read_text(encoding="utf-8")
+    mixed = mixed.replace('-f expected_sha="$revision"', '-f expected_sha="$MERGE_COMMIT_SHA"', 1)
+    assert '-f expected_sha="$MERGE_COMMIT_SHA"' in mixed, "mutation did not apply"
+    (workflow_dir / "merged-pr-main-releasability.yml").write_text(mixed, encoding="utf-8")
+    (workflow_dir / "main-releasability.yml").write_text(
+        (WORKFLOW_ROOT / "main-releasability.yml").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    violations = merged_pr_main_releasability_dispatch_violations(workflow_dir)
+
+    assert any("ONE consistent SHA variable" in violation for violation in violations), violations
+
+
+def test_a_coherent_single_commit_binding_is_still_accepted(tmp_path) -> None:
+    """Divergence half: coherence must not mean 'only the per-revision mode'.
+
+    A dispatcher pinning every point with $MERGE_COMMIT_SHA is internally
+    consistent and must stay valid - rejecting it would make the coherence rule
+    a disguised requirement for one implementation rather than a rule about
+    self-consistency.
+    """
+
+    from scripts.workflow_policy_gate import _pinned_sha_variable
+
+    head_bound = (WORKFLOW_ROOT / "merged-pr-main-releasability.yml").read_text(encoding="utf-8")
+    head_bound = head_bound.replace("$revision", "$MERGE_COMMIT_SHA").replace(
+        "${revision}", "${MERGE_COMMIT_SHA}"
+    )
+
+    assert _pinned_sha_variable(head_bound) == "$MERGE_COMMIT_SHA"

--- a/tests/unit/test_main_gate_commit_coverage.py
+++ b/tests/unit/test_main_gate_commit_coverage.py
@@ -1,0 +1,266 @@
+"""Guards for per-commit main-gate coverage (found by cross-repo review, 2026-08-31).
+
+This repository merges by rebase, so a merged PR of N commits puts N commits
+on main. The dispatcher previously named only ``merge_commit_sha`` - 36 of the
+45 commits merged over 28-31 Aug had no releasability run, invisibly, because
+a run that is never created is not a failure. These tests pin the two halves
+of the fix: the dispatcher enumerates every merged revision, and the daily
+audit fails closed rather than passing while verifying nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from scripts import audit_main_gate_coverage as audit
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_ROOT = ROOT / ".github" / "workflows"
+
+
+def test_merged_pr_dispatch_gates_every_revision_the_pr_put_on_main() -> None:
+    dispatcher = (WORKFLOW_ROOT / "merged-pr-main-releasability.yml").read_text(encoding="utf-8")
+
+    # Enumeration of every revision, oldest first, from full history.
+    assert "COMMIT_COUNT: ${{ github.event.pull_request.commits }}" in dispatcher
+    assert 'git rev-list -n "$COMMIT_COUNT" "$MERGE_COMMIT_SHA" | tac' in dispatcher
+    assert "for revision in $revisions; do" in dispatcher
+    assert "fetch-depth: 0" in dispatcher
+    # Every dispatch is pinned to its own revision, not the PR head.
+    assert 'dispatch_ref="main-releasability-${revision}"' in dispatcher
+    assert '-f expected_sha="$revision"' in dispatcher
+    # The enumeration is only correct under rebase-only merging; the
+    # dispatcher must fail loudly if the repository setting ever changes.
+    assert "allow_squash_merge" in dispatcher
+    assert '"$merge_methods" != "false,false,true"' in dispatcher
+    # Ancestry is judged against the freshly fetched main, and a revision that
+    # is not main history is refused BEFORE any tag is created or gate
+    # dispatched: the guard must sit inside the loop, after the detach onto
+    # FETCH_HEAD and ahead of both the tag write and the workflow dispatch.
+    assert "git checkout --quiet --detach FETCH_HEAD" in dispatcher
+    guard = 'if ! git merge-base --is-ancestor "$revision" HEAD; then'
+    assert guard in dispatcher
+    assert dispatcher.index("git fetch origin main --quiet") < dispatcher.index(
+        "git checkout --quiet --detach FETCH_HEAD"
+    )
+    assert dispatcher.index("for revision in $revisions; do") < dispatcher.index(guard)
+    assert dispatcher.index(guard) < dispatcher.index(
+        'dispatch_ref="main-releasability-${revision}"'
+    )
+    assert dispatcher.index(guard) < dispatcher.index('gh api "repos/$GITHUB_REPOSITORY/git/refs"')
+    assert dispatcher.index(guard) < dispatcher.index("gh workflow run main-releasability.yml")
+
+
+def test_coverage_audit_workflow_runs_the_fail_closed_audit() -> None:
+    workflow = (WORKFLOW_ROOT / "main-gate-coverage-audit.yml").read_text(encoding="utf-8")
+
+    assert "schedule:" in workflow
+    assert "workflow_dispatch" in workflow
+    assert "python scripts/audit_main_gate_coverage.py" in workflow
+    assert "--fail-on-gap" in workflow
+
+
+def test_audit_counts_only_verdict_bearing_runs_and_fails_closed(monkeypatch, capsys) -> None:
+    """A cancelled run evaluated nothing, an unfetchable listing proves
+    nothing, and both must fail the audit rather than pass it."""
+
+    commits = {
+        "a" * 40: ["success"],
+        "b" * 40: ["cancelled"],
+        "c" * 40: None,
+        "d" * 40: [],
+    }
+    monkeypatch.setattr(
+        audit,
+        "_git",
+        lambda *args: [f"{sha} {sha[:9]} subject line" for sha in commits],
+    )
+    monkeypatch.setattr(audit, "_run_conclusions", lambda sha: commits[sha])
+    monkeypatch.setattr(audit.shutil, "which", lambda name: "/usr/bin/gh")
+    monkeypatch.setattr(
+        audit.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: argparse_namespace(limit=400, since_days=7, fail_on_gap=True),
+    )
+
+    exit_code = audit.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "UNGATED  ddddddddd" in output
+    assert "1 passing, 0 with a failing verdict" in output
+    assert "UNKNOWN  ccccccccc" in output
+    assert "UNKNOWN  bbbbbbbbb" in output
+    assert "1 with no verdict-bearing" in output
+
+
+def test_a_full_window_is_not_reported_as_truncated(monkeypatch, capsys) -> None:
+    """A window holding exactly --limit commits was fully examined; only a
+    commit BEYOND the cap proves the span was cut short. Declaring truncation
+    at equality would fail the scheduled audit for no reason."""
+
+    shas = [f"{index:040x}" for index in range(3)]
+    monkeypatch.setattr(
+        audit,
+        "_git",
+        lambda *args: [f"{sha} {sha[:9]} subject line" for sha in shas],
+    )
+    monkeypatch.setattr(audit, "_run_conclusions", lambda sha: ["success"])
+    monkeypatch.setattr(audit.shutil, "which", lambda name: "/usr/bin/gh")
+    monkeypatch.setattr(
+        audit.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: argparse_namespace(limit=3, since_days=7, fail_on_gap=True),
+    )
+
+    exit_code = audit.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "WINDOW TRUNCATED" not in output
+
+
+def test_a_window_beyond_the_cap_fails_closed(monkeypatch, capsys) -> None:
+    shas = [f"{index:040x}" for index in range(4)]
+    monkeypatch.setattr(
+        audit,
+        "_git",
+        lambda *args: [f"{sha} {sha[:9]} subject line" for sha in shas],
+    )
+    monkeypatch.setattr(audit, "_run_conclusions", lambda sha: ["success"])
+    monkeypatch.setattr(audit.shutil, "which", lambda name: "/usr/bin/gh")
+    monkeypatch.setattr(
+        audit.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: argparse_namespace(limit=3, since_days=7, fail_on_gap=True),
+    )
+
+    exit_code = audit.main()
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "WINDOW TRUNCATED" in output
+    assert "audited 3 commit(s)" in output
+
+
+def test_the_window_walks_every_commit_regardless_of_date_order(monkeypatch) -> None:
+    """`--since` stops traversal at the first older commit, so a newer-dated
+    ancestor behind an older-dated one is silently omitted - a green audit for
+    a window it never walked. `--since-as-filter` visits every commit."""
+
+    recorded: list[tuple[str, ...]] = []
+
+    def _record(*args: str) -> list[str]:
+        recorded.append(args)
+        return []
+
+    monkeypatch.setattr(audit, "_git", _record)
+    monkeypatch.setattr(audit.shutil, "which", lambda name: "/usr/bin/gh")
+    monkeypatch.setattr(
+        audit.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: argparse_namespace(limit=400, since_days=7, fail_on_gap=True),
+    )
+
+    audit.main()
+
+    assert recorded, "the audit never asked git for the window"
+    flags = recorded[0]
+    assert any(flag.startswith("--since-as-filter=") for flag in flags), flags
+    assert not any(flag.startswith("--since=") for flag in flags), (
+        "plain --since truncates the window at the first older commit"
+    )
+
+
+def test_audit_fails_closed_when_gh_is_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(audit.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        audit.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: argparse_namespace(limit=400, since_days=7, fail_on_gap=True),
+    )
+
+    assert audit.main() == 1
+
+
+def test_audit_passes_when_every_commit_has_a_verdict(monkeypatch, capsys) -> None:
+    """A failing verdict is information, not a coverage gap: the audit passes
+    but reports the split so coverage and releasability stay distinct claims."""
+
+    commits = {"a" * 40: ["success"], "b" * 40: ["failure", "cancelled"]}
+    monkeypatch.setattr(
+        audit,
+        "_git",
+        lambda *args: [f"{sha} {sha[:9]} subject line" for sha in commits],
+    )
+    monkeypatch.setattr(audit, "_run_conclusions", lambda sha: commits[sha])
+    monkeypatch.setattr(audit.shutil, "which", lambda name: "/usr/bin/gh")
+    monkeypatch.setattr(
+        audit.argparse.ArgumentParser,
+        "parse_args",
+        lambda self: argparse_namespace(limit=400, since_days=7, fail_on_gap=True),
+    )
+
+    assert audit.main() == 0
+    output = capsys.readouterr().out
+    assert "1 passing, 1 with a failing verdict" in output
+    assert "FAILING  bbbbbbbbb" in output
+
+
+def argparse_namespace(**kwargs):
+    import argparse
+
+    return argparse.Namespace(**kwargs)
+
+
+def test_the_dispatcher_passes_only_inputs_this_gate_declares() -> None:
+    """A dispatch carrying an undeclared input 422s and the gate never runs.
+
+    This guard is specific to lotus-manage and has no counterpart in the
+    repository this implementation was ported from, which is exactly why it is
+    here: that dispatcher passes `-f source_branch="main"`, and
+    `main-releasability.yml` HERE declares only `expected_sha` and
+    `triggering_pr`. Copying it verbatim would have made every dispatch fail
+    with 422 - disabling the coverage fix silently, while the dispatcher job
+    itself went green.
+
+    So this compares the two files against each other rather than asserting a
+    remembered list: the gate's declared inputs are the authority, and a future
+    input added to the dispatcher must also be added to the gate.
+    """
+
+    dispatcher = (WORKFLOW_ROOT / "merged-pr-main-releasability.yml").read_text(encoding="utf-8")
+    gate = (WORKFLOW_ROOT / "main-releasability.yml").read_text(encoding="utf-8")
+
+    declared = set(re.findall(r"^      (\w+):$", gate, re.M))
+    assert declared, "could not read any declared workflow_dispatch inputs from the gate"
+
+    # Only the workflow-run invocation, not the `gh api .../git/refs` call
+    # beside it: that one passes -f ref= and -f sha= as REST parameters, which
+    # are not workflow inputs and would be false positives here.
+    invocation = dispatcher.split("gh workflow run main-releasability.yml", 1)
+    assert len(invocation) == 2, "no main-releasability dispatch found"
+    dispatch_call = invocation[1].split("\n\n", 1)[0]
+    passed = set(re.findall(r'-f (\w+)="', dispatch_call))
+    assert passed, "the dispatch passes no inputs at all; the pinning is gone"
+
+    undeclared = passed - declared
+    assert not undeclared, (
+        f"dispatcher passes {sorted(undeclared)}, which main-releasability.yml does not declare; "
+        "the dispatch would 422 and no gate run would be created"
+    )
+
+
+def test_the_dispatcher_asserts_it_dispatched_one_run_per_commit() -> None:
+    """A loop that silently does nothing is the shape of the gap being closed.
+
+    Enumerating revisions and then dispatching none would leave the dispatcher
+    job green with zero coverage created - indistinguishable, from the outside,
+    from the defect this issue reports.
+    """
+
+    dispatcher = (WORKFLOW_ROOT / "merged-pr-main-releasability.yml").read_text(encoding="utf-8")
+
+    assert 'if [ "$dispatched" -ne "$COMMIT_COUNT" ]; then' in dispatcher
+    assert "dispatched=$((dispatched + 1))" in dispatcher


### PR DESCRIPTION
Closes #659.

## Measured, not assumed

**38 of the last 40 commits on `main` have no Main Releasability verdict.** Most are mine — PR #676
put 14 commits on main and only the head was gated. A commit that was never the PR head still
becomes the deployed tree on rollback and bisect, and a run that is never created is not a failure,
so the loss accrued silently.

Merge methods confirmed `squash=false merge=false rebase=true`, which is the precondition that makes
per-commit enumeration correct.

## Why enumeration and dispatch are separate jobs

The obvious shape is a shell `for` loop around the existing dispatch block. That does not work here:
`scripts/workflow_policy_gate.py` validates that block **structurally** — lookup, `if/else` reset,
creation branch, at an exact nesting depth with ordering between them — and a loop nests the whole
thing one level deeper than the control can see.

A matrix keeps the governed step a flat sequence, gives each revision its own job log, and
dispatches sequentially (`max-parallel: 1`) so concurrent tag creation cannot race and drop a
revision's run. `fail-fast: false` so one revision failing does not cancel the others' gate runs.

The enumerating job asserts rebase-only merge methods, refuses any revision that is not an ancestor
of freshly fetched `main`, and asserts it enumerated exactly the PR's commit count — producing a
short list silently is the same defect being fixed.

## The control was not weakened

This changes a governance checker, so that claim is proven rather than asserted. Eight malformations
were driven through it **against the new layout**:

| Malformation | Result |
| --- | --- |
| brace group masked by `\|\| true` | REJECTED |
| dispatch with trailing `\|\| true` | REJECTED |
| repository overridden on the dispatch | REJECTED |
| dispatch not pinned to the immutable ref | REJECTED |
| `expected_sha` pinning removed | REJECTED |
| ref created outside the empty-existing-ref branch | REJECTED |
| mismatched existing ref no longer failing closed | REJECTED |
| `continue-on-error` on the governed step | REJECTED |

The existing rejection tests were **mis-targeted, not broken**: they anchored on the first `run:`
block, which the job split moved into the enumerate job, so each was malforming the wrong step while
still looking like it exercised the control. They now name the dispatch step explicitly, which
cannot silently re-target if another job is added.

The policy gate accepts either the PR-head or per-revision pinning — the per-revision matrix must be
fed from the enumerating job's output rather than a bare variable, so the dispatched SHA stays bound
to the merge event. The audit workflow's permission policy is read-only: a watchdog that could
dispatch would be able to manufacture the coverage it audits.

## Two adopter-side traps from the reference implementation

Both would have disabled this silently while the dispatcher job stayed green:

1. It passes `-f source_branch="main"`, which **this** repository's `main-releasability.yml` does not
   declare. Every dispatch would `422` and no run would be created. A test now compares the inputs
   passed against the inputs the gate declares, so a future addition to one must reach the other.
2. It renames the dispatch step, and `workflow_policy_gate.py` locates that step **by name**. The
   rename made the entire control find nothing. Name restored with a comment marking it load-bearing.

## Verification

3446 unit tests, lint, typecheck and the quality-report gate all clean. The daily audit is
fail-closed (`--fail-on-gap`) and invoked bare — piping it would report the pipe's exit code and
leave the step green while the audit failed on every run.

Historical backfill of the 38 ungated commits is deliberately **not** in this PR: it is a dispatch
exercise against existing history, and bundling it would mix a reviewable control change with a
bulk operation.