### PR TITLE
chore(context): adopt the governed agent operating contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,20 +5,80 @@ This is the governed operating contract for Lotus agent work.
 Repo-root `AGENTS.md` files across Lotus repositories and the deployed local `AGENTS.md` should
 remain synchronized copies of this file.
 
-Use `automation/Sync-AgentOperatingContract.ps1` to synchronize or verify that deployed copy.
+Use `lotus-platform/automation/Sync-AgentOperatingContract.ps1` to synchronize or verify those
+copies. That path identifies the script; it is not a command that runs from where you are
+standing. Run it from the `lotus-platform` checkout, because the qualified form resolves from the
+directory holding the checkouts rather than from the repository you are working in:
 
-## Mandatory Reading Order
+```powershell
+Set-Location "$env:LOTUS_WORKSPACE_ROOT/lotus-platform"
+powershell -ExecutionPolicy Bypass -File automation/Sync-AgentOperatingContract.ps1 -CheckOnly
+```
 
-Before doing substantial work, load context in this order:
+```bash
+cd "$LOTUS_WORKSPACE_ROOT/lotus-platform"
+pwsh -File automation/Sync-AgentOperatingContract.ps1 -CheckOnly
+```
 
-1. `AGENTS.md`
-2. `lotus-platform/context/LOTUS-QUICKSTART-CONTEXT.md`
-3. `lotus-platform/context/LOTUS-ENGINEERING-CONTEXT.md`
-4. the target repository's `REPOSITORY-ENGINEERING-CONTEXT.md`
-5. `lotus-platform/context/CONTEXT-REFERENCE-MAP.md`
-6. `lotus-platform/context/PROCEDURAL-MEMORY-INDEX.md` when the task is primarily about how work should be executed
+Bare `-CheckOnly` verifies the repository-root copy, which is the one CI can check: the deployed
+file exists only on a developer machine. Add `-IncludeDeployedTarget` to check that copy as well,
+and `-AllRepoRoots` to check every sibling checkout.
 
-Use the smallest correct working set. Do not load broad context blindly if the task is narrow.
+Set `LOTUS_WORKSPACE_ROOT` once to the directory holding the Lotus checkouts. Without a
+`lotus-platform` checkout the script cannot be run at all: the GitHub fallback below can display a
+document, and it cannot execute one.
+
+## Progressive Context Discovery
+
+Before substantial work, load this small starting set:
+
+1. the target repository's `AGENTS.md` for mandatory operating rules,
+2. `lotus-platform/context/LOTUS-QUICKSTART-CONTEXT.md` for ecosystem identity and ownership,
+3. the target repository's `REPOSITORY-ENGINEERING-CONTEXT.md` for local architecture, boundaries,
+   commands, and constraints,
+4. `lotus-platform/context/LOTUS-SKILL-ROUTING-MAP.md` to select an applicable skill before acting.
+
+Then load only task-relevant depth:
+
+1. `lotus-platform/context/LOTUS-ENGINEERING-CONTEXT.md` for cross-repository architecture or
+   shared engineering policy,
+2. `lotus-platform/context/CONTEXT-REFERENCE-MAP.md` to locate a specific standard, RFC,
+   contract, or runbook,
+3. `lotus-platform/context/TASK-ROUTING-GUIDE.md` when ownership or the correct context set is
+   unclear,
+4. `lotus-platform/context/PROCEDURAL-MEMORY-INDEX.md` when execution method, recovery, or
+   delivery evidence is central.
+
+Do not load the complete context estate by default. Essential controls in `AGENTS.md` remain
+mandatory even when the rest of the task needs only repository-local context.
+
+Skills live in `lotus-platform/codex/skills/<skill-name>/SKILL.md` and the routing map is keyed by
+task rather than by repository, so an agent in any repository reaches the right skill through the
+task row. Check it even when the task looks narrow: a skill found afterwards means the work was
+done to a convention that already existed and was not followed. Documentation and wiki work is
+covered by `lotus-readme-wiki-governance`; skills, agent context, routing and manifests by
+`lotus-skill-context-governance`.
+
+A path beginning `lotus-platform/` is relative to the directory that holds the Lotus checkouts,
+not to the repository you are working in. Qualifying a path says who owns it; it does not by
+itself say where to stand to read it, and resolving one of these from a repository root reaches
+`<your-repo>/lotus-platform/...`, which does not exist.
+
+Without a sibling checkout, replace the `lotus-platform/` prefix with
+`https://github.com/sgajbi/lotus-platform/blob/main/` and read the document there. One rule
+covers every path under it, including `context/`, `docs/`, `automation/` and
+`codex/skills/<skill-name>/SKILL.md`. The repository is the authoritative source, so a sibling
+checkout is a local convenience rather than a prerequisite.
+
+A path naming a document owned by `lotus-platform` carries the `lotus-platform/` prefix, because
+this file is deployed unchanged into every repository and a bare path resolves inside whichever
+repository is reading it. A path naming a document each repository owns for itself, such as
+`AGENTS.md` or `REPOSITORY-ENGINEERING-CONTEXT.md`, is deliberately bare.
+
+Paths in Lotus documentation are otherwise repository-relative. Where a machine-specific location is
+unavoidable, `<workspace-root>` means the directory holding the Lotus checkouts and `<temp-dir>`
+the local temporary directory; neither is a real path and neither assumes an operating system,
+drive or folder name.
 
 ## Target Repository Root Rule
 
