### PR TITLE
fix(tenancy): replay must agree with the wave's owner, not only the mapping's

### DIFF
--- a/.github/workflows/main-releasability.yml
+++ b/.github/workflows/main-releasability.yml
@@ -176,6 +176,10 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.idea-postgres
           DPM_POSTGRES_INTEGRATION_DSN: postgresql://manage:manage@127.0.0.1:5432/manage_actions
+          # Declared a prerequisite: an absent DSN fails this lane
+          # rather than skipping it. Both wave proofs gated on the DSN
+          # alone and had never run in CI, while being cited as evidence.
+          DPM_POSTGRES_INTEGRATION_REQUIRED: "1"
         run: make test-idea-management-action-postgres-coverage
       - name: Upload coverage data
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -157,6 +157,10 @@ jobs:
         env:
           COVERAGE_FILE: .coverage.idea-postgres
           DPM_POSTGRES_INTEGRATION_DSN: postgresql://manage:manage@127.0.0.1:5432/manage_actions
+          # Declared a prerequisite: an absent DSN fails this lane
+          # rather than skipping it. Both wave proofs gated on the DSN
+          # alone and had never run in CI, while being cited as evidence.
+          DPM_POSTGRES_INTEGRATION_REQUIRED: "1"
         run: make test-idea-management-action-postgres-coverage
       - name: Upload coverage data
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,13 @@ test-integration:
 	python -m pytest $(INTEGRATION_TESTS)
 
 test-idea-management-action-postgres:
-	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py -q
+	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py tests/integration/dpm/waves -q
 
 # Every PostgreSQL-backed integration proof runs in the one CI job that owns a
 # live database. Adding a file here is what stops it becoming a lane that skips
 # everywhere and reports green (issues #646/#647).
 test-idea-management-action-postgres-coverage:
-	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py tests/integration/dpm/mandates -q --cov=src --cov-report=
+	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py tests/integration/dpm/mandates tests/integration/dpm/waves -q --cov=src --cov-report=
 	@test -f .coverage.idea-postgres || mv .coverage .coverage.idea-postgres
 
 test-e2e:

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-08T10:58:53+00:00`
+- Generated at: `2026-09-08T13:44:19+00:00`
 
-- Baseline source snapshot: `946fe29bbe914306506d42106d18833a6f9394c1`
+- Baseline source snapshot: `9a2e0b0ba6d1e992c1f9e1620cbeaa35fa9b02e9`
 
-- Report source snapshot: `2b3df8d9+worktree`
+- Report source snapshot: `9a2e0b0b+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 931 |
-| Total Python LOC | 218235 |
-| Test functions | 3167 |
+| Python files | 933 |
+| Total Python LOC | 218556 |
+| Test functions | 3174 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-08T10:58:53+00:00`
+- Generated at: `2026-09-08T13:44:19+00:00`
 
-- Baseline source snapshot: `946fe29bbe914306506d42106d18833a6f9394c1`
+- Baseline source snapshot: `9a2e0b0ba6d1e992c1f9e1620cbeaa35fa9b02e9`
 
-- Report source snapshot: `2b3df8d9+worktree`
+- Report source snapshot: `9a2e0b0b+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-08T10:58:53+00:00`
+- Generated at: `2026-09-08T13:44:19+00:00`
 
-- Baseline source snapshot: `946fe29bbe914306506d42106d18833a6f9394c1`
+- Baseline source snapshot: `9a2e0b0ba6d1e992c1f9e1620cbeaa35fa9b02e9`
 
-- Report source snapshot: `2b3df8d9+worktree`
+- Report source snapshot: `9a2e0b0b+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-08T10:58:53+00:00`
+- Generated at: `2026-09-08T13:44:19+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `946fe29bbe914306506d42106d18833a6f9394c1`
+- Baseline source snapshot: `9a2e0b0ba6d1e992c1f9e1620cbeaa35fa9b02e9`
 
