### PR TITLE
docs(api): the wave tenant surface, counted rather than named

### DIFF
--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-07T23:12:33+00:00`
+- Generated at: `2026-09-08T10:58:53+00:00`
 
-- Baseline source snapshot: `cda0f4bdb8b327146b78fe33de8e4839900d7e15`
+- Baseline source snapshot: `946fe29bbe914306506d42106d18833a6f9394c1`
 
-- Report source snapshot: `cda0f4bd+worktree`
+- Report source snapshot: `2b3df8d9+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 931 |
-| Total Python LOC | 218128 |
-| Test functions | 3166 |
+| Total Python LOC | 218235 |
+| Test functions | 3167 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-07T23:12:33+00:00`
+- Generated at: `2026-09-08T10:58:53+00:00`
 
-- Baseline source snapshot: `cda0f4bdb8b327146b78fe33de8e4839900d7e15`
+- Baseline source snapshot: `946fe29bbe914306506d42106d18833a6f9394c1`
 
-- Report source snapshot: `cda0f4bd+worktree`
+- Report source snapshot: `2b3df8d9+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-07T23:12:33+00:00`
+- Generated at: `2026-09-08T10:58:53+00:00`
 
-- Baseline source snapshot: `cda0f4bdb8b327146b78fe33de8e4839900d7e15`
+- Baseline source snapshot: `946fe29bbe914306506d42106d18833a6f9394c1`
 
-- Report source snapshot: `cda0f4bd+worktree`
+- Report source snapshot: `2b3df8d9+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-07T23:12:33+00:00`
+- Generated at: `2026-09-08T10:58:53+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `cda0f4bdb8b327146b78fe33de8e4839900d7e15`
+- Baseline source snapshot: `946fe29bbe914306506d42106d18833a6f9394c1`
 