@@ -30,18 +90,26 @@ Before substantial work:
 
 1. infer the target repository from the user request, active goal, issue, PR, branch, file path, or
    explicit repo name,
-2. if the target is a Lotus repository and the current working directory is a different Lotus
+2. inspect the active branch, worktrees, and existing changes before editing; do not overwrite,
+   relocate, or delete work unless ownership is verified, and allow the designated repository owner
+   to continue scoped work,
+3. if the target is a Lotus repository and the current working directory is a different Lotus
    repository, switch command `workdir` to that target repo before reading repo-local context,
    running tests, inspecting git state, editing files, or creating issues,
-3. use `lotus-platform` only for central context, automation, platform contracts, skill source, and
+4. use `lotus-platform` only for central context, automation, platform contracts, skill source, and
    cross-repo governance unless the task explicitly targets `lotus-platform`,
-4. for multi-repo work, state the active repo for each command group and never let one repo's
+5. for multi-repo work, state the active repo for each command group and never let one repo's
    `AGENTS.md` or `REPOSITORY-ENGINEERING-CONTEXT.md` stand in for another repo's local truth,
-5. when delegating or launching background work, pass the exact repository name, absolute repo root,
+6. when delegating or launching background work, pass the exact repository name, absolute repo root,
    branch, read/write scope, and expected evidence so child agents do not inherit the wrong cwd.
 
 If the inherited cwd conflicts with the named target repo, announce the correction briefly and keep
 all subsequent repo-local commands anchored to the target repo.
+
+In a shared checkout, verify ownership and the active branch, stage explicit paths, and never stash
+another session's work. Record provenance and revert rationale through the
+`Agent Context And Task Ledger Playbook` linked from
+`lotus-platform/context/PROCEDURAL-MEMORY-INDEX.md`.
 
 ## Mandatory Operating Rules
 
@@ -69,6 +137,39 @@ closure, and before moving to the next RFC:
 3. inspect unmerged branches that touch durable governance paths,
 4. classify each as `must-merge`, `cherry-pick`, `superseded`, `delete`, or `active`,
 5. merge, cherry-pick, explicitly supersede, or delete unique durable truth before claiming closure.