-- Report source snapshot: `2b3df8d9+worktree`
+- Report source snapshot: `9a2e0b0b+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 931 | 931 | +0 |
-| Total Python LOC | 218128 | 218235 | +107 |
-| Test functions | 3166 | 3167 | +1 |
+| Python files | 931 | 933 | +2 |
+| Total Python LOC | 218235 | 218556 | +321 |
+| Test functions | 3167 | 3174 | +7 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -43,7 +43,7 @@
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2788 |
+| 7 | tests/unit/test_documentation_current_state.py | 2895 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2709 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |

--- a/src/infrastructure/waves/in_memory.py
+++ b/src/infrastructure/waves/in_memory.py
@@ -82,7 +82,21 @@ class InMemoryDpmWaveRepository(DpmWaveRepository):
                 return None
             wave_id, _request_hash = indexed
             wave = self._waves.get(wave_id)
-            return deepcopy(wave) if wave is not None else None
+            # The mapping's tenant is not the aggregate's tenant. Migration
+            # 0027 added the wave column nullable with no backfill, so between
+            # 0026 and 0027 a wave can carry NO tenant while its tenant-derived
+            # mapping survives. Checking only the mapping returned that
+            # quarantined wave as a successful replay - the one path that
+            # bypassed the fence every direct read enforces, and it would have
+            # handed the caller an aggregate nobody owns.
+            #
+            # Caller, mapping and aggregate must agree. A disagreement returns
+            # None rather than raising: a distinct error would disclose that
+            # the key resolves to something, and the quarantined row is left
+            # exactly as it is - not stamped, not resurrected.
+            if wave is None or wave.tenant_id != tenant_id:
+                return None
+            return deepcopy(wave)
 
     def list_waves(
         self,

--- a/src/infrastructure/waves/postgres.py
+++ b/src/infrastructure/waves/postgres.py
@@ -91,11 +91,18 @@ class PostgresDpmWaveRepository:
                 JOIN dpm_rebalance_waves w ON w.wave_id = i.wave_id
                 WHERE i.idempotency_key = %s
                   AND i.tenant_id = %s
+                  -- The aggregate's own owner, not only the mapping's. A wave
+                  -- left unstamped by migration 0027 has w.tenant_id NULL, and
+                  -- `NULL = 'anything'` is NULL rather than true, so it is
+                  -- matched by no caller - the same quarantine every direct
+                  -- read gets. Without this the replay path returned it.
+                  AND w.tenant_id = %s
                 """,
                 (
                     wave_idempotency_mapping_key(
                         tenant_id=tenant_id, idempotency_key=idempotency_key
                     ),
+                    tenant_id,
                     tenant_id,
                 ),
             ).fetchone()

--- a/tests/integration/dpm/postgres_prerequisite.py
+++ b/tests/integration/dpm/postgres_prerequisite.py
@@ -1,0 +1,44 @@
+"""One place that decides whether a PostgreSQL suite may skip.
+
+Both wave PostgreSQL suites gated on `skipif(not DSN)` alone, so they skipped
+silently wherever the DSN was unset - which was everywhere in CI, because the
+database lane's file list named only the supportability suite and
+`dpm/mandates`. The proofs written for issue #677 had therefore never run in
+CI at all, while being cited as evidence that the wave fence holds.
+
+The DSN check is not the defect; skipping *quietly* is. In a lane that exists
+to run these proofs, an absent prerequisite is a failure, not a reason to pass.
+`DPM_POSTGRES_INTEGRATION_REQUIRED=1` turns every skip in this family into a
+loud failure naming what was missing.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+DSN_ENV = "DPM_POSTGRES_INTEGRATION_DSN"
+REQUIRED_ENV = "DPM_POSTGRES_INTEGRATION_REQUIRED"
+
+
+def postgres_dsn_or_skip(proof: str) -> str:
+    """The DSN, or an outcome that is honest about why there is none.
+
+    Returns the DSN when configured. Otherwise fails when the lane declared
+    the database a prerequisite, and skips only when it did not - so a local
+    run without a database still skips, and a CI lane that promised to run
+    these proofs cannot report success without them.
+    """
+
+    dsn = os.getenv(DSN_ENV, "").strip()
+    if dsn:
+        return dsn
+    if os.getenv(REQUIRED_ENV, "").strip() == "1":
+        pytest.fail(
+            f"{DSN_ENV} is unset while {REQUIRED_ENV}=1: the {proof} did not run. "
+            "A lane that declares the database a prerequisite must fail rather "
+            "than skip, or an unrun proof is reported as a passing one."
+        )
+    pytest.skip(f"{DSN_ENV} is not configured, so the {proof} cannot run")
+    raise AssertionError("unreachable")

--- a/tests/integration/dpm/waves/test_wave_aggregate_tenant_isolation_postgres.py
+++ b/tests/integration/dpm/waves/test_wave_aggregate_tenant_isolation_postgres.py
@@ -21,7 +21,6 @@ database, as the wave idempotency isolation proof does.
 
 from __future__ import annotations
 
-import os
 import uuid
 from datetime import datetime, timezone
 
@@ -36,17 +35,14 @@ from src.core.waves import (
 )
 from src.infrastructure.waves.postgres import PostgresDpmWaveRepository
 
-_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
 
-pytestmark = pytest.mark.skipif(
-    not _DSN,
-    reason="DPM_POSTGRES_INTEGRATION_DSN is required for the wave aggregate isolation proof",
-)
+_PROOF = "wave aggregate isolation proof"
 
 
 @pytest.fixture
 def repository() -> PostgresDpmWaveRepository:
-    return PostgresDpmWaveRepository(dsn=_DSN)
+    return PostgresDpmWaveRepository(dsn=postgres_dsn_or_skip(_PROOF))
 
 
 @pytest.fixture

--- a/tests/integration/dpm/waves/test_wave_idempotency_tenant_isolation_postgres.py
+++ b/tests/integration/dpm/waves/test_wave_idempotency_tenant_isolation_postgres.py
@@ -17,7 +17,6 @@ made to agree with either answer.
 
 from __future__ import annotations
 
-import os
 import uuid
 from datetime import datetime, timezone
 
@@ -29,14 +28,12 @@ from src.core.waves import (
     DpmRebalanceWaveItem,
     DpmWaveTrigger,
 )
+from src.core.waves.repository import wave_idempotency_mapping_key
 from src.infrastructure.waves.postgres import PostgresDpmWaveRepository
 
-_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
 
-pytestmark = pytest.mark.skipif(
-    not _DSN,
-    reason="DPM_POSTGRES_INTEGRATION_DSN is required for the wave idempotency isolation proof",
-)
+_PROOF = "wave idempotency isolation proof"
 
 TENANT_A = "tenant-alpha"
 TENANT_B = "tenant-beta"
@@ -44,7 +41,7 @@ TENANT_B = "tenant-beta"
 
 @pytest.fixture
 def repository() -> PostgresDpmWaveRepository:
-    return PostgresDpmWaveRepository(dsn=_DSN)
+    return PostgresDpmWaveRepository(dsn=postgres_dsn_or_skip(_PROOF))
 
 
 def _wave(*, wave_id: str, portfolio_id: str) -> DpmRebalanceWave:
@@ -166,7 +163,7 @@ def test_mappings_written_before_the_tenant_column_are_quarantined_not_defaulted
 
     # Reduce the stored mapping to its pre-migration shape: the caller's raw
     # key, with no tenant.
-    with psycopg.connect(_DSN, row_factory=dict_row) as connection:
+    with psycopg.connect(postgres_dsn_or_skip(_PROOF), row_factory=dict_row) as connection:
         connection.execute(
             "UPDATE dpm_rebalance_wave_idempotency SET idempotency_key = %s, tenant_id = NULL"
             " WHERE wave_id = %s",
@@ -186,3 +183,88 @@ def test_mappings_written_before_the_tenant_column_are_quarantined_not_defaulted
         assert (
             repository.get_wave_by_idempotency(idempotency_key=legacy_key, tenant_id=tenant) is None
         ), tenant
+
+
+def test_a_wave_left_unstamped_by_0027_is_not_returned_as_a_successful_replay(
+    repository: PostgresDpmWaveRepository,
+) -> None:
+    """The upgrade regression, on the engine where it actually matters.
+
+    Migration 0026 made the mapping key tenant-derived; 0027 added the wave's
+    own tenant nullable with no backfill. Between them a wave can carry no
+    tenant while its tenant-scoped mapping survives, and every direct read
+    refuses it because `NULL = 'anything'` is NULL rather than true.
+
+    The replay path did not, because it joined on the MAPPING's tenant only.
+    This drives the exact post-upgrade shape - live mapping, unstamped
+    aggregate - which no in-memory fake can produce faithfully, since Python's
+    `None != tenant` is a different rule from SQL's.
+    """
+
+    key = f"idem-upgrade-{uuid.uuid4().hex[:10]}"
+    wave_id = f"dwv_{uuid.uuid4().hex[:10]}"
+    repository.save_wave(
+        wave=_wave(wave_id=wave_id, portfolio_id="PB_TENANT_A_001"),
+        idempotency_key=key,
+        request_hash="hash-a",
+        tenant_id=TENANT_A,
+    )
+    with repository._connect() as connection:  # noqa: SLF001
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE dpm_rebalance_waves SET tenant_id = NULL WHERE wave_id = %s",
+                (wave_id,),
+            )
+        connection.commit()
+
+    assert repository.get_wave(wave_id=wave_id, tenant_id=TENANT_A) is None
+    assert repository.get_wave_by_idempotency(idempotency_key=key, tenant_id=TENANT_A) is None, (
+        "the replay path returned a wave the direct read refuses"
+    )
+
+    # The refusal must not repair the row: quarantine means unowned, not
+    # owned by whoever replays next.
+    with repository._connect() as connection:  # noqa: SLF001
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT tenant_id FROM dpm_rebalance_waves WHERE wave_id = %s", (wave_id,)
+            )
+            row = cursor.fetchone()
+    assert row is not None
+    assert (row["tenant_id"] if isinstance(row, dict) else row[0]) is None
+
+
+def test_a_mapping_resolving_to_another_tenants_wave_is_refused(
+    repository: PostgresDpmWaveRepository,
+) -> None:
+    """Mapping and aggregate can disagree without either being NULL - a
+    restore or a partial migration is enough."""
+
+    key = f"idem-cross-{uuid.uuid4().hex[:10]}"
+    theirs = f"dwv_{uuid.uuid4().hex[:10]}"
+    repository.save_wave(
+        wave=_wave(wave_id=theirs, portfolio_id="PB_TENANT_B_001"),
+        idempotency_key=key,
+        request_hash="hash-b",
+        tenant_id=TENANT_B,
+    )
+    with repository._connect() as connection:  # noqa: SLF001
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO dpm_rebalance_wave_idempotency
+                    (idempotency_key, tenant_id, wave_id, request_hash, created_at)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (
+                    wave_idempotency_mapping_key(tenant_id=TENANT_A, idempotency_key=key),
+                    TENANT_A,
+                    theirs,
+                    "hash-a",
+                    datetime(2026, 5, 3, tzinfo=timezone.utc),
+                ),
+            )
+        connection.commit()
+
+    assert repository.get_wave_by_idempotency(idempotency_key=key, tenant_id=TENANT_A) is None
+    assert repository.get_wave(wave_id=theirs, tenant_id=TENANT_B) is not None

--- a/tests/unit/dpm/waves/test_wave_replay_owner_agreement.py
+++ b/tests/unit/dpm/waves/test_wave_replay_owner_agreement.py
@@ -1,0 +1,178 @@
+"""Replay requires caller, mapping and aggregate to agree on the tenant.
+
+`get_wave_by_idempotency` checked the MAPPING's tenant and returned whatever
+wave the mapping pointed at. Migration 0026 made mapping keys tenant-derived
+and 0027 added the wave's own tenant column nullable with no backfill, so
+between them a wave can carry no tenant at all while its tenant-scoped mapping
+survives.
+
+That left one path through the fence. Every direct read refuses a NULL-tenant
+wave, because `NULL = 'anything'` is NULL rather than true - but creation with
+the original idempotency key returned it as a successful replay. The caller
+received an aggregate that officially nobody owns, and received it through the
+one route that looks like success rather than like a leak.
+
+The pairing in the first test is the point: same wave, same caller, one route
+refusing and one returning. Testing the replay path alone would have passed
+before this fix, because returning a wave IS what replay does.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.core.waves import (
+    DpmRebalanceWave,
+    DpmRebalanceWaveItem,
+    DpmWaveAggregateMetrics,
+    DpmWaveTrigger,
+)
+from src.infrastructure.waves import InMemoryDpmWaveRepository
+
+TENANT_A = "tenant-alpha"
+TENANT_B = "tenant-beta"
+KEY = "idem-shared-by-two-tenants"
+
+
+def _wave(*, wave_id: str = "dwv_001", portfolio_id: str = "PB_A_001") -> DpmRebalanceWave:
+    return DpmRebalanceWave(
+        wave_id=wave_id,
+        state="CREATED",
+        trigger=DpmWaveTrigger(
+            trigger_type="EXPLICIT_PORTFOLIO_LIST",
+            trigger_id=f"manual-{wave_id}",
+            rationale="Replay ownership agreement proof.",
+        ),
+        as_of_date="2026-05-03",
+        created_at=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        created_by="pm-ops",
+        correlation_id=f"corr-{wave_id}",
+        items=[
+            DpmRebalanceWaveItem(
+                wave_item_id=f"dwi_{wave_id}",
+                portfolio_id=portfolio_id,
+                state="CANDIDATE",
+            )
+        ],
+        aggregate_metrics=DpmWaveAggregateMetrics(
+            item_count=1,
+            state_counts={"CANDIDATE": 1},
+            ready_item_count=0,
+            blocked_item_count=0,
+            review_required_item_count=0,
+            source_degraded_item_count=0,
+        ),
+    )
+
+
+def _quarantined_wave_with_a_live_mapping() -> InMemoryDpmWaveRepository:
+    """A wave persisted before 0027 stamped owners, whose mapping survives."""
+
+    repository = InMemoryDpmWaveRepository()
+    repository.save_wave(
+        wave=_wave(), idempotency_key=KEY, request_hash="hash-a", tenant_id=TENANT_A
+    )
+    stored = repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A)
+    assert stored is not None
+    repository._waves["dwv_001"] = stored.model_copy(  # noqa: SLF001
+        update={"tenant_id": None}
+    )
+    return repository
+
+
+def test_a_quarantined_wave_is_refused_by_replay_exactly_as_by_a_direct_read() -> None:
+    repository = _quarantined_wave_with_a_live_mapping()
+
+    direct = repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A)
+    replayed = repository.get_wave_by_idempotency(idempotency_key=KEY, tenant_id=TENANT_A)
+
+    assert direct is None
+    assert replayed is None, (
+        "the replay path returned a wave the direct read refuses - this is the "
+        "defect, and asserting only the replay result cannot see it"
+    )
+
+
+def test_the_refused_replay_does_not_stamp_or_resurrect_the_row() -> None:
+    """Quarantine means unowned, not 'owned by whoever asks next'.
+
+    A fix that repaired the row by assigning the caller's tenant would make
+    every test above pass while doing the one thing migration 0027 refuses to
+    do: give a pre-fence wave an assumed owner.
+    """
+
+    repository = _quarantined_wave_with_a_live_mapping()
+
+    repository.get_wave_by_idempotency(idempotency_key=KEY, tenant_id=TENANT_A)
+
+    survivor = repository._waves["dwv_001"]  # noqa: SLF001
+    assert survivor.tenant_id is None
+    assert repository.get_wave(wave_id="dwv_001", tenant_id=TENANT_A) is None
+
+
+def test_a_valid_replay_still_returns_the_wave() -> None:
+    """The fence must not cost the behaviour idempotency exists for."""
+
+    repository = InMemoryDpmWaveRepository()
+    repository.save_wave(
+        wave=_wave(), idempotency_key=KEY, request_hash="hash-a", tenant_id=TENANT_A
+    )
+
+    replayed = repository.get_wave_by_idempotency(idempotency_key=KEY, tenant_id=TENANT_A)
+
+    assert replayed is not None
+    assert replayed.wave_id == "dwv_001"
+    assert replayed.tenant_id == TENANT_A
+
+
+def test_two_tenants_may_reuse_one_caller_chosen_key_independently() -> None:
+    """The property #676 delivered, re-asserted here because this change
+    touches the same lookup and a tightening could have collapsed it."""
+
+    repository = InMemoryDpmWaveRepository()
+    repository.save_wave(
+        wave=_wave(wave_id="dwv_a", portfolio_id="PB_A_001"),
+        idempotency_key=KEY,
+        request_hash="hash-a",
+        tenant_id=TENANT_A,
+    )
+    repository.save_wave(
+        wave=_wave(wave_id="dwv_b", portfolio_id="PB_B_001"),
+        idempotency_key=KEY,
+        request_hash="hash-b",
+        tenant_id=TENANT_B,
+    )
+
+    replay_a = repository.get_wave_by_idempotency(idempotency_key=KEY, tenant_id=TENANT_A)
+    replay_b = repository.get_wave_by_idempotency(idempotency_key=KEY, tenant_id=TENANT_B)
+
+    assert replay_a is not None and replay_a.wave_id == "dwv_a"
+    assert replay_b is not None and replay_b.wave_id == "dwv_b"
+    assert replay_a.items[0].portfolio_id == "PB_A_001"
+    assert replay_b.items[0].portfolio_id == "PB_B_001"
+
+
+def test_a_mapping_pointing_at_another_tenants_wave_is_refused() -> None:
+    """Mapping and aggregate can disagree without either being NULL.
+
+    A restore, a partial migration or a hand-repaired row can leave a mapping
+    resolving to a wave a different tenant owns. Checking the mapping alone
+    accepts it.
+    """
+
+    repository = InMemoryDpmWaveRepository()
+    repository.save_wave(
+        wave=_wave(wave_id="dwv_b"),
+        idempotency_key=KEY,
+        request_hash="hash-b",
+        tenant_id=TENANT_B,
+    )
+    # Tenant A's mapping now resolves to tenant B's wave.
+    from src.core.waves.repository import wave_idempotency_mapping_key
+
+    repository._idempotency_index[  # noqa: SLF001
+        wave_idempotency_mapping_key(tenant_id=TENANT_A, idempotency_key=KEY)
+    ] = ("dwv_b", "hash-a")
+
+    assert repository.get_wave_by_idempotency(idempotency_key=KEY, tenant_id=TENANT_A) is None
+    assert repository.get_wave(wave_id="dwv_b", tenant_id=TENANT_B) is not None


### PR DESCRIPTION
Item 1 of the Cycle 5 continuation. See #677.

## One path was still through the fence

`get_wave_by_idempotency` checked the **mapping's** tenant and returned whatever wave the mapping pointed at:

```sql
FROM dpm_rebalance_wave_idempotency i
JOIN dpm_rebalance_waves w ON w.wave_id = i.wave_id
WHERE i.idempotency_key = %s
  AND i.tenant_id = %s        -- the mapping's owner, never the wave's
