### PR TITLE
fix(tenancy): scope the wave aggregate to its tenant (#677)

### DIFF
--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-09-07T06:51:25.026116+00:00",
+  "generatedAt": "2026-09-07T13:40:09.192745+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -20557,7 +20557,7 @@
       "location": "header",
       "required": true,
       "type": "string",
-      "description": "Trusted tenant id. Required: wave preview, create, source-check and selection all read tenant-scoped mandate evidence, and a request that does not state its tenant is refused rather than answered from an assumed one. Also required when resolving persisted bulk-review campaign definitions.",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
       "example": "ENTITY_001",
       "allowedValues": [],
       "semanticId": "lotus.x_tenant_id",
@@ -20581,7 +20581,7 @@
       "location": "header",
       "required": true,
       "type": "string",
-      "description": "Trusted tenant id. Required: wave preview, create, source-check and selection all read tenant-scoped mandate evidence, and a request that does not state its tenant is refused rather than answered from an assumed one. Also required when resolving persisted bulk-review campaign definitions.",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
       "example": "ENTITY_001",
       "allowedValues": [],
       "semanticId": "lotus.x_tenant_id",
@@ -20684,28 +20684,16 @@
       "attributeRef": "#/attributeCatalog/lotus.offset"
     },
     {
-      "name": "wave_id",
+      "name": "x_tenant_id",
       "kind": "request_option",
-      "location": "path",
+      "location": "header",
       "required": true,
       "type": "string",
-      "description": "Durable Manage rebalance wave identifier.",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
       "example": "ENTITY_001",
       "allowedValues": [],
-      "semanticId": "lotus.wave_id",
-      "attributeRef": "#/attributeCatalog/lotus.wave_id"
-    },
-    {
-      "name": "wave_id",
-      "kind": "request_option",
-      "location": "path",
-      "required": true,
-      "type": "string",
-      "description": "Durable Manage rebalance wave identifier.",
-      "example": "ENTITY_001",
-      "allowedValues": [],
-      "semanticId": "lotus.wave_id",
-      "attributeRef": "#/attributeCatalog/lotus.wave_id"
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
     },
     {
       "name": "wave_id",
@@ -20725,7 +20713,55 @@
       "location": "header",
       "required": true,
       "type": "string",
-      "description": "Trusted tenant id. Required: wave preview, create, source-check and selection all read tenant-scoped mandate evidence, and a request that does not state its tenant is refused rather than answered from an assumed one. Also required when resolving persisted bulk-review campaign definitions.",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+    },
+    {
+      "name": "wave_id",
+      "kind": "request_option",
+      "location": "path",
+      "required": true,
+      "type": "string",
+      "description": "Durable Manage rebalance wave identifier.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.wave_id",
+      "attributeRef": "#/attributeCatalog/lotus.wave_id"
+    },
+    {
+      "name": "x_tenant_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": true,
+      "type": "string",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+    },
+    {
+      "name": "wave_id",
+      "kind": "request_option",
+      "location": "path",
+      "required": true,
+      "type": "string",
+      "description": "Durable Manage rebalance wave identifier.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.wave_id",
+      "attributeRef": "#/attributeCatalog/lotus.wave_id"
+    },
+    {
+      "name": "x_tenant_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": true,
+      "type": "string",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
       "example": "ENTITY_001",
       "allowedValues": [],
       "semanticId": "lotus.x_tenant_id",
@@ -20754,6 +20790,18 @@
       "allowedValues": [],
       "semanticId": "lotus.wave_id",
       "attributeRef": "#/attributeCatalog/lotus.wave_id"
+    },
+    {
+      "name": "x_tenant_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": true,
+      "type": "string",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
     },
     {
       "name": "x_correlation_id",
@@ -20797,7 +20845,7 @@
       "location": "header",
       "required": true,
       "type": "string",
-      "description": "Trusted tenant id. Required: wave preview, create, source-check and selection all read tenant-scoped mandate evidence, and a request that does not state its tenant is refused rather than answered from an assumed one. Also required when resolving persisted bulk-review campaign definitions.",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
       "example": "ENTITY_001",
       "allowedValues": [],
       "semanticId": "lotus.x_tenant_id",
@@ -20828,52 +20876,16 @@
       "attributeRef": "#/attributeCatalog/lotus.wave_id"
     },
     {
-      "name": "x_correlation_id",
+      "name": "x_tenant_id",
       "kind": "request_option",
       "location": "header",
-      "required": false,
-      "type": "object",
-      "description": "Optional correlation id for wave supportability and audit traceability.",
-      "example": "ENTITY_001",
-      "allowedValues": [],
-      "semanticId": "lotus.x_correlation_id",
-      "attributeRef": "#/attributeCatalog/lotus.x_correlation_id"
-    },
-    {
-      "name": "wave_id",
-      "kind": "request_option",
-      "location": "path",
       "required": true,
       "type": "string",
-      "description": "Durable Manage rebalance wave identifier.",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
       "example": "ENTITY_001",
       "allowedValues": [],
-      "semanticId": "lotus.wave_id",
-      "attributeRef": "#/attributeCatalog/lotus.wave_id"
-    },
-    {
-      "name": "x_correlation_id",
-      "kind": "request_option",
-      "location": "header",
-      "required": false,
-      "type": "object",
-      "description": "Optional correlation id for wave supportability and audit traceability.",
-      "example": "ENTITY_001",
-      "allowedValues": [],
-      "semanticId": "lotus.x_correlation_id",
-      "attributeRef": "#/attributeCatalog/lotus.x_correlation_id"
-    },
-    {
-      "name": "wave_id",
-      "kind": "request_option",
-      "location": "path",
-      "required": true,
-      "type": "string",
-      "description": "Durable Manage rebalance wave identifier.",
-      "example": "ENTITY_001",
-      "allowedValues": [],
-      "semanticId": "lotus.wave_id",
-      "attributeRef": "#/attributeCatalog/lotus.wave_id"
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
     },
     {
       "name": "x_correlation_id",
@@ -20900,6 +20912,18 @@
       "attributeRef": "#/attributeCatalog/lotus.wave_id"
     },
     {
+      "name": "x_tenant_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": true,
+      "type": "string",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+    },
+    {
       "name": "x_correlation_id",
       "kind": "request_option",
       "location": "header",
@@ -20924,6 +20948,30 @@
       "attributeRef": "#/attributeCatalog/lotus.wave_id"
     },
     {
+      "name": "x_tenant_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": true,
+      "type": "string",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+    },
+    {
+      "name": "x_correlation_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": false,
+      "type": "object",
+      "description": "Optional correlation id for wave supportability and audit traceability.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_correlation_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_correlation_id"
+    },
+    {
       "name": "wave_id",
       "kind": "request_option",
       "location": "path",
@@ -20936,16 +20984,28 @@
       "attributeRef": "#/attributeCatalog/lotus.wave_id"
     },
     {
-      "name": "tenant_id",
+      "name": "x_tenant_id",
       "kind": "request_option",
-      "location": "query",
+      "location": "header",
       "required": true,
       "type": "string",
-      "description": "Tenant whose mandate evidence is being read. Required: mandate snapshots and health snapshots are stored per tenant, and the same mandate id may exist under more than one tenant. Send it as the canonical snake_case query parameter `tenant_id`.",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
       "example": "ENTITY_001",
       "allowedValues": [],
-      "semanticId": "lotus.tenant_id",
-      "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+    },
+    {
+      "name": "x_correlation_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": false,
+      "type": "object",
+      "description": "Optional correlation id for wave supportability and audit traceability.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_correlation_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_correlation_id"
     },
     {
       "name": "wave_id",
@@ -20958,6 +21018,66 @@
       "allowedValues": [],
       "semanticId": "lotus.wave_id",
       "attributeRef": "#/attributeCatalog/lotus.wave_id"
+    },
+    {
+      "name": "x_tenant_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": true,
+      "type": "string",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+    },
+    {
+      "name": "wave_id",
+      "kind": "request_option",
+      "location": "path",
+      "required": true,
+      "type": "string",
+      "description": "Durable Manage rebalance wave identifier.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.wave_id",
+      "attributeRef": "#/attributeCatalog/lotus.wave_id"
+    },
+    {
+      "name": "x_tenant_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": true,
+      "type": "string",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+    },
+    {
+      "name": "wave_id",
+      "kind": "request_option",
+      "location": "path",
+      "required": true,
+      "type": "string",
+      "description": "Durable Manage rebalance wave identifier.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.wave_id",
+      "attributeRef": "#/attributeCatalog/lotus.wave_id"
+    },
+    {
+      "name": "x_tenant_id",
+      "kind": "request_option",
+      "location": "header",
+      "required": true,
+      "type": "string",
+      "description": "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and a request that does not state its tenant is refused rather than answered from an assumed one. Waves persisted before tenant scoping carry no tenant and are reachable from none, including a tenant named `default`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.x_tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
     },
     {
       "name": "idempotency_key",
@@ -98145,6 +98265,14 @@
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
           },
           {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+          },
+          {
             "name": "wave.version",
             "location": "body",
             "required": false,
@@ -99590,6 +99718,14 @@
             "type": "string",
             "semanticId": "lotus.correlation_id",
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          },
+          {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           },
           {
             "name": "wave.version",
@@ -101047,6 +101183,14 @@
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
           },
           {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+          },
+          {
             "name": "wave.version",
             "location": "body",
             "required": false,
@@ -101808,6 +101952,14 @@
             "type": "integer",
             "semanticId": "lotus.offset",
             "attributeRef": "#/attributeCatalog/lotus.offset"
+          },
+          {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
           }
         ]
       },
@@ -102175,6 +102327,14 @@
             "type": "string",
             "semanticId": "lotus.wave_id",
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
           }
         ]
       },
@@ -102347,6 +102507,14 @@
             "type": "string",
             "semanticId": "lotus.correlation_id",
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          },
+          {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           },
           {
             "name": "wave.version",
@@ -103486,6 +103654,14 @@
             "type": "string",
             "semanticId": "lotus.wave_id",
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
           }
         ]
       },
@@ -104097,6 +104273,14 @@
             "type": "string",
             "semanticId": "lotus.correlation_id",
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          },
+          {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           },
           {
             "name": "wave.version",
@@ -104820,6 +105004,14 @@
             "type": "string",
             "semanticId": "lotus.wave_id",
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
           },
           {
             "name": "x-correlation-id",
@@ -107634,6 +107826,14 @@
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
           },
           {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+          },
+          {
             "name": "wave.version",
             "location": "body",
             "required": false,
@@ -108593,6 +108793,14 @@
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
           },
           {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+          },
+          {
             "name": "wave.version",
             "location": "body",
             "required": false,
@@ -109316,6 +109524,14 @@
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
           },
           {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+          },
+          {
             "name": "x-correlation-id",
             "location": "header",
             "required": false,
@@ -109518,6 +109734,14 @@
             "type": "string",
             "semanticId": "lotus.correlation_id",
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          },
+          {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           },
           {
             "name": "wave.version",
@@ -110243,6 +110467,14 @@
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
           },
           {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+          },
+          {
             "name": "x-correlation-id",
             "location": "header",
             "required": false,
@@ -110445,6 +110677,14 @@
             "type": "string",
             "semanticId": "lotus.correlation_id",
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          },
+          {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           },
           {
             "name": "wave.version",
@@ -111170,6 +111410,14 @@
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
           },
           {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+          },
+          {
             "name": "x-correlation-id",
             "location": "header",
             "required": false,
@@ -111372,6 +111620,14 @@
             "type": "string",
             "semanticId": "lotus.correlation_id",
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          },
+          {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           },
           {
             "name": "wave.version",
@@ -112097,6 +112353,14 @@
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
           },
           {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
+          },
+          {
             "name": "x-correlation-id",
             "location": "header",
             "required": false,
@@ -112299,6 +112563,14 @@
             "type": "string",
             "semanticId": "lotus.correlation_id",
             "attributeRef": "#/attributeCatalog/lotus.correlation_id"
+          },
+          {
+            "name": "wave.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           },
           {
             "name": "wave.version",
@@ -113022,6 +113294,14 @@
             "type": "string",
             "semanticId": "lotus.wave_id",
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
           }
         ]
       },
@@ -113471,12 +113751,12 @@
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
           },
           {
-            "name": "tenant_id",
-            "location": "query",
+            "name": "x-tenant-id",
+            "location": "header",
             "required": true,
             "type": "string",
-            "semanticId": "lotus.tenant_id",
-            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
           }
         ]
       },
@@ -114684,6 +114964,14 @@
             "type": "string",
             "semanticId": "lotus.wave_id",
             "attributeRef": "#/attributeCatalog/lotus.wave_id"
+          },
+          {
+            "name": "x-tenant-id",
+            "location": "header",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.x_tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.x_tenant_id"
           }
         ]
       },

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-07T09:19:22+00:00`
+- Generated at: `2026-09-07T14:11:16+00:00`
 
-- Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
+- Baseline source snapshot: `c8130d382c4da0177ee9bca8886b1c21e567aee0`
 
-- Report source snapshot: `63b3e59a+worktree`
+- Report source snapshot: `6fb9998d`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 928 |
-| Total Python LOC | 217192 |
-| Test functions | 3150 |
+| Python files | 931 |
+| Total Python LOC | 218128 |
+| Test functions | 3166 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-07T09:19:22+00:00`
+- Generated at: `2026-09-07T14:11:16+00:00`
 
-- Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
+- Baseline source snapshot: `c8130d382c4da0177ee9bca8886b1c21e567aee0`
 