-- Report source snapshot: `cda0f4bd+worktree`
+- Report source snapshot: `2b3df8d9+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 931 | 931 | +0 |
-| Total Python LOC | 218128 | 218128 | +0 |
-| Test functions | 3166 | 3166 | +0 |
+| Total Python LOC | 218128 | 218235 | +107 |
+| Test functions | 3166 | 3167 | +1 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -58,7 +58,7 @@
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2788 |
+| 7 | tests/unit/test_documentation_current_state.py | 2895 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2709 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -2786,3 +2786,110 @@ def test_rfc0042_gold_standard_tightening_preserves_source_boundaries() -> None:
     )
     assert "governed PM memo request posture are implementation-backed" in supported_features
     assert "A WTBD is not complete until merged to `main`" in supported_features
+
+
+def test_the_wiki_wave_header_count_is_derived_from_the_served_contract() -> None:
+    """The wiki's wave-header claim must track the contract, not be re-typed.
+
+    This page previously said the header applied to four wave operations -
+    "preview, create, source-check and selection ... one selector across all
+    four" - while the served document required it on fifteen. The four were
+    correct when written and the sentence was never revisited.
+
+    Nothing caught it. Every other assertion in this module checks that a
+    document *mentions* something, which a stale document does just as well as
+    a current one; `test_documentation_current_state` measures mention, not
+    currency. A consumer enumerating wave operations from that paragraph built
+    exactly the gap it described, and four of its calls reached lotus-manage
+    with no tenant.
+
+    So this asserts the number rather than the words: add or remove a
+    tenant-headed wave operation and the wiki fails until it is updated.
+    """
+
+    spec = app.openapi()
+    served = {
+        f"{method.upper()} {path}"
+        for path, operations in spec["paths"].items()
+        for method, operation in operations.items()
+        if method in {"get", "post", "put", "patch", "delete"}
+        and "/rebalance/waves" in path
+        and "campaign" not in path
+        and any(
+            parameter["name"].lower() == "x-tenant-id"
+            and parameter["in"] == "header"
+            and parameter.get("required")
+            for parameter in operation.get("parameters", [])
+        )
+    }
+
+    api_surface = (ROOT / "wiki" / "API-Surface.md").read_text(encoding="utf-8")
+    claimed = re.search(r"(\d+) of them, not a named subset", api_surface)
+
+    assert claimed is not None, (
+        "wiki/API-Surface.md no longer states how many wave operations take the "
+        "tenant header; that sentence is what keeps the page honest"
+    )
+    assert int(claimed.group(1)) == len(served), (
+        f"wiki says {claimed.group(1)} wave operations take X-Tenant-Id; the served "
+        f"contract has {len(served)}: {sorted(served)}"
+    )
+    # A subset would satisfy an equality that someone 'fixed' by editing the
+    # number downward, so pin that the aggregate is fenced rather than sampled.
+    assert len(served) >= 15
+
+    # The count alone is too weak: rename one operation and add another and it
+    # stays 15 while the page advertises a route that no longer exists and
+    # omits the one that replaced it. The identities are what a consumer builds
+    # from, so each is asserted verbatim - which is why the page lists
+    # method-and-path rather than friendly names.
+    # Scoped to the tenant-header list, not the whole page. These routes are
+    # also listed in an earlier section, so a page-wide scan finds a deleted
+    # entry there and reports a complete list when it is not - falsification
+    # caught exactly that: removing an operation from this list failed to fail.
+    start = api_surface.index("of them, not a named subset")
+    end = api_surface.index("Those are method-and-path", start)
+    tenant_header_list = api_surface[start:end]
+    # Bullet lines only. The same block names the one unfenced wave route in
+    # prose, deliberately, and a prose mention must not be read as a claim that
+    # the route is fenced.
+    documented = set(
+        re.findall(
+            r"^- `((?:GET|POST|PUT|PATCH|DELETE) /api/v1/rebalance/waves[^`]*)`",
+            tenant_header_list,
+            re.MULTILINE,
+        )
+    )
+    assert served <= documented, f"served but undocumented: {sorted(served - documented)}"
+    stale = {entry for entry in documented if entry not in served and "campaign" not in entry}
+    assert stale == set(), f"documented but no longer served: {sorted(stale)}"
+
+    # The one non-campaign wave route that is NOT fenced. Review caught the
+    # first version of this page claiming "every rebalance-wave operation" when
+    # this route reads the outcome-review aggregate, which carries no tenant -
+    # so a wave-prefixed path does not by itself imply a tenant-partitioned
+    # response. Asserted rather than commented, so the exception cannot grow
+    # silently: a second unfenced wave route fails this until the page says so.
+    unfenced_wave_routes = {
+        f"{method.upper()} {path}"
+        for path, operations in spec["paths"].items()
+        for method, operation in operations.items()
+        if method in {"get", "post", "put", "patch", "delete"}
+        and "/rebalance/waves" in path
+        and "campaign" not in path
+        and not any(
+            "tenant" in parameter["name"].lower() and parameter.get("required")
+            for parameter in operation.get("parameters", [])
+        )
+    }
+    assert unfenced_wave_routes == {"GET /api/v1/rebalance/waves/{wave_id}/outcome-reviews"}, (
+        f"the set of unfenced wave routes changed: {sorted(unfenced_wave_routes)}"
+    )
+    # Named inside the tenant-header block, not merely somewhere on the page:
+    # this route is also listed among the unscoped reads further down, so a
+    # page-wide check passes when the warning beside the fenced list is
+    # deleted - falsification caught exactly that, twice.
+    assert "waves/{wave_id}/outcome-reviews" in tenant_header_list, (
+        "the tenant-header section must name the one wave route that is not fenced; "
+        "a reader of that list would otherwise assume the wave prefix implies fencing"
+    )

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -304,16 +304,61 @@ Source-service callers must use the canonical snake_case query parameters `consu
 `lotus-manage` should not rely on Gateway naming.
 
 The tenant is not always a query parameter. Mandate reads, monitoring-exception reads and the
-command centre take `tenant_id` as above; the rebalance-wave lifecycle commands — preview, create,
-source-check and selection — take the tenant as the `X-Tenant-Id` header, one selector across all
-four. On those surfaces the tenant is required and an absent one is refused rather than answered
-from an assumed tenant.
+command centre take `tenant_id` as above. **The wave aggregate takes the tenant as the
+`X-Tenant-Id` header instead — 15 of them, not a named subset.** On those surfaces the tenant is
+required and an absent one is refused rather than answered from an assumed tenant.
+
+The header is the only selector for the wave and mandate data `lotus-manage` owns. It is **not**
+the only `tenant_id` a wave request can carry: `PM_BOOK_REVIEW` and `CIO_MODEL_CHANGE` preview and
+create bodies accept an optional `tenant_id`, which is forwarded to upstream source products for
+cohort evaluation and is not reconciled against the header. They are different things with the same
+name — the header admits the caller, the body field filters a source lookup — so do not assume
+setting one constrains the other.
+
+One wave-prefixed route is **not** in that set and must not be assumed fenced:
+`GET /api/v1/rebalance/waves/{wave_id}/outcome-reviews`. It reads the outcome-review aggregate,
+which carries no tenant of its own, so a wave-prefixed path does not by itself imply a
+tenant-partitioned response. It is listed with the other unscoped reads below.
+
+- `GET /api/v1/rebalance/waves`
+- `GET /api/v1/rebalance/waves/{wave_id}`
+- `GET /api/v1/rebalance/waves/{wave_id}/items`
+- `GET /api/v1/rebalance/waves/{wave_id}/proof-pack`
+- `GET /api/v1/rebalance/waves/{wave_id}/report-input`
+- `GET /api/v1/rebalance/waves/{wave_id}/supportability`
+- `POST /api/v1/rebalance/waves`
+- `POST /api/v1/rebalance/waves/preview`
+- `POST /api/v1/rebalance/waves/{wave_id}/approve`
+- `POST /api/v1/rebalance/waves/{wave_id}/cancel`
+- `POST /api/v1/rebalance/waves/{wave_id}/handoff`
+- `POST /api/v1/rebalance/waves/{wave_id}/items/{wave_item_id}/select`
+- `POST /api/v1/rebalance/waves/{wave_id}/simulate`
+- `POST /api/v1/rebalance/waves/{wave_id}/source-check`
+- `POST /api/v1/rebalance/waves/{wave_id}/stage`
+
+Those are method-and-path rather than friendly names deliberately: a test asserts each one against
+the served contract, so a renamed or added operation fails this page instead of quietly ageing it.
+
+Do not build a client from a subset of that list. An earlier version of this page named only four
+of the fifteen, and a consumer enumerating wave operations from it reproduced exactly that gap.
+
+**The bulk-review campaign operations under `/rebalance/waves/campaign-*` also require
+`X-Tenant-Id`, and the served OpenAPI document does not say so.** They read the header through a
+trusted-context dependency rather than a declared parameter, so it is enforced — an absent tenant is
+refused — but it is invisible to a generated client. Send it on those routes even though the spec
+does not list it. Tracked as a contract defect rather than a documentation one, because the fix is
+to declare it.
 
 It is not yet universal. Monitoring **run** reads — `GET /monitoring/runs` and
 `GET /monitoring/runs/{monitoring_run_id}` — still accept no tenant and read across tenants,
 because the monitoring-run aggregate carries no tenant of its own. Do not treat monitoring-run
-responses as tenant-fenced. That gap is tracked with the other unscoped wave and proof-pack
-aggregates.
+responses as tenant-fenced. Five operations are in that state: both monitoring-run reads,
+`GET /rebalance/proof-packs/{proof_pack_id}` with its `summary.md` companion, and
+`GET /rebalance/waves/{wave_id}/outcome-reviews` — the last of which sits under the wave prefix
+while reading an aggregate that is not tenant-scoped.
+
+The wave aggregate is **no longer** among them — migration `0027` scoped it, and this sentence
+previously described the state before that change.
 
 Endpoint certification details are tracked in [Endpoint Certification](Endpoint-Certification).
 


### PR DESCRIPTION
`wiki/API-Surface.md` said the `X-Tenant-Id` header applied to **four** wave operations. The served contract requires it on **fifteen**.

> "the rebalance-wave lifecycle commands — preview, create, source-check and selection — take the tenant as the `X-Tenant-Id` header, one selector across all four."

The four were correct when written; the sentence was never revisited after later work extended the fence.

## It had a demonstrated consumer cost

lotus-gateway enumerated wave operations while building its tenant forwarding and shipped without `approve`, `stage`, `handoff` and `cancel`. Those four calls now reach lotus-manage with no tenant and take a 422 — filed as gateway#770, theirs to fix. They built from shipped code rather than this page, so the wiki did not cause it, but **a consumer reading that paragraph today builds the same gap.**

## Two further corrections in the same section

**The "unscoped wave aggregate" sentence described the state before migration 0027 scoped it.** The four operations genuinely without a required tenant are now named: both monitoring-run reads, and `GET /rebalance/proof-packs/{proof_pack_id}` with its `summary.md` companion.

**A caveat that is really a contract defect.** The bulk-review campaign operations under `/rebalance/waves/campaign-*` require `X-Tenant-Id` — enforced 63 times through `campaign_trusted_context_required`, which reads `request.headers` and refuses an absent tenant — but because it is a dependency rather than a declared parameter, **the served OpenAPI never mentions it.** A generated client omits the header and takes a 4xx. Documented here so a consumer is not surprised; the real fix is to declare it, which is a contract change and not this PR.

## The durable part is the test

Every other assertion in `test_documentation_current_state` checks that a document **mentions** something — which a stale document does exactly as well as a current one. The module measures mention, not currency, despite its name. That is why a page naming 4 of 15 passed for as long as it did.

The new test derives the count from the served contract and compares it against the number the page claims:

```python
served = {... operations under /rebalance/waves, excluding campaign-*, requiring x-tenant-id ...}
claimed = re.search(r"(\d+) of them, not a named subset", api_surface)
assert int(claimed.group(1)) == len(served)
assert len(served) >= 15   # a subset cannot satisfy it by editing the number downward
```

Add or remove a tenant-headed wave operation and the wiki fails until it is updated.

**Falsified** — both directions:

```
PROOF FAILS (good): wiki reverted to the old four-operation claim
PROOF FAILS (good): the honesty sentence removed entirely
```

## Gates

| Check | Result |
| --- | --- |
| Unit | 3470 passed, 2 skipped |
| `make lint` | exit 0 |
| `make typecheck` | clean, 554 source files |
| `make static-quality-gates` | exit 0 |

Wiki source changed; `Sync-RepoWikis.ps1 -CheckOnly -AllowUnpublishedSourceChanges` reports the expected unpublished-source warning. Publishing after merge.

## Provenance

Found by lotus-gateway's owner auditing my repositories at the user's request, and verified here against the served OpenAPI rather than taken on report.