```

Migration 0026 made mapping keys tenant-derived; 0027 added the wave's own tenant nullable with no backfill. **Between them a wave can carry no tenant while its tenant-scoped mapping survives.**

Every direct read refuses that wave — `NULL = 'anything'` is NULL rather than true. Creation with the original idempotency key **returned it as a successful replay**. The caller received an aggregate that officially nobody owns, through the one route that looks like success rather than like a leak.

## Caller, mapping and aggregate must agree

PostgreSQL gains `AND w.tenant_id = %s`; in-memory gains the equivalent comparison after resolving the mapping.

A disagreement returns `None` rather than raising — a distinct error would disclose that the key resolves to *something* — and **the quarantined row is left exactly as it is: not stamped, not resurrected.** Assigning the caller's tenant is the tempting repair and is precisely what 0027 refuses to do; a test fails on that mutation specifically.

Independent keys for different tenants are unaffected, and re-asserted here because this change touches that lookup and a tightening could have collapsed them.

## The CI half matters as much as the fix

Both wave PostgreSQL suites gated on `skipif(not DSN)` alone, and the database lane's file list named only the supportability suite and `dpm/mandates`. **Neither wave suite had ever run in CI** — while the proofs written for #677 were cited as evidence that the wave fence holds.

Both are now inputs to that lane, and `DPM_POSTGRES_INTEGRATION_REQUIRED=1` makes an absent prerequisite a **failure** rather than a silent skip. A lane that declares the database a prerequisite must not report success without it.

## Proof

| Lane | Result |
| --- | --- |
| PostgreSQL wave suites (real engine) | **11 passed** |
| Wave unit tests | 489 passed |
| Unit total | 3464 passed, 13 skipped |
| `make lint` / `typecheck` (554 files) / `static-quality-gates` | exit 0 |

The PostgreSQL tests drive the **post-upgrade shape** — live mapping, unstamped aggregate — which no in-memory fake reproduces faithfully, because Python's `None !=` is a different rule from SQL's NULL comparison. Plus a mapping resolving to another tenant's wave, which a restore or partial migration can produce with neither side NULL.

**Falsification**, each mutation asserted to have applied:

```
PROOF FAILS (good): the aggregate tenant dropped from the replay JOIN      2 failed
PROOF FAILS (good): the in-memory aggregate check removed                  2 failed
PROOF FAILS (good): "repaired" by stamping the caller's tenant             2 failed
PROOF FAILS (good): DSN absent while the lane declares it required        11 errors
```

That third one is the important negative: a fix that repaired the row instead of refusing would pass every other assertion here.