+
+## Evidence And Guard Integrity
+
+Always:
+
+1. write file content with the editing/patch mechanism, never a shell heredoc that may interpret
+   escapes,
+2. run a gate bare or explicitly preserve its exit status; do not hide it behind `tee` or `tail`,
+3. prove every new or changed guard fails on representative bad inputs and accepts valid inputs,
+4. compare synchronized files by committed blob SHA, not working-tree bytes,
+5. post issue evidence before closing and verify the comment exists,
+6. keep workflow-changing PRs single-commit unless the repository's per-revision dispatcher is
+   proven to evaluate every intermediate workflow tree,
+7. accept reported output as evidence only when the producing command exits successfully,
+8. classify pattern matches and validate a guard's premise before rewriting or hardening it.
+
+The evidence and failure cases behind these rules live in the
+`Agentic Coding Quality Evaluation Loop` linked from
+`lotus-platform/context/PROCEDURAL-MEMORY-INDEX.md`; they do not
+belong in this mandatory entry contract.
+
+## Where Repository-Scoped Practice Lives
+
+`AGENTS.md` is deployed identically to every repository from this contract and checked by
+`lotus-platform/automation/Sync-AgentOperatingContract.ps1 -CheckOnly`. Nothing repository-specific belongs in it:
+editing one repository's copy forks a governed file.
+
+Repository-scoped working practice — the hazards, conventions and command shapes that are true of
+one repository and not the estate — belongs in that repository's
+`REPOSITORY-ENGINEERING-CONTEXT.md`, under a section that names it as practice rather than
+architecture. Every Lotus repository has that file and each owns its own copy, so it needs no new
+convention and no synchronisation. `CLAUDE.md` is not the home for it: only one repository has one,
+and it is read by a single agent runtime rather than all of them.
 
 ## Delivery Posture
 
@@ -182,7 +283,8 @@ Update the relevant context artifacts when:
 If the change is platform-wide:
 
 1. update the central context system in `lotus-platform/context/`.
-2. update `LOTUS-SKILL-ROUTING-MAP.md` if task routing expectations changed.
+2. update `lotus-platform/context/LOTUS-SKILL-ROUTING-MAP.md` if task routing expectations
+   changed.
 
 If the change is repository-local:
 
@@ -192,20 +294,24 @@ If both changed:
 
 1. update both in the same slice.
 
+Documented commands must state their working directory, provide runnable OS-specific variants, use
+portable paths, and be verified from a fresh checkout. Detailed authoring rules live in
+`lotus-platform/docs/documentation/LOTUS-DOCUMENTATION-LAYERING.md`.
+
 ## Cross-Links
 
 Central context system:
 
-1. `<lotus-platform>/context/LOTUS-QUICKSTART-CONTEXT.md`
-2. `<lotus-platform>/context/LOTUS-ENGINEERING-CONTEXT.md`
-3. `<lotus-platform>/context/CONTEXT-REFERENCE-MAP.md`
-4. `<lotus-platform>/context/PROCEDURAL-MEMORY-INDEX.md`
-5. `<lotus-platform>/context/LOTUS-SKILL-ROUTING-MAP.md`
-6. `<lotus-platform>/context/lotus-context-manifest.json`
-7. `<lotus-platform>/context/platform-engineering-ledger.md`
-8. `<lotus-platform>/context/recent-architectural-decisions-digest.md`
-9. `<lotus-platform>/docs/onboarding/LOTUS-DEVELOPER-ONBOARDING.md`
-10. `<lotus-platform>/docs/onboarding/LOTUS-AGENT-RAMP-UP.md`
+1. `lotus-platform/context/LOTUS-QUICKSTART-CONTEXT.md`
+2. `lotus-platform/context/LOTUS-ENGINEERING-CONTEXT.md`
+3. `lotus-platform/context/CONTEXT-REFERENCE-MAP.md`
+4. `lotus-platform/context/PROCEDURAL-MEMORY-INDEX.md`
+5. `lotus-platform/context/LOTUS-SKILL-ROUTING-MAP.md`
+6. `lotus-platform/context/lotus-context-manifest.json`
+7. `lotus-platform/context/platform-engineering-ledger.md`
+8. `lotus-platform/context/recent-architectural-decisions-digest.md`
+9. `lotus-platform/docs/onboarding/LOTUS-DEVELOPER-ONBOARDING.md`
+10. `lotus-platform/docs/onboarding/LOTUS-AGENT-RAMP-UP.md`
 
 Repository-local context:
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-07T14:11:16+00:00`
+- Generated at: `2026-09-07T23:12:33+00:00`
 
-- Baseline source snapshot: `c8130d382c4da0177ee9bca8886b1c21e567aee0`
+- Baseline source snapshot: `cda0f4bdb8b327146b78fe33de8e4839900d7e15`
 
-- Report source snapshot: `6fb9998d`
+- Report source snapshot: `cda0f4bd+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-07T14:11:16+00:00`
+- Generated at: `2026-09-07T23:12:33+00:00`
 
-- Baseline source snapshot: `c8130d382c4da0177ee9bca8886b1c21e567aee0`
+- Baseline source snapshot: `cda0f4bdb8b327146b78fe33de8e4839900d7e15`
 
-- Report source snapshot: `6fb9998d`
+- Report source snapshot: `cda0f4bd+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-07T14:11:16+00:00`
+- Generated at: `2026-09-07T23:12:33+00:00`
 
-- Baseline source snapshot: `c8130d382c4da0177ee9bca8886b1c21e567aee0`
+- Baseline source snapshot: `cda0f4bdb8b327146b78fe33de8e4839900d7e15`
 
-- Report source snapshot: `6fb9998d`
+- Report source snapshot: `cda0f4bd+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-07T14:11:16+00:00`
+- Generated at: `2026-09-07T23:12:33+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `c8130d382c4da0177ee9bca8886b1c21e567aee0`
+- Baseline source snapshot: `cda0f4bdb8b327146b78fe33de8e4839900d7e15`
 
