### PR TITLE
fix(ci): enumerate the range a merged PR added, not a count of commits

### DIFF
--- a/.github/workflows/merged-pr-main-releasability.yml
+++ b/.github/workflows/merged-pr-main-releasability.yml
@@ -40,11 +40,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           if [ -z "$MERGE_COMMIT_SHA" ]; then
             echo "::error::pull_request.merge_commit_sha is required for exact-main releasability dispatch"
+            exit 1
+          fi
+          if [ -z "$BASE_SHA" ]; then
+            echo "::error::pull_request.base.sha was empty; the merged range cannot be bounded"
             exit 1
           fi
           if [ -z "$COMMIT_COUNT" ] || [ "$COMMIT_COUNT" -lt 1 ]; then
@@ -69,7 +74,17 @@ jobs:
           # Ancestry is judged against the freshly fetched main, not the
           # event-time checkout snapshot.
           git checkout --quiet --detach FETCH_HEAD
-          revisions="$(git rev-list -n "$COMMIT_COUNT" "$MERGE_COMMIT_SHA" | tac)"
+          # Enumerate the RANGE the PR added, not a count of commits walked
+          # back from the tip. `pull_request.commits` describes the branch when
+          # the event fired, not what landed: a rebase that drops a commit
+          # already on main leaves the count larger than the window, and the
+          # walk then runs past this PR's history into commits earlier merges
+          # put there. Those are genuine ancestors of main and genuinely number
+          # COMMIT_COUNT, so the ancestry guard and the count assertion below
+          # both PASS on a wrong enumeration - neither can catch it. Realised
+          # twice in sibling repositories, once re-tagging a base commit.
+          git fetch origin --quiet "$BASE_SHA" || true
+          revisions="$(git rev-list --reverse "$BASE_SHA..$MERGE_COMMIT_SHA")"
           if [ -z "$revisions" ]; then
             echo "::error::No revisions enumerated for merged PR #$PR_NUMBER at $MERGE_COMMIT_SHA"
             exit 1
@@ -84,15 +99,30 @@ jobs:
               echo "::error::Revision $revision is not an ancestor of main; refusing to enumerate it."
               exit 1
             fi
+            # Linearity and contiguity both hold for a squash, so neither
+            # separates "this PR added it" from "it was already there".
+            # Reachability from the base does.
+            if git merge-base --is-ancestor "$revision" "$BASE_SHA"; then
+              echo "::error::Revision $revision is reachable from the PR base; it was not added by this PR."
+              exit 1
+            fi
             enumerated=$((enumerated + 1))
           done
 
           # A merged PR of N commits must enumerate N revisions. Asserted rather
           # than assumed, because producing an empty or short list silently is
           # the exact shape of the gap being closed.
-          if [ "$enumerated" -ne "$COMMIT_COUNT" ]; then
-            echo "::error::Enumerated $enumerated revisions for a $COMMIT_COUNT-commit PR #$PR_NUMBER"
+          # The count is now an ASYMMETRIC cross-check, not the enumeration.
+          # Fewer than COMMIT_COUNT is a stale count over a complete range -
+          # an ordinary rebase does this, so it is a notice rather than a
+          # failure. More means the range spans revisions the PR did not add,
+          # and that is refused BEFORE anything is tagged.
+          if [ "$enumerated" -gt "$COMMIT_COUNT" ]; then
+            echo "::error::Enumerated $enumerated revisions for a $COMMIT_COUNT-commit PR #$PR_NUMBER; the range spans revisions this PR did not add."
             exit 1
+          fi
+          if [ "$enumerated" -lt "$COMMIT_COUNT" ]; then
+            echo "::notice::Enumerated $enumerated of a declared $COMMIT_COUNT commits for PR #$PR_NUMBER; pull_request.commits predates the rebase."
           fi
 
           payload="$(printf '%s\n' $revisions | jq -R . | jq -sc .)"

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-08T13:44:19+00:00`
+- Generated at: `2026-09-08T14:05:03+00:00`
 
-- Baseline source snapshot: `9a2e0b0ba6d1e992c1f9e1620cbeaa35fa9b02e9`
+- Baseline source snapshot: `1af776536c62668b9551429146cd8f4c5a22f91b`
 
-- Report source snapshot: `9a2e0b0b+worktree`
+- Report source snapshot: `1af77653+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 933 |
-| Total Python LOC | 218556 |
+| Total Python LOC | 218596 |
 | Test functions | 3174 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-08T13:44:19+00:00`
+- Generated at: `2026-09-08T14:05:03+00:00`
 
-- Baseline source snapshot: `9a2e0b0ba6d1e992c1f9e1620cbeaa35fa9b02e9`
+- Baseline source snapshot: `1af776536c62668b9551429146cd8f4c5a22f91b`
 
-- Report source snapshot: `9a2e0b0b+worktree`
+- Report source snapshot: `1af77653+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-08T13:44:19+00:00`
+- Generated at: `2026-09-08T14:05:03+00:00`
 
-- Baseline source snapshot: `9a2e0b0ba6d1e992c1f9e1620cbeaa35fa9b02e9`
+- Baseline source snapshot: `1af776536c62668b9551429146cd8f4c5a22f91b`
 
-- Report source snapshot: `9a2e0b0b+worktree`
+- Report source snapshot: `1af77653+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-08T13:44:19+00:00`
+- Generated at: `2026-09-08T14:05:03+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `9a2e0b0ba6d1e992c1f9e1620cbeaa35fa9b02e9`
+- Baseline source snapshot: `1af776536c62668b9551429146cd8f4c5a22f91b`
 
