### PR TITLE
fix(runtime): scope monitoring-run reads to their recorded tenant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,17 +59,11 @@ test-integration:
 # ONE list, named once. The two targets below carried separate copies and had
 # already drifted - `dpm/mandates` was in the coverage target and not the plain
 # one - which is the same failure in a smaller form: the lane an operator runs
-# by hand and the lane CI runs were proving different things.
-#
-# `tests/unit/dpm/supportability/test_postgres_lane_inputs.py` asserts this
-# variable names every PostgreSQL proof file in the tree, so adding one is not
-# a step anybody has to remember.
-POSTGRES_INTEGRATION_TESTS = \
-	tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py \
-	tests/integration/dpm/supportability/test_dpm_postgres_repository_integration.py \
-	tests/integration/dpm/supportability/test_dpm_policy_pack_postgres_repository_integration.py \
-	tests/integration/dpm/mandates \
-	tests/integration/dpm/waves
+# by hand and the lane CI runs were proving different things. Running the
+# complete integration tree makes adapter imports, package re-exports and
+# fixture-supplied repositories irrelevant to reachability: every integration
+# proof is in the live-database lane without another list to maintain.
+POSTGRES_INTEGRATION_TESTS = tests/integration
 
 test-idea-management-action-postgres:
 	python -m pytest $(POSTGRES_INTEGRATION_TESTS) -q

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,30 @@ test-unit:
 test-integration:
 	python -m pytest $(INTEGRATION_TESTS)
 
-test-idea-management-action-postgres:
-	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py tests/integration/dpm/waves -q
-
 # Every PostgreSQL-backed integration proof runs in the one CI job that owns a
-# live database. Adding a file here is what stops it becoming a lane that skips
-# everywhere and reports green (issues #646/#647).
+# live database. This list is the lane's input, and a proof absent from it is
+# indistinguishable from a proof that passed (issues #646/#647/#677).
+#
+# ONE list, named once. The two targets below carried separate copies and had
+# already drifted - `dpm/mandates` was in the coverage target and not the plain
+# one - which is the same failure in a smaller form: the lane an operator runs
+# by hand and the lane CI runs were proving different things.
+#
+# `tests/unit/dpm/supportability/test_postgres_lane_inputs.py` asserts this
+# variable names every PostgreSQL proof file in the tree, so adding one is not
+# a step anybody has to remember.
+POSTGRES_INTEGRATION_TESTS = \
+	tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py \
+	tests/integration/dpm/supportability/test_dpm_postgres_repository_integration.py \
+	tests/integration/dpm/supportability/test_dpm_policy_pack_postgres_repository_integration.py \
+	tests/integration/dpm/mandates \
+	tests/integration/dpm/waves
+
+test-idea-management-action-postgres:
+	python -m pytest $(POSTGRES_INTEGRATION_TESTS) -q
+
 test-idea-management-action-postgres-coverage:
-	python -m pytest tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py tests/integration/dpm/mandates tests/integration/dpm/waves -q --cov=src --cov-report=
+	python -m pytest $(POSTGRES_INTEGRATION_TESTS) -q --cov=src --cov-report=
 	@test -f .coverage.idea-postgres || mv .coverage .coverage.idea-postgres
 
 test-e2e:

--- a/docs/architecture/dpm-command-center-gateway-workbench-handoff.md
+++ b/docs/architecture/dpm-command-center-gateway-workbench-handoff.md
@@ -42,7 +42,7 @@ Gateway should expose a product-facing command-center contract that composes the
 | --- | --- | --- |
 | Book-level health cockpit | `GET /api/v1/dpm/command-center` | Pass tenant, portfolio-manager, book, as-of, and health filters. Preserve supportability and source-run lineage. |
 | Monitoring execution | `POST /api/v1/dpm/monitoring/run-once` | Restrict execution to entitled books or explicit mandate ids. Add user, tenant, and channel context. |