-- Report source snapshot: `6fb9998d`
+- Report source snapshot: `cda0f4bd+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 928 | 931 | +3 |
-| Total Python LOC | 217192 | 218128 | +936 |
-| Test functions | 3150 | 3166 | +16 |
+| Python files | 931 | 931 | +0 |
+| Total Python LOC | 218128 | 218128 | +0 |
+| Test functions | 3166 | 3166 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,14 +37,14 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 7756 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 7777 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3395 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
 | 7 | tests/unit/test_documentation_current_state.py | 2788 |
-| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2708 |
+| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2709 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
@@ -71,7 +71,7 @@
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 791 |
-| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 410 |
+| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 404 |
 | 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 380 |
 | 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
 | 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
@@ -104,7 +104,7 @@
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 791 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 410 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 404 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |


### PR DESCRIPTION
Cycle 5 assignment item 6 for this repository: *"Adopt current context; main still has 90614999."*

## What changed

`AGENTS.md` was at blob `90614999`; the governed source in lotus-platform is `edc4c248`. Synchronized through `automation/Sync-AgentOperatingContract.ps1` rather than by hand, so the deployed copy is a byte-identical lift and not a paraphrase.

**Verified by committed blob, not working-tree bytes:**

```
git rev-parse HEAD:AGENTS.md                    -> edc4c248524b7b866840321ccc20ad45637bf6ad
git rev-parse origin/main:AGENTS.md  (platform) -> edc4c248524b7b866840321ccc20ad45637bf6ad
```

`Sync-AgentOperatingContract.ps1 -CheckOnly -Repository lotus-manage` previously failed naming that exact mismatch. It passes now.

## Why the four quality reports move with it

They are not incidental churn, and I checked rather than assuming. With main's `AGENTS.md` restored into the working tree, `engineering_health_report.py --check` **exits 0**; with the synchronized one it reports all four stale. The reports genuinely track this file's content, so regenerating them is part of this change rather than an unrelated edit riding along.

## Deliberate non-changes

- **No `CLAUDE.md` added.** The contract states only one repository has one, and manage is not it. Adding an adapter here would be inventing a convention the contract explicitly places elsewhere.
- **No wiki change.** `AGENTS.md` is the agent operating contract, not operator-facing published truth, and repo-local `wiki/` source is untouched. Parity verified at `DiffCount 0` before and after, so this is an explicit no-wiki-change decision rather than an omission.
- **`REPOSITORY-ENGINEERING-CONTEXT.md` left alone.** It carries no machine-specific paths and has the expected 11 sections. It *does* contain delivery-diary material — other repositories' PR numbers, commit SHAs and wiki hashes around lines 115–161 — which the Context Maintenance Rule says belongs in GitHub rather than in that file. I have not removed it here: some of those lines describe capabilities and contract boundaries that genuinely exist, with the PR reference as provenance, so separating durable boundary fact from history is a judgement call. Folding a debatable content rewrite into a mechanical sync would make this commit untruthful about what it does. Raised for its own lane.

## Gates

| Check | Result |
| --- | --- |
| `make lint` | exit 0 |
| `make static-quality-gates` | exit 0 |
| `make typecheck` | clean, 554 source files |
| Unit | 3458 passed, 13 skipped |
| `Sync-RepoWikis.ps1 -CheckOnly` | exit 0, DiffCount 0 |

No runtime, migration, API or test behaviour is touched.