-- Report source snapshot: `9a2e0b0b+worktree`
+- Report source snapshot: `1af77653+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 931 | 933 | +2 |
-| Total Python LOC | 218235 | 218556 | +321 |
-| Test functions | 3167 | 3174 | +7 |
+| Python files | 933 | 933 | +0 |
+| Total Python LOC | 218556 | 218596 | +40 |
+| Test functions | 3174 | 3174 | +0 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/tests/unit/test_main_gate_commit_coverage.py
+++ b/tests/unit/test_main_gate_commit_coverage.py
@@ -22,10 +22,42 @@ WORKFLOW_ROOT = ROOT / ".github" / "workflows"
 def test_merged_pr_dispatch_gates_every_revision_the_pr_put_on_main() -> None:
     dispatcher = (WORKFLOW_ROOT / "merged-pr-main-releasability.yml").read_text(encoding="utf-8")
 
-    # Enumeration of every revision, oldest first, from full history.
+    # Enumerate the RANGE the PR added, oldest first - not a count of commits
+    # walked back from the tip.
+    #
+    # This assertion previously pinned `git rev-list -n "$COMMIT_COUNT"
+    # "$MERGE_COMMIT_SHA" | tac`, so the test and the defect were wrong
+    # together and a correction would have failed the suite while reading as
+    # though the correction were the mistake. `pull_request.commits` describes
+    # the branch when the event fired, not what landed: after a rebase that
+    # drops a commit already on main, the count exceeds the window and the walk
+    # runs into commits earlier merges put there. Those are genuine ancestors
+    # of main and genuinely number COMMIT_COUNT, so the ancestry guard and the
+    # count assertion both pass on a wrong enumeration.
     assert "COMMIT_COUNT: ${{ github.event.pull_request.commits }}" in dispatcher
-    assert 'git rev-list -n "$COMMIT_COUNT" "$MERGE_COMMIT_SHA" | tac' in dispatcher
+    assert "BASE_SHA: ${{ github.event.pull_request.base.sha }}" in dispatcher
+    assert 'git rev-list --reverse "$BASE_SHA..$MERGE_COMMIT_SHA"' in dispatcher
+    assert 'git rev-list -n "$COMMIT_COUNT"' not in dispatcher, (
+        "the count-bounded walk is the defect this test used to pin"
+    )
     assert "for revision in $revisions; do" in dispatcher
+
+    # The base must be bound and required; an unbounded range is unbounded
+    # error, and the walk runs further back the larger the discrepancy.
+    assert 'if [ -z "$BASE_SHA" ]; then' in dispatcher
+
+    # Reachability from the base is what separates "this PR added it" from
+    # "it was already there". Linearity and contiguity both hold for a squash.
+    assert 'if git merge-base --is-ancestor "$revision" "$BASE_SHA"; then' in dispatcher
+
+    # The count survives as an ASYMMETRIC cross-check. Fewer than declared is
+    # an ordinary rebase and must not fail; more means the range spans
+    # revisions the PR did not add and is refused before anything is tagged.
+    assert '[ "$enumerated" -gt "$COMMIT_COUNT" ]' in dispatcher
+    assert '[ "$enumerated" -lt "$COMMIT_COUNT" ]' in dispatcher
+    assert '-ne "$COMMIT_COUNT"' not in dispatcher, (
+        "a symmetric count check fails every ordinary rebase"
+    )
     assert "fetch-depth: 0" in dispatcher
     # Every dispatch is pinned to its own revision, not the PR head.
     assert 'dispatch_ref="main-releasability-${revision}"' in dispatcher