-| Monitoring run audit | `GET /api/v1/dpm/monitoring/runs` and `GET /api/v1/dpm/monitoring/runs/{monitoring_run_id}` | Provide newest-first audit view and drill-down. |
+| Monitoring run audit | `GET /api/v1/dpm/monitoring/runs` and `GET /api/v1/dpm/monitoring/runs/{monitoring_run_id}` | Provide newest-first audit view and drill-down. **Both require `tenant_id`** and return only that tenant's runs; forward the tenant already resolved for the cockpit rather than deriving a second one. A call without it is refused with `422`. |
 | Exception queue | `GET /api/v1/dpm/exceptions` | Shape for table and drill-down panels without changing reason codes, severity, or recommended action. |
 | Exception resolution | `POST /api/v1/dpm/exceptions/{exception_id}/resolve` | Enforce resolver entitlement and pass bounded resolution reason. |
 | Mandate drill-down | `GET /api/v1/mandates/{mandate_id}`, `GET /api/v1/mandates/{mandate_id}/health`, `GET /api/v1/mandates/{mandate_id}/diff` | Provide twin, score, dimension evidence, and version delta for the selected mandate. Forward `as_of_date` to the health read for historical reviews and preserve the resolved snapshot date. |

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-09-07T13:40:09.192745+00:00",
+  "generatedAt": "2026-09-08T15:05:01.396422+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -18728,6 +18728,18 @@
       "attributeRef": "#/attributeCatalog/lotus.limit"
     },
     {
+      "name": "tenant_id",
+      "kind": "request_option",
+      "location": "query",
+      "required": true,
+      "type": "string",
+      "description": "Tenant whose mandate evidence is being read. Required: mandate snapshots and health snapshots are stored per tenant, and the same mandate id may exist under more than one tenant. Send it as the canonical snake_case query parameter `tenant_id`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+    },
+    {
       "name": "status_filter",
       "kind": "request_option",
       "location": "query",
@@ -18774,6 +18786,18 @@
       "allowedValues": [],
       "semanticId": "lotus.monitoring_run_id",
       "attributeRef": "#/attributeCatalog/lotus.monitoring_run_id"
+    },
+    {
+      "name": "tenant_id",
+      "kind": "request_option",
+      "location": "query",
+      "required": true,
+      "type": "string",
+      "description": "Tenant whose mandate evidence is being read. Required: mandate snapshots and health snapshots are stored per tenant, and the same mandate id may exist under more than one tenant. Send it as the canonical snake_case query parameter `tenant_id`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.tenant_id"
     },
     {
       "name": "tenant_id",
@@ -62707,6 +62731,14 @@
       "request": {
         "fields": [
           {
+            "name": "tenant_id",
+            "location": "query",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+          },
+          {
             "name": "status_filter",
             "location": "query",
             "required": false,
@@ -62864,6 +62896,14 @@
             "type": "string",
             "semanticId": "lotus.monitoring_run_id",
             "attributeRef": "#/attributeCatalog/lotus.monitoring_run_id"
+          },
+          {
+            "name": "tenant_id",
+            "location": "query",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           }
         ]
       },

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-08T23:49:01+00:00`
+- Generated at: `2026-09-09T00:03:27+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `7a176aa2+worktree`
+- Report source snapshot: `030ac897+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 936 |
-| Total Python LOC | 219821 |
-| Test functions | 3193 |
+| Total Python LOC | 219542 |
+| Test functions | 3189 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-08T23:37:01+00:00`
+- Generated at: `2026-09-08T23:49:01+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `516d6f18+worktree`
+- Report source snapshot: `7a176aa2+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 936 |
-| Total Python LOC | 219786 |
+| Total Python LOC | 219821 |
 | Test functions | 3193 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-08T14:05:03+00:00`
+- Generated at: `2026-09-08T15:08:37+00:00`
 
-- Baseline source snapshot: `1af776536c62668b9551429146cd8f4c5a22f91b`
+- Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `1af77653+worktree`
+- Report source snapshot: `0e23e6fc+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 933 |
-| Total Python LOC | 218596 |
-| Test functions | 3174 |
+| Python files | 936 |
+| Total Python LOC | 219429 |
+| Test functions | 3188 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-08T15:08:37+00:00`
+- Generated at: `2026-09-08T15:34:28+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `0e23e6fc+worktree`
+- Report source snapshot: `6330968d+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 936 |
-| Total Python LOC | 219429 |
-| Test functions | 3188 |
+| Total Python LOC | 219556 |
+| Test functions | 3190 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-08T15:34:28+00:00`
+- Generated at: `2026-09-08T23:18:42+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `6330968d+worktree`
+- Report source snapshot: `6e781702+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 936 |
-| Total Python LOC | 219556 |
-| Test functions | 3190 |
+| Total Python LOC | 219809 |
+| Test functions | 3193 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-08T23:18:42+00:00`
+- Generated at: `2026-09-08T23:37:01+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `6e781702+worktree`
+- Report source snapshot: `516d6f18+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 936 |
-| Total Python LOC | 219809 |
+| Total Python LOC | 219786 |
 | Test functions | 3193 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-08T14:05:03+00:00`
+- Generated at: `2026-09-08T15:08:37+00:00`
 
-- Baseline source snapshot: `1af776536c62668b9551429146cd8f4c5a22f91b`
+- Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `1af77653+worktree`
+- Report source snapshot: `0e23e6fc+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-08T23:37:01+00:00`
+- Generated at: `2026-09-08T23:49:01+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `516d6f18+worktree`
+- Report source snapshot: `7a176aa2+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-08T23:49:01+00:00`
+- Generated at: `2026-09-09T00:03:27+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `7a176aa2+worktree`
+- Report source snapshot: `030ac897+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-08T15:08:37+00:00`
+- Generated at: `2026-09-08T15:34:28+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `0e23e6fc+worktree`
+- Report source snapshot: `6330968d+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-08T23:18:42+00:00`
+- Generated at: `2026-09-08T23:37:01+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `6e781702+worktree`
+- Report source snapshot: `516d6f18+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-08T15:34:28+00:00`
+- Generated at: `2026-09-08T23:18:42+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `6330968d+worktree`
+- Report source snapshot: `6e781702+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-08T23:37:01+00:00`
+- Generated at: `2026-09-08T23:49:01+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `516d6f18+worktree`
+- Report source snapshot: `7a176aa2+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-08T15:34:28+00:00`
+- Generated at: `2026-09-08T23:18:42+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `6330968d+worktree`
+- Report source snapshot: `6e781702+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-08T15:08:37+00:00`
+- Generated at: `2026-09-08T15:34:28+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `0e23e6fc+worktree`
+- Report source snapshot: `6330968d+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-08T23:18:42+00:00`
+- Generated at: `2026-09-08T23:37:01+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `6e781702+worktree`
+- Report source snapshot: `516d6f18+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-08T23:49:01+00:00`
+- Generated at: `2026-09-09T00:03:27+00:00`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `7a176aa2+worktree`
+- Report source snapshot: `030ac897+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-08T14:05:03+00:00`
+- Generated at: `2026-09-08T15:08:37+00:00`
 
-- Baseline source snapshot: `1af776536c62668b9551429146cd8f4c5a22f91b`
+- Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `1af77653+worktree`
+- Report source snapshot: `0e23e6fc+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-08T23:49:01+00:00`
+- Generated at: `2026-09-09T00:03:27+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `7a176aa2+worktree`
+- Report source snapshot: `030ac897+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 933 | 936 | +3 |
-| Total Python LOC | 218596 | 219821 | +1225 |
-| Test functions | 3174 | 3193 | +19 |
+| Total Python LOC | 218596 | 219542 | +946 |
+| Test functions | 3174 | 3189 | +15 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-08T14:05:03+00:00`
+- Generated at: `2026-09-08T15:08:37+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `1af776536c62668b9551429146cd8f4c5a22f91b`
+- Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `1af77653+worktree`
+- Report source snapshot: `0e23e6fc+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 933 | 933 | +0 |
-| Total Python LOC | 218556 | 218596 | +40 |
-| Test functions | 3174 | 3174 | +0 |
+| Python files | 933 | 936 | +3 |
+| Total Python LOC | 218596 | 219429 | +833 |
+| Test functions | 3174 | 3188 | +14 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -58,7 +58,7 @@
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2895 |
+| 7 | tests/unit/test_documentation_current_state.py | 2970 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2709 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-08T23:37:01+00:00`
+- Generated at: `2026-09-08T23:49:01+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `516d6f18+worktree`
+- Report source snapshot: `7a176aa2+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 933 | 936 | +3 |
-| Total Python LOC | 218596 | 219786 | +1190 |
+| Total Python LOC | 218596 | 219821 | +1225 |
 | Test functions | 3174 | 3193 | +19 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-08T15:08:37+00:00`
+- Generated at: `2026-09-08T15:34:28+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `0e23e6fc+worktree`
+- Report source snapshot: `6330968d+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 933 | 936 | +3 |
-| Total Python LOC | 218596 | 219429 | +833 |
-| Test functions | 3174 | 3188 | +14 |
+| Total Python LOC | 218596 | 219556 | +960 |
+| Test functions | 3174 | 3190 | +16 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -93,7 +93,7 @@
 | 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 334 |
 | 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
 | 9 | test_wave_openapi_pins_campaign_workflow_assignment_and_automation_contracts | tests/unit/dpm/api/test_waves_api.py | 268 |
-| 10 | test_dpm_supportability_and_async_schemas_have_descriptions_and_examples | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 237 |
+| 10 | execute | tests/unit/dpm/supportability/test_dpm_mandate_repository.py | 242 |
 
 ## Most Complex Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-08T15:34:28+00:00`
+- Generated at: `2026-09-08T23:18:42+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `6330968d+worktree`
+- Report source snapshot: `6e781702+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 933 | 936 | +3 |
-| Total Python LOC | 218596 | 219556 | +960 |
-| Test functions | 3174 | 3190 | +16 |
+| Total Python LOC | 218596 | 219809 | +1213 |
+| Test functions | 3174 | 3193 | +19 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -93,7 +93,7 @@
 | 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 334 |
 | 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
 | 9 | test_wave_openapi_pins_campaign_workflow_assignment_and_automation_contracts | tests/unit/dpm/api/test_waves_api.py | 268 |
-| 10 | execute | tests/unit/dpm/supportability/test_dpm_mandate_repository.py | 242 |
+| 10 | execute | tests/unit/dpm/supportability/test_dpm_mandate_repository.py | 246 |
 
 ## Most Complex Functions
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-08T23:18:42+00:00`
+- Generated at: `2026-09-08T23:37:01+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
 
-- Report source snapshot: `6e781702+worktree`
+- Report source snapshot: `516d6f18+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 933 | 936 | +3 |
-| Total Python LOC | 218596 | 219809 | +1213 |
+| Total Python LOC | 218596 | 219786 | +1190 |
 | Test functions | 3174 | 3193 | +19 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/src/api/routers/monitoring_run_read_routes.py
+++ b/src/api/routers/monitoring_run_read_routes.py
@@ -4,6 +4,7 @@ from typing import Literal, Optional
 
 from fastapi import Depends, Query
 
+from src.api.routers.mandate_tenant_query import MandateTenantId
 from src.api.dependencies import get_mandate_repository
 from src.api.routers.mandate_http import read_mandate_with_not_found_http_mapping
 from src.api.routers.monitoring import router
@@ -24,6 +25,7 @@ from src.core.mandates import DpmMonitoringRun
     responses={200: {"description": "Bounded monitoring run page."}},
 )
 async def read_monitoring_runs(
+    tenant_id: MandateTenantId,
     status_filter: Optional[Literal["SUCCEEDED", "FAILED"]] = Query(
         default=None,
         description="Optional terminal status filter.",
@@ -38,6 +40,7 @@ async def read_monitoring_runs(
         status=status_filter,
         limit=limit,
         cursor=cursor,
+        tenant_id=tenant_id,
     )
     return DpmMonitoringRunPage(items=items, next_cursor=next_cursor)
 
@@ -54,11 +57,13 @@ async def read_monitoring_runs(
 )
 async def read_monitoring_run(
     monitoring_run_id: str,
+    tenant_id: MandateTenantId,
     repository: DpmMandateRepository = Depends(get_mandate_repository),
 ) -> DpmMonitoringRun:
     return read_mandate_with_not_found_http_mapping(
         lambda: get_monitoring_run(
             repository=repository,
             monitoring_run_id=monitoring_run_id,
+            tenant_id=tenant_id,
         )
     )

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -207,8 +207,9 @@ def get_monitoring_run(
     *,
     repository: DpmMandateRepository,
     monitoring_run_id: str,
+    tenant_id: str,
 ) -> DpmMonitoringRun:
-    run = repository.get_monitoring_run(monitoring_run_id=monitoring_run_id)
+    run = repository.get_monitoring_run(monitoring_run_id=monitoring_run_id, tenant_id=tenant_id)
     if run is None:
         raise DpmMonitoringRunNotFoundError("DPM_MONITORING_RUN_NOT_FOUND")
     return run
@@ -220,8 +221,11 @@ def list_monitoring_runs(
     status: Optional[str],
     limit: int,
     cursor: Optional[str],
+    tenant_id: str,
 ) -> tuple[list[DpmMonitoringRun], Optional[str]]:
-    return repository.list_monitoring_runs(status=status, limit=limit, cursor=cursor)
+    return repository.list_monitoring_runs(
+        status=status, limit=limit, cursor=cursor, tenant_id=tenant_id
+    )
 
 
 def list_monitoring_exceptions(
@@ -273,7 +277,13 @@ def get_command_center_summary(
     health_state: Optional[str],
     limit: int,
 ) -> DpmCommandCenterSummary:
-    runs, _ = repository.list_monitoring_runs(status=None, limit=200, cursor=None)
+    # Fenced in the query rather than after the fetch. This previously read
+    # every tenant's runs and narrowed them in Python, so the caller's own
+    # page size was spent on rows they may not see - a correctness bug that
+    # presents as a short result rather than as a leak.
+    runs, _ = repository.list_monitoring_runs(
+        status=None, limit=200, cursor=None, tenant_id=tenant_id
+    )
     latest_run = latest_command_center_run(
         runs,
         tenant_id=tenant_id,

--- a/src/core/mandate_repository.py
+++ b/src/core/mandate_repository.py
@@ -72,6 +72,7 @@ class DpmMandateRepository(Protocol):
         self,
         *,
         monitoring_run_id: str,
+        tenant_id: str,
     ) -> Optional[DpmMonitoringRun]: ...
 
     def list_monitoring_runs(
@@ -80,6 +81,7 @@ class DpmMandateRepository(Protocol):
         status: Optional[str],
         limit: int,
         cursor: Optional[str],
+        tenant_id: str,
     ) -> tuple[list[DpmMonitoringRun], Optional[str]]: ...
 
     def list_monitoring_exceptions(

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -194,10 +194,18 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
         self,
         *,
         monitoring_run_id: str,
+        tenant_id: str,
     ) -> Optional[DpmMonitoringRun]:
         with self._lock:
             run = self._monitoring_runs.get(monitoring_run_id)
-            return deepcopy(run) if run is not None else None
+            # The tenant lives in `filters`, not as a model field: the column
+            # is fed from `run.filters.get("tenant_id")`. Reading it the same
+            # way here keeps the two adapters answering one question rather
+            # than two. A run with no recorded tenant is matched by no caller,
+            # the same quarantine the mandate and wave aggregates use.
+            if run is None or run.filters.get("tenant_id") != tenant_id:
+                return None
+            return deepcopy(run)
 
     def list_monitoring_runs(
         self,
@@ -205,9 +213,16 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
         status: Optional[str],
         limit: int,
         cursor: Optional[str],
+        tenant_id: str,
     ) -> tuple[list[DpmMonitoringRun], Optional[str]]:
         with self._lock:
-            rows = list(self._monitoring_runs.values())
+            # Filtered before paging: filtering a page would silently return
+            # fewer of the caller's own runs than the page they asked for.
+            rows = [
+                row
+                for row in self._monitoring_runs.values()
+                if row.filters.get("tenant_id") == tenant_id
+            ]
             if status is not None:
                 rows = [row for row in rows if row.status == status]
             rows = sorted(

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -439,26 +439,40 @@ class PostgresDpmMandateRepository:
             args.append(status)
         if cursor is not None:
             where_clauses.append(
-                """
+                f"""
                 (
                     started_at < (
                         SELECT started_at FROM dpm_monitoring_runs
                         WHERE monitoring_run_id = %s AND tenant_id = %s
+                          AND {_OWNER_AGREEMENT_SQL}
                     )
                     OR (
                         started_at = (
                             SELECT started_at FROM dpm_monitoring_runs
                             WHERE monitoring_run_id = %s AND tenant_id = %s
+                              AND {_OWNER_AGREEMENT_SQL}
                         )
                         AND monitoring_run_id < %s
                     )
                 )
                 """
             )
-            # The cursor row is resolved under the same tenant. An unfenced
-            # subquery leaks ordering position even when the page is fenced:
-            # another tenant's run id would still resolve to a started_at.
-            args.extend([cursor, tenant_id, cursor, tenant_id, cursor])
+            # The anchor row is resolved under EXACTLY the visibility rule the
+            # page uses. Two predicates, not one:
+            #
+            # the tenant, because an unfenced subquery leaks ordering position
+            # even when the page is fenced - another tenant's run id would
+            # still resolve to a started_at;
+            #
+            # and the owner agreement, because a contradictory row is invisible
+            # to everyone yet its column still names a tenant. That tenant
+            # could hand back the row's own id as a cursor and page from a
+            # position it cannot see - and the two adapters disagreed about
+            # what happened next, PostgreSQL returning older valid runs while
+            # the in-memory store returned nothing. A cursor naming a row the
+            # caller cannot read is refused, which is what it already does for
+            # every other invisible row.
+            args.extend([cursor, tenant_id, tenant_id, cursor, tenant_id, tenant_id, cursor])
         where_sql = f"WHERE {' AND '.join(where_clauses)}"
         query = f"""
             SELECT payload_json, monitoring_run_id

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -62,21 +62,25 @@ _MANDATE_VERSION_ORDER = (
 )
 
 
-def _run_owned_by(run: DpmMonitoringRun, tenant_id: str) -> bool:
-    """The stored column and the stored body must name the same owner.
-
-    `tenant_id` is a column AND a key inside `filters_json`/`payload_json`, fed
-    from one value at insert. The ON CONFLICT clause refreshes the payload and
-    the filters but deliberately never the column, so a later save carrying a
-    different tenant rewrites the body while the fence keeps answering with the
-    original owner. The column then admits the caller and the payload handed
-    back is another tenant's.
-
-    Both must agree with the caller, so a row whose own two records disagree is
-    served to nobody rather than to whichever of the two the fence consulted.
-    """
-
-    return run.filters.get("tenant_id") == tenant_id
+# The stored column and the stored body must name the same owner.
+#
+# `tenant_id` is a column AND a key inside `payload_json`, fed from one value at
+# insert. The ON CONFLICT clause refreshes the payload and the filters but
+# deliberately never the column, so a later save carrying a different tenant
+# rewrites the body while the fence keeps answering with the original owner. The
+# column then admits the caller and the payload handed back is another tenant's.
+#
+# Both must agree with the caller, so a row whose own two records disagree is
+# served to nobody rather than to whichever of the two the fence consulted.
+#
+# In SQL rather than after the fetch, and that placement is the whole point.
+# Applied in Python this predicate runs AFTER `LIMIT`, so contradictory rows
+# consume the fetched window and the caller receives a SHORT page with no
+# cursor while its own older runs remain unread - a filtered page instead of a
+# filtered set, which is the exact defect the tenant predicate is seeded to
+# avoid two lines below. `payload_json` is JSONB (migration 0004), so the
+# engine can answer this as part of the set.
+_OWNER_AGREEMENT_SQL = "payload_json -> 'filters' ->> 'tenant_id' = %s"
 
 
 class PostgresDpmMandateRepository:
@@ -409,14 +413,13 @@ class PostgresDpmMandateRepository:
     ) -> Optional[DpmMonitoringRun]:
         query = (
             "SELECT payload_json FROM dpm_monitoring_runs "
-            "WHERE monitoring_run_id = %s AND tenant_id = %s"
+            f"WHERE monitoring_run_id = %s AND tenant_id = %s AND {_OWNER_AGREEMENT_SQL}"
         )
         with closing(self._connect()) as connection:
-            row = connection.execute(query, (monitoring_run_id, tenant_id)).fetchone()
+            row = connection.execute(query, (monitoring_run_id, tenant_id, tenant_id)).fetchone()
         if row is None:
             return None
-        run = load_model_json(DpmMonitoringRun, _payload(row))
-        return run if _run_owned_by(run, tenant_id) else None
+        return load_model_json(DpmMonitoringRun, _payload(row))
 
     def list_monitoring_runs(
         self,
@@ -429,8 +432,8 @@ class PostgresDpmMandateRepository:
         # Seeded, not appended conditionally: the tenant predicate is not
         # optional, and a shape where it is one clause among several invites a
         # later edit that makes it conditional too.
-        where_clauses: list[str] = ["tenant_id = %s"]
-        args: list[Any] = [tenant_id]
+        where_clauses: list[str] = ["tenant_id = %s", _OWNER_AGREEMENT_SQL]
+        args: list[Any] = [tenant_id, tenant_id]
         if status is not None:
             where_clauses.append("status = %s")
             args.append(status)
@@ -467,11 +470,7 @@ class PostgresDpmMandateRepository:
         args.append(limit + 1)
         with closing(self._connect()) as connection:
             rows = connection.execute(query, tuple(args)).fetchall()
-        runs = [
-            run
-            for run in (load_model_json(DpmMonitoringRun, _payload(row)) for row in rows)
-            if _run_owned_by(run, tenant_id)
-        ]
+        runs = [load_model_json(DpmMonitoringRun, _payload(row)) for row in rows]
         page = runs[:limit]
         next_cursor = page[-1].monitoring_run_id if len(runs) > limit else None
         return page, next_cursor

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -62,6 +62,23 @@ _MANDATE_VERSION_ORDER = (
 )
 
 
+def _run_owned_by(run: DpmMonitoringRun, tenant_id: str) -> bool:
+    """The stored column and the stored body must name the same owner.
+
+    `tenant_id` is a column AND a key inside `filters_json`/`payload_json`, fed
+    from one value at insert. The ON CONFLICT clause refreshes the payload and
+    the filters but deliberately never the column, so a later save carrying a
+    different tenant rewrites the body while the fence keeps answering with the
+    original owner. The column then admits the caller and the payload handed
+    back is another tenant's.
+
+    Both must agree with the caller, so a row whose own two records disagree is
+    served to nobody rather than to whichever of the two the fence consulted.
+    """
+
+    return run.filters.get("tenant_id") == tenant_id
+
+
 class PostgresDpmMandateRepository:
     def __init__(self, *, dsn: str) -> None:
         if not dsn:
@@ -388,13 +405,18 @@ class PostgresDpmMandateRepository:
         self,
         *,
         monitoring_run_id: str,
+        tenant_id: str,
     ) -> Optional[DpmMonitoringRun]:
-        query = "SELECT payload_json FROM dpm_monitoring_runs WHERE monitoring_run_id = %s"
+        query = (
+            "SELECT payload_json FROM dpm_monitoring_runs "
+            "WHERE monitoring_run_id = %s AND tenant_id = %s"
+        )
         with closing(self._connect()) as connection:
-            row = connection.execute(query, (monitoring_run_id,)).fetchone()
+            row = connection.execute(query, (monitoring_run_id, tenant_id)).fetchone()
         if row is None:
             return None
-        return load_model_json(DpmMonitoringRun, _payload(row))
+        run = load_model_json(DpmMonitoringRun, _payload(row))
+        return run if _run_owned_by(run, tenant_id) else None
 
     def list_monitoring_runs(
         self,
@@ -402,9 +424,13 @@ class PostgresDpmMandateRepository:
         status: Optional[str],
         limit: int,
         cursor: Optional[str],
+        tenant_id: str,
     ) -> tuple[list[DpmMonitoringRun], Optional[str]]:
-        where_clauses: list[str] = []
-        args: list[Any] = []
+        # Seeded, not appended conditionally: the tenant predicate is not
+        # optional, and a shape where it is one clause among several invites a
+        # later edit that makes it conditional too.
+        where_clauses: list[str] = ["tenant_id = %s"]
+        args: list[Any] = [tenant_id]
         if status is not None:
             where_clauses.append("status = %s")
             args.append(status)
@@ -412,16 +438,25 @@ class PostgresDpmMandateRepository:
             where_clauses.append(
                 """
                 (
-                    started_at < (SELECT started_at FROM dpm_monitoring_runs WHERE monitoring_run_id = %s)
+                    started_at < (
+                        SELECT started_at FROM dpm_monitoring_runs
+                        WHERE monitoring_run_id = %s AND tenant_id = %s
+                    )
                     OR (
-                        started_at = (SELECT started_at FROM dpm_monitoring_runs WHERE monitoring_run_id = %s)
+                        started_at = (
+                            SELECT started_at FROM dpm_monitoring_runs
+                            WHERE monitoring_run_id = %s AND tenant_id = %s
+                        )
                         AND monitoring_run_id < %s
                     )
                 )
                 """
             )
-            args.extend([cursor, cursor, cursor])
-        where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+            # The cursor row is resolved under the same tenant. An unfenced
+            # subquery leaks ordering position even when the page is fenced:
+            # another tenant's run id would still resolve to a started_at.
+            args.extend([cursor, tenant_id, cursor, tenant_id, cursor])
+        where_sql = f"WHERE {' AND '.join(where_clauses)}"
         query = f"""
             SELECT payload_json, monitoring_run_id
             FROM dpm_monitoring_runs
@@ -432,7 +467,11 @@ class PostgresDpmMandateRepository:
         args.append(limit + 1)
         with closing(self._connect()) as connection:
             rows = connection.execute(query, tuple(args)).fetchall()
-        runs = [load_model_json(DpmMonitoringRun, _payload(row)) for row in rows]
+        runs = [
+            run
+            for run in (load_model_json(DpmMonitoringRun, _payload(row)) for row in rows)
+            if _run_owned_by(run, tenant_id)
+        ]
         page = runs[:limit]
         next_cursor = page[-1].monitoring_run_id if len(runs) > limit else None
         return page, next_cursor

--- a/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_temporal_reads_postgres.py
@@ -18,7 +18,6 @@ CI job that owns the database runs this file explicitly.
 
 from __future__ import annotations
 
-import os
 import random
 import uuid
 
@@ -41,13 +40,11 @@ from src.core.mandates import (
 )
 from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository
 
-_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
+
+_PROOF = "mandate temporal-read proof"
 
 TENANT_ID = "tenant-integration"
-
-pytestmark = pytest.mark.skipif(
-    not _DSN, reason="DPM_POSTGRES_INTEGRATION_DSN is required for the temporal-read proof"
-)
 
 _AS_OF = date(2026, 5, 3)
 
@@ -78,7 +75,7 @@ def _twin(
 
 @pytest.fixture
 def repository() -> PostgresDpmMandateRepository:
-    return PostgresDpmMandateRepository(dsn=_DSN)
+    return PostgresDpmMandateRepository(dsn=postgres_dsn_or_skip(_PROOF))
 
 
 def _clear(repository: PostgresDpmMandateRepository, mandate_id: str) -> None:

--- a/tests/integration/dpm/mandates/test_mandate_tenant_isolation_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_tenant_isolation_postgres.py
@@ -13,7 +13,6 @@ store can be made to agree with any claim about them, including a false one.
 from __future__ import annotations
 
 import json
-import os
 import uuid
 from contextlib import closing
 from datetime import date
@@ -23,11 +22,9 @@ import pytest
 from src.core.mandates import DpmMandateConstraintSet, DpmMandateDigitalTwin, DpmMandateReviewPolicy
 from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository
 
-_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
 
-pytestmark = pytest.mark.skipif(
-    not _DSN, reason="DPM_POSTGRES_INTEGRATION_DSN is required for the tenant isolation proof"
-)
+_PROOF = "mandate tenant isolation proof"
 
 TENANT_A = "tenant-alpha"
 TENANT_B = "tenant-beta"
@@ -35,7 +32,7 @@ TENANT_B = "tenant-beta"
 
 @pytest.fixture
 def repository() -> PostgresDpmMandateRepository:
-    return PostgresDpmMandateRepository(dsn=_DSN)
+    return PostgresDpmMandateRepository(dsn=postgres_dsn_or_skip(_PROOF))
 
 
 def _twin(

--- a/tests/integration/dpm/mandates/test_monitoring_run_tenant_fence_postgres.py
+++ b/tests/integration/dpm/mandates/test_monitoring_run_tenant_fence_postgres.py
@@ -246,3 +246,76 @@ def test_a_row_whose_column_and_payload_disagree_is_served_to_nobody(
 
     assert repository.get_monitoring_run(monitoring_run_id=run_id, tenant_id=tenant_a) is None
     assert repository.get_monitoring_run(monitoring_run_id=run_id, tenant_id=tenant_b) is None
+
+
+def test_a_contradictory_row_does_not_shorten_the_page_it_is_excluded_from(
+    repository: PostgresDpmMandateRepository, tenants: tuple[str, str]
+) -> None:
+    """The owner-agreement predicate must filter the SET, not the fetched page.
+
+    The first version of this fence compared the payload's tenant in Python,
+    after the query had already applied `LIMIT`. A contradictory row that sorts
+    ahead of the caller's own runs then consumed the window and was dropped
+    afterwards, so the caller received a SHORT page - here, an EMPTY one with
+    no cursor - while its own older runs sat unread and unreachable.
+
+    That is the same defect as filtering a page instead of a set, arriving
+    through a second predicate rather than the tenant one. Raised in review on
+    PR #695; this is the case it named.
+    """
+
+    tenant_a, tenant_b = tenants
+    suffix = uuid.uuid4().hex[:12]
+    contradictory = f"dmr_split_{suffix}"
+    newer = f"dmr_valid_newer_{suffix}"
+    older = f"dmr_valid_older_{suffix}"
+
+    # Newest, and contradictory: the column says tenant A, the body says B.
+    # Two saves, because that is how the row reaches this state in production -
+    # ON CONFLICT refreshes the body and leaves the owner column alone.
+    repository.save_monitoring_run(
+        _run(
+            run_id=contradictory,
+            tenant_id=tenant_a,
+            requested_at=datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    repository.save_monitoring_run(
+        _run(
+            run_id=contradictory,
+            tenant_id=tenant_b,
+            requested_at=datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    # Two valid runs, so a correct page still has a NEXT one. With a single
+    # valid run the absent cursor is right for a different reason and the test
+    # could not tell a preserved window from an exhausted one.
+    repository.save_monitoring_run(
+        _run(
+            run_id=newer,
+            tenant_id=tenant_a,
+            requested_at=datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    repository.save_monitoring_run(
+        _run(
+            run_id=older,
+            tenant_id=tenant_a,
+            requested_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+
+    page, cursor = repository.list_monitoring_runs(
+        status=None, limit=1, cursor=None, tenant_id=tenant_a
+    )
+
+    assert [item.monitoring_run_id for item in page] == [newer], (
+        "the contradictory row consumed the page window and was filtered "
+        "afterwards, so the caller's own run was never returned"
+    )
+    assert cursor == newer, "the window was consumed, so no next page was offered"
+
+    following, _ = repository.list_monitoring_runs(
+        status=None, limit=50, cursor=cursor, tenant_id=tenant_a
+    )
+    assert [item.monitoring_run_id for item in following] == [older]

--- a/tests/integration/dpm/mandates/test_monitoring_run_tenant_fence_postgres.py
+++ b/tests/integration/dpm/mandates/test_monitoring_run_tenant_fence_postgres.py
@@ -319,3 +319,67 @@ def test_a_contradictory_row_does_not_shorten_the_page_it_is_excluded_from(
         status=None, limit=50, cursor=cursor, tenant_id=tenant_a
     )
     assert [item.monitoring_run_id for item in following] == [older]
+
+
+def test_a_cursor_naming_an_invisible_contradictory_row_is_refused(
+    repository: PostgresDpmMandateRepository, tenants: tuple[str, str]
+) -> None:
+    """The anchor resolves under the page's own visibility rule, both predicates.
+
+    A contradictory row is invisible to every caller, but its `tenant_id`
+    COLUMN still names one. That tenant could pass the row's id as a cursor and
+    page from a position it cannot read, because the anchor subqueries checked
+    only the column. The two adapters then disagreed about the consequence -
+    PostgreSQL returned the valid runs older than the invisible row, the
+    in-memory store returned nothing - which is its own signal that the rule
+    was stated in two places and only one of them was complete.
+
+    A cursor naming a row the caller cannot read is refused, exactly as it
+    already is for another tenant's row. Raised in review on PR #695.
+    """
+
+    tenant_a, tenant_b = tenants
+    suffix = uuid.uuid4().hex[:12]
+    contradictory = f"dmr_split_{suffix}"
+    older = f"dmr_older_{suffix}"
+
+    repository.save_monitoring_run(
+        _run(
+            run_id=contradictory,
+            tenant_id=tenant_a,
+            requested_at=datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    repository.save_monitoring_run(
+        _run(
+            run_id=contradictory,
+            tenant_id=tenant_b,
+            requested_at=datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    repository.save_monitoring_run(
+        _run(
+            run_id=older,
+            tenant_id=tenant_a,
+            requested_at=datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+
+    # The column still names tenant A, which is what made this reachable.
+    with closing(repository._connect()) as connection:  # noqa: SLF001
+        row = connection.execute(
+            "SELECT tenant_id FROM dpm_monitoring_runs WHERE monitoring_run_id = %s",
+            (contradictory,),
+        ).fetchone()
+    column = row["tenant_id"] if isinstance(row, dict) else row[0]
+    assert column == tenant_a, "the premise of this test is that the column still admits A"
+
+    page, cursor = repository.list_monitoring_runs(
+        status=None, limit=50, cursor=contradictory, tenant_id=tenant_a
+    )
+
+    assert page == [], (
+        "a row the caller cannot read positioned its page; the anchor subquery "
+        "applies the tenant predicate but not the owner agreement"
+    )
+    assert cursor is None

--- a/tests/integration/dpm/mandates/test_monitoring_run_tenant_fence_postgres.py
+++ b/tests/integration/dpm/mandates/test_monitoring_run_tenant_fence_postgres.py
@@ -1,0 +1,248 @@
+"""Monitoring-run read fencing, proven against PostgreSQL (#693).
+
+The unit proofs in `tests/unit/dpm/mandates/test_monitoring_run_read_fence.py`
+decide these questions in Python, and for the PostgreSQL adapter they decide
+them against a hand-written fake that re-implements the SQL rather than
+executing it. Falsification showed exactly what that costs: removing
+`AND tenant_id = %s` from the direct-read query left every unit test passing,
+because the fake never reads the query text. The predicate under test is not
+observable there at all.
+
+Four properties belong to the engine and are only really proven here:
+
+1. the fence is a WHERE predicate - it either reached the statement or it did
+   not, and no Python object can stand in for that,
+2. a NULL `tenant_id` is matched by no equality predicate, because
+   `NULL = 'anything'` evaluates to NULL rather than to false. The column has
+   been nullable since migration 0003 and was never backfilled, so the
+   quarantine claim rests on three-valued logic Python does not share,
+3. the cursor subquery resolves the anchor row under the caller's tenant, so
+   another tenant's run id cannot position the page,
+4. filtering happens before LIMIT, which is an ordering the planner decides
+   from the statement, not something the adapter can assert about itself.
+
+Requires a real engine: set DPM_POSTGRES_INTEGRATION_DSN to a disposable
+database. In the CI lane that owns one, an absent DSN fails rather than skips.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from contextlib import closing
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.core.mandates import DpmMonitoringRun
+from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository
+
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
+
+_PROOF = "monitoring-run tenant fence proof"
+
+
+@pytest.fixture
+def repository() -> PostgresDpmMandateRepository:
+    return PostgresDpmMandateRepository(dsn=postgres_dsn_or_skip(_PROOF))
+
+
+@pytest.fixture
+def tenants() -> tuple[str, str]:
+    """A fresh tenant pair per test, against a database that is not reset.
+
+    Isolating by tenant rather than by cleanup keeps the teardown honest: a
+    test that deleted its rows by tenant would be exercising the predicate it
+    is meant to be proving.
+    """
+
+    run = uuid.uuid4().hex[:12]
+    return f"tenant-alpha-{run}", f"tenant-beta-{run}"
+
+
+def _run(
+    *,
+    run_id: str,
+    tenant_id: str | None,
+    requested_at: datetime = datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+    status: str = "SUCCEEDED",
+) -> DpmMonitoringRun:
+    filters: dict[str, Any] = {"portfolio_manager_id": "PM_SG_DPM_001"}
+    if tenant_id is not None:
+        filters["tenant_id"] = tenant_id
+    return DpmMonitoringRun(
+        monitoring_run_id=run_id,
+        as_of_date=date(2026, 5, 3),
+        requested_at=requested_at,
+        completed_at=requested_at + timedelta(seconds=2),
+        status=status,
+        mandate_ids=["MANDATE_PB_SG_GLOBAL_BAL_001"],
+        filters=filters,
+        total_mandates=1,
+        health_distribution={"READY": 1},
+        exception_count=0,
+        source_readiness_summary={"READY": 1},
+    )
+
+
+def test_a_run_is_readable_only_by_the_tenant_recorded_on_its_row(
+    repository: PostgresDpmMandateRepository, tenants: tuple[str, str]
+) -> None:
+    tenant_a, tenant_b = tenants
+    run_id = f"dmr_{uuid.uuid4().hex[:12]}"
+    repository.save_monitoring_run(_run(run_id=run_id, tenant_id=tenant_b))
+
+    assert repository.get_monitoring_run(monitoring_run_id=run_id, tenant_id=tenant_a) is None
+    owned = repository.get_monitoring_run(monitoring_run_id=run_id, tenant_id=tenant_b)
+    assert owned is not None and owned.monitoring_run_id == run_id
+
+
+def test_a_null_tenant_row_is_matched_by_no_caller(
+    repository: PostgresDpmMandateRepository, tenants: tuple[str, str]
+) -> None:
+    """`NULL = 'anything'` is NULL, so the row is quarantined by the engine.
+
+    This is the claim migration 0003's nullable column rests on, and it is a
+    property of three-valued logic rather than of the adapter. Python's
+    `None != tenant` reaches the same verdict by a different rule, so the
+    in-memory agreement is not evidence for this one.
+    """
+
+    tenant_a, _ = tenants
+    run_id = f"dmr_{uuid.uuid4().hex[:12]}"
+    repository.save_monitoring_run(_run(run_id=run_id, tenant_id=None))
+
+    with closing(repository._connect()) as connection:  # noqa: SLF001
+        row = connection.execute(
+            "SELECT tenant_id FROM dpm_monitoring_runs WHERE monitoring_run_id = %s",
+            (run_id,),
+        ).fetchone()
+    stored = row["tenant_id"] if isinstance(row, dict) else row[0]
+    assert stored is None, "the row must actually carry NULL for this proof to mean anything"
+
+    assert repository.get_monitoring_run(monitoring_run_id=run_id, tenant_id=tenant_a) is None
+    page, _ = repository.list_monitoring_runs(
+        status=None, limit=50, cursor=None, tenant_id=tenant_a
+    )
+    assert [item.monitoring_run_id for item in page] == []
+
+
+def test_a_list_page_is_filtered_before_it_is_limited(
+    repository: PostgresDpmMandateRepository, tenants: tuple[str, str]
+) -> None:
+    """Filtering a page rather than the set presents as a SHORT result.
+
+    Tenant B's run is the most recent, so a LIMIT applied before the tenant
+    predicate would consume the page on a row tenant A may not see, and A would
+    receive fewer of its own runs than it asked for rather than a leak.
+    """
+
+    tenant_a, tenant_b = tenants
+    suffix = uuid.uuid4().hex[:12]
+    repository.save_monitoring_run(
+        _run(
+            run_id=f"dmr_b_{suffix}",
+            tenant_id=tenant_b,
+            requested_at=datetime(2026, 5, 4, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    repository.save_monitoring_run(
+        _run(
+            run_id=f"dmr_a_{suffix}",
+            tenant_id=tenant_a,
+            requested_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+
+    page, _ = repository.list_monitoring_runs(status=None, limit=1, cursor=None, tenant_id=tenant_a)
+
+    assert [item.monitoring_run_id for item in page] == [f"dmr_a_{suffix}"]
+
+
+def test_another_tenants_run_id_cannot_position_the_page(
+    repository: PostgresDpmMandateRepository, tenants: tuple[str, str]
+) -> None:
+    """The cursor subquery is fenced, so the anchor row resolves for one tenant.
+
+    An unfenced subquery leaks ordering position even when the page itself is
+    fenced: tenant B's run id resolves to a `started_at`, and tenant A's page
+    silently continues from a position B chose.
+    """
+
+    tenant_a, tenant_b = tenants
+    suffix = uuid.uuid4().hex[:12]
+    late = f"dmr_a_late_{suffix}"
+    mid = f"dmr_b_mid_{suffix}"
+    early = f"dmr_a_early_{suffix}"
+    repository.save_monitoring_run(
+        _run(
+            run_id=late,
+            tenant_id=tenant_a,
+            requested_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    repository.save_monitoring_run(
+        _run(
+            run_id=mid,
+            tenant_id=tenant_b,
+            requested_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+    repository.save_monitoring_run(
+        _run(
+            run_id=early,
+            tenant_id=tenant_a,
+            requested_at=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+        )
+    )
+
+    foreign_page, foreign_cursor = repository.list_monitoring_runs(
+        status=None, limit=50, cursor=mid, tenant_id=tenant_a
+    )
+    assert [item.monitoring_run_id for item in foreign_page] == []
+    assert foreign_cursor is None
+
+    # The caller's own cursor still pages, so the refusal above is the tenant
+    # predicate rather than a cursor that stopped working at all.
+    first, own_cursor = repository.list_monitoring_runs(
+        status=None, limit=1, cursor=None, tenant_id=tenant_a
+    )
+    assert [item.monitoring_run_id for item in first] == [late]
+    following, _ = repository.list_monitoring_runs(
+        status=None, limit=50, cursor=own_cursor, tenant_id=tenant_a
+    )
+    assert [item.monitoring_run_id for item in following] == [early]
+
+
+def test_a_row_whose_column_and_payload_disagree_is_served_to_nobody(
+    repository: PostgresDpmMandateRepository, tenants: tuple[str, str]
+) -> None:
+    """`ON CONFLICT` refreshes the body and never the owner column.
+
+    A re-save carrying a different tenant rewrites `payload_json` and
+    `filters_json` while `tenant_id` keeps naming the original owner. Fencing
+    on the column alone then admits the original tenant and hands back a body
+    that says someone else. Neither record is trusted over the other.
+    """
+
+    tenant_a, tenant_b = tenants
+    run_id = f"dmr_{uuid.uuid4().hex[:12]}"
+    repository.save_monitoring_run(_run(run_id=run_id, tenant_id=tenant_a))
+    repository.save_monitoring_run(_run(run_id=run_id, tenant_id=tenant_b))
+
+    with closing(repository._connect()) as connection:  # noqa: SLF001
+        row = connection.execute(
+            "SELECT tenant_id, payload_json FROM dpm_monitoring_runs WHERE monitoring_run_id = %s",
+            (run_id,),
+        ).fetchone()
+    column = row["tenant_id"] if isinstance(row, dict) else row[0]
+    payload = row["payload_json"] if isinstance(row, dict) else row[1]
+    # JSONB comes back decoded; a TEXT column would not.
+    body = payload if isinstance(payload, dict) else json.loads(payload)
+    body_tenant = body["filters"]["tenant_id"]
+    assert column == tenant_a, "the conflict clause is expected to leave the owner column alone"
+    assert body_tenant == tenant_b, "the conflict clause is expected to refresh the body"
+
+    assert repository.get_monitoring_run(monitoring_run_id=run_id, tenant_id=tenant_a) is None
+    assert repository.get_monitoring_run(monitoring_run_id=run_id, tenant_id=tenant_b) is None

--- a/tests/integration/dpm/pm_quality/test_pm_quality_endpoint_lifecycle.py
+++ b/tests/integration/dpm/pm_quality/test_pm_quality_endpoint_lifecycle.py
@@ -13,6 +13,13 @@ from src.infrastructure.outcomes import InMemoryDpmOutcomeReviewRepository
 from src.infrastructure.pm_quality import postgres as pm_quality_postgres
 
 
+# This module deliberately exercises PostgreSQL repository behavior through an
+# in-process driver substitute and contains no live-database proof. The lane
+# inventory requires this explicit whole-module declaration; one monkeypatch is
+# insufficient because a mixed module may also contain a separate live test.
+POSTGRES_LANE_CLASSIFICATION = "fake-backed-module"
+
+
 PM_QUALITY_POSTGRES_SINGLETONS = (
     "_POSTGRES_PM_QUALITY_POLICY_REPOSITORY",
     "_POSTGRES_PM_QUALITY_SCORE_RUN_REPOSITORY",

--- a/tests/integration/dpm/pm_quality/test_pm_quality_endpoint_lifecycle.py
+++ b/tests/integration/dpm/pm_quality/test_pm_quality_endpoint_lifecycle.py
@@ -13,13 +13,6 @@ from src.infrastructure.outcomes import InMemoryDpmOutcomeReviewRepository
 from src.infrastructure.pm_quality import postgres as pm_quality_postgres
 
 
-# This module deliberately exercises PostgreSQL repository behavior through an
-# in-process driver substitute and contains no live-database proof. The lane
-# inventory requires this explicit whole-module declaration; one monkeypatch is
-# insufficient because a mixed module may also contain a separate live test.
-POSTGRES_LANE_CLASSIFICATION = "fake-backed-module"
-
-
 PM_QUALITY_POSTGRES_SINGLETONS = (
     "_POSTGRES_PM_QUALITY_POLICY_REPOSITORY",
     "_POSTGRES_PM_QUALITY_SCORE_RUN_REPOSITORY",

--- a/tests/integration/dpm/postgres_prerequisite.py
+++ b/tests/integration/dpm/postgres_prerequisite.py
@@ -22,13 +22,17 @@ DSN_ENV = "DPM_POSTGRES_INTEGRATION_DSN"
 REQUIRED_ENV = "DPM_POSTGRES_INTEGRATION_REQUIRED"
 
 
-def postgres_dsn_or_skip(proof: str) -> str:
+def postgres_dsn_or_skip(proof: str, *, module_level: bool = False) -> str:
     """The DSN, or an outcome that is honest about why there is none.
 
     Returns the DSN when configured. Otherwise fails when the lane declared
     the database a prerequisite, and skips only when it did not - so a local
     run without a database still skips, and a CI lane that promised to run
     these proofs cannot report success without them.
+
+    Pass `module_level=True` when calling this during import rather than from
+    inside a test; pytest refuses a module-level skip otherwise, and the suite
+    would report a collection error instead of a skip.
     """
 
     dsn = os.getenv(DSN_ENV, "").strip()
@@ -40,5 +44,39 @@ def postgres_dsn_or_skip(proof: str) -> str:
             "A lane that declares the database a prerequisite must fail rather "
             "than skip, or an unrun proof is reported as a passing one."
         )
-    pytest.skip(f"{DSN_ENV} is not configured, so the {proof} cannot run")
+    pytest.skip(
+        f"{DSN_ENV} is not configured, so the {proof} cannot run",
+        allow_module_level=module_level,
+    )
     raise AssertionError("unreachable")
+
+
+def postgres_dsn_or_fake(proof: str) -> str | None:
+    """The DSN, or None for a suite that legitimately runs against a fake.
+
+    Two suites name every test `test_live_postgres_*` and fall back to an
+    in-process fake when no DSN is set, so they always report a pass and never
+    say which engine produced it. The fallback itself is defensible - the
+    contracts they assert are worth running locally without a database - but
+    two things about it were not:
+
+    the fallback also fired on ANY exception while a DSN WAS configured, so a
+    refused connection, a failed migration or a bad credential silently became
+    a green run against the fake; and it consulted the DSN alone, so the lane
+    that declares a database a prerequisite could not make it fail.
+
+    Returning None says "no database was offered". A caller may then use its
+    fake. Being handed a DSN means the real engine is expected to work, and a
+    failure from it belongs to the test rather than to a fallback.
+    """
+
+    dsn = os.getenv(DSN_ENV, "").strip()
+    if dsn:
+        return dsn
+    if os.getenv(REQUIRED_ENV, "").strip() == "1":
+        pytest.fail(
+            f"{DSN_ENV} is unset while {REQUIRED_ENV}=1: the {proof} would have run "
+            "against its in-process fake and reported a pass. A lane that declares "
+            "the database a prerequisite must fail rather than substitute one."
+        )
+    return None

--- a/tests/integration/dpm/supportability/test_dpm_policy_pack_postgres_repository_integration.py
+++ b/tests/integration/dpm/supportability/test_dpm_policy_pack_postgres_repository_integration.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 from contextlib import closing
 
@@ -6,22 +5,29 @@ import pytest
 
 from src.core.rebalance.policy_packs import DpmPolicyPackDefinition
 from src.infrastructure.dpm_policy_packs.postgres import PostgresDpmPolicyPackRepository
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_fake
 from tests.unit.dpm.supportability.test_dpm_policy_pack_postgres_repository import (
     _build_repository as _build_fake_repository,
 )
 
-_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
+_PROOF = "live policy-pack repository contract"
 
 
 @pytest.fixture
 def repository(monkeypatch: pytest.MonkeyPatch) -> PostgresDpmPolicyPackRepository:
-    if _DSN:
-        try:
-            repo = PostgresDpmPolicyPackRepository(dsn=_DSN)
-            _reset_tables(repo)
-            return repo
-        except Exception:
-            pass
+    """The real engine when one is offered, the fake only when none is.
+
+    The previous form caught every exception from the real repository and fell
+    through to the fake, so a refused connection or a failed migration produced
+    a green run under a name that says `live_postgres`. A configured DSN now
+    means the real engine is expected to work.
+    """
+
+    dsn = postgres_dsn_or_fake(_PROOF)
+    if dsn is not None:
+        repo = PostgresDpmPolicyPackRepository(dsn=dsn)
+        _reset_tables(repo)
+        return repo
     repo, _ = _build_fake_repository(monkeypatch)
     return repo
 

--- a/tests/integration/dpm/supportability/test_dpm_postgres_repository_integration.py
+++ b/tests/integration/dpm/supportability/test_dpm_postgres_repository_integration.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 from contextlib import closing
 from datetime import datetime, timedelta, timezone
@@ -14,22 +13,29 @@ from src.core.rebalance_runs.models import (
     DpmRunWorkflowDecisionRecord,
 )
 from src.infrastructure.rebalance_runs.postgres import PostgresDpmRunRepository
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_fake
 from tests.unit.dpm.supportability.test_dpm_postgres_repository_scaffold import (
     _build_repository as _build_fake_repository,
 )
 
-_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
+_PROOF = "live run-repository contract"
 
 
 @pytest.fixture
 def repository(monkeypatch: pytest.MonkeyPatch) -> PostgresDpmRunRepository:
-    if _DSN:
-        try:
-            repo = PostgresDpmRunRepository(dsn=_DSN)
-            _reset_tables(repo)
-            return repo
-        except Exception:
-            pass
+    """The real engine when one is offered, the fake only when none is.
+
+    The previous form caught every exception from the real repository and fell
+    through to the fake, so a refused connection or a failed migration produced
+    a green run under a name that says `live_postgres`. A configured DSN now
+    means the real engine is expected to work.
+    """
+
+    dsn = postgres_dsn_or_fake(_PROOF)
+    if dsn is not None:
+        repo = PostgresDpmRunRepository(dsn=dsn)
+        _reset_tables(repo)
+        return repo
     repo, _ = _build_fake_repository(monkeypatch)
     return repo
 

--- a/tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py
+++ b/tests/integration/dpm/supportability/test_idea_management_action_postgres_integration.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import uuid
 from datetime import datetime, timezone
 
@@ -14,13 +13,18 @@ from src.core.rebalance_runs.idea_action_intake import idea_management_action_hi
 from src.core.rebalance_runs.idea_management_action_repository import (
     IdeaManagementActionRepositoryConflictError,
 )
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
+
 from src.infrastructure.rebalance_runs.idea_management_actions_postgres import (
     PostgresIdeaManagementActionRepository,
 )
 
 
-_DSN = os.getenv("DPM_POSTGRES_INTEGRATION_DSN", "").strip()
-pytestmark = pytest.mark.skipif(not _DSN, reason="DPM_POSTGRES_INTEGRATION_DSN is required")
+# The lane is named after this suite and it still decided its own skip, so
+# `DPM_POSTGRES_INTEGRATION_REQUIRED=1` never reached it: with no DSN it
+# skipped quietly in the one job that owns a database.
+_PROOF = "idea-management-action persistence proof"
+_DSN = postgres_dsn_or_skip(_PROOF, module_level=True)
 
 
 def _action(*, suffix: str, fingerprint: str = "sha256:0123456789ab"):

--- a/tests/unit/dpm/api/test_monitoring_api.py
+++ b/tests/unit/dpm/api/test_monitoring_api.py
@@ -140,9 +140,11 @@ def test_monitoring_run_once_persists_run_health_and_exception_queue() -> None:
                 "requested_by": "ops_sg_001",
             },
         )
-        runs_response = client.get("/api/v1/dpm/monitoring/runs?status_filter=SUCCEEDED")
+        runs_response = client.get(
+            "/api/v1/dpm/monitoring/runs?status_filter=SUCCEEDED&tenant_id=default"
+        )
         run_id = run_response.json()["monitoring_run_id"]
-        run_detail = client.get(f"/api/v1/dpm/monitoring/runs/{run_id}")
+        run_detail = client.get(f"/api/v1/dpm/monitoring/runs/{run_id}?tenant_id=default")
         exceptions_response = client.get(
             f"/api/v1/dpm/exceptions?mandate_id={MANDATE_ID}&portfolio_id={PORTFOLIO_ID}&tenant_id=default"
         )
@@ -569,7 +571,7 @@ def test_monitoring_run_and_exception_error_paths_and_resolution() -> None:
             "/api/v1/dpm/monitoring/run-once",
             json={"mandate_ids": ["UNKNOWN"], "as_of_date": "2026-05-03", "tenant_id": "default"},
         )
-        missing_run = client.get("/api/v1/dpm/monitoring/runs/UNKNOWN")
+        missing_run = client.get("/api/v1/dpm/monitoring/runs/UNKNOWN?tenant_id=default")
         client.post(
             "/api/v1/dpm/monitoring/run-once",
             json={"mandate_ids": [MANDATE_ID], "as_of_date": "2026-05-03", "tenant_id": "default"},

--- a/tests/unit/dpm/mandates/test_monitoring_run_read_fence.py
+++ b/tests/unit/dpm/mandates/test_monitoring_run_read_fence.py
@@ -203,9 +203,12 @@ def test_a_row_whose_column_and_payload_disagree_is_served_to_nobody(
     repository.save_monitoring_run(_run(run_id="dmr_split", tenant_id=TENANT_A))
 
     # The body now claims tenant B while the column still says tenant A -
-    # reachable through the conflict clause, reproduced here directly.
+    # reachable through the conflict clause, reproduced here directly. Both
+    # halves of the body are set, because the adapter compares the payload's
+    # tenant in SQL and returns the payload to the caller.
     stored = store.monitoring_runs["dmr_split"]
     stored["payload_json"] = _run(run_id="dmr_split", tenant_id=TENANT_B).model_dump_json()
+    stored["payload_tenant_id"] = TENANT_B
 
     assert repository.get_monitoring_run(monitoring_run_id="dmr_split", tenant_id=TENANT_A) is None
     assert repository.get_monitoring_run(monitoring_run_id="dmr_split", tenant_id=TENANT_B) is None

--- a/tests/unit/dpm/mandates/test_monitoring_run_read_fence.py
+++ b/tests/unit/dpm/mandates/test_monitoring_run_read_fence.py
@@ -1,0 +1,215 @@
+"""Monitoring-run reads answer to one tenant (issue #693).
+
+`get_monitoring_run` and `list_monitoring_runs` took no tenant at all. Every
+persisted run - the mandates it covered, the health distribution across them,
+the source-readiness summary and the failure reason - was readable by anyone
+who could reach the route, and the list returned every tenant's runs in one
+page. The tenant was already recorded on the row and simply never consulted.
+
+Three properties are proved here, and the third is the one a parameter-threading
+fix does not give you:
+
+  1. a run belonging to another tenant is refused,
+  2. a run with NO recorded tenant is matched by nobody rather than by whoever
+     asks - the same quarantine the mandate, exception and wave columns use,
+  3. the CURSOR is resolved under the caller's tenant. A fenced page whose
+     cursor subquery is unfenced still leaks ordering position: another
+     tenant's run id resolves to a `started_at` and silently decides where the
+     caller's page begins.
+
+Each is asserted against both adapters, because they answer the question from
+different stores - the column for PostgreSQL, `filters` for in-memory - and a
+fence that holds in one is not evidence about the other.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from src.core.mandates import DpmMonitoringRun
+from src.infrastructure.mandates.in_memory import InMemoryDpmMandateRepository
+
+from tests.unit.dpm.supportability.test_dpm_mandate_repository import (  # noqa: E501
+    _postgres_repository,
+)
+
+TENANT_A = "tenant-alpha"
+TENANT_B = "tenant-beta"
+
+
+def _run(
+    *,
+    run_id: str,
+    tenant_id: str | None,
+    requested_at: datetime = datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+    status: str = "SUCCEEDED",
+) -> DpmMonitoringRun:
+    filters: dict[str, Any] = {"portfolio_manager_id": "PM_SG_DPM_001"}
+    if tenant_id is not None:
+        filters["tenant_id"] = tenant_id
+    return DpmMonitoringRun(
+        monitoring_run_id=run_id,
+        as_of_date=date(2026, 5, 3),
+        requested_at=requested_at,
+        completed_at=requested_at + timedelta(seconds=2),
+        status=status,
+        mandate_ids=["MANDATE_PB_SG_GLOBAL_BAL_001"],
+        filters=filters,
+        total_mandates=1,
+        health_distribution={"READY": 1},
+        exception_count=0,
+        source_readiness_summary={"READY": 1},
+    )
+
+
+@pytest.fixture(name="repositories")
+def _repositories(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Both adapters, seeded identically, exercised by the same assertions."""
+
+    postgres, _ = _postgres_repository(monkeypatch)
+    return [InMemoryDpmMandateRepository(), postgres]
+
+
+def test_a_run_belonging_to_another_tenant_is_not_readable(repositories: list[Any]) -> None:
+    for repository in repositories:
+        repository.save_monitoring_run(_run(run_id="dmr_b", tenant_id=TENANT_B))
+
+        assert repository.get_monitoring_run(monitoring_run_id="dmr_b", tenant_id=TENANT_A) is None
+        owned = repository.get_monitoring_run(monitoring_run_id="dmr_b", tenant_id=TENANT_B)
+        assert owned is not None, "the fence must not cost the read it exists to scope"
+        assert owned.monitoring_run_id == "dmr_b"
+
+
+def test_a_run_with_no_recorded_tenant_is_matched_by_nobody(repositories: list[Any]) -> None:
+    """Quarantine, not 'owned by whoever asks'.
+
+    The `tenant_id` column has been nullable since 0003 and was never
+    backfilled, so runs written before the tenant was recorded carry none. A
+    fence that treated a missing owner as a wildcard would hand every one of
+    them to the first caller who named any tenant.
+    """
+
+    for repository in repositories:
+        repository.save_monitoring_run(_run(run_id="dmr_unowned", tenant_id=None))
+
+        for caller in (TENANT_A, TENANT_B, "default"):
+            assert (
+                repository.get_monitoring_run(monitoring_run_id="dmr_unowned", tenant_id=caller)
+                is None
+            )
+        page, _ = repository.list_monitoring_runs(
+            status=None, limit=10, cursor=None, tenant_id=TENANT_A
+        )
+        assert page == []
+
+
+def test_a_list_returns_only_the_callers_runs(repositories: list[Any]) -> None:
+    for repository in repositories:
+        repository.save_monitoring_run(_run(run_id="dmr_a", tenant_id=TENANT_A))
+        repository.save_monitoring_run(
+            _run(
+                run_id="dmr_b",
+                tenant_id=TENANT_B,
+                requested_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+        )
+
+        page_a, _ = repository.list_monitoring_runs(
+            status=None, limit=10, cursor=None, tenant_id=TENANT_A
+        )
+        page_b, _ = repository.list_monitoring_runs(
+            status=None, limit=10, cursor=None, tenant_id=TENANT_B
+        )
+
+        assert [run.monitoring_run_id for run in page_a] == ["dmr_a"]
+        assert [run.monitoring_run_id for run in page_b] == ["dmr_b"]
+
+
+def test_a_cursor_naming_another_tenants_run_does_not_position_the_page(
+    repositories: list[Any],
+) -> None:
+    """The subquery fence, asserted where its absence is observable.
+
+    Tenant A holds two runs. Tenant B holds one, timed between them. If the
+    cursor row is resolved WITHOUT the tenant predicate, B's run id resolves to
+    its `started_at` and A's page silently continues from a position B chose -
+    which is both a leak of B's ordering and a page A never asked for.
+    """
+
+    for repository in repositories:
+        repository.save_monitoring_run(
+            _run(
+                run_id="dmr_a_late",
+                tenant_id=TENANT_A,
+                requested_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+            )
+        )
+        repository.save_monitoring_run(
+            _run(
+                run_id="dmr_b_mid",
+                tenant_id=TENANT_B,
+                requested_at=datetime(2026, 5, 2, 12, 0, tzinfo=timezone.utc),
+            )
+        )
+        repository.save_monitoring_run(
+            _run(
+                run_id="dmr_a_early",
+                tenant_id=TENANT_A,
+                requested_at=datetime(2026, 5, 1, 12, 0, tzinfo=timezone.utc),
+            )
+        )
+
+        page, cursor = repository.list_monitoring_runs(
+            status=None, limit=10, cursor="dmr_b_mid", tenant_id=TENANT_A
+        )
+
+        assert page == [], (
+            "tenant B's run id resolved to an ordering position for tenant A: "
+            "the cursor subquery is not fenced"
+        )
+        assert cursor is None
+
+        # The caller's own cursor still pages, so the refusal above is the
+        # tenant predicate and not a cursor that stopped working.
+        first, own_cursor = repository.list_monitoring_runs(
+            status=None, limit=1, cursor=None, tenant_id=TENANT_A
+        )
+        assert [run.monitoring_run_id for run in first] == ["dmr_a_late"]
+        following, _ = repository.list_monitoring_runs(
+            status=None, limit=10, cursor=own_cursor, tenant_id=TENANT_A
+        )
+        assert [run.monitoring_run_id for run in following] == ["dmr_a_early"]
+
+
+def test_a_row_whose_column_and_payload_disagree_is_served_to_nobody(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fence reads the column; the caller receives the payload.
+
+    `ON CONFLICT (monitoring_run_id) DO UPDATE` refreshes `payload_json` and
+    `filters_json` and deliberately never `tenant_id`, so a later save carrying
+    a different tenant rewrites the body while the column keeps naming the
+    original owner. Fencing on the column alone then admits tenant A and hands
+    back a run whose own body says tenant B.
+
+    Neither value is trusted over the other: a row that contradicts itself is
+    returned to no caller.
+    """
+
+    repository, store = _postgres_repository(monkeypatch)
+    repository.save_monitoring_run(_run(run_id="dmr_split", tenant_id=TENANT_A))
+
+    # The body now claims tenant B while the column still says tenant A -
+    # reachable through the conflict clause, reproduced here directly.
+    stored = store.monitoring_runs["dmr_split"]
+    stored["payload_json"] = _run(run_id="dmr_split", tenant_id=TENANT_B).model_dump_json()
+
+    assert repository.get_monitoring_run(monitoring_run_id="dmr_split", tenant_id=TENANT_A) is None
+    assert repository.get_monitoring_run(monitoring_run_id="dmr_split", tenant_id=TENANT_B) is None
+    page, _ = repository.list_monitoring_runs(
+        status=None, limit=10, cursor=None, tenant_id=TENANT_A
+    )
+    assert page == []

--- a/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
@@ -1,3 +1,5 @@
+import json
+
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any
@@ -899,6 +901,10 @@ class _FakeConnection:
                 "tenant_id": params[4],
                 "started_at": params[8],
                 "payload_json": params[11],
+                # The body's own tenant, which the adapter now compares in SQL.
+                # ON CONFLICT refreshes this and never the column above, so the
+                # two can disagree and the fake must be able to represent that.
+                "payload_tenant_id": json.loads(params[6]).get("tenant_id"),
             }
             return _FakeResult(rowcount=1)
         if (
@@ -906,7 +912,11 @@ class _FakeConnection:
             and "where monitoring_run_id" in normalized
         ):
             row = self.store.monitoring_runs.get(str(params[0]))
-            if row is None or row["tenant_id"] != params[1]:
+            if (
+                row is None
+                or row["tenant_id"] != params[1]
+                or row["payload_tenant_id"] != params[2]
+            ):
                 return _FakeResult()
             return _FakeResult(rows=[{"payload_json": row["payload_json"]}])
         if "select payload_json, monitoring_run_id from dpm_monitoring_runs" in normalized:
@@ -916,8 +926,15 @@ class _FakeConnection:
             rows = list(self.store.monitoring_runs.values())
             arg_index = 0
             tenant_id = params[arg_index]
-            arg_index += 1
-            rows = [row for row in rows if row["tenant_id"] == tenant_id]
+            arg_index += 2  # the tenant is bound twice: column, then payload
+            # Both predicates are in the WHERE clause, so both apply to the SET
+            # before LIMIT. Filtering here rather than after the slice below is
+            # what makes the fake able to fail the short-page case at all.
+            rows = [
+                row
+                for row in rows
+                if row["tenant_id"] == tenant_id and row["payload_tenant_id"] == tenant_id
+            ]
             if "status = %s" in normalized:
                 rows = [row for row in rows if row["status"] == params[arg_index]]
                 arg_index += 1

--- a/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
@@ -940,15 +940,19 @@ class _FakeConnection:
                 arg_index += 1
             if "monitoring_run_id < %s" in normalized:
                 cursor = params[arg_index]
-                arg_index += 5
-                # The cursor row resolves under the SAME tenant, which is the
-                # point of the subquery fence: another tenant's run id must not
-                # resolve to a started_at and so must not position the page.
+                arg_index += 7
+                # The anchor resolves under the SAME visibility rule as the
+                # page: tenant AND owner agreement. Another tenant's run id
+                # must not resolve to a started_at, and neither must a
+                # contradictory row that no caller can read - even though its
+                # column still names this tenant.
                 anchor = next(
                     (
                         row
                         for row in self.store.monitoring_runs.values()
-                        if row["monitoring_run_id"] == cursor and row["tenant_id"] == tenant_id
+                        if row["monitoring_run_id"] == cursor
+                        and row["tenant_id"] == tenant_id
+                        and row["payload_tenant_id"] == tenant_id
                     ),
                     None,
                 )

--- a/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_mandate_repository.py
@@ -73,6 +73,7 @@ def _monitoring_run(
     run_id: str = "dmr_20260503_120000",
     status: str = "SUCCEEDED",
     requested_at: datetime = datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+    tenant_id: str | None = "default",
 ) -> DpmMonitoringRun:
     return DpmMonitoringRun(
         monitoring_run_id=run_id,
@@ -81,7 +82,11 @@ def _monitoring_run(
         completed_at=requested_at + timedelta(seconds=2),
         status=status,
         mandate_ids=["MANDATE_PB_SG_GLOBAL_BAL_001"],
-        filters={"tenant_id": "default", "portfolio_manager_id": "PM_SG_DPM_001"},
+        filters=(
+            {"portfolio_manager_id": "PM_SG_DPM_001"}
+            if tenant_id is None
+            else {"tenant_id": tenant_id, "portfolio_manager_id": "PM_SG_DPM_001"}
+        ),
         total_mandates=1,
         health_distribution={"READY": 1},
         exception_count=0,
@@ -682,28 +687,36 @@ def test_repository_persists_pages_and_purges_monitoring_runs() -> None:
     repository.save_monitoring_run(latest_run)
     repository.save_monitoring_run(failed_run)
 
-    first_page, cursor = repository.list_monitoring_runs(status=None, limit=1, cursor=None)
+    first_page, cursor = repository.list_monitoring_runs(
+        status=None, limit=1, cursor=None, tenant_id="default"
+    )
     second_page, second_cursor = repository.list_monitoring_runs(
         status=None,
         limit=1,
         cursor=cursor,
+        tenant_id="default",
     )
     failed_page, failed_cursor = repository.list_monitoring_runs(
         status="FAILED",
         limit=10,
         cursor=None,
+        tenant_id="default",
     )
     missing_page, missing_cursor = repository.list_monitoring_runs(
         status=None,
         limit=10,
         cursor="UNKNOWN_RUN",
+        tenant_id="default",
     )
     purged = repository.purge_mandate_records_before(
         cutoff=datetime(2025, 1, 1, tzinfo=timezone.utc)
     )
 
     assert (
-        repository.get_monitoring_run(monitoring_run_id=latest_run.monitoring_run_id) == latest_run
+        repository.get_monitoring_run(
+            monitoring_run_id=latest_run.monitoring_run_id, tenant_id="default"
+        )
+        == latest_run
     )
     assert first_page == [latest_run]
     assert cursor == latest_run.monitoring_run_id
@@ -714,7 +727,12 @@ def test_repository_persists_pages_and_purges_monitoring_runs() -> None:
     assert missing_page == []
     assert missing_cursor is None
     assert purged == 1
-    assert repository.get_monitoring_run(monitoring_run_id=old_run.monitoring_run_id) is None
+    assert (
+        repository.get_monitoring_run(
+            monitoring_run_id=old_run.monitoring_run_id, tenant_id="default"
+        )
+        is None
+    )
 
 
 def test_repository_serialization_round_trip_preserves_domain_types() -> None:
@@ -872,9 +890,13 @@ class _FakeConnection:
             return _FakeResult(rows=[{"payload_json": row["payload_json"]} for row in rows])
 
         if normalized.startswith("insert into dpm_monitoring_runs"):
+            # tenant_id is the fifth INSERT column. A fake that drops it cannot
+            # observe the fence at all, and every tenant assertion below would
+            # pass against a store that never scoped anything.
             self.store.monitoring_runs[str(params[0])] = {
                 "monitoring_run_id": params[0],
                 "status": params[2],
+                "tenant_id": params[4],
                 "started_at": params[8],
                 "payload_json": params[11],
             }
@@ -884,19 +906,47 @@ class _FakeConnection:
             and "where monitoring_run_id" in normalized
         ):
             row = self.store.monitoring_runs.get(str(params[0]))
-            return (
-                _FakeResult(rows=[{"payload_json": row["payload_json"]}]) if row else _FakeResult()
-            )
+            if row is None or row["tenant_id"] != params[1]:
+                return _FakeResult()
+            return _FakeResult(rows=[{"payload_json": row["payload_json"]}])
         if "select payload_json, monitoring_run_id from dpm_monitoring_runs" in normalized:
+            # Bound arguments in the order the SQL names them: tenant first
+            # (the fence is seeded, not appended), then the optional status,
+            # then the cursor clause's five.
             rows = list(self.store.monitoring_runs.values())
             arg_index = 0
+            tenant_id = params[arg_index]
+            arg_index += 1
+            rows = [row for row in rows if row["tenant_id"] == tenant_id]
             if "status = %s" in normalized:
                 rows = [row for row in rows if row["status"] == params[arg_index]]
                 arg_index += 1
             if "monitoring_run_id < %s" in normalized:
                 cursor = params[arg_index]
-                arg_index += 3
-                rows = [row for row in rows if row["monitoring_run_id"] < cursor]
+                arg_index += 5
+                # The cursor row resolves under the SAME tenant, which is the
+                # point of the subquery fence: another tenant's run id must not
+                # resolve to a started_at and so must not position the page.
+                anchor = next(
+                    (
+                        row
+                        for row in self.store.monitoring_runs.values()
+                        if row["monitoring_run_id"] == cursor and row["tenant_id"] == tenant_id
+                    ),
+                    None,
+                )
+                if anchor is None:
+                    rows = []
+                else:
+                    rows = [
+                        row
+                        for row in rows
+                        if row["started_at"] < anchor["started_at"]
+                        or (
+                            row["started_at"] == anchor["started_at"]
+                            and row["monitoring_run_id"] < cursor
+                        )
+                    ]
             limit = int(params[-1])
             rows = sorted(
                 rows,
@@ -1277,22 +1327,31 @@ def test_postgres_repository_persists_reads_and_pages_monitoring_runs(
     repository.save_monitoring_run(latest_run)
     repository.save_monitoring_run(failed_run)
 
-    first_page, cursor = repository.list_monitoring_runs(status=None, limit=1, cursor=None)
+    first_page, cursor = repository.list_monitoring_runs(
+        status=None, limit=1, cursor=None, tenant_id="default"
+    )
     second_page, second_cursor = repository.list_monitoring_runs(
         status=None,
         limit=1,
         cursor=cursor,
+        tenant_id="default",
     )
     failed_page, failed_cursor = repository.list_monitoring_runs(
         status="FAILED",
         limit=10,
         cursor=None,
+        tenant_id="default",
     )
 
     assert (
-        repository.get_monitoring_run(monitoring_run_id=latest_run.monitoring_run_id) == latest_run
+        repository.get_monitoring_run(
+            monitoring_run_id=latest_run.monitoring_run_id, tenant_id="default"
+        )
+        == latest_run
     )
-    assert repository.get_monitoring_run(monitoring_run_id="UNKNOWN_RUN") is None
+    assert (
+        repository.get_monitoring_run(monitoring_run_id="UNKNOWN_RUN", tenant_id="default") is None
+    )
     assert first_page == [latest_run]
     assert cursor == latest_run.monitoring_run_id
     assert second_page == [older_run]

--- a/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
+++ b/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
@@ -105,7 +105,11 @@ def imports_a_postgres_adapter(source: str) -> bool:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             if any(
-                alias.name.startswith(ADAPTER_MODULE_ROOT) and "postgres" in alias.name.casefold()
+                alias.name.startswith(ADAPTER_MODULE_ROOT)
+                and (
+                    "postgres" in alias.name.casefold()
+                    or _package_exports_postgres_adapter(alias.name)
+                )
                 for alias in node.names
             ):
                 return True
@@ -117,7 +121,36 @@ def imports_a_postgres_adapter(source: str) -> bool:
                 return True
             if any("postgres" in alias.name.casefold() for alias in node.names):
                 return True
+            if any(
+                _package_exports_postgres_adapter(f"{module}.{alias.name}") for alias in node.names
+            ):
+                return True
     return False
+
+
+def _package_exports_postgres_adapter(module: str) -> bool:
+    """Whether a repository package directly exports a PostgreSQL adapter.
+
+    Importing `src.infrastructure.mandates as mandates` gives the caller every
+    name exported from that package even though neither the import path nor its
+    local alias says `postgres`. Resolve that ambiguity from the package source
+    instead of guessing from the test filename or treating all infrastructure
+    imports as database proof.
+    """
+
+    package_init = REPOSITORY_ROOT.joinpath(*module.split("."), "__init__.py")
+    if not package_init.is_file():
+        return False
+    try:
+        tree = ast.parse(package_init.read_text(encoding="utf-8"))
+    except SyntaxError:  # pragma: no cover - broken package source fails elsewhere
+        return False
+    return any(
+        "postgres" in (node.module or "").casefold()
+        or any("postgres" in alias.name.casefold() for alias in node.names)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import | ast.ImportFrom)
+    )
 
 
 def stubs_the_driver(source: str) -> bool:
@@ -176,6 +209,8 @@ def test_the_detector_reads_every_import_form_and_only_imports() -> None:
     assert imports_a_postgres_adapter(
         "from src.infrastructure.mandates import PostgresDpmMandateRepository\n"
     )
+    assert imports_a_postgres_adapter("import src.infrastructure.mandates as mandates\n")
+    assert imports_a_postgres_adapter("from src.infrastructure import mandates\n")
     assert imports_a_postgres_adapter("import src.infrastructure.waves.postgres\n")
 
     assert not imports_a_postgres_adapter("from src.infrastructure.mandates.in_memory import X\n")

--- a/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
+++ b/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
@@ -1,0 +1,115 @@
+"""Every PostgreSQL proof is reachable from the lane that owns a database (#693).
+
+The lane's input is a hand-written list in the Makefile. A proof file absent
+from it does not fail, does not skip and does not appear anywhere in the run -
+it is indistinguishable from a proof that passed. That is not hypothetical:
+issue #677's wave isolation proofs were cited as evidence for months while the
+list named only the supportability suite and `dpm/mandates`, so they had never
+executed in CI at all.
+
+Aligning the list once fixes today's omission and nothing else. This test makes
+the omission impossible to repeat: it enumerates the PostgreSQL proof files that
+exist and asserts each is covered by a path the lane names.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+MAKEFILE = REPOSITORY_ROOT / "Makefile"
+INTEGRATION_ROOT = REPOSITORY_ROOT / "tests" / "integration"
+
+# A file is a PostgreSQL proof when it imports the adapter package or the
+# shared prerequisite. Matching on the FILENAME would have been simpler and
+# wrong: `test_mandate_temporal_reads_postgres.py` says so in its name, but
+# nothing makes the next author repeat the convention, and a proof that quietly
+# fell outside the naming rule is precisely the case this test exists to catch.
+MARKERS = (
+    "postgres_dsn_or_skip",
+    "postgres_dsn_or_fake",
+    "DPM_POSTGRES_INTEGRATION_DSN",
+)
+
+# The two forms of the prerequisite. Either consults
+# DPM_POSTGRES_INTEGRATION_REQUIRED; a file using neither decides its own fate
+# and the lane cannot make it run.
+PREREQUISITE_HELPERS = ("postgres_dsn_or_skip", "postgres_dsn_or_fake")
+
+
+def _lane_paths() -> list[str]:
+    """The paths named by POSTGRES_INTEGRATION_TESTS, following its line continuations."""
+
+    text = MAKEFILE.read_text(encoding="utf-8")
+    match = re.search(
+        r"^POSTGRES_INTEGRATION_TESTS\s*=\s*((?:.*\\\n)*.*)$",
+        text,
+        re.MULTILINE,
+    )
+    assert match, "the lane variable POSTGRES_INTEGRATION_TESTS is not defined in the Makefile"
+    return [
+        token
+        for token in match.group(1).replace("\\\n", " ").split()
+        if token and not token.startswith("$")
+    ]
+
+
+def _postgres_proof_files() -> list[Path]:
+    return sorted(
+        path
+        for path in INTEGRATION_ROOT.rglob("test_*.py")
+        if any(marker in path.read_text(encoding="utf-8") for marker in MARKERS)
+    )
+
+
+def test_the_lane_names_every_postgres_proof_file() -> None:
+    lane = [(REPOSITORY_ROOT / path).resolve() for path in _lane_paths()]
+    proofs = _postgres_proof_files()
+
+    assert proofs, "no PostgreSQL proof files were found; the detector below proves nothing"
+
+    unreachable = [
+        proof.relative_to(REPOSITORY_ROOT).as_posix()
+        for proof in proofs
+        if not any(proof == entry or entry in proof.parents for entry in lane)
+    ]
+
+    assert not unreachable, (
+        "these PostgreSQL proofs are not reachable from POSTGRES_INTEGRATION_TESTS, "
+        "so the database lane runs green without them: " + ", ".join(unreachable)
+    )
+
+
+def test_every_lane_path_exists() -> None:
+    """A stale entry is the same defect read backwards.
+
+    A path that no longer exists makes the list look larger than the coverage
+    it buys, and pytest accepts a directory that is empty without complaint.
+    """
+
+    missing = [path for path in _lane_paths() if not (REPOSITORY_ROOT / path).exists()]
+
+    assert not missing, f"POSTGRES_INTEGRATION_TESTS names paths that do not exist: {missing}"
+
+
+def test_no_postgres_proof_gates_itself_on_a_bare_dsn_check() -> None:
+    """The prerequisite must be consulted, not merely present in the environment.
+
+    `DPM_POSTGRES_INTEGRATION_REQUIRED=1` is set in both workflows, but it only
+    reaches files that route through `postgres_dsn_or_skip`. A file keeping its
+    own `skipif(not DSN)` skips silently in the lane that declared the database
+    a prerequisite - which is the exact shape of the defect the flag was added
+    to close, surviving in the files that did not adopt it.
+    """
+
+    offenders = [
+        proof.relative_to(REPOSITORY_ROOT).as_posix()
+        for proof in _postgres_proof_files()
+        if not any(helper in proof.read_text(encoding="utf-8") for helper in PREREQUISITE_HELPERS)
+    ]
+
+    assert not offenders, (
+        "these PostgreSQL proofs decide their own skip and so ignore "
+        "DPM_POSTGRES_INTEGRATION_REQUIRED: " + ", ".join(offenders)
+    )

--- a/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
+++ b/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
@@ -45,21 +45,19 @@ INTEGRATION_ROOT = REPOSITORY_ROOT / "tests" / "integration"
 # through the prerequisite would make it fail for want of a database it does
 # not want. Both review rounds on PR #695 found one half of this.
 #
-# So: an import makes a file a candidate, and a candidate is a proof unless it
-# stubs the driver. The exclusion is asserted rather than assumed - a candidate
-# that is neither in the lane nor visibly stubbed fails, so "it uses a fake"
-# has to be true in the file rather than believed about it.
+# So: an import makes a file a candidate, and a candidate is a proof unless the
+# entire module explicitly declares itself fake-backed. Inferring module intent
+# from one monkeypatch is unsafe because a later live test can share that file.
+# The exclusion is asserted rather than assumed - a candidate that is neither
+# in the lane nor explicitly classified fails.
 #
 # Imports are parsed, not pattern-matched: `from src.infrastructure.pm_quality
 # import postgres as pm_quality_postgres` puts the word after the `import`
 # keyword and defeats any regex anchored on the module path.
 ADAPTER_MODULE_ROOT = "src.infrastructure"
 
-# Replacing this adapter hook substitutes the database driver itself. Merely
-# importing, calling or discussing the hook proves nothing about whether the
-# test uses a real database, so the detector below requires an actual patch
-# operation against an imported PostgreSQL adapter module.
-DRIVER_IMPORT_HOOK = "_import_psycopg"
+FAKE_BACKED_CLASSIFICATION_NAME = "POSTGRES_LANE_CLASSIFICATION"
+FAKE_BACKED_CLASSIFICATION_VALUE = "fake-backed-module"
 
 MARKERS = (
     "postgres_dsn_or_skip",
@@ -107,7 +105,7 @@ def imports_a_postgres_adapter(source: str) -> bool:
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             if any(
-                alias.name.startswith(ADAPTER_MODULE_ROOT) and "postgres" in alias.name
+                alias.name.startswith(ADAPTER_MODULE_ROOT) and "postgres" in alias.name.casefold()
                 for alias in node.names
             ):
                 return True
@@ -115,64 +113,30 @@ def imports_a_postgres_adapter(source: str) -> bool:
             module = node.module or ""
             if not module.startswith(ADAPTER_MODULE_ROOT):
                 continue
-            if "postgres" in module:
+            if "postgres" in module.casefold():
                 return True
-            if any("postgres" in alias.name for alias in node.names):
+            if any("postgres" in alias.name.casefold() for alias in node.names):
                 return True
     return False
 
 
-def _dotted_name(node: ast.expr) -> str | None:
-    """Return a dotted expression name without evaluating it."""
-
-    if isinstance(node, ast.Name):
-        return node.id
-    if isinstance(node, ast.Attribute):
-        prefix = _dotted_name(node.value)
-        return f"{prefix}.{node.attr}" if prefix else None
-    return None
-
-
-def _postgres_adapter_bindings(tree: ast.AST) -> set[str]:
-    """Names in this module that resolve to PostgreSQL adapter modules."""
-
-    bindings: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if alias.name.startswith(ADAPTER_MODULE_ROOT) and "postgres" in alias.name:
-                    bindings.add(alias.asname or alias.name)
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            if not module.startswith(ADAPTER_MODULE_ROOT):
-                continue
-            for alias in node.names:
-                if "postgres" in alias.name:
-                    bindings.add(alias.asname or alias.name)
-    return bindings
-
-
 def stubs_the_driver(source: str) -> bool:
-    """True only for an actual driver-hook patch on an imported adapter."""
+    """True only when the module explicitly declares itself wholly fake-backed."""
 
     try:
         tree = ast.parse(source)
     except SyntaxError:  # pragma: no cover - a broken test file fails elsewhere
         return False
 
-    adapter_bindings = _postgres_adapter_bindings(tree)
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or len(node.args) < 2:
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
             continue
-        operation = _dotted_name(node.func)
-        if operation not in {"monkeypatch.setattr", "patch.object"}:
-            continue
-        target = _dotted_name(node.args[0])
-        attribute = node.args[1]
+        target = node.targets[0]
         if (
-            target in adapter_bindings
-            and isinstance(attribute, ast.Constant)
-            and attribute.value == DRIVER_IMPORT_HOOK
+            isinstance(target, ast.Name)
+            and target.id == FAKE_BACKED_CLASSIFICATION_NAME
+            and isinstance(node.value, ast.Constant)
+            and node.value.value == FAKE_BACKED_CLASSIFICATION_VALUE
         ):
             return True
     return False
@@ -207,6 +171,11 @@ def test_the_detector_reads_every_import_form_and_only_imports() -> None:
     assert imports_a_postgres_adapter(
         "from src.infrastructure.pm_quality import postgres as pm_quality_postgres\n"
     )
+    # Public package exports are a supported import form too; the class name is
+    # capitalized and the package path itself need not contain `postgres`.
+    assert imports_a_postgres_adapter(
+        "from src.infrastructure.mandates import PostgresDpmMandateRepository\n"
+    )
     assert imports_a_postgres_adapter("import src.infrastructure.waves.postgres\n")
 
     assert not imports_a_postgres_adapter("from src.infrastructure.mandates.in_memory import X\n")
@@ -215,23 +184,24 @@ def test_the_detector_reads_every_import_form_and_only_imports() -> None:
     assert not imports_a_postgres_adapter("from tests.helpers.postgres import thing\n")
 
 
-def test_the_stub_detector_requires_an_actual_adapter_driver_patch() -> None:
+def test_the_stub_detector_requires_an_explicit_whole_module_classification() -> None:
     import_line = "from src.infrastructure.pm_quality import postgres as pm_quality_postgres\n"
+    classification = 'POSTGRES_LANE_CLASSIFICATION = "fake-backed-module"\n'
 
-    assert stubs_the_driver(
+    assert stubs_the_driver(import_line + classification)
+
+    # A patch in one test says nothing about a second test in the same module.
+    # Without the whole-module declaration, the module remains a live proof.
+    assert not stubs_the_driver(
         import_line + 'monkeypatch.setattr(pm_quality_postgres, "_import_psycopg", lambda: fake)\n'
     )
-    assert stubs_the_driver(
-        import_line + 'patch.object(pm_quality_postgres, "_import_psycopg", return_value=fake)\n'
-    )
-
-    # Genuine database proofs may call or mention the helpers. Neither is a
-    # driver substitution, and excluding either would hide real proof again.
     assert not stubs_the_driver(import_line + "assert pm_quality_postgres.has_psycopg()\n")
     assert not stubs_the_driver(import_line + "pm_quality_postgres._import_psycopg()\n")
-    assert not stubs_the_driver(import_line + '"""Uses _import_psycopg directly."""\n')
     assert not stubs_the_driver(
-        import_line + 'monkeypatch.setattr(unrelated_module, "_import_psycopg", lambda: fake)\n'
+        import_line + '"""POSTGRES_LANE_CLASSIFICATION = \'fake-backed-module\'"""\n'
+    )
+    assert not stubs_the_driver(
+        import_line + 'POSTGRES_LANE_CLASSIFICATION = "mixed-or-live-module"\n'
     )
 
 

--- a/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
+++ b/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
@@ -55,13 +55,11 @@ INTEGRATION_ROOT = REPOSITORY_ROOT / "tests" / "integration"
 # keyword and defeats any regex anchored on the module path.
 ADAPTER_MODULE_ROOT = "src.infrastructure"
 
-# What a file does to run the adapter without a database. Naming these is the
-# point: the exclusion is a statement about the file, checkable by reading it.
-DRIVER_STUB_MARKERS = (
-    "has_psycopg",
-    "_import_psycopg",
-    "_FakePsycopg",
-)
+# Replacing this adapter hook substitutes the database driver itself. Merely
+# importing, calling or discussing the hook proves nothing about whether the
+# test uses a real database, so the detector below requires an actual patch
+# operation against an imported PostgreSQL adapter module.
+DRIVER_IMPORT_HOOK = "_import_psycopg"
 
 MARKERS = (
     "postgres_dsn_or_skip",
@@ -124,8 +122,60 @@ def imports_a_postgres_adapter(source: str) -> bool:
     return False
 
 
+def _dotted_name(node: ast.expr) -> str | None:
+    """Return a dotted expression name without evaluating it."""
+
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _dotted_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else None
+    return None
+
+
+def _postgres_adapter_bindings(tree: ast.AST) -> set[str]:
+    """Names in this module that resolve to PostgreSQL adapter modules."""
+
+    bindings: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith(ADAPTER_MODULE_ROOT) and "postgres" in alias.name:
+                    bindings.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if not module.startswith(ADAPTER_MODULE_ROOT):
+                continue
+            for alias in node.names:
+                if "postgres" in alias.name:
+                    bindings.add(alias.asname or alias.name)
+    return bindings
+
+
 def stubs_the_driver(source: str) -> bool:
-    return any(marker in source for marker in DRIVER_STUB_MARKERS)
+    """True only for an actual driver-hook patch on an imported adapter."""
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:  # pragma: no cover - a broken test file fails elsewhere
+        return False
+
+    adapter_bindings = _postgres_adapter_bindings(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or len(node.args) < 2:
+            continue
+        operation = _dotted_name(node.func)
+        if operation not in {"monkeypatch.setattr", "patch.object"}:
+            continue
+        target = _dotted_name(node.args[0])
+        attribute = node.args[1]
+        if (
+            target in adapter_bindings
+            and isinstance(attribute, ast.Constant)
+            and attribute.value == DRIVER_IMPORT_HOOK
+        ):
+            return True
+    return False
 
 
 def _candidate_files() -> list[Path]:
@@ -163,6 +213,26 @@ def test_the_detector_reads_every_import_form_and_only_imports() -> None:
     # A mention in prose is not an import, and neither is an unrelated package.
     assert not imports_a_postgres_adapter('"""Talks about src.infrastructure.waves.postgres."""\n')
     assert not imports_a_postgres_adapter("from tests.helpers.postgres import thing\n")
+
+
+def test_the_stub_detector_requires_an_actual_adapter_driver_patch() -> None:
+    import_line = "from src.infrastructure.pm_quality import postgres as pm_quality_postgres\n"
+
+    assert stubs_the_driver(
+        import_line + 'monkeypatch.setattr(pm_quality_postgres, "_import_psycopg", lambda: fake)\n'
+    )
+    assert stubs_the_driver(
+        import_line + 'patch.object(pm_quality_postgres, "_import_psycopg", return_value=fake)\n'
+    )
+
+    # Genuine database proofs may call or mention the helpers. Neither is a
+    # driver substitution, and excluding either would hide real proof again.
+    assert not stubs_the_driver(import_line + "assert pm_quality_postgres.has_psycopg()\n")
+    assert not stubs_the_driver(import_line + "pm_quality_postgres._import_psycopg()\n")
+    assert not stubs_the_driver(import_line + '"""Uses _import_psycopg directly."""\n')
+    assert not stubs_the_driver(
+        import_line + 'monkeypatch.setattr(unrelated_module, "_import_psycopg", lambda: fake)\n'
+    )
 
 
 def _postgres_proof_files() -> list[Path]:

--- a/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
+++ b/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
@@ -14,6 +14,7 @@ exist and asserts each is covered by a path the lane names.
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -21,23 +22,45 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 MAKEFILE = REPOSITORY_ROOT / "Makefile"
 INTEGRATION_ROOT = REPOSITORY_ROOT / "tests" / "integration"
 
-# What makes a file a PostgreSQL proof: it imports a PostgreSQL ADAPTER.
+# Two questions, deliberately kept apart.
+#
+#   CANDIDATE  does this file import a PostgreSQL adapter?
+#   PROOF      does it run that adapter against a REAL database?
+#
+# Collapsing them is wrong in both directions, and this module has now made
+# both mistakes.
 #
 # Matching on the FILENAME would have been simpler and wrong -
 # `test_mandate_temporal_reads_postgres.py` says so in its name, but nothing
-# makes the next author repeat the convention. The first version of this test
-# then made the same mistake one level down: it matched the prerequisite helper
-# names and one environment-variable string, so a proof reaching PostgreSQL
-# through its own DSN variable and its own skip was invisible, and BOTH tests
-# below passed while the lane omitted exactly the file they claim to cover.
-# Raised in review on PR #695.
+# makes the next author repeat the convention. The first version then made the
+# same mistake one level down, keying on the prerequisite helper names and one
+# environment-variable string, so a proof reaching PostgreSQL through its own
+# DSN variable was invisible.
 #
-# The import is the thing that cannot be avoided: a test cannot exercise the
-# PostgreSQL adapter without naming it. The helper and env-var markers are kept
-# as a widening, not as the definition.
-ADAPTER_IMPORT = re.compile(
-    r"^\s*(?:from|import)\s+src\.infrastructure\.[\w.]*postgres[\w.]*",
-    re.MULTILINE,
+# Widening to the adapter import alone is the opposite error.
+# `tests/integration/dpm/pm_quality/test_pm_quality_endpoint_lifecycle.py`
+# imports the adapter and then monkeypatches `has_psycopg` and
+# `_import_psycopg` with a fake driver. It never opens a connection. Adding it
+# to the database lane would demand a DSN it does not use, and routing it
+# through the prerequisite would make it fail for want of a database it does
+# not want. Both review rounds on PR #695 found one half of this.
+#
+# So: an import makes a file a candidate, and a candidate is a proof unless it
+# stubs the driver. The exclusion is asserted rather than assumed - a candidate
+# that is neither in the lane nor visibly stubbed fails, so "it uses a fake"
+# has to be true in the file rather than believed about it.
+#
+# Imports are parsed, not pattern-matched: `from src.infrastructure.pm_quality
+# import postgres as pm_quality_postgres` puts the word after the `import`
+# keyword and defeats any regex anchored on the module path.
+ADAPTER_MODULE_ROOT = "src.infrastructure"
+
+# What a file does to run the adapter without a database. Naming these is the
+# point: the exclusion is a statement about the file, checkable by reading it.
+DRIVER_STUB_MARKERS = (
+    "has_psycopg",
+    "_import_psycopg",
+    "_FakePsycopg",
 )
 
 MARKERS = (
@@ -69,33 +92,111 @@ def _lane_paths() -> list[str]:
     ]
 
 
-def _postgres_proof_files() -> list[Path]:
-    def is_proof(path: Path) -> bool:
-        text = path.read_text(encoding="utf-8")
-        return bool(ADAPTER_IMPORT.search(text)) or any(marker in text for marker in MARKERS)
+def imports_a_postgres_adapter(source: str) -> bool:
+    """True when the file imports a PostgreSQL adapter, in any import form.
 
-    return sorted(path for path in INTEGRATION_ROOT.rglob("test_*.py") if is_proof(path))
-
-
-def test_the_detector_recognises_an_adapter_import_on_its_own() -> None:
-    """The widened detector must actually widen.
-
-    A detector that still keys on the helper names would pass every assertion
-    below while missing the file they exist to catch, and nothing about a green
-    run distinguishes the two. So this asserts the discriminating case directly:
-    an adapter import, with no helper name and no environment variable
-    anywhere.
+    Parsed rather than pattern-matched, because the module path is not the only
+    place the name appears: `from src.infrastructure.pm_quality import postgres
+    as pm_quality_postgres` carries it as an imported NAME, and a regex anchored
+    on the dotted path misses it entirely.
     """
 
-    assert ADAPTER_IMPORT.search(
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:  # pragma: no cover - a broken test file fails elsewhere
+        return False
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            if any(
+                alias.name.startswith(ADAPTER_MODULE_ROOT) and "postgres" in alias.name
+                for alias in node.names
+            ):
+                return True
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if not module.startswith(ADAPTER_MODULE_ROOT):
+                continue
+            if "postgres" in module:
+                return True
+            if any("postgres" in alias.name for alias in node.names):
+                return True
+    return False
+
+
+def stubs_the_driver(source: str) -> bool:
+    return any(marker in source for marker in DRIVER_STUB_MARKERS)
+
+
+def _candidate_files() -> list[Path]:
+    """Files that import a PostgreSQL adapter, stubbed or not."""
+
+    return sorted(
+        path
+        for path in INTEGRATION_ROOT.rglob("test_*.py")
+        if imports_a_postgres_adapter(path.read_text(encoding="utf-8"))
+        or any(marker in path.read_text(encoding="utf-8") for marker in MARKERS)
+    )
+
+
+def test_the_detector_reads_every_import_form_and_only_imports() -> None:
+    """The discriminating cases, asserted directly.
+
+    A detector that quietly stopped matching would pass every assertion below,
+    because they all measure a set it produces. These measure the detector.
+    """
+
+    assert imports_a_postgres_adapter(
         "from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository\n"
     )
-    assert ADAPTER_IMPORT.search(
+    assert imports_a_postgres_adapter(
         "from src.infrastructure.rebalance_runs.idea_management_actions_postgres import X\n"
     )
-    assert not ADAPTER_IMPORT.search("from src.infrastructure.mandates.in_memory import X\n")
-    # A mention in prose or a docstring is not an import.
-    assert not ADAPTER_IMPORT.search('"""Talks about src.infrastructure.waves.postgres."""\n')
+    # The form the previous regex missed: the name follows `import`, not the
+    # module path. Present in this repository today.
+    assert imports_a_postgres_adapter(
+        "from src.infrastructure.pm_quality import postgres as pm_quality_postgres\n"
+    )
+    assert imports_a_postgres_adapter("import src.infrastructure.waves.postgres\n")
+
+    assert not imports_a_postgres_adapter("from src.infrastructure.mandates.in_memory import X\n")
+    # A mention in prose is not an import, and neither is an unrelated package.
+    assert not imports_a_postgres_adapter('"""Talks about src.infrastructure.waves.postgres."""\n')
+    assert not imports_a_postgres_adapter("from tests.helpers.postgres import thing\n")
+
+
+def _postgres_proof_files() -> list[Path]:
+    """Candidates that actually reach a database - stubs excluded."""
+
+    return [
+        path
+        for path in _candidate_files()
+        if not stubs_the_driver(path.read_text(encoding="utf-8"))
+    ]
+
+
+def test_every_candidate_is_either_in_the_lane_or_visibly_stubbed() -> None:
+    """A candidate excluded for using a fake must SAY it uses a fake.
+
+    Without this, "not a real proof" is a belief about a file rather than a
+    property of it, and the exclusion becomes the hiding place: a genuine proof
+    that simply forgot the prerequisite would be indistinguishable from one
+    that deliberately runs against a stub.
+    """
+
+    lane = [(REPOSITORY_ROOT / path).resolve() for path in _lane_paths()]
+    unexplained = []
+    for path in _candidate_files():
+        in_lane = any(path == entry or entry in path.parents for entry in lane)
+        if in_lane or stubs_the_driver(path.read_text(encoding="utf-8")):
+            continue
+        unexplained.append(path.relative_to(REPOSITORY_ROOT).as_posix())
+
+    assert not unexplained, (
+        "these files import a PostgreSQL adapter, are not in the database lane, "
+        "and do not visibly stub the driver - so nothing says whether they are "
+        "unrun proofs or fake-backed tests: " + ", ".join(unexplained)
+    )
 
 
 def test_the_lane_names_every_postgres_proof_file() -> None:

--- a/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
+++ b/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
@@ -1,20 +1,14 @@
-"""Every PostgreSQL proof is reachable from the lane that owns a database (#693).
+"""The live PostgreSQL lane must execute the complete integration tree (#693).
 
-The lane's input is a hand-written list in the Makefile. A proof file absent
-from it does not fail, does not skip and does not appear anywhere in the run -
-it is indistinguishable from a proof that passed. That is not hypothetical:
-issue #677's wave isolation proofs were cited as evidence for months while the
-list named only the supportability suite and `dpm/mandates`, so they had never
-executed in CI at all.
-
-Aligning the list once fixes today's omission and nothing else. This test makes
-the omission impossible to repeat: it enumerates the PostgreSQL proof files that
-exist and asserts each is covered by a path the lane names.
+A hand-written subset cannot prove reachability. Adapter use may arrive through
+direct imports, package exports, local helpers or pytest fixtures, and every
+classifier for those shapes creates another way for a real proof to disappear.
+The database lane therefore owns all integration modules. This contract pins
+that simple invariant and makes a future narrowing fail visibly.
 """
 
 from __future__ import annotations
 
-import ast
 import re
 from pathlib import Path
 
@@ -22,57 +16,9 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 MAKEFILE = REPOSITORY_ROOT / "Makefile"
 INTEGRATION_ROOT = REPOSITORY_ROOT / "tests" / "integration"
 
-# Two questions, deliberately kept apart.
-#
-#   CANDIDATE  does this file import a PostgreSQL adapter?
-#   PROOF      does it run that adapter against a REAL database?
-#
-# Collapsing them is wrong in both directions, and this module has now made
-# both mistakes.
-#
-# Matching on the FILENAME would have been simpler and wrong -
-# `test_mandate_temporal_reads_postgres.py` says so in its name, but nothing
-# makes the next author repeat the convention. The first version then made the
-# same mistake one level down, keying on the prerequisite helper names and one
-# environment-variable string, so a proof reaching PostgreSQL through its own
-# DSN variable was invisible.
-#
-# Widening to the adapter import alone is the opposite error.
-# `tests/integration/dpm/pm_quality/test_pm_quality_endpoint_lifecycle.py`
-# imports the adapter and then monkeypatches `has_psycopg` and
-# `_import_psycopg` with a fake driver. It never opens a connection. Adding it
-# to the database lane would demand a DSN it does not use, and routing it
-# through the prerequisite would make it fail for want of a database it does
-# not want. Both review rounds on PR #695 found one half of this.
-#
-# So: an import makes a file a candidate, and a candidate is a proof unless the
-# entire module explicitly declares itself fake-backed. Inferring module intent
-# from one monkeypatch is unsafe because a later live test can share that file.
-# The exclusion is asserted rather than assumed - a candidate that is neither
-# in the lane nor explicitly classified fails.
-#
-# Imports are parsed, not pattern-matched: `from src.infrastructure.pm_quality
-# import postgres as pm_quality_postgres` puts the word after the `import`
-# keyword and defeats any regex anchored on the module path.
-ADAPTER_MODULE_ROOT = "src.infrastructure"
-
-FAKE_BACKED_CLASSIFICATION_NAME = "POSTGRES_LANE_CLASSIFICATION"
-FAKE_BACKED_CLASSIFICATION_VALUE = "fake-backed-module"
-
-MARKERS = (
-    "postgres_dsn_or_skip",
-    "postgres_dsn_or_fake",
-    "DPM_POSTGRES_INTEGRATION_DSN",
-)
-
-# The two forms of the prerequisite. Either consults
-# DPM_POSTGRES_INTEGRATION_REQUIRED; a file using neither decides its own fate
-# and the lane cannot make it run.
-PREREQUISITE_HELPERS = ("postgres_dsn_or_skip", "postgres_dsn_or_fake")
-
 
 def _lane_paths() -> list[str]:
-    """The paths named by POSTGRES_INTEGRATION_TESTS, following its line continuations."""
+    """Read POSTGRES_INTEGRATION_TESTS, following Make line continuations."""
 
     text = MAKEFILE.read_text(encoding="utf-8")
     match = re.search(
@@ -80,7 +26,7 @@ def _lane_paths() -> list[str]:
         text,
         re.MULTILINE,
     )
-    assert match, "the lane variable POSTGRES_INTEGRATION_TESTS is not defined in the Makefile"
+    assert match, "the lane variable POSTGRES_INTEGRATION_TESTS is not defined"
     return [
         token
         for token in match.group(1).replace("\\\n", " ").split()
@@ -88,239 +34,21 @@ def _lane_paths() -> list[str]:
     ]
 
 
-def imports_a_postgres_adapter(source: str) -> bool:
-    """True when the file imports a PostgreSQL adapter, in any import form.
+def test_postgres_lane_owns_the_complete_integration_tree() -> None:
+    assert _lane_paths() == ["tests/integration"]
 
-    Parsed rather than pattern-matched, because the module path is not the only
-    place the name appears: `from src.infrastructure.pm_quality import postgres
-    as pm_quality_postgres` carries it as an imported NAME, and a regex anchored
-    on the dotted path misses it entirely.
-    """
-
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:  # pragma: no cover - a broken test file fails elsewhere
-        return False
-
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            if any(
-                alias.name.startswith(ADAPTER_MODULE_ROOT)
-                and (
-                    "postgres" in alias.name.casefold()
-                    or _package_exports_postgres_adapter(alias.name)
-                )
-                for alias in node.names
-            ):
-                return True
-        elif isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            if not module.startswith(ADAPTER_MODULE_ROOT):
-                continue
-            if "postgres" in module.casefold():
-                return True
-            if any("postgres" in alias.name.casefold() for alias in node.names):
-                return True
-            if any(
-                _package_exports_postgres_adapter(f"{module}.{alias.name}") for alias in node.names
-            ):
-                return True
-    return False
+    integration_files = sorted(INTEGRATION_ROOT.rglob("test_*.py"))
+    assert integration_files, "the integration lane contains no test modules"
+    lane_root = (REPOSITORY_ROOT / _lane_paths()[0]).resolve()
+    assert all(lane_root in path.resolve().parents for path in integration_files)
 
 
-def _package_exports_postgres_adapter(module: str) -> bool:
-    """Whether a repository package directly exports a PostgreSQL adapter.
-
-    Importing `src.infrastructure.mandates as mandates` gives the caller every
-    name exported from that package even though neither the import path nor its
-    local alias says `postgres`. Resolve that ambiguity from the package source
-    instead of guessing from the test filename or treating all infrastructure
-    imports as database proof.
-    """
-
-    package_init = REPOSITORY_ROOT.joinpath(*module.split("."), "__init__.py")
-    if not package_init.is_file():
-        return False
-    try:
-        tree = ast.parse(package_init.read_text(encoding="utf-8"))
-    except SyntaxError:  # pragma: no cover - broken package source fails elsewhere
-        return False
-    return any(
-        "postgres" in (node.module or "").casefold()
-        or any("postgres" in alias.name.casefold() for alias in node.names)
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Import | ast.ImportFrom)
-    )
-
-
-def stubs_the_driver(source: str) -> bool:
-    """True only when the module explicitly declares itself wholly fake-backed."""
-
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:  # pragma: no cover - a broken test file fails elsewhere
-        return False
-
-    for node in tree.body:
-        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
-            continue
-        target = node.targets[0]
-        if (
-            isinstance(target, ast.Name)
-            and target.id == FAKE_BACKED_CLASSIFICATION_NAME
-            and isinstance(node.value, ast.Constant)
-            and node.value.value == FAKE_BACKED_CLASSIFICATION_VALUE
-        ):
-            return True
-    return False
-
-
-def _candidate_files() -> list[Path]:
-    """Files that import a PostgreSQL adapter, stubbed or not."""
-
-    return sorted(
-        path
-        for path in INTEGRATION_ROOT.rglob("test_*.py")
-        if imports_a_postgres_adapter(path.read_text(encoding="utf-8"))
-        or any(marker in path.read_text(encoding="utf-8") for marker in MARKERS)
-    )
-
-
-def test_the_detector_reads_every_import_form_and_only_imports() -> None:
-    """The discriminating cases, asserted directly.
-
-    A detector that quietly stopped matching would pass every assertion below,
-    because they all measure a set it produces. These measure the detector.
-    """
-
-    assert imports_a_postgres_adapter(
-        "from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository\n"
-    )
-    assert imports_a_postgres_adapter(
-        "from src.infrastructure.rebalance_runs.idea_management_actions_postgres import X\n"
-    )
-    # The form the previous regex missed: the name follows `import`, not the
-    # module path. Present in this repository today.
-    assert imports_a_postgres_adapter(
-        "from src.infrastructure.pm_quality import postgres as pm_quality_postgres\n"
-    )
-    # Public package exports are a supported import form too; the class name is
-    # capitalized and the package path itself need not contain `postgres`.
-    assert imports_a_postgres_adapter(
-        "from src.infrastructure.mandates import PostgresDpmMandateRepository\n"
-    )
-    assert imports_a_postgres_adapter("import src.infrastructure.mandates as mandates\n")
-    assert imports_a_postgres_adapter("from src.infrastructure import mandates\n")
-    assert imports_a_postgres_adapter("import src.infrastructure.waves.postgres\n")
-
-    assert not imports_a_postgres_adapter("from src.infrastructure.mandates.in_memory import X\n")
-    # A mention in prose is not an import, and neither is an unrelated package.
-    assert not imports_a_postgres_adapter('"""Talks about src.infrastructure.waves.postgres."""\n')
-    assert not imports_a_postgres_adapter("from tests.helpers.postgres import thing\n")
-
-
-def test_the_stub_detector_requires_an_explicit_whole_module_classification() -> None:
-    import_line = "from src.infrastructure.pm_quality import postgres as pm_quality_postgres\n"
-    classification = 'POSTGRES_LANE_CLASSIFICATION = "fake-backed-module"\n'
-
-    assert stubs_the_driver(import_line + classification)
-
-    # A patch in one test says nothing about a second test in the same module.
-    # Without the whole-module declaration, the module remains a live proof.
-    assert not stubs_the_driver(
-        import_line + 'monkeypatch.setattr(pm_quality_postgres, "_import_psycopg", lambda: fake)\n'
-    )
-    assert not stubs_the_driver(import_line + "assert pm_quality_postgres.has_psycopg()\n")
-    assert not stubs_the_driver(import_line + "pm_quality_postgres._import_psycopg()\n")
-    assert not stubs_the_driver(
-        import_line + '"""POSTGRES_LANE_CLASSIFICATION = \'fake-backed-module\'"""\n'
-    )
-    assert not stubs_the_driver(
-        import_line + 'POSTGRES_LANE_CLASSIFICATION = "mixed-or-live-module"\n'
-    )
-
-
-def _postgres_proof_files() -> list[Path]:
-    """Candidates that actually reach a database - stubs excluded."""
-
-    return [
-        path
-        for path in _candidate_files()
-        if not stubs_the_driver(path.read_text(encoding="utf-8"))
-    ]
-
-
-def test_every_candidate_is_either_in_the_lane_or_visibly_stubbed() -> None:
-    """A candidate excluded for using a fake must SAY it uses a fake.
-
-    Without this, "not a real proof" is a belief about a file rather than a
-    property of it, and the exclusion becomes the hiding place: a genuine proof
-    that simply forgot the prerequisite would be indistinguishable from one
-    that deliberately runs against a stub.
-    """
-
-    lane = [(REPOSITORY_ROOT / path).resolve() for path in _lane_paths()]
-    unexplained = []
-    for path in _candidate_files():
-        in_lane = any(path == entry or entry in path.parents for entry in lane)
-        if in_lane or stubs_the_driver(path.read_text(encoding="utf-8")):
-            continue
-        unexplained.append(path.relative_to(REPOSITORY_ROOT).as_posix())
-
-    assert not unexplained, (
-        "these files import a PostgreSQL adapter, are not in the database lane, "
-        "and do not visibly stub the driver - so nothing says whether they are "
-        "unrun proofs or fake-backed tests: " + ", ".join(unexplained)
-    )
-
-
-def test_the_lane_names_every_postgres_proof_file() -> None:
-    lane = [(REPOSITORY_ROOT / path).resolve() for path in _lane_paths()]
-    proofs = _postgres_proof_files()
-
-    assert proofs, "no PostgreSQL proof files were found; the detector below proves nothing"
-
-    unreachable = [
-        proof.relative_to(REPOSITORY_ROOT).as_posix()
-        for proof in proofs
-        if not any(proof == entry or entry in proof.parents for entry in lane)
-    ]
-
-    assert not unreachable, (
-        "these PostgreSQL proofs are not reachable from POSTGRES_INTEGRATION_TESTS, "
-        "so the database lane runs green without them: " + ", ".join(unreachable)
-    )
-
-
-def test_every_lane_path_exists() -> None:
-    """A stale entry is the same defect read backwards.
-
-    A path that no longer exists makes the list look larger than the coverage
-    it buys, and pytest accepts a directory that is empty without complaint.
-    """
-
-    missing = [path for path in _lane_paths() if not (REPOSITORY_ROOT / path).exists()]
-
-    assert not missing, f"POSTGRES_INTEGRATION_TESTS names paths that do not exist: {missing}"
-
-
-def test_no_postgres_proof_gates_itself_on_a_bare_dsn_check() -> None:
-    """The prerequisite must be consulted, not merely present in the environment.
-
-    `DPM_POSTGRES_INTEGRATION_REQUIRED=1` is set in both workflows, but it only
-    reaches files that route through `postgres_dsn_or_skip`. A file keeping its
-    own `skipif(not DSN)` skips silently in the lane that declared the database
-    a prerequisite - which is the exact shape of the defect the flag was added
-    to close, surviving in the files that did not adopt it.
-    """
-
-    offenders = [
-        proof.relative_to(REPOSITORY_ROOT).as_posix()
-        for proof in _postgres_proof_files()
-        if not any(helper in proof.read_text(encoding="utf-8") for helper in PREREQUISITE_HELPERS)
-    ]
-
-    assert not offenders, (
-        "these PostgreSQL proofs decide their own skip and so ignore "
-        "DPM_POSTGRES_INTEGRATION_REQUIRED: " + ", ".join(offenders)
-    )
+def test_postgres_lane_target_uses_the_governed_variable() -> None:
+    text = MAKEFILE.read_text(encoding="utf-8")
+    for target in (
+        "test-idea-management-action-postgres",
+        "test-idea-management-action-postgres-coverage",
+    ):
+        match = re.search(rf"^{target}:\n((?:\t.*\n)+)", text, re.MULTILINE)
+        assert match, f"Makefile target {target} is missing"
+        assert "$(POSTGRES_INTEGRATION_TESTS)" in match.group(1)

--- a/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
+++ b/tests/unit/dpm/supportability/test_postgres_lane_inputs.py
@@ -21,11 +21,25 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 MAKEFILE = REPOSITORY_ROOT / "Makefile"
 INTEGRATION_ROOT = REPOSITORY_ROOT / "tests" / "integration"
 
-# A file is a PostgreSQL proof when it imports the adapter package or the
-# shared prerequisite. Matching on the FILENAME would have been simpler and
-# wrong: `test_mandate_temporal_reads_postgres.py` says so in its name, but
-# nothing makes the next author repeat the convention, and a proof that quietly
-# fell outside the naming rule is precisely the case this test exists to catch.
+# What makes a file a PostgreSQL proof: it imports a PostgreSQL ADAPTER.
+#
+# Matching on the FILENAME would have been simpler and wrong -
+# `test_mandate_temporal_reads_postgres.py` says so in its name, but nothing
+# makes the next author repeat the convention. The first version of this test
+# then made the same mistake one level down: it matched the prerequisite helper
+# names and one environment-variable string, so a proof reaching PostgreSQL
+# through its own DSN variable and its own skip was invisible, and BOTH tests
+# below passed while the lane omitted exactly the file they claim to cover.
+# Raised in review on PR #695.
+#
+# The import is the thing that cannot be avoided: a test cannot exercise the
+# PostgreSQL adapter without naming it. The helper and env-var markers are kept
+# as a widening, not as the definition.
+ADAPTER_IMPORT = re.compile(
+    r"^\s*(?:from|import)\s+src\.infrastructure\.[\w.]*postgres[\w.]*",
+    re.MULTILINE,
+)
+
 MARKERS = (
     "postgres_dsn_or_skip",
     "postgres_dsn_or_fake",
@@ -56,11 +70,32 @@ def _lane_paths() -> list[str]:
 
 
 def _postgres_proof_files() -> list[Path]:
-    return sorted(
-        path
-        for path in INTEGRATION_ROOT.rglob("test_*.py")
-        if any(marker in path.read_text(encoding="utf-8") for marker in MARKERS)
+    def is_proof(path: Path) -> bool:
+        text = path.read_text(encoding="utf-8")
+        return bool(ADAPTER_IMPORT.search(text)) or any(marker in text for marker in MARKERS)
+
+    return sorted(path for path in INTEGRATION_ROOT.rglob("test_*.py") if is_proof(path))
+
+
+def test_the_detector_recognises_an_adapter_import_on_its_own() -> None:
+    """The widened detector must actually widen.
+
+    A detector that still keys on the helper names would pass every assertion
+    below while missing the file they exist to catch, and nothing about a green
+    run distinguishes the two. So this asserts the discriminating case directly:
+    an adapter import, with no helper name and no environment variable
+    anywhere.
+    """
+
+    assert ADAPTER_IMPORT.search(
+        "from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository\n"
     )
+    assert ADAPTER_IMPORT.search(
+        "from src.infrastructure.rebalance_runs.idea_management_actions_postgres import X\n"
+    )
+    assert not ADAPTER_IMPORT.search("from src.infrastructure.mandates.in_memory import X\n")
+    # A mention in prose or a docstring is not an import.
+    assert not ADAPTER_IMPORT.search('"""Talks about src.infrastructure.waves.postgres."""\n')
 
 
 def test_the_lane_names_every_postgres_proof_file() -> None:

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -2893,3 +2893,78 @@ def test_the_wiki_wave_header_count_is_derived_from_the_served_contract() -> Non
         "the tenant-header section must name the one wave route that is not fenced; "
         "a reader of that list would otherwise assume the wave prefix implies fencing"
     )
+
+
+def _tenant_query_is_required(operation: dict[str, object]) -> bool:
+    return any(
+        parameter["name"] == "tenant_id"
+        and parameter["in"] == "query"
+        and parameter.get("required")
+        for parameter in operation.get("parameters", [])  # type: ignore[union-attr]
+    )
+
+
+def test_the_wiki_tenant_scope_claims_are_derived_from_the_served_contract() -> None:
+    """The page's scoped/unscoped claims must fail when the contract moves.
+
+    The paragraph this pins previously said monitoring-run reads were unfenced
+    "because the monitoring-run aggregate carries no tenant of its own". The
+    column had existed since migration 0003; the reads simply never consulted
+    it. The sentence was wrong on the day it was written and nothing could tell,
+    because every other assertion about this page checks that it MENTIONS
+    something - which a false statement does as well as a true one.
+
+    So this reads the served document. Fence one of the operations named below
+    as unscoped, or unfence one named as scoped, and this test fails until the
+    page is corrected.
+    """
+
+    spec = app.openapi()
+    operations = {
+        f"{method.upper()} {path}": operation
+        for path, path_item in spec["paths"].items()
+        for method, operation in path_item.items()
+        if method in {"get", "post", "put", "patch", "delete"}
+    }
+
+    scoped = {
+        "GET /api/v1/dpm/monitoring/runs",
+        "GET /api/v1/dpm/monitoring/runs/{monitoring_run_id}",
+    }
+    # Named as unscoped on the page. `report-input` and `ai-evidence-input` are
+    # deliberately absent: they DO declare a required tenant_id and are still
+    # unfenced, which is why the page describes them separately and issue #694
+    # calls the parameter misleading rather than missing. A membership test
+    # here would report them as fenced.
+    unscoped = {
+        "GET /api/v1/rebalance/proof-packs/{proof_pack_id}",
+        "GET /api/v1/rebalance/proof-packs/{proof_pack_id}/summary.md",
+        "GET /api/v1/rebalance/waves/{wave_id}/outcome-reviews",
+    }
+
+    missing = sorted((scoped | unscoped) - set(operations))
+    assert not missing, f"the page names operations the contract does not serve: {missing}"
+
+    unfenced_but_claimed_scoped = sorted(
+        name for name in scoped if not _tenant_query_is_required(operations[name])
+    )
+    assert not unfenced_but_claimed_scoped, (
+        "wiki/API-Surface.md says these take a required tenant_id and the served "
+        f"contract disagrees: {unfenced_but_claimed_scoped}"
+    )
+
+    fenced_but_claimed_unscoped = sorted(
+        name for name in unscoped if _tenant_query_is_required(operations[name])
+    )
+    assert not fenced_but_claimed_unscoped, (
+        "wiki/API-Surface.md still lists these as unscoped after they were fenced; "
+        f"update the page and issue #694: {fenced_but_claimed_unscoped}"
+    )
+
+    api_surface = (ROOT / "wiki" / "API-Surface.md").read_text(encoding="utf-8")
+    assert "required `tenant_id` query parameter" in api_surface
+    assert "matched\n  by no caller at all rather than by whoever asks" in api_surface, (
+        "the page must keep saying that a NULL-tenant run is quarantined rather "
+        "than defaulted; that is the property the migration relies on"
+    )
+    assert "issue #694" in api_surface

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -349,13 +349,30 @@ refused — but it is invisible to a generated client. Send it on those routes e
 does not list it. Tracked as a contract defect rather than a documentation one, because the fix is
 to declare it.
 
-It is not yet universal. Monitoring **run** reads — `GET /monitoring/runs` and
-`GET /monitoring/runs/{monitoring_run_id}` — still accept no tenant and read across tenants,
-because the monitoring-run aggregate carries no tenant of its own. Do not treat monitoring-run
-responses as tenant-fenced. Five operations are in that state: both monitoring-run reads,
-`GET /rebalance/proof-packs/{proof_pack_id}` with its `summary.md` companion, and
-`GET /rebalance/waves/{wave_id}/outcome-reviews` — the last of which sits under the wave prefix
-while reading an aggregate that is not tenant-scoped.
+It is not yet universal, and this page previously said something false about why. Monitoring
+**run** reads read across no tenants any more: `GET /monitoring/runs` and
+`GET /monitoring/runs/{monitoring_run_id}` now take a **required `tenant_id` query parameter**,
+the same selector their mandate siblings use, and return only that tenant's runs. The reason
+given here before — that the monitoring-run aggregate "carries no tenant of its own" — was
+simply wrong. `dpm_monitoring_runs.tenant_id` has existed since migration `0003`. The column was
+populated all along and the reads never consulted it.
+
+Two limits on that fence are worth stating plainly, because neither is visible from the contract:
+
+- A run whose `tenant_id` is NULL — the column is nullable and was never backfilled — is matched
+  by no caller at all rather than by whoever asks. Those runs are quarantined, not defaulted, and
+  attributing them is an operator action.
+- The recorded tenant comes from the request body's `filters` on the write path and is not
+  reconciled against an admitted caller identity. Read fencing therefore scopes what a caller can
+  **see**; it does not yet stop a caller recording a run under a tenant it merely names. That gap
+  is tracked on issue #693 and is not closed by this change.
+
+Three operations remain genuinely unscoped: `GET /rebalance/proof-packs/{proof_pack_id}` with its
+`summary.md` companion, and `GET /rebalance/waves/{wave_id}/outcome-reviews` — the last of which
+sits under the wave prefix while reading an aggregate that is not tenant-scoped. The proof-pack
+reads are worse than unscoped: `GET /rebalance/proof-packs/{proof_pack_id}/report-input` and
+`/ai-evidence-input` **require** a `tenant_id` and then use it only for downstream enrichment, so
+the parameter looks like a fence and is not one. Tracked on issue #694.
 
 The wave aggregate is **no longer** among them — migration `0027` scoped it, and this sentence
 previously described the state before that change.


### PR DESCRIPTION
Closes part of #693. See #694 and lotus-gateway#778.

## The defect

`GET /api/v1/dpm/monitoring/runs` and `GET /api/v1/dpm/monitoring/runs/{monitoring_run_id}` took no tenant at all. Every persisted run — the mandates it covered, the health distribution across them, the source-readiness summary, the failure reason — was readable by anyone who could reach the route, and the list returned every tenant's runs in one page.

`dpm_monitoring_runs.tenant_id` has existed since migration `0003` and was populated all along. The reads never consulted it. `wiki/API-Surface.md` explained the gap by saying the aggregate "carries no tenant of its own"; that was never true, and is corrected here.

## What is fenced, beyond threading a parameter

| Property | Why a parameter alone does not give it |
| --- | --- |
| A run with **no recorded tenant** is matched by nobody | The column is nullable and was never backfilled. Treating a missing owner as a wildcard would hand every pre-fence run to the first caller who names any tenant. |
| The **cursor** resolves under the caller's tenant | A fenced page with an unfenced cursor subquery still leaks ordering position: another tenant's run id resolves to a `started_at` and decides where the caller's page begins. |
| The **column and the payload must both** name the caller | `ON CONFLICT` refreshes `payload_json` and `filters_json` and deliberately never `tenant_id`. A re-save under a different tenant rewrites the body while the fence keeps answering with the original owner — the caller is admitted by the column and handed a body that says someone else. |
| The command centre fences **in the query** | It read 200 unscoped rows and narrowed them in Python, so a tenant's latest run could sit behind 200 other tenants' rows. That presents as a short result rather than as a leak. |

## Why the PostgreSQL proofs, and what they exposed

The unit-level "postgres" tests run against a hand-written fake that re-implements the SQL rather than executing it. Falsification showed the cost: **removing `AND tenant_id = %s` from the direct-read query left every unit test passing**, because the fake never reads the query text.

Against a real engine each predicate fails when reverted:

```
REFUSED  direct read predicate removed
REFUSED  list fence unseeded
REFUSED  cursor subquery unfenced
REFUSED  column/payload agreement dropped
```

Chasing that exposed a wider gap, so this repairs the lane as well:

- **One list, not two.** `POSTGRES_INTEGRATION_TESTS` replaces two hand-maintained copies that had already drifted — `dpm/mandates` was in the coverage target and not the plain one, so the lane an operator runs by hand and the lane CI runs were proving different things.
- **Four suites the lane could not make run.** Two were absent from it entirely, and both fell back to an in-process fake on *any* exception while a DSN was configured — a refused connection or a failed migration produced a green run under a name that says `live_postgres`. Two more, including the suite the lane is named after, kept their own `skipif(not DSN)` and so ignored `DPM_POSTGRES_INTEGRATION_REQUIRED`.
- **The complete integration tree is the governed lane input.** `POSTGRES_INTEGRATION_TESTS = tests/integration` removes the brittle file classifier entirely, so PostgreSQL adapters supplied through package exports, fixtures, and helper modules cannot silently escape the live-engine lane. `tests/unit/dpm/supportability/test_postgres_lane_inputs.py` pins that complete-tree contract and proves both plain and coverage targets consume it.

Verified on exact head `88f67eb0bec0de032b21d0a412b07806a7c10344`: `make test-idea-management-action-postgres` → **253 passed** against a real PostgreSQL with `DPM_POSTGRES_INTEGRATION_REQUIRED=1`. Without a DSN and without the required flag → **219 passed, 33 skipped** (honest). The required flag with no DSN still fails loudly during prerequisite validation.

## Documentation measured, not re-typed

The new test derives the page's scoped/unscoped claims from the served OpenAPI: fence an operation the page calls unscoped, or unfence one it calls scoped, and it fails. Falsified in three directions. The old paragraph was wrong on the day it was written and nothing could tell — every other assertion about that page checks that it *mentions* something, which a false statement does as well as a true one.

## Consumer impact — read before merging

`lotus-gateway` forwards no tenant on either route ([client](https://github.com/sgajbi/lotus-gateway/blob/main/src/app/clients/dpm_command_center_client.py#L34-L56)) and its two command-centre monitoring routes will return **422** until it does.

Extra query parameters are ignored by manage today, so **Gateway can forward the tenant before this lands** and the two changes need not be coupled. Filed as [lotus-gateway#778](https://github.com/sgajbi/lotus-gateway/issues/778) with the exact change, following the `DpmManageTenantId` pattern its already-fenced calls use. If this merges first the routes refuse rather than return cross-tenant data — the right failure, but worth avoiding.

## Deliberately not in scope

Proof-pack reads have **no recorded owner to consult**: no column, no model field, nothing persisted — while `/report-input` and `/ai-evidence-input` *require* a `tenant_id` and use it only for downstream enrichment, so the parameter reads as a fence and is not one. That needs migration `0028` and a write path, and is #694 rather than a widening of this change. Issue #693 stays open for it.

Also unclosed and stated on #693: the recorded tenant comes from the request body's `filters` with no admission check, so this scopes what a caller can **see** and not yet what it can **record**.

## Gates

`make lint` · `make typecheck` (554 files) · engineering-health report check — all exit 0. Unit **3476 passed, 13 skipped**; the complete integration-tree PostgreSQL lane **253 passed** against a live engine and **219 passed, 33 skipped** without a DSN. Exact-head GitHub runs: PR Merge Gate [34293476460](https://github.com/sgajbi/lotus-manage/actions/runs/34293476460), Remote Feature Lane [34293472212](https://github.com/sgajbi/lotus-manage/actions/runs/34293472212), and both Quality Baseline runs [34293472817](https://github.com/sgajbi/lotus-manage/actions/runs/34293472817) / [34293476461](https://github.com/sgajbi/lotus-manage/actions/runs/34293476461) — all green on `88f67eb0bec0de032b21d0a412b07806a7c10344`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