-- Report source snapshot: `63b3e59a+worktree`
+- Report source snapshot: `6fb9998d`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 
@@ -22,7 +22,7 @@
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 791 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 410 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 404 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
@@ -52,7 +52,7 @@
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 791 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 410 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 404 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-07T09:19:22+00:00`
+- Generated at: `2026-09-07T14:11:16+00:00`
 
-- Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
+- Baseline source snapshot: `c8130d382c4da0177ee9bca8886b1c21e567aee0`
 
-- Report source snapshot: `63b3e59a+worktree`
+- Report source snapshot: `6fb9998d`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-07T09:19:22+00:00`
+- Generated at: `2026-09-07T14:11:16+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `8ae9804b14fe59d3020aeaa5b27bd9c32352fb4a`
+- Baseline source snapshot: `c8130d382c4da0177ee9bca8886b1c21e567aee0`
 
-- Report source snapshot: `63b3e59a+worktree`
+- Report source snapshot: `6fb9998d`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 926 | 928 | +2 |
-| Total Python LOC | 216545 | 217192 | +647 |
-| Test functions | 3138 | 3150 | +12 |
+| Python files | 928 | 931 | +3 |
+| Total Python LOC | 217192 | 218128 | +936 |
+| Test functions | 3150 | 3166 | +16 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -39,7 +39,7 @@
 | --- | --- | --- |
 | 1 | tests/unit/dpm/api/test_waves_api.py | 7756 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
-| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3386 |
+| 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3395 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
@@ -52,14 +52,14 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 7756 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 7777 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3395 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 7 | tests/unit/test_documentation_current_state.py | 2788 |
-| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2708 |
+| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2709 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
@@ -86,7 +86,7 @@
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 791 |
-| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 410 |
+| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 404 |
 | 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 380 |
 | 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
 | 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
@@ -119,7 +119,7 @@
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 791 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 410 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 404 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |

--- a/src/api/routers/wave_read_http.py
+++ b/src/api/routers/wave_read_http.py
@@ -14,11 +14,13 @@ def get_wave_detail_response(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> DpmWaveDetailResponse:
     try:
         payload = wave_service.retrieve_wave_detail(
             wave_id=wave_id,
             wave_repository=wave_repository,
+            tenant_id=tenant_id,
         )
     except wave_service.DpmWaveLookupError as exc:
         raise wave_lookup_http_exception(exc) from exc
@@ -29,11 +31,13 @@ def get_wave_items_response(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> DpmWaveItemsResponse:
     try:
         payload = wave_service.list_wave_items(
             wave_id=wave_id,
             wave_repository=wave_repository,
+            tenant_id=tenant_id,
         )
     except wave_service.DpmWaveLookupError as exc:
         raise wave_lookup_http_exception(exc) from exc
@@ -44,11 +48,13 @@ def get_wave_proof_pack_posture_response(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> DpmWaveProofPackPostureResponse:
     try:
         payload = wave_service.proof_pack_posture(
             wave_id=wave_id,
             wave_repository=wave_repository,
+            tenant_id=tenant_id,
         )
     except wave_service.DpmWaveLookupError as exc:
         raise wave_lookup_http_exception(exc) from exc

--- a/src/api/routers/wave_read_routes.py
+++ b/src/api/routers/wave_read_routes.py
@@ -14,7 +14,7 @@ from src.api.routers.wave_response_contracts import (
     DpmWaveItemsResponse,
     DpmWaveSearchResponse,
 )
-from src.api.routers.wave_route_parameters import WaveIdPath
+from src.api.routers.wave_route_parameters import WaveIdPath, WaveTenantIdHeader
 from src.api.routers.wave_search_http import search_waves_response
 from src.core.waves import DpmWaveRepository
 
@@ -71,6 +71,7 @@ def register_wave_read_routes(router: APIRouter) -> None:
         },
     )
     def search_waves(
+        x_tenant_id: WaveTenantIdHeader,
         state: Annotated[
             str | None,
             Query(
@@ -108,6 +109,7 @@ def register_wave_read_routes(router: APIRouter) -> None:
     ) -> DpmWaveSearchResponse:
         return search_waves_response(
             wave_repository=wave_repository,
+            tenant_id=x_tenant_id,
             state=state,
             trigger_type=trigger_type,
             as_of_date=as_of_date,
@@ -134,11 +136,13 @@ def register_wave_read_routes(router: APIRouter) -> None:
     )
     def get_wave_detail(
         wave_id: WaveIdPath,
+        x_tenant_id: WaveTenantIdHeader,
         wave_repository: DpmWaveRepository = Depends(get_wave_repository),
     ) -> DpmWaveDetailResponse:
         return get_wave_detail_response(
             wave_id=wave_id,
             wave_repository=wave_repository,
+            tenant_id=x_tenant_id,
         )
 
     @router.get(
@@ -159,9 +163,11 @@ def register_wave_read_routes(router: APIRouter) -> None:
     )
     def get_wave_items(
         wave_id: WaveIdPath,
+        x_tenant_id: WaveTenantIdHeader,
         wave_repository: DpmWaveRepository = Depends(get_wave_repository),
     ) -> DpmWaveItemsResponse:
         return get_wave_items_response(
             wave_id=wave_id,
             wave_repository=wave_repository,
+            tenant_id=x_tenant_id,
         )

--- a/src/api/routers/wave_read_support_routes.py
+++ b/src/api/routers/wave_read_support_routes.py
@@ -4,7 +4,6 @@ import logging
 
 from fastapi import APIRouter, Depends, status
 
-from src.api.routers.mandate_tenant_query import MandateTenantId
 from src.api.dependencies import (
     get_mandate_repository,
     get_outcome_review_repository,
@@ -17,7 +16,7 @@ from src.api.routers.wave_response_contracts import (
     DpmWaveProofPackPostureResponse,
     DpmWaveSupportabilityResponse,
 )
-from src.api.routers.wave_route_parameters import WaveIdPath
+from src.api.routers.wave_route_parameters import WaveIdPath, WaveTenantIdHeader
 from src.api.routers.wave_supportability_http import get_wave_supportability_response
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.outcomes.repository import DpmOutcomeReviewRepository
@@ -46,11 +45,13 @@ logger = logging.getLogger(__name__)
 )
 def get_wave_proof_pack_posture(
     wave_id: WaveIdPath,
+    x_tenant_id: WaveTenantIdHeader,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveProofPackPostureResponse:
     return get_wave_proof_pack_posture_response(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=x_tenant_id,
     )
 
 
@@ -78,8 +79,12 @@ def get_wave_proof_pack_posture(
     },
 )
 def get_wave_report_input(
-    tenant_id: MandateTenantId,
     wave_id: WaveIdPath,
+    # One selector per aggregate (issue #677): every wave route now takes the
+    # wave tenant header. This route previously took a tenant_id QUERY param
+    # while the wave lifecycle took the header - two mechanisms on one
+    # aggregate, which is the confusion #676 already had to fix once.
+    x_tenant_id: WaveTenantIdHeader,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
     proof_pack_repository: DpmProofPackRepository = Depends(get_proof_pack_repository),
     outcome_review_repository: DpmOutcomeReviewRepository = Depends(get_outcome_review_repository),
@@ -88,10 +93,10 @@ def get_wave_report_input(
     return get_wave_report_input_response(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=x_tenant_id,
         proof_pack_repository=proof_pack_repository,
         outcome_review_repository=outcome_review_repository,
         mandate_repository=mandate_repository,
-        tenant_id=tenant_id,
     )
 
 
@@ -113,10 +118,12 @@ def get_wave_report_input(
 )
 def get_wave_supportability(
     wave_id: WaveIdPath,
+    x_tenant_id: WaveTenantIdHeader,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveSupportabilityResponse:
     return get_wave_supportability_response(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=x_tenant_id,
         logger=logger,
     )

--- a/src/api/routers/wave_route_parameters.py
+++ b/src/api/routers/wave_route_parameters.py
@@ -65,11 +65,15 @@ WaveTenantIdHeader = Annotated[
         # 422 (issue #648). Leaving it optional published a contract that
         # disagreed with the behaviour: every generated client and integration
         # test would have been built to omit a header the service rejects.
+        # Stated as a rule rather than a route list. The previous wording named
+        # the four routes that had it at the time, and #677 put it on every
+        # wave route - a list is wrong the moment the next one is added, and
+        # nothing would have failed to say so.
         description=(
-            "Trusted tenant id. Required: wave preview, create, source-check and selection all "
-            "read tenant-scoped mandate evidence, and a request that does not state its tenant is "
-            "refused rather than answered from an assumed one. Also required when resolving "
-            "persisted bulk-review campaign definitions."
+            "Trusted tenant id. Required on every wave route: a wave belongs to one tenant, and "
+            "a request that does not state its tenant is refused rather than answered from an "
+            "assumed one. Waves persisted before tenant scoping carry no tenant and are reachable "
+            "from none, including a tenant named `default`."
         ),
         examples=["tenant-sg"],
     ),

--- a/src/api/routers/wave_search_http.py
+++ b/src/api/routers/wave_search_http.py
@@ -10,6 +10,7 @@ from src.core.waves import DpmWaveRepository
 def search_waves_response(
     *,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     state: str | None,
     trigger_type: str | None,
     as_of_date: str | None,
@@ -19,6 +20,7 @@ def search_waves_response(
 ) -> DpmWaveSearchResponse:
     items = wave_service.search_waves(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         state=state,
         trigger_type=trigger_type,
         as_of_date=as_of_date,

--- a/src/api/routers/wave_simulation_http.py
+++ b/src/api/routers/wave_simulation_http.py
@@ -38,6 +38,7 @@ def simulate_wave_response(
     construction_repository: ConstructionRepository,
     run_service: DpmRunSupportService,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     risk_authority_client: RiskAuthorityClient | None,
 ) -> DpmWaveResponse:
     try:
@@ -50,6 +51,7 @@ def simulate_wave_response(
             construction_repository=construction_repository,
             run_service=run_service,
             wave_repository=wave_repository,
+            tenant_id=tenant_id,
             risk_authority_client=risk_authority_client,
         )
     except wave_service.DpmWaveLookupError as exc:

--- a/src/api/routers/wave_simulation_routes.py
+++ b/src/api/routers/wave_simulation_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, status
 
+from src.api.routers.wave_route_parameters import WaveTenantIdHeader
 from src.api.dependencies import (
     get_construction_repository,
     get_risk_authority_client,
@@ -43,6 +44,7 @@ router = APIRouter()
 def simulate_wave(
     wave_id: WaveIdPath,
     request: DpmWaveSimulationRequest,
+    x_tenant_id: WaveTenantIdHeader,
     x_correlation_id: WaveCorrelationIdHeader = None,
     construction_repository: ConstructionRepository = Depends(get_construction_repository),
     risk_authority_client: RiskAuthorityClient | None = Depends(get_risk_authority_client),
@@ -56,5 +58,6 @@ def simulate_wave(
         construction_repository=construction_repository,
         run_service=run_service,
         wave_repository=wave_repository,
+        tenant_id=x_tenant_id,
         risk_authority_client=risk_authority_client,
     )

--- a/src/api/routers/wave_supportability_http.py
+++ b/src/api/routers/wave_supportability_http.py
@@ -16,12 +16,14 @@ def get_wave_supportability_response(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     logger: logging.Logger,
 ) -> DpmWaveSupportabilityResponse:
     try:
         payload = wave_service.wave_supportability(
             wave_id=wave_id,
             wave_repository=wave_repository,
+            tenant_id=tenant_id,
         )
     except wave_service.DpmWaveLookupError as exc:
         record_wave_supportability(

--- a/src/api/routers/wave_workflow_command_http.py
+++ b/src/api/routers/wave_workflow_command_http.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Protocol
 
 from src.api.routers.wave_http_errors import (
     wave_lookup_http_exception,
@@ -11,10 +11,28 @@ from src.api.routers.wave_response_contracts import DpmWaveResponse, wave_respon
 from src.api.services import wave_service
 from src.core.waves import DpmRebalanceWave, DpmWaveRepository
 
-WaveWorkflowCommand = Callable[
-    ...,
-    tuple[DpmRebalanceWave, bool],
-]
+
+class WaveWorkflowCommand(Protocol):
+    """The four workflow commands, named argument by argument.
+
+    This was `Callable[..., tuple[DpmRebalanceWave, bool]]`. The ellipsis erases
+    the parameter list, so when the commands gained a required `tenant_id` the
+    dispatcher kept calling them without it and mypy had nothing to check the
+    call against - the four endpoints failed at request time instead. Spelling
+    the arguments out makes a future required argument a type error here.
+    """
+
+    def __call__(
+        self,
+        *,
+        wave_id: str,
+        actor_id: str,
+        reason_code: str,
+        comment: str | None,
+        correlation_id: str,
+        wave_repository: DpmWaveRepository,
+        tenant_id: str,
+    ) -> tuple[DpmRebalanceWave, bool]: ...
 
 
 def run_wave_workflow_command_response(
@@ -24,6 +42,7 @@ def run_wave_workflow_command_response(
     request: DpmWaveWorkflowCommandRequest,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> DpmWaveResponse:
     try:
         wave, replayed = command(
@@ -33,6 +52,7 @@ def run_wave_workflow_command_response(
             comment=request.comment,
             correlation_id=correlation_id,
             wave_repository=wave_repository,
+            tenant_id=tenant_id,
         )
     except wave_service.DpmWaveLookupError as exc:
         raise wave_lookup_http_exception(exc) from exc

--- a/src/api/routers/wave_workflow_routes.py
+++ b/src/api/routers/wave_workflow_routes.py
@@ -5,7 +5,11 @@ from fastapi import APIRouter, Depends, status
 from src.api.dependencies import get_wave_repository
 from src.api.routers.wave_request_models import DpmWaveWorkflowCommandRequest
 from src.api.routers.wave_response_contracts import DpmWaveResponse
-from src.api.routers.wave_route_parameters import WaveCorrelationIdHeader, WaveIdPath
+from src.api.routers.wave_route_parameters import (
+    WaveCorrelationIdHeader,
+    WaveIdPath,
+    WaveTenantIdHeader,
+)
 from src.api.routers.wave_workflow_command_http import run_wave_workflow_command_response
 from src.api.services import wave_service
 from src.core.waves import DpmWaveRepository
@@ -35,6 +39,7 @@ router = APIRouter()
 def approve_wave(
     wave_id: WaveIdPath,
     request: DpmWaveWorkflowCommandRequest,
+    x_tenant_id: WaveTenantIdHeader,
     x_correlation_id: WaveCorrelationIdHeader = None,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
@@ -44,6 +49,7 @@ def approve_wave(
         request=request,
         correlation_id=x_correlation_id or f"corr_wave_approve_{wave_id}",
         wave_repository=wave_repository,
+        tenant_id=x_tenant_id,
     )
 
 
@@ -68,6 +74,7 @@ def approve_wave(
 def stage_wave(
     wave_id: WaveIdPath,
     request: DpmWaveWorkflowCommandRequest,
+    x_tenant_id: WaveTenantIdHeader,
     x_correlation_id: WaveCorrelationIdHeader = None,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
@@ -77,6 +84,7 @@ def stage_wave(
         request=request,
         correlation_id=x_correlation_id or f"corr_wave_stage_{wave_id}",
         wave_repository=wave_repository,
+        tenant_id=x_tenant_id,
     )
 
 
@@ -100,6 +108,7 @@ def stage_wave(
 def handoff_wave(
     wave_id: WaveIdPath,
     request: DpmWaveWorkflowCommandRequest,
+    x_tenant_id: WaveTenantIdHeader,
     x_correlation_id: WaveCorrelationIdHeader = None,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
@@ -109,6 +118,7 @@ def handoff_wave(
         request=request,
         correlation_id=x_correlation_id or f"corr_wave_handoff_{wave_id}",
         wave_repository=wave_repository,
+        tenant_id=x_tenant_id,
     )
 
 
@@ -135,6 +145,7 @@ def handoff_wave(
 def cancel_wave(
     wave_id: WaveIdPath,
     request: DpmWaveWorkflowCommandRequest,
+    x_tenant_id: WaveTenantIdHeader,
     x_correlation_id: WaveCorrelationIdHeader = None,
     wave_repository: DpmWaveRepository = Depends(get_wave_repository),
 ) -> DpmWaveResponse:
@@ -144,4 +155,5 @@ def cancel_wave(
         request=request,
         correlation_id=x_correlation_id or f"corr_wave_cancel_{wave_id}",
         wave_repository=wave_repository,
+        tenant_id=x_tenant_id,
     )

--- a/src/api/services/wave_lifecycle_commands.py
+++ b/src/api/services/wave_lifecycle_commands.py
@@ -17,10 +17,12 @@ def approve_persisted_wave(
     comment: str | None,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> tuple[DpmRebalanceWave, bool]:
     prepared = prepare_wave_transition(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         replay_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
         allowed_states={"SIMULATED", "PARTIALLY_SIMULATED", "REVIEW_REQUIRED"},
         error_code="DPM_WAVE_APPROVAL_INVALID_STATE",
@@ -38,6 +40,7 @@ def approve_persisted_wave(
     )
     persist_transitioned_wave(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         source_wave=prepared.wave,
         transitioned_wave=approved,
     )
@@ -52,10 +55,12 @@ def stage_persisted_wave(
     comment: str | None,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> tuple[DpmRebalanceWave, bool]:
     prepared = prepare_wave_transition(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         replay_states={"STAGED", "HANDOFF_READY"},
         allowed_states={"APPROVED", "APPROVED_WITH_EXCEPTIONS"},
         error_code="DPM_WAVE_STAGE_INVALID_STATE",
@@ -73,6 +78,7 @@ def stage_persisted_wave(
     )
     persist_transitioned_wave(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         source_wave=prepared.wave,
         transitioned_wave=staged,
     )
@@ -87,10 +93,12 @@ def handoff_persisted_wave(
     comment: str | None,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> tuple[DpmRebalanceWave, bool]:
     prepared = prepare_wave_transition(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         replay_states={"HANDOFF_READY"},
         allowed_states={"STAGED"},
         error_code="DPM_WAVE_HANDOFF_INVALID_STATE",
@@ -108,6 +116,7 @@ def handoff_persisted_wave(
     )
     persist_transitioned_wave(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         source_wave=prepared.wave,
         transitioned_wave=handoff_ready,
     )
@@ -122,10 +131,12 @@ def cancel_persisted_wave(
     comment: str | None,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> tuple[DpmRebalanceWave, bool]:
     prepared = prepare_wave_transition(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         replay_states={"CANCELLED"},
         allowed_states=None,
         error_code="DPM_WAVE_CANCEL_INVALID_STATE",
@@ -143,6 +154,7 @@ def cancel_persisted_wave(
     )
     persist_transitioned_wave(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         source_wave=prepared.wave,
         transitioned_wave=cancelled,
     )

--- a/src/api/services/wave_lookup.py
+++ b/src/api/services/wave_lookup.py
@@ -6,8 +6,17 @@ def get_wave_or_raise(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> DpmRebalanceWave:
-    wave = wave_repository.get_wave(wave_id=wave_id)
+    """Load one of THIS TENANT's waves, refusing before any caller acts on it.
+
+    The refusal for another tenant's wave is deliberately the same
+    DPM_WAVE_NOT_FOUND as for an absent one (issue #677). A distinguishable
+    error would confirm the id exists and belongs to somebody, which is the
+    cross-tenant information the fence exists to withhold.
+    """
+
+    wave = wave_repository.get_wave(wave_id=wave_id, tenant_id=tenant_id)
     if wave is None:
         raise DpmWaveLookupError("DPM_WAVE_NOT_FOUND", f"Wave {wave_id} was not found.")
     return wave

--- a/src/api/services/wave_persistence.py
+++ b/src/api/services/wave_persistence.py
@@ -32,9 +32,21 @@ def update_wave_or_raise(
     wave_repository: DpmWaveRepository,
     wave: DpmRebalanceWave,
     expected_version: int,
+    tenant_id: str,
 ) -> None:
+    """Persist a wave update for this tenant.
+
+    The tenant reaches the repository so it can ride in the UPDATE predicate
+    rather than being checked before it (issue #677). A wave owned by another
+    tenant matches no row and surfaces as the same version conflict as a stale
+    expected_version - the caller cannot tell the two apart, which is what
+    stops the write path being used to probe for foreign wave ids.
+    """
+
     try:
-        wave_repository.update_wave(wave=wave, expected_version=expected_version)
+        wave_repository.update_wave(
+            wave=wave, expected_version=expected_version, tenant_id=tenant_id
+        )
     except DpmWaveVersionConflictError as exc:
         raise DpmWaveValidationError("DPM_WAVE_VERSION_CONFLICT", str(exc)) from exc
 

--- a/src/api/services/wave_preparation_commands.py
+++ b/src/api/services/wave_preparation_commands.py
@@ -26,6 +26,7 @@ def source_check_persisted_wave(
     prepared = prepare_wave_transition(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         replay_states={"SOURCE_CHECKED"},
         allowed_states={"CREATED"},
         error_code="DPM_WAVE_SOURCE_CHECK_INVALID_STATE",
@@ -43,6 +44,7 @@ def source_check_persisted_wave(
     )
     persist_transitioned_wave(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         source_wave=prepared.wave,
         transitioned_wave=checked,
     )
@@ -59,11 +61,13 @@ def simulate_persisted_wave(
     construction_repository: ConstructionRepository,
     run_service: DpmRunSupportService,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     risk_authority_client: RiskAuthorityClient | None = None,
 ) -> tuple[DpmRebalanceWave, bool]:
     prepared = prepare_wave_transition(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         replay_states={"SIMULATED", "PARTIALLY_SIMULATED", "SIMULATION_FAILED"},
         allowed_states={"SOURCE_CHECKED"},
         error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
@@ -84,6 +88,7 @@ def simulate_persisted_wave(
     )
     persist_transitioned_wave(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         source_wave=prepared.wave,
         transitioned_wave=completed,
     )

--- a/src/api/services/wave_read_model_queries.py
+++ b/src/api/services/wave_read_model_queries.py
@@ -13,8 +13,9 @@ def wave_supportability_for_id(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> dict[str, object]:
-    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository, tenant_id=tenant_id)
     return wave_supportability_payload(wave)
 
 
@@ -22,8 +23,9 @@ def wave_detail_for_id(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> dict[str, object]:
-    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository, tenant_id=tenant_id)
     return wave_detail_payload(wave)
 
 
@@ -31,8 +33,9 @@ def wave_items_for_id(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> dict[str, object]:
-    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository, tenant_id=tenant_id)
     return wave_items_payload(wave)
 
 
@@ -40,8 +43,9 @@ def wave_proof_pack_posture_for_id(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> dict[str, object]:
-    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository, tenant_id=tenant_id)
     return proof_pack_posture_for_wave(wave=wave)
 
 
@@ -49,19 +53,23 @@ def wave_report_input_for_id(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     proof_pack_repository: DpmProofPackRepository | None = None,
     outcome_review_repository: DpmOutcomeReviewRepository | None = None,
     mandate_repository: DpmMandateRepository | None = None,
-    tenant_id: str | None = None,
 ) -> DpmWaveReportInput:
-    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    # The tenant was previously optional here with a None default. A fenced
+    # read cannot have an optional tenant: the default would silently mean
+    # "unscoped", which is the state issue #677 removes. It is now the
+    # required parameter above.
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository, tenant_id=tenant_id)
     return build_report_input_for_wave(
         wave=wave,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         proof_pack_repository=proof_pack_repository,
         outcome_review_repository=outcome_review_repository,
         mandate_repository=mandate_repository,
-        tenant_id=tenant_id,
     )
 
 

--- a/src/api/services/wave_search.py
+++ b/src/api/services/wave_search.py
@@ -5,6 +5,7 @@ from src.core.waves import DpmRebalanceWave, DpmRebalanceWaveEvent, DpmWaveRepos
 def search_wave_summaries(
     *,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     state: str | None = None,
     trigger_type: str | None = None,
     as_of_date: str | None = None,
@@ -13,6 +14,7 @@ def search_wave_summaries(
     offset: int = 0,
 ) -> list[dict[str, object]]:
     waves = wave_repository.list_waves(
+        tenant_id=tenant_id,
         state=state,
         trigger_type=trigger_type,
         as_of_date=as_of_date,

--- a/src/api/services/wave_selection_command.py
+++ b/src/api/services/wave_selection_command.py
@@ -34,6 +34,7 @@ def select_persisted_wave_item_alternative(
     prepared = prepare_wave_transition(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         replay_states=set(),
         allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
         error_code="DPM_WAVE_SELECTION_INVALID_STATE",
@@ -68,6 +69,7 @@ def select_persisted_wave_item_alternative(
     )
     persist_transitioned_wave(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         source_wave=prepared.wave,
         transitioned_wave=updated,
     )

--- a/src/api/services/wave_service.py
+++ b/src/api/services/wave_service.py
@@ -111,6 +111,7 @@ def simulate_wave(
     construction_repository: ConstructionRepository,
     run_service: DpmRunSupportService,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     risk_authority_client: RiskAuthorityClient | None = None,
 ) -> tuple[DpmRebalanceWave, bool]:
     return wave_preparation_commands.simulate_persisted_wave(
@@ -122,6 +123,7 @@ def simulate_wave(
         construction_repository=construction_repository,
         run_service=run_service,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         risk_authority_client=risk_authority_client,
     )
 
@@ -169,6 +171,7 @@ def approve_wave(
     comment: str | None,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> tuple[DpmRebalanceWave, bool]:
     return wave_lifecycle_commands.approve_persisted_wave(
         wave_id=wave_id,
@@ -177,6 +180,7 @@ def approve_wave(
         comment=comment,
         correlation_id=correlation_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
     )
 
 
@@ -188,6 +192,7 @@ def stage_wave(
     comment: str | None,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> tuple[DpmRebalanceWave, bool]:
     return wave_lifecycle_commands.stage_persisted_wave(
         wave_id=wave_id,
@@ -196,6 +201,7 @@ def stage_wave(
         comment=comment,
         correlation_id=correlation_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
     )
 
 
@@ -207,6 +213,7 @@ def handoff_wave(
     comment: str | None,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> tuple[DpmRebalanceWave, bool]:
     return wave_lifecycle_commands.handoff_persisted_wave(
         wave_id=wave_id,
@@ -215,6 +222,7 @@ def handoff_wave(
         comment=comment,
         correlation_id=correlation_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
     )
 
 
@@ -226,6 +234,7 @@ def cancel_wave(
     comment: str | None,
     correlation_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> tuple[DpmRebalanceWave, bool]:
     return wave_lifecycle_commands.cancel_persisted_wave(
         wave_id=wave_id,
@@ -234,6 +243,7 @@ def cancel_wave(
         comment=comment,
         correlation_id=correlation_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
     )
 
 
@@ -245,16 +255,19 @@ def wave_supportability(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> dict[str, object]:
     return wave_read_model_queries.wave_supportability_for_id(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
     )
 
 
 def search_waves(
     *,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     state: str | None = None,
     trigger_type: str | None = None,
     as_of_date: str | None = None,
@@ -264,6 +277,7 @@ def search_waves(
 ) -> list[dict[str, object]]:
     return wave_search.search_wave_summaries(
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         state=state,
         trigger_type=trigger_type,
         as_of_date=as_of_date,
@@ -277,10 +291,12 @@ def retrieve_wave_detail(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> dict[str, object]:
     return wave_read_model_queries.wave_detail_for_id(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
     )
 
 
@@ -288,10 +304,12 @@ def list_wave_items(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> dict[str, object]:
     return wave_read_model_queries.wave_items_for_id(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
     )
 
 
@@ -299,10 +317,12 @@ def proof_pack_posture(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
 ) -> dict[str, object]:
     return wave_read_model_queries.wave_proof_pack_posture_for_id(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
     )
 
 
@@ -310,16 +330,20 @@ def get_report_input(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    # Required, not `str | None = None`. An optional tenant on a fenced read
+    # defaults to "unscoped", which is the state issue #677 removes - and an
+    # optional parameter is exactly how the unscoped path survived being
+    # noticed.
+    tenant_id: str,
     proof_pack_repository: DpmProofPackRepository | None = None,
     outcome_review_repository: DpmOutcomeReviewRepository | None = None,
     mandate_repository: DpmMandateRepository | None = None,
-    tenant_id: str | None = None,
 ) -> DpmWaveReportInput:
     return wave_read_model_queries.wave_report_input_for_id(
         wave_id=wave_id,
         wave_repository=wave_repository,
+        tenant_id=tenant_id,
         proof_pack_repository=proof_pack_repository,
         outcome_review_repository=outcome_review_repository,
         mandate_repository=mandate_repository,
-        tenant_id=tenant_id,
     )

--- a/src/api/services/wave_transition_execution.py
+++ b/src/api/services/wave_transition_execution.py
@@ -18,12 +18,28 @@ def prepare_wave_transition(
     *,
     wave_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     replay_states: set[str],
     allowed_states: set[str] | None,
     error_code: str,
     action_phrase: str,
 ) -> PreparedWaveTransition:
-    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository)
+    """Load and admit a wave for transition, refusing before any state change.
+
+    This is the sharpest of the three defects in issue #677: the load used to
+    resolve a wave by id alone, so a wave created under one tenant could be
+    source-checked or selected against by another - and #676's tenant argument
+    made the MANDATE reads on those paths look correct while the wave itself
+    was never that caller's to touch. An unfenced read here leads to an
+    unfenced write.
+
+    The tenant fence is inside the load, before the idempotent-replay shortcut
+    and before the state guard. Ordering matters: replaying first would return
+    another tenant's wave as a successful no-op, which is a read, and a
+    refusal that arrives after the transition is not a refusal.
+    """
+
+    wave = get_wave_or_raise(wave_id=wave_id, wave_repository=wave_repository, tenant_id=tenant_id)
     if wave_state_is_idempotent(wave, replay_states=replay_states):
         return PreparedWaveTransition(wave=wave, replayed=True)
     if allowed_states is not None:
@@ -41,11 +57,20 @@ def persist_transitioned_wave(
     wave_repository: DpmWaveRepository,
     source_wave: DpmRebalanceWave,
     transitioned_wave: DpmRebalanceWave,
+    tenant_id: str,
 ) -> None:
+    """Write the transition, with the tenant in the update predicate.
+
+    Fencing only the read would leave the write reachable by a caller that
+    obtained a wave some other way, so the tenant travels to the UPDATE rather
+    than being trusted from the earlier load (issue #677).
+    """
+
     update_wave_or_raise(
         wave_repository=wave_repository,
         wave=transitioned_wave,
         expected_version=source_wave.version,
+        tenant_id=tenant_id,
     )
 
 

--- a/src/core/portfolio_memory/candidate_portfolios.py
+++ b/src/core/portfolio_memory/candidate_portfolios.py
@@ -9,6 +9,7 @@ from src.core.portfolio_memory.source_repositories import (
     build_portfolio_memory_source_repositories,
     require_campaign_definition_tenant_id,
     require_mandate_tenant_id,
+    require_wave_tenant_id,
     require_pm_quality_tenant_id,
 )
 from src.core.portfolio_memory.search_request import validate_portfolio_memory_source_scan_limit
@@ -55,7 +56,13 @@ def candidate_portfolio_ids_from_sources(
     )
     candidates = _explicit_candidate_ids(portfolio_ids)
     candidates.update(_proof_pack_candidate_ids(repositories, source_scan_limit))
-    candidates.update(_wave_candidate_ids(repositories, source_scan_limit))
+    candidates.update(
+        _wave_candidate_ids(
+            require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories),
+            repositories,
+            source_scan_limit,
+        )
+    )
     candidates.update(_outcome_review_candidate_ids(repositories, source_scan_limit))
     candidates.update(
         _mandate_exception_candidate_ids(
@@ -98,12 +105,15 @@ def _proof_pack_candidate_ids(
 
 
 def _wave_candidate_ids(
+    tenant_id: str,
     repositories: PortfolioMemorySourceRepositories,
     source_scan_limit: int,
 ) -> set[str]:
     return {
         item.portfolio_id
-        for wave in repositories.wave_repository.list_waves(limit=source_scan_limit)
+        for wave in repositories.wave_repository.list_waves(
+            tenant_id=tenant_id, limit=source_scan_limit
+        )
         for item in wave.items
     }
 

--- a/src/core/portfolio_memory/search_source_collection.py
+++ b/src/core/portfolio_memory/search_source_collection.py
@@ -28,6 +28,7 @@ from src.core.portfolio_memory.source_repositories import (
     PortfolioMemorySourceRepositories,
     require_campaign_definition_tenant_id,
     require_mandate_tenant_id,
+    require_wave_tenant_id,
 )
 from src.core.portfolio_memory.wave_projection import wave_events
 
@@ -62,6 +63,7 @@ def collect_portfolio_memory_search_events(
         limit=limit,
     )
     _collect_wave_events(
+        tenant_id=require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories),
         repositories=repositories,
         candidates=candidates,
         events_by_portfolio_id=events_by_portfolio_id,
@@ -146,12 +148,13 @@ def _collect_proof_pack_events(
 
 def _collect_wave_events(
     *,
+    tenant_id: str,
     repositories: PortfolioMemorySourceRepositories,
     candidates: set[str],
     events_by_portfolio_id: dict[str, list[DpmPortfolioMemoryEvent]],
     limit: int,
 ) -> None:
-    for wave in repositories.wave_repository.list_waves(limit=limit):
+    for wave in repositories.wave_repository.list_waves(tenant_id=tenant_id, limit=limit):
         matching_portfolio_ids = {
             item.portfolio_id for item in wave.items if item.portfolio_id.strip()
         }

--- a/src/core/portfolio_memory/service.py
+++ b/src/core/portfolio_memory/service.py
@@ -44,6 +44,7 @@ from src.core.portfolio_memory.source_repositories import (
     require_campaign_definition_tenant_id as _require_campaign_definition_tenant_id,
     require_mandate_tenant_id as _require_mandate_tenant_id,
     require_pm_quality_tenant_id as _require_pm_quality_tenant_id,
+    require_wave_tenant_id,
 )
 from src.core.proof_packs.repository import DpmProofPackRepository
 from src.core.waves.campaign_repository import DpmBulkReviewCampaignDefinitionRepository
@@ -91,7 +92,7 @@ def _require_tenant_id_for_tenant_scoped_sources(
     *,
     tenant_id: str | None,
     repositories: PortfolioMemorySourceRepositories,
-) -> str | None:
+) -> str:
     pm_quality_tenant_id = _require_pm_quality_tenant_id(
         tenant_id=tenant_id,
         repositories=repositories,
@@ -110,10 +111,19 @@ def _require_tenant_id_for_tenant_scoped_sources(
     # the other families, found irrelevant to them, and discarded as None -
     # which then reaches the mandate collector as an absent tenant even though
     # the caller supplied one.
-    return _require_mandate_tenant_id(
+    mandate_tenant_id = _require_mandate_tenant_id(
         tenant_id=tenant_id,
         repositories=repositories,
     )
+    if mandate_tenant_id is not None:
+        return mandate_tenant_id
+    # Waves close the chain rather than adding another optional link. Every
+    # optional family above answers None when absent, so before #677 a bundle
+    # carrying only the mandatory sources fell through all of them and returned
+    # None - the caller's tenant validated against families it did not use and
+    # then discarded. `wave_repository` is not optional on the bundle, so a
+    # wave source is always present and this step always requires a tenant.
+    return require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories)
 
 
 def build_portfolio_memory_from_sources(

--- a/src/core/portfolio_memory/source_collection.py
+++ b/src/core/portfolio_memory/source_collection.py
@@ -12,6 +12,7 @@ from src.core.portfolio_memory.source_repositories import (
     PortfolioMemorySourceRepositories,
     require_campaign_definition_tenant_id,
     require_mandate_tenant_id,
+    require_wave_tenant_id,
 )
 from src.core.portfolio_memory.wave_collection import wave_memory_events
 
@@ -57,6 +58,7 @@ def collect_portfolio_memory_events(
 
     events.extend(
         wave_memory_events(
+            tenant_id=require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories),
             portfolio_id=portfolio_id,
             wave_repository=repositories.wave_repository,
             limit=limit,

--- a/src/core/portfolio_memory/source_repositories.py
+++ b/src/core/portfolio_memory/source_repositories.py
@@ -78,6 +78,24 @@ def require_mandate_tenant_id(
     return tenant_id.strip()
 
 
+def require_wave_tenant_id(
+    *,
+    tenant_id: str | None,
+    repositories: PortfolioMemorySourceRepositories,
+) -> str:
+    """Waves are tenant-scoped, so a wave-sourced scan must name its tenant.
+
+    Mirrors require_mandate_tenant_id rather than inventing a second
+    convention. Unlike that one this never returns None: the wave repository is
+    not optional on this path, and returning None would reintroduce the
+    unscoped list_waves that issue #677 removes.
+    """
+
+    if tenant_id is None or not tenant_id.strip():
+        raise ValueError("tenant_id is required when portfolio memory includes wave sources")
+    return tenant_id.strip()
+
+
 def build_portfolio_memory_source_repositories(
     *,
     proof_pack_repository: DpmProofPackRepository,

--- a/src/core/portfolio_memory/wave_collection.py
+++ b/src/core/portfolio_memory/wave_collection.py
@@ -9,12 +9,13 @@ def wave_memory_events(
     *,
     portfolio_id: str,
     wave_repository: DpmWaveRepository,
+    tenant_id: str,
     limit: int,
 ) -> list[DpmPortfolioMemoryEvent]:
     """Collect rebalance-wave memory events for waves containing one portfolio."""
 
     events: list[DpmPortfolioMemoryEvent] = []
-    for wave in wave_repository.list_waves(limit=limit):
+    for wave in wave_repository.list_waves(tenant_id=tenant_id, limit=limit):
         if not any(item.portfolio_id == portfolio_id for item in wave.items):
             continue
         events.extend(wave_events(wave=wave, portfolio_id=portfolio_id))

--- a/src/core/waves/models.py
+++ b/src/core/waves/models.py
@@ -520,6 +520,17 @@ class DpmRebalanceWave(BaseModel):
         examples=["pm_001"],
     )
     correlation_id: str = Field(description="Creation correlation id.", examples=["corr-wave-001"])
+    tenant_id: str | None = Field(
+        default=None,
+        description=(
+            "Tenant that owns this wave. Optional on the model and NOT NULL nowhere, because "
+            "waves persisted before the tenant fence (issue #677) carry none and must stay "
+            "unreachable rather than be assigned an assumed owner. Repository reads require a "
+            "tenant, so a wave without one is matched by no equality predicate - it is "
+            "quarantined, not public."
+        ),
+        examples=["tenant-sg"],
+    )
     version: int = Field(
         default=1,
         description="Optimistic concurrency version.",

--- a/src/core/waves/repository.py
+++ b/src/core/waves/repository.py
@@ -49,8 +49,18 @@ class DpmWaveRepository(Protocol):
         call site; a mapping written without one is reachable by no tenant.
         """
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
-        """Return a wave by id, or None when absent."""
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
+        """Return this tenant's wave by id, or None when it is not theirs.
+
+        `tenant_id` is required rather than defaulted so mypy enumerates every
+        call site (issue #677). Before the fence this returned any wave to any
+        caller, and the transition path reads through here - so an unfenced
+        read led directly to an unfenced write.
+
+        A wave belonging to another tenant, or to none, returns None rather
+        than raising: a distinguishable refusal would disclose that the id
+        exists and belongs to someone.
+        """
 
     def get_wave_by_idempotency(
         self,
@@ -74,18 +84,33 @@ class DpmWaveRepository(Protocol):
     def list_waves(
         self,
         *,
+        tenant_id: str,
         state: str | None = None,
         trigger_type: str | None = None,
         as_of_date: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[DpmRebalanceWave]:
-        """Return a bounded page of waves matching optional search filters."""
+        """Return a bounded page of THIS TENANT's waves matching the filters.
+
+        Placed first and required, so a caller cannot get a cross-tenant page
+        by omitting it (issue #677). The optional filters narrow within one
+        tenant; they never widen across tenants.
+        """
 
     def update_wave(
         self,
         *,
         wave: DpmRebalanceWave,
         expected_version: int,
+        tenant_id: str,
     ) -> None:
-        """Persist a wave update using optimistic concurrency."""
+        """Persist a wave update for this tenant using optimistic concurrency.
+
+        The tenant is part of the update predicate, not merely checked before
+        it: a check-then-write leaves a window, and this is the write half of
+        the transition path (issue #677). A wave belonging to another tenant
+        matches no row and raises the same version-conflict error as a stale
+        expected_version - deliberately indistinguishable, so a caller cannot
+        probe for another tenant's wave ids.
+        """

--- a/src/infrastructure/postgres_migrations/dpm/0027_wave_tenant_scope.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0027_wave_tenant_scope.sql
@@ -1,0 +1,47 @@
+-- Tenant-scope the rebalance wave aggregate (issue #677).
+--
+-- Waves carried no tenant at all: every wave was addressable by wave_id alone,
+-- so a wave created under one tenant could be read, listed, and - the sharpest
+-- of the three - source-checked or selected against by another. #676 added a
+-- tenant argument to the MANDATE reads those paths perform, which made the
+-- mandate evidence look correctly scoped while the wave itself was never that
+-- caller's to touch. An unfenced read on the transition path leads to an
+-- unfenced write.
+--
+-- This is not the same defect as wave idempotency, which #676 closed by
+-- deriving the stored mapping key from the tenant (migration 0026). That path
+-- is complete and must not be reimplemented here.
+--
+-- Nullable with no backfill, matching 0024, 0025 and 0026: a wave persisted
+-- before the fence carries no tenant and is therefore matched by no equality
+-- predicate - reachable from no tenant, including one literally named
+-- `default` and the empty string. Assigning those rows an assumed tenant is
+-- precisely what would let one tenant read waves it never created. They remain
+-- present for deliberate attribution.
+ALTER TABLE dpm_rebalance_waves
+    ADD COLUMN IF NOT EXISTS tenant_id TEXT NULL;
+
+-- Reads are always (tenant, wave) or (tenant, filters); the tenant leads so the
+-- index serves the fence rather than only the lookup.
+CREATE INDEX IF NOT EXISTS idx_dpm_rebalance_waves_tenant_wave
+    ON dpm_rebalance_waves (tenant_id, wave_id);
+
+CREATE INDEX IF NOT EXISTS idx_dpm_rebalance_waves_tenant_created
+    ON dpm_rebalance_waves (tenant_id, created_at DESC, wave_id DESC);
+
+-- Fencing the reads is not enough while a key stays global. `correlation_id`
+-- arrives on the caller's own X-Correlation-Id header and was unique across
+-- every tenant, so a value one tenant had already used made another tenant's
+-- legitimate create fail with a unique violation: a denial caused by data that
+-- caller cannot see, and an existence oracle for a value it chose itself. The
+-- uniqueness that was intended is per tenant. Migration 0026 made the same
+-- correction for the caller-chosen idempotency key; this is the second and last
+-- caller-supplied wave key that was still global.
+DROP INDEX IF EXISTS idx_dpm_rebalance_waves_correlation;
+
+-- Waves persisted before the fence carry tenant_id NULL, and PostgreSQL treats
+-- NULLs as distinct in a unique index, so those rows are no longer constrained
+-- against each other. They already satisfied the stricter global index and
+-- save_wave stamps the tenant, so no new row can be written without one.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_dpm_rebalance_waves_tenant_correlation
+    ON dpm_rebalance_waves (tenant_id, correlation_id);

--- a/src/infrastructure/waves/in_memory.py
+++ b/src/infrastructure/waves/in_memory.py
@@ -50,12 +50,20 @@ class InMemoryDpmWaveRepository(DpmWaveRepository):
                 wave_id=wave.wave_id,
                 request_hash=request_hash,
             )
-            _store_wave(waves=self._waves, wave=wave)
+            # Stamped from the argument, so a caller cannot persist a wave
+            # claiming one tenant while the record says another.
+            _store_wave(waves=self._waves, wave=wave.model_copy(update={"tenant_id": tenant_id}))
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
         with self._lock:
             wave = self._waves.get(wave_id)
-            return deepcopy(wave) if wave is not None else None
+            # None rather than a distinguishable refusal: telling a caller that
+            # the id exists but is someone else's is itself cross-tenant
+            # information (issue #677). A wave with no tenant - persisted before
+            # the fence - matches no caller and is quarantined, not public.
+            if wave is None or wave.tenant_id != tenant_id:
+                return None
+            return deepcopy(wave)
 
     def get_wave_by_idempotency(
         self, *, idempotency_key: str, tenant_id: str
@@ -79,6 +87,7 @@ class InMemoryDpmWaveRepository(DpmWaveRepository):
     def list_waves(
         self,
         *,
+        tenant_id: str,
         state: str | None = None,
         trigger_type: str | None = None,
         as_of_date: str | None = None,
@@ -86,20 +95,33 @@ class InMemoryDpmWaveRepository(DpmWaveRepository):
         offset: int = 0,
     ) -> list[DpmRebalanceWave]:
         with self._lock:
+            # Tenant applied BEFORE paging, not after: filtering a page would
+            # let another tenant's waves consume the limit and silently shorten
+            # this caller's results (issue #677).
+            owned = [wave for wave in self._waves.values() if wave.tenant_id == tenant_id]
             waves = _filtered_waves(
-                waves=self._waves.values(),
+                waves=owned,
                 state=state,
                 trigger_type=trigger_type,
                 as_of_date=as_of_date,
             )
             return _copied_wave_page(waves=waves, limit=limit, offset=offset)
 
-    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int, tenant_id: str) -> None:
         with self._lock:
             current = self._waves.get(wave.wave_id)
-            if current is None or current.version != expected_version:
+            # The tenant is part of the same guarded comparison as the version,
+            # so there is no window between checking ownership and writing. A
+            # foreign wave raises the SAME error as a stale version, on purpose:
+            # a distinct error would let a caller probe for wave ids it does not
+            # own (issue #677).
+            if (
+                current is None
+                or current.version != expected_version
+                or current.tenant_id != tenant_id
+            ):
                 raise DpmWaveVersionConflictError("DPM_WAVE_VERSION_CONFLICT")
-            self._waves[wave.wave_id] = deepcopy(wave)
+            self._waves[wave.wave_id] = deepcopy(wave.model_copy(update={"tenant_id": tenant_id}))
 
 
 def _raise_if_idempotency_conflict(

--- a/src/infrastructure/waves/postgres.py
+++ b/src/infrastructure/waves/postgres.py
@@ -50,7 +50,11 @@ class PostgresDpmWaveRepository:
                 idempotency_key=mapping_key,
                 request_hash=request_hash,
             )
-            _insert_wave_row(connection=connection, wave=wave)
+            # Stamped from the argument so the stored record cannot
+            # disagree with the tenant the caller claimed.
+            _insert_wave_row(
+                connection=connection, wave=wave.model_copy(update={"tenant_id": tenant_id})
+            )
             _insert_idempotency_marker(
                 connection=connection,
                 wave=wave,
@@ -61,15 +65,16 @@ class PostgresDpmWaveRepository:
             _insert_new_events(connection=connection, wave=wave)
             connection.commit()
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
         with closing(self._connect()) as connection:
             row = connection.execute(
                 """
                 SELECT wave_json
                 FROM dpm_rebalance_waves
                 WHERE wave_id = %s
+                  AND tenant_id = %s
                 """,
-                (wave_id,),
+                (wave_id, tenant_id),
             ).fetchone()
         if row is None:
             return None
@@ -101,14 +106,17 @@ class PostgresDpmWaveRepository:
     def list_waves(
         self,
         *,
+        tenant_id: str,
         state: str | None = None,
         trigger_type: str | None = None,
         as_of_date: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[DpmRebalanceWave]:
-        clauses: list[str] = []
-        args: list[Any] = []
+        # Seeded rather than appended conditionally: the tenant predicate is not
+        # one of the optional filters and must never be absent (issue #677).
+        clauses: list[str] = ["tenant_id = %s"]
+        args: list[Any] = [tenant_id]
         if state is not None:
             clauses.append("state = %s")
             args.append(state)
@@ -118,7 +126,7 @@ class PostgresDpmWaveRepository:
         if as_of_date is not None:
             clauses.append("as_of_date = %s")
             args.append(as_of_date)
-        where_clause = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        where_clause = f"WHERE {' AND '.join(clauses)}"
         args.extend([limit, offset])
         with closing(self._connect()) as connection:
             rows = connection.execute(
@@ -133,7 +141,13 @@ class PostgresDpmWaveRepository:
             ).fetchall()
         return [load_model_json(DpmRebalanceWave, _payload(row)) for row in rows]
 
-    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int, tenant_id: str) -> None:
+        # The tenant rides in the UPDATE predicate rather than a prior SELECT:
+        # a check-then-write leaves a window, and this is the write half of the
+        # transition path. A foreign wave matches no row and raises the same
+        # version-conflict error as a stale version - indistinguishable on
+        # purpose, so a caller cannot probe for wave ids it does not own.
+        stamped = wave.model_copy(update={"tenant_id": tenant_id})
         with closing(self._connect()) as connection:
             result = connection.execute(
                 """
@@ -144,19 +158,21 @@ class PostgresDpmWaveRepository:
                     retention_policy = %s
                 WHERE wave_id = %s
                 AND version = %s
+                AND tenant_id = %s
                 """,
                 (
-                    wave.state,
-                    wave.version,
-                    dump_model_json(wave),
-                    wave.retention_policy,
-                    wave.wave_id,
+                    stamped.state,
+                    stamped.version,
+                    dump_model_json(stamped),
+                    stamped.retention_policy,
+                    stamped.wave_id,
                     expected_version,
+                    tenant_id,
                 ),
             )
             if result.rowcount != 1:
                 raise DpmWaveVersionConflictError("DPM_WAVE_VERSION_CONFLICT")
-            _insert_new_events(connection=connection, wave=wave)
+            _insert_new_events(connection=connection, wave=stamped)
             connection.commit()
 
     def _connect(self) -> Any:
@@ -185,6 +201,9 @@ def _wave_row_args(wave: DpmRebalanceWave) -> tuple[Any, ...]:
         wave.version,
         dump_model_json(wave),
         wave.retention_policy,
+        # Persisted as its own column, not only inside wave_json, so the fence
+        # is an indexable predicate rather than a JSON extraction (issue #677).
+        wave.tenant_id,
     )
 
 
@@ -224,8 +243,9 @@ def _insert_wave_row(*, connection: Any, wave: DpmRebalanceWave) -> None:
             correlation_id,
             version,
             wave_json,
-            retention_policy
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            retention_policy,
+            tenant_id
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (wave_id) DO NOTHING
         """,
         _wave_row_args(wave),

--- a/tests/integration/dpm/waves/test_wave_aggregate_tenant_isolation_postgres.py
+++ b/tests/integration/dpm/waves/test_wave_aggregate_tenant_isolation_postgres.py
@@ -1,0 +1,290 @@
+"""Wave-aggregate tenant isolation, proven against PostgreSQL (#677).
+
+The in-memory proofs in `tests/unit/dpm/waves/test_wave_tenant_fence.py` decide
+the same questions in Python. Four properties here are not Python's to decide,
+and the in-memory store can be made to agree with either answer:
+
+1. the fence lives in a SQL predicate, so it either reached the WHERE clause or
+   it did not,
+2. `list_waves` filters before LIMIT/OFFSET - the engine applies them in the
+   order the query states, and filtering a page instead of the set is a bug
+   that presents as a short result rather than a leak,
+3. a row whose `tenant_id` is NULL is matched by no equality predicate, because
+   `NULL = 'anything'` is NULL rather than false. Python's `None != tenant`
+   answers this by a completely different rule, so the quarantine claim is only
+   really proven here,
+4. `correlation_id` uniqueness is per tenant, which is a property of an index.
+
+Requires a real engine. Set DPM_POSTGRES_INTEGRATION_DSN to a disposable
+database, as the wave idempotency isolation proof does.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from src.core.waves import (
+    DpmRebalanceWave,
+    DpmRebalanceWaveItem,
+    DpmWaveAggregateMetrics,
+    DpmWaveTrigger,
+    DpmWaveVersionConflictError,
+)
+from src.infrastructure.waves.postgres import PostgresDpmWaveRepository
+
+_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
+
+pytestmark = pytest.mark.skipif(
+    not _DSN,
+    reason="DPM_POSTGRES_INTEGRATION_DSN is required for the wave aggregate isolation proof",
+)
+
+
+@pytest.fixture
+def repository() -> PostgresDpmWaveRepository:
+    return PostgresDpmWaveRepository(dsn=_DSN)
+
+
+@pytest.fixture
+def tenants() -> tuple[str, str]:
+    """A fresh pair of tenants per test, against a database that is not reset.
+
+    Fixed tenant names made every run read the rows of every run before it, so
+    a listing assertion depended on residue and the same suite gave different
+    answers twice in a row. Isolating by tenant rather than by cleanup also
+    keeps the teardown honest: a test that deleted rows by tenant would be
+    exercising the very predicate under test.
+    """
+
+    run = uuid.uuid4().hex[:12]
+    return f"tenant-alpha-{run}", f"tenant-beta-{run}"
+
+
+def _wave(
+    *,
+    wave_id: str,
+    portfolio_id: str = "PB_SG_GLOBAL_BAL_001",
+    correlation_id: str | None = None,
+) -> DpmRebalanceWave:
+    return DpmRebalanceWave(
+        wave_id=wave_id,
+        state="CREATED",
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="wave-aggregate-isolation",
+            rationale="Prove the wave aggregate is fenced in SQL.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm-ops",
+        correlation_id=correlation_id or f"corr-{wave_id}",
+        items=[
+            DpmRebalanceWaveItem(
+                wave_item_id=f"dwi_{uuid.uuid4().hex[:8]}",
+                portfolio_id=portfolio_id,
+                state="CANDIDATE",
+            )
+        ],
+        aggregate_metrics=DpmWaveAggregateMetrics(
+            item_count=1,
+            state_counts={"CANDIDATE": 1},
+            ready_item_count=0,
+            blocked_item_count=0,
+            review_required_item_count=0,
+            source_degraded_item_count=0,
+        ),
+    )
+
+
+def _new_wave_id() -> str:
+    return f"dwv_{uuid.uuid4().hex[:12]}"
+
+
+def test_a_wave_is_readable_only_by_the_tenant_that_created_it(
+    repository: PostgresDpmWaveRepository,
+    tenants: tuple[str, str],
+) -> None:
+    tenant_a, tenant_b = tenants
+
+    wave_id = _new_wave_id()
+    repository.save_wave(
+        wave=_wave(wave_id=wave_id, portfolio_id="PB_TENANT_A_001"),
+        idempotency_key=None,
+        request_hash=None,
+        tenant_id=tenant_a,
+    )
+
+    owned = repository.get_wave(wave_id=wave_id, tenant_id=tenant_a)
+
+    assert owned is not None
+    assert owned.items[0].portfolio_id == "PB_TENANT_A_001"
+    # The wave_id is the table's PRIMARY KEY, so this row is trivially
+    # addressable. Only the tenant predicate keeps the other caller out.
+    assert repository.get_wave(wave_id=wave_id, tenant_id=tenant_b) is None
+
+
+def test_the_tenant_filter_is_applied_before_limit_and_offset(
+    repository: PostgresDpmWaveRepository,
+    tenants: tuple[str, str],
+) -> None:
+    """Paging first would silently return fewer of the caller's own waves.
+
+    That is a correctness bug rather than a leak, so a test that only looked
+    for another tenant's data in the result would pass while it happened.
+    """
+
+    tenant_a, tenant_b = tenants
+
+    # A fixed date: the tenant fixture already isolates this test, and a
+    # random one would only hide a residue problem it no longer has.
+    as_of_date = "2026-05-03"
+    for _ in range(3):
+        repository.save_wave(
+            wave=_wave(wave_id=_new_wave_id()).model_copy(update={"as_of_date": as_of_date}),
+            idempotency_key=None,
+            request_hash=None,
+            tenant_id=tenant_b,
+        )
+    owned_id = _new_wave_id()
+    repository.save_wave(
+        wave=_wave(wave_id=owned_id).model_copy(update={"as_of_date": as_of_date}),
+        idempotency_key=None,
+        request_hash=None,
+        tenant_id=tenant_a,
+    )
+
+    page = repository.list_waves(tenant_id=tenant_a, as_of_date=as_of_date, limit=2, offset=0)
+
+    assert [wave.wave_id for wave in page] == [owned_id]
+
+
+def test_another_tenant_cannot_write_a_wave_it_can_name(
+    repository: PostgresDpmWaveRepository,
+    tenants: tuple[str, str],
+) -> None:
+    """The tenant travels into the UPDATE predicate, not a check before it.
+
+    A caller holding the record - from an export, a log, a prior grant - still
+    changes no row, and cannot distinguish that refusal from a stale version.
+    """
+
+    tenant_a, tenant_b = tenants
+
+    wave_id = _new_wave_id()
+    original = _wave(wave_id=wave_id)
+    repository.save_wave(wave=original, idempotency_key=None, request_hash=None, tenant_id=tenant_a)
+    stored = repository.get_wave(wave_id=wave_id, tenant_id=tenant_a)
+    assert stored is not None
+
+    tampered = stored.model_copy(update={"state": "CANCELLED", "version": stored.version + 1})
+    with pytest.raises(DpmWaveVersionConflictError):
+        repository.update_wave(wave=tampered, expected_version=stored.version, tenant_id=tenant_b)
+
+    survivor = repository.get_wave(wave_id=wave_id, tenant_id=tenant_a)
+    assert survivor is not None
+    assert survivor.state == "CREATED"
+    assert survivor.version == stored.version
+
+
+def test_a_wave_persisted_before_the_fence_is_matched_by_no_tenant(
+    repository: PostgresDpmWaveRepository,
+    tenants: tuple[str, str],
+) -> None:
+    """The quarantine claim, decided by SQL's NULL rules rather than Python's.
+
+    `tenant_id = 'anything'` against a NULL evaluates to NULL, which WHERE
+    treats as not-matched - so the row is reachable from no tenant at all,
+    including one named `default`, which is the value a backfill would most
+    plausibly choose. Migration 0027 adds the column nullable and backfills
+    nothing precisely so these rows stay unattributed until a human attributes
+    them.
+    """
+
+    tenant_a, tenant_b = tenants
+
+    wave_id = _new_wave_id()
+    repository.save_wave(
+        wave=_wave(wave_id=wave_id), idempotency_key=None, request_hash=None, tenant_id=tenant_a
+    )
+    with repository._connect() as connection:  # noqa: SLF001
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE dpm_rebalance_waves SET tenant_id = NULL WHERE wave_id = %s",
+                (wave_id,),
+            )
+        connection.commit()
+
+    for tenant in (tenant_a, tenant_b, "default", ""):
+        assert repository.get_wave(wave_id=wave_id, tenant_id=tenant) is None, tenant
+        listed = repository.list_waves(tenant_id=tenant, limit=100, offset=0)
+        assert all(wave.wave_id != wave_id for wave in listed), tenant
+
+
+def test_two_tenants_may_choose_the_same_correlation_id(
+    repository: PostgresDpmWaveRepository,
+    tenants: tuple[str, str],
+) -> None:
+    """correlation_id arrives on the caller's own header.
+
+    While its unique index was global, a value one tenant had already used made
+    another tenant's create fail - a denial caused by data that caller cannot
+    see, and an existence oracle for a value it chose itself. Before migration
+    0027 scoped that index, the second save here raised a unique violation.
+    """
+
+    tenant_a, tenant_b = tenants
+
+    shared_correlation_id = f"corr-shared-{uuid.uuid4().hex[:10]}"
+    wave_a = _wave(
+        wave_id=_new_wave_id(),
+        portfolio_id="PB_TENANT_A_001",
+        correlation_id=shared_correlation_id,
+    )
+    wave_b = _wave(
+        wave_id=_new_wave_id(),
+        portfolio_id="PB_TENANT_B_001",
+        correlation_id=shared_correlation_id,
+    )
+
+    repository.save_wave(wave=wave_a, idempotency_key=None, request_hash=None, tenant_id=tenant_a)
+    repository.save_wave(wave=wave_b, idempotency_key=None, request_hash=None, tenant_id=tenant_b)
+
+    stored_a = repository.get_wave(wave_id=wave_a.wave_id, tenant_id=tenant_a)
+    stored_b = repository.get_wave(wave_id=wave_b.wave_id, tenant_id=tenant_b)
+    assert stored_a is not None and stored_a.items[0].portfolio_id == "PB_TENANT_A_001"
+    assert stored_b is not None and stored_b.items[0].portfolio_id == "PB_TENANT_B_001"
+
+
+def test_one_tenant_still_cannot_reuse_its_own_correlation_id(
+    repository: PostgresDpmWaveRepository,
+    tenants: tuple[str, str],
+) -> None:
+    """Scoping the index must not have dropped the guarantee it carried.
+
+    Without this, deleting the unique index entirely would pass every other
+    test in this file.
+    """
+
+    tenant_a, tenant_b = tenants
+
+    correlation_id = f"corr-reused-{uuid.uuid4().hex[:10]}"
+    repository.save_wave(
+        wave=_wave(wave_id=_new_wave_id(), correlation_id=correlation_id),
+        idempotency_key=None,
+        request_hash=None,
+        tenant_id=tenant_a,
+    )
+
+    with pytest.raises(Exception) as duplicate:
+        repository.save_wave(
+            wave=_wave(wave_id=_new_wave_id(), correlation_id=correlation_id),
+            idempotency_key=None,
+            request_hash=None,
+            tenant_id=tenant_a,
+        )
+
+    assert "idx_dpm_rebalance_waves_tenant_correlation" in str(duplicate.value)

--- a/tests/support/postgres_migration_sql.py
+++ b/tests/support/postgres_migration_sql.py
@@ -1,0 +1,38 @@
+"""Which statements a fake psycopg connection should acknowledge, not model.
+
+Three fake connections carried their own copy of this keyword list, so
+migration 0027 - which drops one index and creates another - broke two of them
+and left the third latently broken. Adding a keyword in three places is the
+kind of duplication that gets fixed twice and forgotten once.
+
+The fakes exist to model DML for one table each. Schema statements from
+`apply_postgres_migrations` are not theirs to model, and are proven against a
+real engine in the PostgreSQL lanes; acknowledging them here keeps the fake
+loud about DML it genuinely does not handle.
+"""
+
+from __future__ import annotations
+
+# The migration runner splits each file on `;`, so a statement is matched on
+# its own rather than inheriting a keyword from earlier in its file - an index
+# statement needs its own entry even when its migration also creates a table.
+# `CREATE UNIQUE INDEX` does not contain the substring `CREATE INDEX`, and
+# `DROP INDEX` shares no keyword with any of the others.
+MIGRATION_DDL_KEYWORDS = (
+    "CREATE TABLE",
+    "ALTER TABLE",
+    "CREATE INDEX",
+    "CREATE UNIQUE INDEX",
+    "DROP INDEX",
+    "schema_migrations",
+)
+
+
+def is_migration_ddl(sql: str) -> bool:
+    """True when this statement is schema work a table fake should let pass.
+
+    Migration files open with a comment block, so a startswith check on the
+    keyword never matches - the keyword is looked for anywhere in the text.
+    """
+
+    return any(keyword in sql for keyword in MIGRATION_DDL_KEYWORDS)

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -163,7 +163,7 @@ def _repositories() -> tuple[
         retention_expires_at=None,
     )
     wave_repository.save_wave(
-        wave=_wave(), idempotency_key=None, request_hash=None, tenant_id="tenant-test"
+        wave=_wave(), idempotency_key=None, request_hash=None, tenant_id=TENANT_ID
     )
     outcome_repository.save_outcome_review(review=_review(), retention_expires_at=None)
     mandate_repository.save_mandate_snapshot(_mandate_twin(), tenant_id=TENANT_ID)
@@ -2005,6 +2005,7 @@ def test_portfolio_memory_search_counts_artifact_only_source_systems_and_types()
         event_type="PROOF_PACK_CREATED",
         source_system="lotus-report",
         source_type="REPORT_INPUT",
+        tenant_id=TENANT_ID,
     )
 
     assert page.returned_count == 1

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -888,7 +888,7 @@ def _save_supportability_wave(
         ),
         idempotency_key=None,
         request_hash=None,
-        tenant_id="tenant-test",
+        tenant_id="tenant-sg",
     )
 
 
@@ -905,7 +905,7 @@ class _SaveConflictWaveRepository(InMemoryDpmWaveRepository):
 
 
 class _VersionConflictWaveRepository(InMemoryDpmWaveRepository):
-    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int, tenant_id: str) -> None:
         raise DpmWaveVersionConflictError("stale durable wave version")
 
 
@@ -968,9 +968,7 @@ def _save_wave_for_service(
             source_degraded_item_count=1 if item.state == "SOURCE_DEGRADED" else 0,
         ),
     )
-    repository.save_wave(
-        wave=wave, idempotency_key=None, request_hash=None, tenant_id="tenant-test"
-    )
+    repository.save_wave(wave=wave, idempotency_key=None, request_hash=None, tenant_id="tenant-sg")
     return wave
 
 
@@ -1004,7 +1002,9 @@ def test_wave_preview_returns_source_backed_and_blocked_items_without_persistenc
     }
     assert payload["wave"]["items"][0]["mandate_id"] == MANDATE_ID
     assert payload["wave"]["items"][1]["reason_codes"] == ["MISSING_AFFECTED_PORTFOLIO_SOURCE"]
-    assert wave_repository.get_wave(wave_id=payload["wave"]["wave_id"]) is None
+    assert (
+        wave_repository.get_wave(wave_id=payload["wave"]["wave_id"], tenant_id="tenant-sg") is None
+    )
 
 
 def test_wave_create_persists_and_replays_by_idempotency_key() -> None:
@@ -1033,7 +1033,10 @@ def test_wave_create_persists_and_replays_by_idempotency_key() -> None:
     assert first_payload["idempotent_replay"] is False
     assert second_payload["idempotent_replay"] is True
     assert second_payload["wave"]["wave_id"] == first_payload["wave"]["wave_id"]
-    assert wave_repository.get_wave(wave_id=first_payload["wave"]["wave_id"]) is not None
+    assert (
+        wave_repository.get_wave(wave_id=first_payload["wave"]["wave_id"], tenant_id="tenant-sg")
+        is not None
+    )
 
 
 def test_pm_book_wave_preview_resolves_source_owned_cohort(monkeypatch) -> None:
@@ -1096,7 +1099,10 @@ def test_pm_book_wave_create_persists_resolved_source_owned_cohort(monkeypatch) 
     assert payload["durable"] is True
     assert payload["wave"]["trigger"]["trigger_type"] == "PM_BOOK_REVIEW"
     assert payload["wave"]["aggregate_metrics"]["state_counts"] == {"CANDIDATE": 1}
-    assert wave_repository.get_wave(wave_id=payload["wave"]["wave_id"]) is not None
+    assert (
+        wave_repository.get_wave(wave_id=payload["wave"]["wave_id"], tenant_id="tenant-sg")
+        is not None
+    )
 
 
 @pytest.mark.parametrize(
@@ -1248,7 +1254,10 @@ def test_cio_model_change_wave_create_persists_resolved_source_owned_cohort(monk
     assert payload["durable"] is True
     assert payload["wave"]["trigger"]["trigger_type"] == "CIO_MODEL_CHANGE"
     assert payload["wave"]["aggregate_metrics"]["state_counts"] == {"CANDIDATE": 1}
-    assert wave_repository.get_wave(wave_id=payload["wave"]["wave_id"]) is not None
+    assert (
+        wave_repository.get_wave(wave_id=payload["wave"]["wave_id"], tenant_id="tenant-sg")
+        is not None
+    )
 
 
 @pytest.mark.parametrize(
@@ -1416,7 +1425,10 @@ def test_risk_event_wave_create_persists_resolved_source_owned_cohort() -> None:
     assert payload["durable"] is True
     assert payload["wave"]["trigger"]["trigger_type"] == "RISK_EVENT"
     assert payload["wave"]["aggregate_metrics"]["state_counts"] == {"CANDIDATE": 1}
-    assert wave_repository.get_wave(wave_id=payload["wave"]["wave_id"]) is not None
+    assert (
+        wave_repository.get_wave(wave_id=payload["wave"]["wave_id"], tenant_id="tenant-sg")
+        is not None
+    )
 
 
 def test_tactical_house_view_wave_preview_resolves_advise_owned_cohort() -> None:
@@ -1524,7 +1536,10 @@ def test_tactical_house_view_wave_create_persists_resolved_advise_owned_cohort()
     assert payload["durable"] is True
     assert payload["wave"]["trigger"]["trigger_type"] == "TACTICAL_HOUSE_VIEW"
     assert payload["wave"]["aggregate_metrics"]["state_counts"] == {"CANDIDATE": 1}
-    assert wave_repository.get_wave(wave_id=payload["wave"]["wave_id"]) is not None
+    assert (
+        wave_repository.get_wave(wave_id=payload["wave"]["wave_id"], tenant_id="tenant-sg")
+        is not None
+    )
 
 
 @pytest.mark.parametrize(
@@ -2008,7 +2023,9 @@ def test_bulk_review_campaign_create_persists_core_portfolio_universe_candidates
     assert payload["durable"] is True
     assert payload["wave"]["trigger"]["trigger_type"] == "BULK_REVIEW_CAMPAIGN"
     assert payload["wave"]["aggregate_metrics"]["state_counts"] == {"CANDIDATE": 1}
-    persisted_wave = wave_repository.get_wave(wave_id=payload["wave"]["wave_id"])
+    persisted_wave = wave_repository.get_wave(
+        wave_id=payload["wave"]["wave_id"], tenant_id="tenant-sg"
+    )
     assert persisted_wave is not None
     page_ref = next(
         ref
@@ -2651,7 +2668,7 @@ def test_bulk_review_campaign_definition_launch_creates_durable_wave_and_replays
         "BulkReviewCampaignMembership",
         "BulkReviewCampaignGovernance",
     }
-    assert wave_repository.get_wave(wave_id=wave["wave_id"]) is not None
+    assert wave_repository.get_wave(wave_id=wave["wave_id"], tenant_id="tenant-sg") is not None
     assert fetched.status_code == 200
     assert len(fetched.json()["launch_history"]) == 1
     assert fetched.json()["launch_history"][0]["wave_id"] == wave["wave_id"]
@@ -2706,7 +2723,7 @@ def test_bulk_review_campaign_definition_launch_retry_repairs_missing_audit() ->
         }
         failed = client.post(f"{route}/launch", json=launch_request)
         persisted_waves_after_failure = wave_repository.list_waves(
-            trigger_type="BULK_REVIEW_CAMPAIGN"
+            trigger_type="BULK_REVIEW_CAMPAIGN", tenant_id="tenant-sg"
         )
         missing_audit = client.get(f"{route}/launch-history")
         repaired = client.post(f"{route}/launch", json=launch_request)
@@ -2728,7 +2745,10 @@ def test_bulk_review_campaign_definition_launch_retry_repairs_missing_audit() ->
     assert repaired.status_code == 201
     assert repaired.json()["idempotent_replay"] is True
     assert repaired.json()["wave"]["wave_id"] == durable_wave.wave_id
-    assert len(wave_repository.list_waves(trigger_type="BULK_REVIEW_CAMPAIGN")) == 1
+    assert (
+        len(wave_repository.list_waves(trigger_type="BULK_REVIEW_CAMPAIGN", tenant_id="tenant-sg"))
+        == 1
+    )
     assert replayed.status_code == 201
     assert replayed.json()["idempotent_replay"] is True
     assert replayed.json()["wave"]["wave_id"] == durable_wave.wave_id
@@ -2780,7 +2800,7 @@ def test_bulk_review_campaign_definition_launch_fails_closed_when_readiness_bloc
     assert "BULK_REVIEW_CAMPAIGN_EXPIRED" in blocked_payload["reasonCodes"]
     assert "BULK_REVIEW_CAMPAIGN_ACTOR_NOT_ENTITLED" in blocked_payload["reasonCodes"]
     assert blocked_payload["readiness"]["preview_create_allowed"] is False
-    assert wave_repository.list_waves() == []
+    assert wave_repository.list_waves(tenant_id="tenant-sg") == []
     assert missing.status_code == 404
     assert _error_reason_code(missing) == "BULK_REVIEW_CAMPAIGN_DEFINITION_NOT_FOUND"
 
@@ -4637,7 +4657,10 @@ def test_bulk_review_campaign_create_persists_manage_membership_wave() -> None:
     assert payload["durable"] is True
     assert payload["wave"]["trigger"]["trigger_type"] == "BULK_REVIEW_CAMPAIGN"
     assert payload["wave"]["aggregate_metrics"]["state_counts"] == {"CANDIDATE": 1}
-    assert wave_repository.get_wave(wave_id=payload["wave"]["wave_id"]) is not None
+    assert (
+        wave_repository.get_wave(wave_id=payload["wave"]["wave_id"], tenant_id="tenant-sg")
+        is not None
+    )
 
 
 @pytest.mark.parametrize(
@@ -5110,7 +5133,7 @@ def test_wave_source_check_reports_missing_and_invalid_state_errors() -> None:
             wave=DpmRebalanceWave.model_validate(draft.json()["wave"]),
             idempotency_key=None,
             request_hash=None,
-            tenant_id="tenant-test",
+            tenant_id="tenant-sg",
         )
         invalid = client.post(
             f"/api/v1/rebalance/waves/{draft.json()['wave']['wave_id']}/source-check",
@@ -5206,7 +5229,7 @@ def test_wave_simulate_selects_alternative_and_links_proof_pack_after_reload() -
     assert selected_item["state"] == "PROOF_PACK_READY"
     assert selected_item["selected_alternative_id"] == "alt_min_turnover"
     assert selected_item["proof_pack_id"].startswith("dpp_")
-    persisted = wave_repository.get_wave(wave_id=wave_id)
+    persisted = wave_repository.get_wave(wave_id=wave_id, tenant_id="tenant-sg")
     assert persisted is not None
     assert persisted.items[0].selected_alternative_id == "alt_min_turnover"
     assert persisted.items[0].proof_pack_id == selected_item["proof_pack_id"]
@@ -5854,7 +5877,7 @@ def test_wave_approval_staging_and_handoff_are_durable_and_idempotent() -> None:
     assert handoff_replay.json()["idempotent_replay"] is True
     assert handoff_replay.json()["wave"]["handoff_refs"] == handoff_payload["wave"]["handoff_refs"]
 
-    persisted = wave_repository.get_wave(wave_id=wave_id)
+    persisted = wave_repository.get_wave(wave_id=wave_id, tenant_id="tenant-sg")
     assert persisted is not None
     assert persisted.state == "HANDOFF_READY"
     assert len(persisted.handoff_refs) == 1
@@ -5955,7 +5978,7 @@ def test_wave_cancel_is_durable_idempotent_and_rejects_handoff_ready_waves() -> 
     assert payload["wave"]["items"][0]["diagnostics"]["external_execution_claimed"] is False
     assert payload["wave"]["events"][-1]["reason_code"] == "WAVE_CANCELLED"
     assert replay.json()["idempotent_replay"] is True
-    persisted = wave_repository.get_wave(wave_id=wave_id)
+    persisted = wave_repository.get_wave(wave_id=wave_id, tenant_id="tenant-sg")
     assert persisted is not None
     assert persisted.state == "CANCELLED"
     assert invalid.status_code == 422
@@ -6153,6 +6176,7 @@ def test_wave_services_translate_durable_write_conflicts_to_governed_errors() ->
             construction_repository=InMemoryConstructionRepository(),
             run_service=_run_service(),
             wave_repository=simulate_repository,
+            tenant_id="tenant-sg",
         )
     assert simulate_exc.value.code == "DPM_WAVE_VERSION_CONFLICT"
 
@@ -6210,6 +6234,7 @@ def test_wave_services_translate_durable_write_conflicts_to_governed_errors() ->
                 reason_code="CONFLICT_TEST",
                 comment="Conflict test comment.",
                 correlation_id="corr-conflict-command",
+                tenant_id="tenant-sg",
                 **extra_kwargs,
             )
         assert exc.value.code == "DPM_WAVE_VERSION_CONFLICT"
@@ -6237,14 +6262,15 @@ def test_wave_selection_translates_durable_write_conflict_to_governed_error() ->
         construction_repository=construction_repository,
         run_service=_run_service(),
         wave_repository=normal_repository,
+        tenant_id="tenant-sg",
     )
-    simulated = normal_repository.get_wave(wave_id=source_checked.wave_id)
+    simulated = normal_repository.get_wave(wave_id=source_checked.wave_id, tenant_id="tenant-sg")
     assert simulated is not None
     assert simulated.items[0].alternative_set_id is not None
 
     conflict_repository = _VersionConflictWaveRepository()
     conflict_repository.save_wave(
-        wave=simulated, idempotency_key=None, request_hash=None, tenant_id="tenant-test"
+        wave=simulated, idempotency_key=None, request_hash=None, tenant_id="tenant-sg"
     )
 
     with pytest.raises(wave_service.DpmWaveValidationError) as exc:
@@ -6309,6 +6335,7 @@ def test_wave_services_reject_no_eligible_approval_stage_and_handoff() -> None:
                 comment=None,
                 correlation_id=f"corr-{wave_id}",
                 wave_repository=repository,
+                tenant_id="tenant-sg",
             )
 
         assert exc.value.code == expected_code
@@ -6403,13 +6430,11 @@ def test_wave_supportability_filters_and_private_helper_edges() -> None:
         ],
     )
     blocked = wave_service.wave_supportability(
-        wave_id="dwv_filter_blocked",
-        wave_repository=repository,
+        wave_id="dwv_filter_blocked", wave_repository=repository, tenant_id="tenant-sg"
     )
 
     ready_search = wave_service.search_waves(
-        wave_repository=repository,
-        supportability_state="ready",
+        wave_repository=repository, supportability_state="ready", tenant_id="tenant-sg"
     )
 
     assert [item["wave_id"] for item in ready_search] == ["dwv_filter_ready"]
@@ -6556,12 +6581,10 @@ def test_wave_supportability_service_reports_ready_and_info_only_postures() -> N
     )
 
     ready = wave_service.wave_supportability(
-        wave_id="dwv_support_ready",
-        wave_repository=repository,
+        wave_id="dwv_support_ready", wave_repository=repository, tenant_id="tenant-sg"
     )
     info_only = wave_service.wave_supportability(
-        wave_id="dwv_support_info",
-        wave_repository=repository,
+        wave_id="dwv_support_info", wave_repository=repository, tenant_id="tenant-sg"
     )
 
     assert ready["supportability_state"] == "ready"
@@ -6628,12 +6651,10 @@ def test_wave_supportability_service_reports_degraded_and_blocked_actions() -> N
     )
 
     degraded = wave_service.wave_supportability(
-        wave_id="dwv_support_degraded",
-        wave_repository=repository,
+        wave_id="dwv_support_degraded", wave_repository=repository, tenant_id="tenant-sg"
     )
     blocked = wave_service.wave_supportability(
-        wave_id="dwv_support_blocked",
-        wave_repository=repository,
+        wave_id="dwv_support_blocked", wave_repository=repository, tenant_id="tenant-sg"
     )
 
     assert degraded["supportability_state"] == "degraded"
@@ -6740,7 +6761,7 @@ def test_wave_read_apis_return_durable_search_detail_items_and_proof_pack_postur
         ],
     )
     wave_repository.save_wave(
-        wave=wave, idempotency_key=None, request_hash=None, tenant_id="tenant-test"
+        wave=wave, idempotency_key=None, request_hash=None, tenant_id="tenant-sg"
     )
 
     with _client(mandate_repository, wave_repository) as client:
@@ -6976,7 +6997,7 @@ def test_bulk_review_campaign_wave_report_input_carries_universe_boundary() -> N
         ],
     )
     wave_repository.save_wave(
-        wave=wave, idempotency_key=None, request_hash=None, tenant_id="tenant-test"
+        wave=wave, idempotency_key=None, request_hash=None, tenant_id="tenant-sg"
     )
 
     with _client(InMemoryDpmMandateRepository(), wave_repository) as client:
@@ -7057,7 +7078,7 @@ def test_wave_report_input_rejects_external_execution_claims() -> None:
         ],
     )
     wave_repository.save_wave(
-        wave=wave, idempotency_key=None, request_hash=None, tenant_id="tenant-test"
+        wave=wave, idempotency_key=None, request_hash=None, tenant_id="tenant-sg"
     )
 
     with _client(InMemoryDpmMandateRepository(), wave_repository) as client:

--- a/tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py
+++ b/tests/unit/dpm/portfolio_memory/test_candidate_portfolios.py
@@ -62,6 +62,7 @@ def test_candidate_portfolio_ids_support_optional_repositories() -> None:
         pm_quality_score_run_repository=None,
         portfolio_ids=None,
         source_scan_limit=100,
+        tenant_id="tenant-sg",
     )
 
     assert candidates == [PORTFOLIO_ID]
@@ -78,6 +79,7 @@ def test_candidate_portfolio_ids_default_optional_repositories_to_empty_sources(
         outcome_review_repository=outcome_repository,
         portfolio_ids=None,
         source_scan_limit=100,
+        tenant_id="tenant-sg",
     )
 
     assert candidates == [PORTFOLIO_ID]

--- a/tests/unit/dpm/portfolio_memory/test_service.py
+++ b/tests/unit/dpm/portfolio_memory/test_service.py
@@ -72,6 +72,7 @@ class _CountingWaveRepository(InMemoryDpmWaveRepository):
         as_of_date: str | None = None,
         limit: int = 50,
         offset: int = 0,
+        tenant_id: str,
     ) -> list[DpmRebalanceWave]:
         self.list_calls += 1
         return super().list_waves(
@@ -80,6 +81,7 @@ class _CountingWaveRepository(InMemoryDpmWaveRepository):
             as_of_date=as_of_date,
             limit=limit,
             offset=offset,
+            tenant_id=tenant_id,
         )
 
 
@@ -321,6 +323,7 @@ def test_search_portfolio_memory_from_sources_supplements_explicit_portfolio_sou
         portfolio_ids=[PORTFOLIO_ID],
         source_scan_limit=2,
         generated_at=datetime(2026, 5, 31, 11, 0, tzinfo=timezone.utc),
+        tenant_id="tenant-test",
     )
 
     explicit_item = next(item for item in page.items if item.portfolio_id == PORTFOLIO_ID)

--- a/tests/unit/dpm/portfolio_memory/test_source_collection.py
+++ b/tests/unit/dpm/portfolio_memory/test_source_collection.py
@@ -30,6 +30,7 @@ def test_collect_portfolio_memory_events_collects_required_source_families() -> 
             outcome_review_repository=outcome_repository,
         ),
         limit=100,
+        tenant_id="tenant-sg",
     )
 
     event_types = {event.event_type for event in events}
@@ -82,6 +83,7 @@ def test_collect_portfolio_memory_events_skips_optional_empty_repositories() -> 
             construction_repository=InMemoryConstructionRepository(),
         ),
         limit=100,
+        tenant_id="tenant-sg",
     )
 
     assert "CONSTRUCTION_ALTERNATIVE_SET" not in {event.event_type for event in events}
@@ -104,4 +106,5 @@ def test_collect_portfolio_memory_events_rejects_unsafe_source_scan_limits(
                 outcome_review_repository=outcome_repository,
             ),
             limit=limit,
+            tenant_id="tenant-sg",
         )

--- a/tests/unit/dpm/portfolio_memory/test_wave_collection.py
+++ b/tests/unit/dpm/portfolio_memory/test_wave_collection.py
@@ -10,9 +10,7 @@ def test_wave_memory_events_projects_matching_wave_events() -> None:
     )
 
     events = wave_memory_events(
-        portfolio_id=PORTFOLIO_ID,
-        wave_repository=repository,
-        limit=100,
+        portfolio_id=PORTFOLIO_ID, wave_repository=repository, limit=100, tenant_id="tenant-test"
     )
 
     assert [event.event_type for event in events] == [
@@ -42,9 +40,7 @@ def test_wave_memory_events_skips_waves_without_matching_portfolio_items() -> No
     )
 
     events = wave_memory_events(
-        portfolio_id=PORTFOLIO_ID,
-        wave_repository=repository,
-        limit=100,
+        portfolio_id=PORTFOLIO_ID, wave_repository=repository, limit=100, tenant_id="tenant-test"
     )
 
     assert events == []

--- a/tests/unit/dpm/supportability/test_dpm_policy_pack_postgres_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_policy_pack_postgres_repository.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import src.infrastructure.dpm_policy_packs.postgres as postgres_module
 from src.core.rebalance.policy_packs import DpmPolicyPackDefinition
 from src.infrastructure.dpm_policy_packs.postgres import PostgresDpmPolicyPackRepository
+from tests.support.postgres_migration_sql import is_migration_ddl
 
 
 class _FakeCursor:
@@ -83,13 +84,7 @@ class _FakeConnection:
             # Migration 0025 fences monitoring exceptions by tenant
             # (issue #648); this fake models a different table.
             return _FakeCursor()
-        # Schema statements from apply_postgres_migrations. Migration files
-        # open with a comment block, so a startswith check on the keyword
-        # never matches - look for the statement keyword anywhere.
-        if any(
-            keyword in sql
-            for keyword in ("CREATE TABLE", "ALTER TABLE", "CREATE INDEX", "schema_migrations")
-        ):
+        if is_migration_ddl(sql):
             return _FakeCursor()
         raise AssertionError(f"Unhandled SQL: {sql}")
 

--- a/tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py
+++ b/tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py
@@ -16,6 +16,8 @@ from src.infrastructure.rebalance_runs.postgres import (
     _json_dump,
 )
 
+from tests.support.postgres_migration_sql import is_migration_ddl
+
 
 class _FakeCursor:
     def __init__(self, row=None, rows=None, rowcount=0):
@@ -443,13 +445,7 @@ class _FakeConnection:
             # table, so the statement is acknowledged here and proven
             # for real in the mandate integration lane.
             return _FakeCursor()
-        # Schema statements from apply_postgres_migrations. Migration files
-        # open with a comment block, so a startswith check on the keyword
-        # never matches - look for the statement keyword anywhere.
-        if any(
-            keyword in sql
-            for keyword in ("CREATE TABLE", "ALTER TABLE", "CREATE INDEX", "schema_migrations")
-        ):
+        if is_migration_ddl(sql):
             return _FakeCursor()
         raise AssertionError(f"Unexpected SQL: {sql}")
 

--- a/tests/unit/dpm/waves/test_wave_domain.py
+++ b/tests/unit/dpm/waves/test_wave_domain.py
@@ -21,6 +21,7 @@ from src.core.waves import (
 from src.infrastructure.waves import InMemoryDpmWaveRepository
 from src.infrastructure.waves import in_memory as in_memory_module
 from src.infrastructure.waves.postgres import PostgresDpmWaveRepository
+from tests.support.postgres_migration_sql import is_migration_ddl
 
 
 ROOT = Path(__file__).resolve().parents[4]
@@ -131,11 +132,11 @@ def test_in_memory_wave_repository_is_defensive_and_version_guarded() -> None:
         wave=wave, idempotency_key="idem-1", request_hash="hash-1", tenant_id="tenant-test"
     )
 
-    loaded = repository.get_wave(wave_id=wave.wave_id)
+    loaded = repository.get_wave(wave_id=wave.wave_id, tenant_id="tenant-test")
     assert loaded is not None
     loaded.items[0].state = "SOURCE_BLOCKED"
 
-    reloaded = repository.get_wave(wave_id=wave.wave_id)
+    reloaded = repository.get_wave(wave_id=wave.wave_id, tenant_id="tenant-test")
     assert reloaded is not None
     assert reloaded.items[0].state == "CANDIDATE"
 
@@ -144,11 +145,11 @@ def test_in_memory_wave_repository_is_defensive_and_version_guarded() -> None:
         to_state="PREVIEWED",
         event=_event("DRAFT", "PREVIEWED"),
     )
-    repository.update_wave(wave=updated, expected_version=1)
-    assert repository.get_wave(wave_id=wave.wave_id).version == 2  # type: ignore[union-attr]
+    repository.update_wave(wave=updated, expected_version=1, tenant_id="tenant-test")
+    assert repository.get_wave(wave_id=wave.wave_id, tenant_id="tenant-test").version == 2  # type: ignore[union-attr]
 
     with pytest.raises(DpmWaveVersionConflictError):
-        repository.update_wave(wave=updated, expected_version=1)
+        repository.update_wave(wave=updated, expected_version=1, tenant_id="tenant-test")
 
 
 def test_in_memory_wave_repository_enforces_idempotency_conflict() -> None:
@@ -189,7 +190,7 @@ def test_in_memory_wave_repository_replays_idempotent_wave() -> None:
 
     replay = repository.get_wave_by_idempotency(idempotency_key="idem-1", tenant_id="tenant-test")
 
-    assert replay == wave
+    assert replay == wave.model_copy(update={"tenant_id": "tenant-test"})
 
 
 def test_in_memory_wave_write_helpers_preserve_idempotency_and_copy_contract() -> None:
@@ -257,6 +258,7 @@ def test_in_memory_wave_repository_lists_filtered_sorted_defensive_pages() -> No
         as_of_date="2026-05-03",
         limit=1,
         offset=0,
+        tenant_id="tenant-test",
     )
     second_page = repository.list_waves(
         state="DRAFT",
@@ -264,12 +266,16 @@ def test_in_memory_wave_repository_lists_filtered_sorted_defensive_pages() -> No
         as_of_date="2026-05-03",
         limit=1,
         offset=1,
+        tenant_id="tenant-test",
     )
 
     assert [wave.wave_id for wave in first_page] == ["dwv_newer"]
     assert [wave.wave_id for wave in second_page] == ["dwv_older"]
     first_page[0].items[0].state = "SOURCE_BLOCKED"
-    assert repository.get_wave(wave_id="dwv_newer").items[0].state == "CANDIDATE"  # type: ignore[union-attr]
+    assert (
+        repository.get_wave(wave_id="dwv_newer", tenant_id="tenant-test").items[0].state
+        == "CANDIDATE"
+    )  # type: ignore[union-attr]
 
 
 def test_wave_postgres_migration_declares_persistence_tables() -> None:
@@ -430,13 +436,7 @@ class _FakeWaveConnection:
                 }
             )
             return _FakeCursor(rowcount=1)
-        # Schema statements from apply_postgres_migrations. Migration files
-        # open with a comment block, so a startswith check on the keyword
-        # never matches - look for the statement keyword anywhere.
-        if any(
-            keyword in sql
-            for keyword in ("CREATE TABLE", "ALTER TABLE", "CREATE INDEX", "schema_migrations")
-        ):
+        if is_migration_ddl(sql):
             return _FakeCursor()
         raise AssertionError(f"Unexpected SQL: {sql}")
 
@@ -511,19 +511,25 @@ def test_postgres_wave_repository_roundtrip_idempotency_and_update() -> None:
     repository.save_wave(
         wave=wave, idempotency_key="idem-1", request_hash="hash-1", tenant_id="tenant-test"
     )
-    loaded = repository.get_wave(wave_id=wave.wave_id)
+    loaded = repository.get_wave(wave_id=wave.wave_id, tenant_id="tenant-test")
     replay = repository.get_wave_by_idempotency(idempotency_key="idem-1", tenant_id="tenant-test")
     updated = apply_wave_transition(
         wave=wave,
         to_state="CREATED",
         event=_event("PREVIEWED", "CREATED"),
     )
-    repository.update_wave(wave=updated, expected_version=2)
+    repository.update_wave(wave=updated, expected_version=2, tenant_id="tenant-test")
 
-    assert loaded == wave
-    assert replay == wave
-    assert repository.get_wave(wave_id=wave.wave_id) == updated
-    assert repository.list_waves(limit=10, offset=0) == [updated]
+    # Storage stamps the owning tenant, so a read never equals the unstamped
+    # local value. Comparing against the stamped wave keeps the round-trip
+    # assertion intact and additionally pins that the stamp is what came back.
+    owned = wave.model_copy(update={"tenant_id": "tenant-test"})
+    owned_update = updated.model_copy(update={"tenant_id": "tenant-test"})
+
+    assert loaded == owned
+    assert replay == owned
+    assert repository.get_wave(wave_id=wave.wave_id, tenant_id="tenant-test") == owned_update
+    assert repository.list_waves(limit=10, offset=0, tenant_id="tenant-test") == [owned_update]
     assert sorted(fake.events) == ["evt-draft-previewed", "evt-previewed-created"]
     assert fake.commits == 2
     assert fake.closed == 6
@@ -549,7 +555,7 @@ def test_postgres_wave_repository_conflicts() -> None:
             tenant_id="tenant-test",
         )
     with pytest.raises(DpmWaveVersionConflictError):
-        repository.update_wave(wave=wave, expected_version=99)
+        repository.update_wave(wave=wave, expected_version=99, tenant_id="tenant-test")
 
 
 def test_postgres_wave_payload_accepts_non_string_json() -> None:
@@ -561,13 +567,13 @@ def test_postgres_wave_payload_accepts_non_string_json() -> None:
     )
     fake.waves[wave.wave_id]["wave_json"] = wave.model_dump(mode="json")
 
-    assert repository.get_wave(wave_id=wave.wave_id) == wave
+    assert repository.get_wave(wave_id=wave.wave_id, tenant_id="tenant-test") == wave
 
 
 def test_postgres_wave_repository_returns_none_for_missing_reads() -> None:
     repository = _postgres_repository(_FakeWaveConnection())
 
-    assert repository.get_wave(wave_id="dwv_missing") is None
+    assert repository.get_wave(wave_id="dwv_missing", tenant_id="tenant-test") is None
     assert (
         repository.get_wave_by_idempotency(idempotency_key="idem-missing", tenant_id="tenant-test")
         is None
@@ -588,12 +594,16 @@ def test_postgres_wave_repository_list_applies_durable_filters() -> None:
         as_of_date="2026-05-03",
         limit=25,
         offset=5,
+        tenant_id="tenant-test",
     )
 
     query, args = fake.queries[-1]
     assert listed == []
-    assert "WHERE state = %s AND trigger_type = %s AND as_of_date = %s" in query
-    assert args == ("DRAFT", "EXPLICIT_PORTFOLIO_LIST", "2026-05-03", 25, 5)
+    # The tenant leads the WHERE clause rather than being appended, so the
+    # index on (tenant_id, ...) is usable and no filter combination can produce
+    # a plan that scans another tenant's rows before discarding them.
+    assert "WHERE tenant_id = %s AND state = %s AND trigger_type = %s AND as_of_date = %s" in query
+    assert args == ("tenant-test", "DRAFT", "EXPLICIT_PORTFOLIO_LIST", "2026-05-03", 25, 5)
 
 
 def test_postgres_wave_payload_serializes_driver_native_json_values() -> None:

--- a/tests/unit/dpm/waves/test_wave_lifecycle_commands.py
+++ b/tests/unit/dpm/waves/test_wave_lifecycle_commands.py
@@ -17,12 +17,12 @@ class _WaveRepository:
         self.updated_wave: DpmRebalanceWave | None = None
         self.expected_version: int | None = None
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
         if wave_id == self.wave.wave_id:
             return self.wave
         return None
 
-    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int, tenant_id: str) -> None:
         self.updated_wave = wave
         self.expected_version = expected_version
 
@@ -66,6 +66,7 @@ def test_approve_persisted_wave_builds_and_persists_approved_transition() -> Non
         comment=None,
         correlation_id="corr-approve",
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
 
     assert replayed is False
@@ -85,6 +86,7 @@ def test_stage_handoff_and_cancel_persisted_wave_commands_update_expected_versio
         comment=None,
         correlation_id="corr-stage",
         wave_repository=stage_repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
 
     handoff_repository = _WaveRepository(staged)
@@ -95,6 +97,7 @@ def test_stage_handoff_and_cancel_persisted_wave_commands_update_expected_versio
         comment=None,
         correlation_id="corr-handoff",
         wave_repository=handoff_repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
 
     cancel_source = _wave(wave_id="dwv_lifecycle_cancel", state="STAGED", item_state="STAGED")
@@ -106,6 +109,7 @@ def test_stage_handoff_and_cancel_persisted_wave_commands_update_expected_versio
         comment=None,
         correlation_id="corr-cancel",
         wave_repository=cancel_repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
 
     assert stage_replayed is False
@@ -130,6 +134,7 @@ def test_cancel_persisted_wave_replays_existing_cancelled_wave() -> None:
         comment=None,
         correlation_id="corr-cancel",
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
 
     assert cancelled is wave

--- a/tests/unit/dpm/waves/test_wave_lookup.py
+++ b/tests/unit/dpm/waves/test_wave_lookup.py
@@ -10,7 +10,7 @@ class _WaveRepository:
         self.wave = wave
         self.requested_wave_ids: list[str] = []
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
         self.requested_wave_ids.append(wave_id)
         return self.wave
 
@@ -22,6 +22,7 @@ def test_get_wave_or_raise_returns_loaded_wave() -> None:
     loaded = get_wave_or_raise(
         wave_id="dwv_lookup",
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
 
     assert loaded is wave
@@ -35,6 +36,7 @@ def test_get_wave_or_raise_raises_governed_lookup_error_for_missing_wave() -> No
         get_wave_or_raise(
             wave_id="dwv_missing",
             wave_repository=repository,  # type: ignore[arg-type]
+            tenant_id="tenant-sg",
         )
 
     assert exc_info.value.code == "DPM_WAVE_NOT_FOUND"

--- a/tests/unit/dpm/waves/test_wave_persistence.py
+++ b/tests/unit/dpm/waves/test_wave_persistence.py
@@ -39,7 +39,7 @@ class _WaveRepository:
         self.idempotency_key = idempotency_key
         self.request_hash = request_hash
 
-    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int, tenant_id: str) -> None:
         if self.update_conflict:
             raise DpmWaveVersionConflictError("expected version mismatch")
         self.updated_wave = wave
@@ -94,6 +94,7 @@ def test_update_wave_or_raise_persists_with_expected_version() -> None:
         wave_repository=repository,  # type: ignore[arg-type]
         wave=wave,
         expected_version=3,
+        tenant_id="tenant-test",
     )
 
     assert repository.updated_wave is wave
@@ -108,6 +109,7 @@ def test_update_wave_or_raise_translates_version_conflict() -> None:
             wave_repository=_WaveRepository(update_conflict=True),  # type: ignore[arg-type]
             wave=wave,
             expected_version=3,
+            tenant_id="tenant-test",
         )
 
     assert exc_info.value.code == "DPM_WAVE_VERSION_CONFLICT"

--- a/tests/unit/dpm/waves/test_wave_preparation_commands.py
+++ b/tests/unit/dpm/waves/test_wave_preparation_commands.py
@@ -39,12 +39,12 @@ class _WaveRepository:
         self.updated_wave: DpmRebalanceWave | None = None
         self.expected_version: int | None = None
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
         if wave_id == self.wave.wave_id:
             return self.wave
         return None
 
-    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int, tenant_id: str) -> None:
         self.updated_wave = wave
         self.expected_version = expected_version
 
@@ -106,6 +106,7 @@ def test_simulate_persisted_wave_blocks_missing_inputs_and_persists_transition()
         construction_repository=object(),  # type: ignore[arg-type]
         run_service=object(),  # type: ignore[arg-type]
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-test",
     )
 
     assert replayed is False
@@ -128,6 +129,7 @@ def test_simulate_persisted_wave_replays_completed_simulation() -> None:
         construction_repository=object(),  # type: ignore[arg-type]
         run_service=object(),  # type: ignore[arg-type]
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-test",
     )
 
     assert simulated is wave

--- a/tests/unit/dpm/waves/test_wave_read_model_queries.py
+++ b/tests/unit/dpm/waves/test_wave_read_model_queries.py
@@ -21,7 +21,7 @@ class _WaveRepository:
         self.wave = wave
         self.requested_wave_ids: list[str] = []
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
         self.requested_wave_ids.append(wave_id)
         if wave_id == self.wave.wave_id:
             return self.wave
@@ -67,18 +67,22 @@ def test_wave_read_model_queries_load_wave_before_projection() -> None:
     supportability = wave_supportability_for_id(
         wave_id=wave.wave_id,
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
     detail = wave_detail_for_id(
         wave_id=wave.wave_id,
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
     items = wave_items_for_id(
         wave_id=wave.wave_id,
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
     posture = wave_proof_pack_posture_for_id(
         wave_id=wave.wave_id,
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
 
     assert repository.requested_wave_ids == [wave.wave_id] * 4
@@ -95,6 +99,7 @@ def test_wave_report_input_query_loads_wave_before_report_assembly() -> None:
     report_input = wave_report_input_for_id(
         wave_id=wave.wave_id,
         wave_repository=repository,  # type: ignore[arg-type]
+        tenant_id="tenant-sg",
     )
 
     assert repository.requested_wave_ids == [wave.wave_id]

--- a/tests/unit/dpm/waves/test_wave_search.py
+++ b/tests/unit/dpm/waves/test_wave_search.py
@@ -29,6 +29,7 @@ class _WaveRepository:
         as_of_date: str | None,
         limit: int,
         offset: int,
+        tenant_id: str,
     ) -> list[DpmRebalanceWave]:
         self.filters = {
             "state": state,
@@ -36,6 +37,7 @@ class _WaveRepository:
             "as_of_date": as_of_date,
             "limit": limit,
             "offset": offset,
+            "tenant_id": tenant_id,
         }
         return self.waves
 
@@ -95,9 +97,11 @@ def test_search_wave_summaries_projects_summary_fields_and_repository_filters() 
         as_of_date="2026-05-03",
         limit=10,
         offset=5,
+        tenant_id="tenant-sg",
     )
 
     assert repository.filters == {
+        "tenant_id": "tenant-sg",
         "state": "SOURCE_CHECKED",
         "trigger_type": "EXPLICIT_PORTFOLIO_LIST",
         "as_of_date": "2026-05-03",
@@ -119,6 +123,7 @@ def test_search_wave_summaries_filters_by_supportability_state() -> None:
             ]
         ),  # type: ignore[arg-type]
         supportability_state="blocked",
+        tenant_id="tenant-sg",
     )
 
     assert [summary["wave_id"] for summary in summaries] == ["dwv_blocked"]

--- a/tests/unit/dpm/waves/test_wave_selection_command.py
+++ b/tests/unit/dpm/waves/test_wave_selection_command.py
@@ -9,12 +9,12 @@ class _WaveRepository:
         self.updated_wave: DpmRebalanceWave | None = None
         self.expected_version: int | None = None
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
         if wave_id == self.wave.wave_id:
             return self.wave
         return None
 
-    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int, tenant_id: str) -> None:
         self.updated_wave = wave
         self.expected_version = expected_version
 

--- a/tests/unit/dpm/waves/test_wave_tenant_fence.py
+++ b/tests/unit/dpm/waves/test_wave_tenant_fence.py
@@ -1,0 +1,268 @@
+"""A wave belongs to one tenant, on every path that reads or writes it (#677).
+
+Waves carried no tenant at all: every wave was addressable by wave_id alone, so
+a wave created under one tenant could be read, listed, and - sharpest of the
+three - source-checked or selected against by another. #676 added a tenant to
+the MANDATE reads those paths perform, which made the mandate evidence look
+correctly scoped while the wave itself was never that caller's to touch.
+
+This is distinct from wave idempotency, which #676 closed by deriving the
+stored mapping key from the tenant. That path is complete and is not
+reimplemented here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from src.api.services.wave_errors import DpmWaveLookupError, DpmWaveValidationError
+from src.api.services.wave_lookup import get_wave_or_raise
+from src.api.services.wave_persistence import update_wave_or_raise
+from src.api.services.wave_transition_execution import prepare_wave_transition
+from src.core.waves import (
+    DpmRebalanceWave,
+    DpmRebalanceWaveItem,
+    DpmWaveAggregateMetrics,
+    DpmWaveTrigger,
+)
+from src.infrastructure.waves import InMemoryDpmWaveRepository
+
+TENANT_A = "tenant-alpha"
+TENANT_B = "tenant-beta"
+
+
+def _wave(*, wave_id: str = "dwv_001", state: str = "CREATED") -> DpmRebalanceWave:
+    return DpmRebalanceWave(
+        wave_id=wave_id,
+        state=state,
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id="manual-wave-001",
+            rationale="Tenant fence proof.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm-ops",
+        correlation_id=f"corr-{wave_id}",
+        items=[
+            DpmRebalanceWaveItem(
+                wave_item_id="dwi_001",
+                portfolio_id="PB_SG_GLOBAL_BAL_001",
+                state="CANDIDATE",
+            )
+        ],
+        aggregate_metrics=DpmWaveAggregateMetrics(
+            item_count=1,
+            state_counts={"CANDIDATE": 1},
+            ready_item_count=0,
+            blocked_item_count=0,
+            review_required_item_count=0,
+            source_degraded_item_count=0,
+        ),
+    )
+
+
+def _repository_with_tenant_a_wave() -> InMemoryDpmWaveRepository:
+    repository = InMemoryDpmWaveRepository()
+    repository.save_wave(wave=_wave(), idempotency_key=None, request_hash=None, tenant_id=TENANT_A)
+    return repository
+
+
+def test_another_tenant_cannot_read_a_wave() -> None:
+    repository = _repository_with_tenant_a_wave()
+
+    assert repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A) is not None
+    assert repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_B) is None
+
+
+def test_the_refusal_is_indistinguishable_from_an_absent_wave() -> None:
+    """A distinct error would confirm the id exists and belongs to somebody.
+
+    That confirmation is itself cross-tenant information, so both cases raise
+    the same DPM_WAVE_NOT_FOUND code.
+
+    The comparison is on the CODE, not the message: the message embeds the wave
+    id the caller itself supplied, so it differs between the two cases without
+    disclosing anything the caller did not already know. Comparing messages
+    would fail for a reason that is not a leak - which is what it did on first
+    run, and is worth keeping stated so nobody 'fixes' it by removing the id
+    from the message.
+    """
+
+    repository = _repository_with_tenant_a_wave()
+
+    with pytest.raises(DpmWaveLookupError) as foreign:
+        get_wave_or_raise(wave_id="dwv_001", wave_repository=repository, tenant_id=TENANT_B)
+    with pytest.raises(DpmWaveLookupError) as absent:
+        get_wave_or_raise(
+            wave_id="dwv_does_not_exist", wave_repository=repository, tenant_id=TENANT_B
+        )
+
+    assert foreign.value.code == absent.value.code == "DPM_WAVE_NOT_FOUND"
+
+
+def test_another_tenant_cannot_list_a_wave() -> None:
+    repository = _repository_with_tenant_a_wave()
+
+    assert [wave.wave_id for wave in repository.list_waves(tenant_id=TENANT_A)] == ["dwv_001"]
+    assert repository.list_waves(tenant_id=TENANT_B) == []
+
+
+def test_the_tenant_filter_is_applied_before_paging_not_after() -> None:
+    """Filtering a page would let another tenant's waves consume the limit.
+
+    The caller would silently receive fewer of its own waves than the page it
+    asked for - a correctness bug that presents as a short result rather than a
+    leak, so a leak-only test would not catch it.
+    """
+
+    repository = InMemoryDpmWaveRepository()
+    for index in range(3):
+        repository.save_wave(
+            wave=_wave(wave_id=f"dwv_b{index}"),
+            idempotency_key=None,
+            request_hash=None,
+            tenant_id=TENANT_B,
+        )
+    repository.save_wave(
+        wave=_wave(wave_id="dwv_a0"), idempotency_key=None, request_hash=None, tenant_id=TENANT_A
+    )
+
+    page = repository.list_waves(tenant_id=TENANT_A, limit=2)
+
+    assert [wave.wave_id for wave in page] == ["dwv_a0"]
+
+
+def test_another_tenant_cannot_transition_a_wave_and_is_refused_before_any_effect() -> None:
+    """The sharpest of the three: an unfenced read here leads to an unfenced write."""
+
+    repository = _repository_with_tenant_a_wave()
+
+    with pytest.raises(DpmWaveLookupError):
+        prepare_wave_transition(
+            wave_id="dwv_001",
+            wave_repository=repository,
+            tenant_id=TENANT_B,
+            replay_states=set(),
+            allowed_states={"CREATED"},
+            error_code="DPM_WAVE_SOURCE_CHECK_INVALID_STATE",
+            action_phrase="be source-checked",
+        )
+
+    survivor = repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A)
+    assert survivor is not None
+    assert survivor.state == "CREATED"
+    assert survivor.version == 1
+
+
+def test_the_replay_shortcut_cannot_return_another_tenants_wave() -> None:
+    """Ordering proof: the fence sits before the idempotent-replay shortcut.
+
+    If the replay check ran first, a foreign wave already in a replay state
+    would be returned as a successful no-op. That is still a read, and it would
+    pass a test that only exercised the state guard.
+    """
+
+    repository = InMemoryDpmWaveRepository()
+    repository.save_wave(
+        wave=_wave(state="SOURCE_CHECKED"),
+        idempotency_key=None,
+        request_hash=None,
+        tenant_id=TENANT_A,
+    )
+
+    with pytest.raises(DpmWaveLookupError):
+        prepare_wave_transition(
+            wave_id="dwv_001",
+            wave_repository=repository,
+            tenant_id=TENANT_B,
+            replay_states={"SOURCE_CHECKED"},
+            allowed_states={"CREATED"},
+            error_code="DPM_WAVE_SOURCE_CHECK_INVALID_STATE",
+            action_phrase="be source-checked",
+        )
+
+
+def test_another_tenant_cannot_write_a_wave_even_holding_the_record() -> None:
+    """Fencing only the read would leave the write reachable.
+
+    The tenant travels to the UPDATE predicate rather than being trusted from
+    an earlier load, so a caller that obtained the wave some other way still
+    cannot persist over it.
+    """
+
+    repository = _repository_with_tenant_a_wave()
+    stolen = repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A)
+    assert stolen is not None
+    tampered = stolen.model_copy(update={"state": "CANCELLED", "version": 2})
+
+    with pytest.raises(DpmWaveValidationError):
+        update_wave_or_raise(
+            wave_repository=repository,
+            wave=tampered,
+            expected_version=1,
+            tenant_id=TENANT_B,
+        )
+
+    survivor = repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A)
+    assert survivor is not None
+    assert survivor.state == "CREATED"
+
+
+def test_the_foreign_write_refusal_matches_a_stale_version_refusal() -> None:
+    """Indistinguishable on purpose, so the write path cannot be used to probe.
+
+    A distinct "not your wave" error would let a caller enumerate which wave
+    ids exist under other tenants by watching which error comes back.
+    """
+
+    repository = _repository_with_tenant_a_wave()
+    wave = repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A)
+    assert wave is not None
+
+    with pytest.raises(DpmWaveValidationError) as foreign:
+        update_wave_or_raise(
+            wave_repository=repository, wave=wave, expected_version=1, tenant_id=TENANT_B
+        )
+    with pytest.raises(DpmWaveValidationError) as stale:
+        update_wave_or_raise(
+            wave_repository=repository, wave=wave, expected_version=99, tenant_id=TENANT_A
+        )
+
+    assert foreign.value.args[0] == stale.value.args[0]
+
+
+def test_a_wave_persisted_before_the_fence_is_reachable_from_no_tenant() -> None:
+    """Quarantine, not a default owner.
+
+    Attributing unattributed rows to an assumed tenant is exactly what would
+    hand one tenant waves it never created - including under a tenant literally
+    named `default`, which is the value a backfill would most plausibly choose.
+    """
+
+    repository = InMemoryDpmWaveRepository()
+    repository.save_wave(wave=_wave(), idempotency_key=None, request_hash=None, tenant_id=TENANT_A)
+    stored = repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A)
+    assert stored is not None
+    repository._waves["dwv_001"] = stored.model_copy(update={"tenant_id": None})  # noqa: SLF001
+
+    for tenant in (TENANT_A, TENANT_B, "default", ""):
+        assert repository.get_wave(wave_id="dwv_001", tenant_id=tenant) is None, tenant
+        assert repository.list_waves(tenant_id=tenant) == [], tenant
+
+
+def test_saving_stamps_the_tenant_so_the_record_cannot_disagree_with_the_claim() -> None:
+    """A caller must not be able to persist a wave labelled as another tenant's."""
+
+    repository = InMemoryDpmWaveRepository()
+    mislabelled = _wave().model_copy(update={"tenant_id": TENANT_B})
+
+    repository.save_wave(
+        wave=mislabelled, idempotency_key=None, request_hash=None, tenant_id=TENANT_A
+    )
+
+    assert repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_B) is None
+    owned = repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A)
+    assert owned is not None and owned.tenant_id == TENANT_A

--- a/tests/unit/dpm/waves/test_wave_transition_execution.py
+++ b/tests/unit/dpm/waves/test_wave_transition_execution.py
@@ -16,12 +16,12 @@ class _WaveRepository:
         self.updated_wave: DpmRebalanceWave | None = None
         self.expected_version: int | None = None
 
-    def get_wave(self, *, wave_id: str) -> DpmRebalanceWave | None:
+    def get_wave(self, *, wave_id: str, tenant_id: str) -> DpmRebalanceWave | None:
         if wave_id == self.wave.wave_id:
             return self.wave
         return None
 
-    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int) -> None:
+    def update_wave(self, *, wave: DpmRebalanceWave, expected_version: int, tenant_id: str) -> None:
         self.updated_wave = wave
         self.expected_version = expected_version
 
@@ -44,6 +44,7 @@ def test_prepare_wave_transition_returns_replayed_wave_without_state_guard() -> 
         allowed_states={"SOURCE_CHECKED"},
         error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
         action_phrase="be simulated",
+        tenant_id="tenant-sg",
     )
 
     assert prepared == PreparedWaveTransition(wave=wave, replayed=True)
@@ -59,6 +60,7 @@ def test_prepare_wave_transition_requires_allowed_state_for_new_transition() -> 
         allowed_states={"SOURCE_CHECKED"},
         error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
         action_phrase="be simulated",
+        tenant_id="tenant-sg",
     )
 
     assert prepared == PreparedWaveTransition(wave=wave, replayed=False)
@@ -74,6 +76,7 @@ def test_prepare_wave_transition_supports_non_replayable_allowed_transition() ->
         allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
         error_code="DPM_WAVE_SELECTION_INVALID_STATE",
         action_phrase="record alternative selection",
+        tenant_id="tenant-sg",
     )
 
     assert prepared == PreparedWaveTransition(wave=wave, replayed=False)
@@ -90,6 +93,7 @@ def test_prepare_wave_transition_with_empty_replay_states_requires_allowed_state
             allowed_states={"SIMULATED", "PARTIALLY_SIMULATED"},
             error_code="DPM_WAVE_SELECTION_INVALID_STATE",
             action_phrase="record alternative selection",
+            tenant_id="tenant-sg",
         )
 
     assert exc_info.value.code == "DPM_WAVE_SELECTION_INVALID_STATE"
@@ -105,6 +109,7 @@ def test_prepare_wave_transition_supports_explicitly_unguarded_transition() -> N
         allowed_states=None,
         error_code="DPM_WAVE_CANCEL_INVALID_STATE",
         action_phrase="be cancelled",
+        tenant_id="tenant-sg",
     )
 
     assert prepared == PreparedWaveTransition(wave=wave, replayed=False)
@@ -121,6 +126,7 @@ def test_prepare_wave_transition_preserves_state_validation_error() -> None:
             allowed_states={"SOURCE_CHECKED"},
             error_code="DPM_WAVE_SIMULATION_INVALID_STATE",
             action_phrase="be simulated",
+            tenant_id="tenant-sg",
         )
 
     assert exc_info.value.code == "DPM_WAVE_SIMULATION_INVALID_STATE"
@@ -135,6 +141,7 @@ def test_persist_transitioned_wave_uses_source_wave_version_for_optimistic_updat
         wave_repository=repository,  # type: ignore[arg-type]
         source_wave=source_wave,
         transitioned_wave=transitioned_wave,
+        tenant_id="tenant-sg",
     )
 
     assert repository.updated_wave is transitioned_wave


### PR DESCRIPTION
Closes #677.

## What was wrong

Waves carried no tenant at all. Every wave was addressable by `wave_id` alone, so a wave created under one tenant could be read, listed, and — sharpest of the three — source-checked or selected against by another. #676 added a tenant to the **mandate** reads those paths perform, which made the mandate evidence look correctly scoped while the wave itself was never that caller's to touch.

## The fence

- `get_wave` / `list_waves` / `update_wave` require the tenant **on the protocol**, so mypy enumerated the call sites rather than leaving me to find them.
- `prepare_wave_transition` fences **inside the load and before the idempotent-replay shortcut**. A foreign wave already in a replay state would otherwise be returned as a successful no-op — still a read, and it would pass a test that only exercised the state guard.
- `update_wave` carries the tenant **in the UPDATE predicate**, not a check before it, so a caller holding the record some other way still changes no row.
- Both refusals are indistinguishable from the ordinary ones on purpose: a foreign read raises the same `DPM_WAVE_NOT_FOUND` as an absent wave, a foreign write the same version conflict as a stale version. A distinct error would let a caller enumerate which wave ids exist under other tenants.

## The key that was still global

`correlation_id` arrives on the caller's own `X-Correlation-Id` header and was unique across every tenant. A value one tenant had already used made another tenant's legitimate create fail with a unique violation — a denial caused by data that caller cannot see, and an existence oracle for a value it chose itself. Migration 0027 re-scopes that index, as 0026 did for the caller-chosen idempotency key. The `#676` test file had flagged this and deferred it here.