@@ -255,9 +287,16 @@ def test_the_dispatcher_passes_only_inputs_this_gate_declares() -> None:
 def test_the_dispatcher_asserts_it_enumerated_one_revision_per_commit() -> None:
     """A loop that silently produces nothing is the shape of the gap being closed.
 
-    Enumerating zero or too few revisions would leave the job green with no
-    coverage created - indistinguishable, from the outside, from the defect this
-    issue reports. The count is asserted against the PR's own commit count.
+    Enumerating zero revisions would leave the job green with no coverage
+    created - indistinguishable, from the outside, from the defect this issue
+    reports.
+
+    The count is no longer asserted for equality. `pull_request.commits`
+    describes the branch when the event fired, so an ordinary rebase makes it
+    exceed what landed, and a symmetric check fails every such merge. It is an
+    asymmetric cross-check instead: MORE enumerated than declared means the
+    range spans revisions the PR did not add and is refused; FEWER is a stale
+    count over a complete range and is a notice.
 
     Enumeration and dispatch are separate jobs so the dispatch step stays a flat
     lookup / conditional ref creation / dispatch sequence: workflow_policy_gate
@@ -267,7 +306,8 @@ def test_the_dispatcher_asserts_it_enumerated_one_revision_per_commit() -> None:
 
     dispatcher = (WORKFLOW_ROOT / "merged-pr-main-releasability.yml").read_text(encoding="utf-8")
 
-    assert 'if [ "$enumerated" -ne "$COMMIT_COUNT" ]; then' in dispatcher
+    assert 'if [ -z "$revisions" ]; then' in dispatcher
+    assert '[ "$enumerated" -gt "$COMMIT_COUNT" ]' in dispatcher
     assert "enumerated=$((enumerated + 1))" in dispatcher
     # One dispatch job per enumerated revision, fed from the enumerating job so
     # the dispatched SHA stays bound to the merge event rather than to anything


### PR DESCRIPTION
Reported by lotus-platform's owner from a cross-repository sweep (lotus-platform#859); verified here against the shipped workflow before changing anything.

## Both existing guards pass on a wrong enumeration

The dispatcher walked:

```sh
git rev-list -n "$COMMIT_COUNT" "$MERGE_COMMIT_SHA" | tac
```

`pull_request.commits` describes the branch **when the event fired**, not what landed. A rebase that drops a commit already on main leaves the count larger than the window, and the walk runs past this PR's history into commits earlier merges put there.

Neither guard catches it:

- those extra revisions are **genuine ancestors of main**, so the ancestry check passes
- they genuinely **number `COMMIT_COUNT`**, so the count assertion passes

Two realised instances in siblings: one dispatch refused entirely because the walk reached `base.sha` and a commit is its own ancestor, so **nothing was gated**; another **re-tagged and re-dispatched the base commit**. The error direction is unbounded — a larger discrepancy walks further back, and nothing bounds it.

## The fix

```sh
git rev-list --reverse "$BASE_SHA..$MERGE_COMMIT_SHA"
```

with `BASE_SHA` bound to `pull_request.base.sha` and **required** — an unbounded range is unbounded error.

Each revision is additionally asserted **not reachable from the base**. Linearity and contiguity both hold for a squash, so neither separates "this PR added it" from "it was already there"; reachability from the base does.

The count survives as an **asymmetric** cross-check:

| | |
| --- | --- |
| fewer than declared | stale count over a complete range — an ordinary rebase. **Notice**, not a failure |
| more than declared | the range spans revisions the PR did not add. **Refused before anything is tagged** |

## Two tests were pinning the defect

This is the part worth reading. One asserted the count-bounded `rev-list` string **literally**, so the guard and its test were wrong together — this correction would have failed the suite while reading as though the correction were the mistake. The other asserted the symmetric count check, which fails every ordinary rebase.

Both are rewritten against the shipped workflow and now assert the defective forms are **absent**, so a revert fails rather than passes.

## Falsification

```
PROOF FAILS (good): reverted to the count-bounded walk (the original defect)   1 failed
PROOF FAILS (good): reachability-from-base check removed                       1 failed
PROOF FAILS (good): base binding dropped                                       1 failed
PROOF FAILS (good): count check made symmetric again                           2 failed
```

The first two would have **passed** before this change.

| Check | Result |
| --- | --- |
| Unit | 3464 passed, 13 skipped |
| `make lint` / `typecheck` (554 files) / `static-quality-gates` | exit 0 |

The governed workflow validator permits both forms, so nothing central catches this or a later revert — a repo-local pin is the only thing that will, which is why the tests assert absence rather than only presence.