## Existing rows

Migration 0027 adds `tenant_id` **nullable and backfills nothing**, matching 0024–0026. A wave persisted before the fence is matched by no equality predicate and is reachable from **no** tenant, including one literally named `default` — the value a backfill would most plausibly choose. Those rows stay present for deliberate attribution.

## Two defects found while threading it, both of which typechecked clean before

1. **The portfolio-memory tenant chain returned `None` for a valid caller.** It asked each optional source family in turn and fell through to `None` when none claimed the tenant, so a bundle carrying only the mandatory sources validated the caller's tenant against families it did not use and then discarded it. `wave_repository` is not optional on that bundle, so waves now close the chain and the tenant is always required.
2. **The workflow dispatcher was `Callable[..., ...]`.** The ellipsis erases the parameter list, so when the four commands gained a required tenant the dispatcher kept calling them without it and mypy had nothing to check the call against — approve, stage, handoff and cancel failed at request time. It is a `Protocol` now, so the next required argument is a type error there instead.

Three fake psycopg connections each carried their own copy of the migration-DDL keyword list, so this migration broke two of them and left the third latently broken. That list now lives in `tests/support/postgres_migration_sql.py`.

## Proof

| Lane | Result |
| --- | --- |
| In-memory fence proofs | 10 passed (`tests/unit/dpm/waves/test_wave_tenant_fence.py`) |
| PostgreSQL aggregate proofs | 6 passed (new), 9 total in the wave lane |
| Unit | 3469 passed |
| Integration | 244 passed |
| E2E | 28 passed |
| `make typecheck` | clean, 554 source files |
| `make lint`, `make static-quality-gates`, `make openapi-gate` | exit 0 |

The PostgreSQL proofs decide four things Python cannot, and which the in-memory store can be made to agree with either way: that the fence reached the `WHERE` clause, that filtering precedes `LIMIT`/`OFFSET`, that `correlation_id` uniqueness is per tenant, and that a `NULL` tenant is matched by no equality predicate — SQL's `NULL = 'x'` rule differs from Python's `None !=`, so the quarantine claim is only really proven there.

**Falsification** — every filter was reverted in turn and had to break a proof:

```
4 of 4 reverted in-memory filters broke at least one proof
  get_wave no longer compares the tenant        6 failed
  list_waves returns every tenant's waves       3 failed
  update_wave drops the tenant from its guard   2 failed
  save_wave stops stamping the tenant           8 failed

3 of 3 reverted PostgreSQL fences broke at least one proof
  get_wave drops the tenant from its WHERE clause          4 failed
  update_wave drops the tenant from its UPDATE predicate   1 failed
  correlation_id is globally unique again                  2 failed
```

Reinstating the global `correlation_id` index required truncating the table first — the rows the fixed schema accepts are rows the old one forbids, which is the finding restated as a schema fact.

## Contract change

Every wave route now takes `X-Tenant-Id`, **including report-input, which previously took a `tenant_id` query parameter**. One selector per aggregate. This changes what lotus-gateway#763 documents; I will correct that handoff rather than leave it stale.

## Not in this PR

`tests/unit/dpm/engine/` decides whether 13 solver tests run by importing `cvxpy` in a subprocess with a **3-second timeout**. Under load the import exceeds it and those tests silently skip, taking their covered lines with them and dropping the coverage gate from 99.00 to 98.98 between two otherwise identical local runs. Pre-existing and unrelated to tenancy — filed separately rather than mixed into this commit.