### PR TITLE
fix(dpm): fence proof packs by tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ available. That file is the authority; read it rather than a prose list, which c
 
 RFC-0040 is implementation-backed for Manage-owned pre-trade proof packs - durable JSON,
 deterministic Markdown, report-input and AI-evidence handoffs, hashes, lineage, retention metadata,
-immutable persistence, certified APIs, and source-backed mandate-context attachment. Downstream
+immutable persistence, required tenant-fenced reads/replay/listing, certified APIs, and source-backed
+mandate-context attachment. Legacy proof packs without attributable tenant ownership remain
+quarantined rather than being assigned to an assumed caller. Downstream
 realization has landed in the owning apps: Gateway composition and Workbench review UX, report
 materialization in `lotus-render`/`lotus-report`/`lotus-archive`, and governed AI PM memo support in
 `lotus-ai`/`lotus-gateway`/`lotus-workbench`. Proof packs support **internal review only** - the

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -192,7 +192,8 @@ Current repository posture:
 14. RFC-0040 has delivered the implementation-backed manage pre-trade proof-pack backend
     foundation: durable `DpmPreTradeProofPack` JSON, deterministic Markdown summary, report-input
     handoff, AI-evidence handoff with forbidden-action/field guardrails, immutable in-memory and
-    PostgreSQL persistence, append-only refs, retention metadata, section/content hashes, source
+    PostgreSQL persistence, tenant-owned direct/replay/list reads, nullable migration quarantine for
+    unattributed legacy rows, append-only refs, retention metadata, section/content hashes, source
     lineage, source-backed mandate-context attachment from persisted RFC-0038 mandate twin and
     health evidence when available, certified `/api/v1/rebalance/proof-packs/*` APIs, and
     canonical Postgres-backed live proof under `output/rfc0040-proof/20260503-135112`,

--- a/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-manage-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-09-08T15:05:01.396422+00:00",
+  "generatedAt": "2026-09-09T01:43:05.149715+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.access_classification",
@@ -19004,6 +19004,18 @@
       "attributeRef": "#/attributeCatalog/lotus.proof_pack_id"
     },
     {
+      "name": "tenant_id",
+      "kind": "request_option",
+      "location": "query",
+      "required": true,
+      "type": "string",
+      "description": "Tenant whose mandate evidence is being read. Required: mandate snapshots and health snapshots are stored per tenant, and the same mandate id may exist under more than one tenant. Send it as the canonical snake_case query parameter `tenant_id`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+    },
+    {
       "name": "proof_pack_id",
       "kind": "request_option",
       "location": "path",
@@ -19014,6 +19026,18 @@
       "allowedValues": [],
       "semanticId": "lotus.proof_pack_id",
       "attributeRef": "#/attributeCatalog/lotus.proof_pack_id"
+    },
+    {
+      "name": "tenant_id",
+      "kind": "request_option",
+      "location": "query",
+      "required": true,
+      "type": "string",
+      "description": "Tenant whose mandate evidence is being read. Required: mandate snapshots and health snapshots are stored per tenant, and the same mandate id may exist under more than one tenant. Send it as the canonical snake_case query parameter `tenant_id`.",
+      "example": "ENTITY_001",
+      "allowedValues": [],
+      "semanticId": "lotus.tenant_id",
+      "attributeRef": "#/attributeCatalog/lotus.tenant_id"
     },
     {
       "name": "proof_pack_id",
@@ -67304,6 +67328,14 @@
             "attributeRef": "#/attributeCatalog/lotus.proof_pack_version"
           },
           {
+            "name": "proof_pack.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
+          },
+          {
             "name": "proof_pack.portfolio_id",
             "location": "body",
             "required": true,
@@ -68601,6 +68633,14 @@
             "type": "string",
             "semanticId": "lotus.proof_pack_id",
             "attributeRef": "#/attributeCatalog/lotus.proof_pack_id"
+          },
+          {
+            "name": "tenant_id",
+            "location": "query",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           }
         ]
       },
@@ -68629,6 +68669,14 @@
             "type": "string",
             "semanticId": "lotus.proof_pack_version",
             "attributeRef": "#/attributeCatalog/lotus.proof_pack_version"
+          },
+          {
+            "name": "proof_pack.tenant_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           },
           {
             "name": "proof_pack.portfolio_id",
@@ -69904,6 +69952,14 @@
             "type": "string",
             "semanticId": "lotus.proof_pack_id",
             "attributeRef": "#/attributeCatalog/lotus.proof_pack_id"
+          },
+          {
+            "name": "tenant_id",
+            "location": "query",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.tenant_id",
+            "attributeRef": "#/attributeCatalog/lotus.tenant_id"
           }
         ]
       },

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T00:03:27+00:00`
+- Generated at: `2026-09-09T02:34:34+00:00`
 
-- Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
+- Baseline source snapshot: `a07363e1941c1f173e7bcca74002616afacf6d03`
 
-- Report source snapshot: `030ac897+worktree`
+- Report source snapshot: `70e22473+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 936 |
-| Total Python LOC | 219542 |
-| Test functions | 3189 |
+| Python files | 937 |
+| Total Python LOC | 220197 |
+| Test functions | 3201 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T00:03:27+00:00`
+- Generated at: `2026-09-09T02:34:34+00:00`
 
-- Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
+- Baseline source snapshot: `a07363e1941c1f173e7bcca74002616afacf6d03`
 
-- Report source snapshot: `030ac897+worktree`
+- Report source snapshot: `70e22473+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T00:03:27+00:00`
+- Generated at: `2026-09-09T02:34:34+00:00`
 
-- Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
+- Baseline source snapshot: `a07363e1941c1f173e7bcca74002616afacf6d03`
 
-- Report source snapshot: `030ac897+worktree`
+- Report source snapshot: `70e22473+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T00:03:27+00:00`
+- Generated at: `2026-09-09T02:34:34+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `0e23e6fcbecfd31a4d5937573db582a1a5b07373`
+- Baseline source snapshot: `a07363e1941c1f173e7bcca74002616afacf6d03`
 
-- Report source snapshot: `030ac897+worktree`
+- Report source snapshot: `70e22473+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 933 | 936 | +3 |
-| Total Python LOC | 218596 | 219542 | +946 |
-| Test functions | 3174 | 3189 | +15 |
+| Python files | 936 | 937 | +1 |
+| Total Python LOC | 219542 | 220197 | +655 |
+| Test functions | 3189 | 3201 | +12 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -43,7 +43,7 @@
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2895 |
+| 7 | tests/unit/test_documentation_current_state.py | 2970 |
 | 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2709 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
@@ -52,14 +52,14 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 7777 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 7779 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3395 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2970 |
-| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2709 |
+| 7 | tests/unit/test_documentation_current_state.py | 2969 |
+| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2711 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 
@@ -78,7 +78,7 @@
 | 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 334 |
 | 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
 | 9 | test_wave_openapi_pins_campaign_workflow_assignment_and_automation_contracts | tests/unit/dpm/api/test_waves_api.py | 268 |
-| 10 | test_dpm_supportability_and_async_schemas_have_descriptions_and_examples | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 237 |
+| 10 | execute | tests/unit/dpm/supportability/test_dpm_mandate_repository.py | 246 |
 
 ### current branch
 

--- a/src/api/routers/proof_pack_generate_routes.py
+++ b/src/api/routers/proof_pack_generate_routes.py
@@ -175,7 +175,7 @@ def _to_generate_response(
     scope = f"?tenant_id={quote(tenant_id, safe='')}"
     return DpmProofPackGenerateResponse(
         proof_pack=proof_pack,
-        markdown_url=f"{base}/summary.md" if include_markdown else None,
+        markdown_url=f"{base}/summary.md{scope}" if include_markdown else None,
         report_input_url=f"{base}/report-input{scope}" if include_report_input else None,
         ai_evidence_input_url=(
             f"{base}/ai-evidence-input{scope}" if include_ai_evidence_input else None

--- a/src/api/routers/proof_pack_read_routes.py
+++ b/src/api/routers/proof_pack_read_routes.py
@@ -6,6 +6,7 @@ from fastapi import Depends, Path, status
 from fastapi.responses import PlainTextResponse
 
 from src.api.dependencies import get_proof_pack_repository
+from src.api.routers.mandate_tenant_query import MandateTenantId
 from src.api.routers.proof_pack_http import PROOF_PACK_ROUTE_ERRORS, proof_pack_http_exception
 from src.api.routers.proof_pack_models import DpmProofPackLookupResponse
 from src.api.routers.proof_packs import router
@@ -27,6 +28,7 @@ from src.core.common.identity_examples import PROOF_PACK_ID_EXAMPLE
     },
 )
 def get_proof_pack(
+    tenant_id: MandateTenantId,
     proof_pack_id: Annotated[
         str,
         Path(description="Proof-pack identifier.", examples=[PROOF_PACK_ID_EXAMPLE]),
@@ -38,6 +40,7 @@ def get_proof_pack(
             proof_pack=proof_pack_service.get_proof_pack(
                 proof_pack_id=proof_pack_id,
                 proof_pack_repository=proof_pack_repository,
+                tenant_id=tenant_id,
             )
         )
     except PROOF_PACK_ROUTE_ERRORS as exc:
@@ -56,6 +59,7 @@ def get_proof_pack(
     },
 )
 def get_proof_pack_markdown(
+    tenant_id: MandateTenantId,
     proof_pack_id: Annotated[
         str,
         Path(description="Proof-pack identifier.", examples=[PROOF_PACK_ID_EXAMPLE]),
@@ -66,6 +70,7 @@ def get_proof_pack_markdown(
         proof_pack = proof_pack_service.get_proof_pack(
             proof_pack_id=proof_pack_id,
             proof_pack_repository=proof_pack_repository,
+            tenant_id=tenant_id,
         )
         return render_proof_pack_markdown(proof_pack)
     except PROOF_PACK_ROUTE_ERRORS as exc:

--- a/src/api/services/proof_pack_persistence.py
+++ b/src/api/services/proof_pack_persistence.py
@@ -13,6 +13,7 @@ def persist_proof_pack(
     proof_pack_repository: DpmProofPackRepository,
     proof_pack: DpmPreTradeProofPack,
     idempotency_key: str | None,
+    tenant_id: str,
     persisted_at: datetime | None = None,
 ) -> None:
     retention_base = persisted_at or datetime.now(timezone.utc)
@@ -20,6 +21,7 @@ def persist_proof_pack(
         proof_pack=proof_pack,
         idempotency_key=idempotency_key,
         retention_expires_at=retention_base + timedelta(days=PROOF_PACK_RETENTION_DAYS),
+        tenant_id=tenant_id,
     )
 
 

--- a/src/api/services/proof_pack_replay.py
+++ b/src/api/services/proof_pack_replay.py
@@ -9,11 +9,16 @@ def find_replayable_proof_pack(
     proof_pack_id: str,
     idempotency_key: str | None,
     proof_pack_repository: DpmProofPackRepository,
+    tenant_id: str,
 ) -> DpmPreTradeProofPack | None:
     if idempotency_key is not None:
         existing = proof_pack_repository.get_proof_pack_by_idempotency(
-            idempotency_key=idempotency_key
+            idempotency_key=idempotency_key,
+            tenant_id=tenant_id,
         )
         if existing is not None:
             return existing
-    return proof_pack_repository.get_proof_pack(proof_pack_id=proof_pack_id)
+    return proof_pack_repository.get_proof_pack(
+        proof_pack_id=proof_pack_id,
+        tenant_id=tenant_id,
+    )

--- a/src/api/services/proof_pack_service.py
+++ b/src/api/services/proof_pack_service.py
@@ -65,6 +65,7 @@ def generate_proof_pack_from_run(
         ),
         idempotency_key=idempotency_key,
         proof_pack_repository=proof_pack_repository,
+        tenant_id=tenant_id,
     )
     if existing is not None:
         return existing
@@ -92,6 +93,7 @@ def generate_proof_pack_from_run(
         proof_pack_repository=proof_pack_repository,
         proof_pack=proof_pack,
         idempotency_key=idempotency_key,
+        tenant_id=tenant_id,
     )
     return proof_pack
 
@@ -120,6 +122,7 @@ def generate_proof_pack_from_selected_alternative(
         ),
         idempotency_key=idempotency_key,
         proof_pack_repository=proof_pack_repository,
+        tenant_id=tenant_id,
     )
     if existing is not None:
         return existing
@@ -150,6 +153,7 @@ def generate_proof_pack_from_selected_alternative(
         proof_pack_repository=proof_pack_repository,
         proof_pack=proof_pack,
         idempotency_key=idempotency_key,
+        tenant_id=tenant_id,
     )
     return proof_pack
 
@@ -158,8 +162,12 @@ def get_proof_pack(
     *,
     proof_pack_id: str,
     proof_pack_repository: DpmProofPackRepository,
+    tenant_id: str,
 ) -> DpmPreTradeProofPack:
-    proof_pack = proof_pack_repository.get_proof_pack(proof_pack_id=proof_pack_id)
+    proof_pack = proof_pack_repository.get_proof_pack(
+        proof_pack_id=proof_pack_id,
+        tenant_id=tenant_id,
+    )
     if proof_pack is None:
         raise DpmRunNotFoundError("DPM_PROOF_PACK_NOT_FOUND")
     return hydrate_handoff_refs(
@@ -172,10 +180,12 @@ def get_report_input_ref(
     *,
     proof_pack_id: str,
     proof_pack_repository: DpmProofPackRepository,
+    tenant_id: str,
 ) -> DpmProofPackEvidenceRef:
     proof_pack = get_proof_pack(
         proof_pack_id=proof_pack_id,
         proof_pack_repository=proof_pack_repository,
+        tenant_id=tenant_id,
     )
     ref = require_handoff_ref(
         proof_pack_id=proof_pack_id,
@@ -192,10 +202,12 @@ def get_ai_evidence_ref(
     *,
     proof_pack_id: str,
     proof_pack_repository: DpmProofPackRepository,
+    tenant_id: str,
 ) -> DpmProofPackEvidenceRef:
     proof_pack = get_proof_pack(
         proof_pack_id=proof_pack_id,
         proof_pack_repository=proof_pack_repository,
+        tenant_id=tenant_id,
     )
     ref = require_handoff_ref(
         proof_pack_id=proof_pack_id,
@@ -217,11 +229,12 @@ def get_report_input(
     wave_repository: DpmWaveRepository | None = None,
     outcome_review_repository: DpmOutcomeReviewRepository | None = None,
     mandate_repository: DpmMandateRepository | None = None,
-    tenant_id: str | None = None,
+    tenant_id: str,
 ) -> DpmProofPackReportInput:
     proof_pack = get_proof_pack(
         proof_pack_id=proof_pack_id,
         proof_pack_repository=proof_pack_repository,
+        tenant_id=tenant_id,
     )
     return build_proof_pack_report_input(
         proof_pack=proof_pack,
@@ -240,11 +253,12 @@ def get_ai_evidence_input(
     wave_repository: DpmWaveRepository | None = None,
     outcome_review_repository: DpmOutcomeReviewRepository | None = None,
     mandate_repository: DpmMandateRepository | None = None,
-    tenant_id: str | None = None,
+    tenant_id: str,
 ) -> DpmProofPackAiEvidenceInput:
     proof_pack = get_proof_pack(
         proof_pack_id=proof_pack_id,
         proof_pack_repository=proof_pack_repository,
+        tenant_id=tenant_id,
     )
     return build_proof_pack_ai_evidence_input(
         proof_pack=proof_pack,

--- a/src/core/portfolio_memory/candidate_portfolios.py
+++ b/src/core/portfolio_memory/candidate_portfolios.py
@@ -54,11 +54,18 @@ def candidate_portfolio_ids_from_sources(
     source_scan_limit = validate_portfolio_memory_source_scan_limit(
         source_scan_limit=source_scan_limit
     )
+    scoped_tenant_id = require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories)
     candidates = _explicit_candidate_ids(portfolio_ids)
-    candidates.update(_proof_pack_candidate_ids(repositories, source_scan_limit))
+    candidates.update(
+        _proof_pack_candidate_ids(
+            scoped_tenant_id,
+            repositories,
+            source_scan_limit,
+        )
+    )
     candidates.update(
         _wave_candidate_ids(
-            require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories),
+            scoped_tenant_id,
             repositories,
             source_scan_limit,
         )
@@ -93,13 +100,14 @@ def _explicit_candidate_ids(portfolio_ids: list[str] | None) -> set[str]:
 
 
 def _proof_pack_candidate_ids(
+    tenant_id: str,
     repositories: PortfolioMemorySourceRepositories,
     source_scan_limit: int,
 ) -> set[str]:
     return {
         proof_pack.portfolio_id
         for proof_pack in repositories.proof_pack_repository.list_proof_packs(
-            limit=source_scan_limit
+            tenant_id=tenant_id, limit=source_scan_limit
         )
     }
 

--- a/src/core/portfolio_memory/proof_pack_collection.py
+++ b/src/core/portfolio_memory/proof_pack_collection.py
@@ -10,6 +10,7 @@ def proof_pack_memory_events(
     portfolio_id: str,
     proof_pack_repository: DpmProofPackRepository,
     limit: int,
+    tenant_id: str,
 ) -> list[DpmPortfolioMemoryEvent]:
     """Collect proof-pack memory events for one portfolio."""
 
@@ -17,6 +18,7 @@ def proof_pack_memory_events(
     for proof_pack in proof_pack_repository.list_proof_packs(
         portfolio_id=portfolio_id,
         limit=limit,
+        tenant_id=tenant_id,
     ):
         events.extend(proof_pack_events(proof_pack))
     return events

--- a/src/core/portfolio_memory/search_source_collection.py
+++ b/src/core/portfolio_memory/search_source_collection.py
@@ -50,12 +50,14 @@ def collect_portfolio_memory_search_events(
 
     limit = validate_portfolio_memory_read_limit(limit=limit)
     explicit_portfolio_ids = set(portfolio_ids)
+    scoped_tenant_id = require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories)
     candidates = set(explicit_portfolio_ids)
     events_by_portfolio_id: dict[str, list[DpmPortfolioMemoryEvent]] = defaultdict(list)
     for portfolio_id in candidates:
         events_by_portfolio_id.setdefault(portfolio_id, [])
 
     _collect_proof_pack_events(
+        tenant_id=scoped_tenant_id,
         repositories=repositories,
         explicit_portfolio_ids=explicit_portfolio_ids,
         candidates=candidates,
@@ -63,7 +65,7 @@ def collect_portfolio_memory_search_events(
         limit=limit,
     )
     _collect_wave_events(
-        tenant_id=require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories),
+        tenant_id=scoped_tenant_id,
         repositories=repositories,
         candidates=candidates,
         events_by_portfolio_id=events_by_portfolio_id,
@@ -123,6 +125,7 @@ def collect_portfolio_memory_search_events(
 
 def _collect_proof_pack_events(
     *,
+    tenant_id: str,
     repositories: PortfolioMemorySourceRepositories,
     explicit_portfolio_ids: set[str],
     candidates: set[str],
@@ -130,12 +133,15 @@ def _collect_proof_pack_events(
     limit: int,
 ) -> None:
     seen_proof_pack_ids: set[str] = set()
-    for proof_pack in repositories.proof_pack_repository.list_proof_packs(limit=limit):
+    for proof_pack in repositories.proof_pack_repository.list_proof_packs(
+        tenant_id=tenant_id, limit=limit
+    ):
         seen_proof_pack_ids.add(proof_pack.proof_pack_id)
         candidates.add(proof_pack.portfolio_id)
         events_by_portfolio_id[proof_pack.portfolio_id].extend(proof_pack_events(proof_pack))
     for portfolio_id in sorted(explicit_portfolio_ids):
         for proof_pack in repositories.proof_pack_repository.list_proof_packs(
+            tenant_id=tenant_id,
             portfolio_id=portfolio_id,
             limit=limit,
         ):

--- a/src/core/portfolio_memory/source_collection.py
+++ b/src/core/portfolio_memory/source_collection.py
@@ -27,9 +27,11 @@ def collect_portfolio_memory_events(
     """Collect source-family memory events without aggregating or hashing them."""
 
     limit = validate_portfolio_memory_read_limit(limit=limit)
+    scoped_tenant_id = require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories)
     events: list[DpmPortfolioMemoryEvent] = []
     events.extend(
         proof_pack_memory_events(
+            tenant_id=scoped_tenant_id,
             portfolio_id=portfolio_id,
             proof_pack_repository=repositories.proof_pack_repository,
             limit=limit,
@@ -58,7 +60,7 @@ def collect_portfolio_memory_events(
 
     events.extend(
         wave_memory_events(
-            tenant_id=require_wave_tenant_id(tenant_id=tenant_id, repositories=repositories),
+            tenant_id=scoped_tenant_id,
             portfolio_id=portfolio_id,
             wave_repository=repositories.wave_repository,
             limit=limit,

--- a/src/core/proof_packs/builder.py
+++ b/src/core/proof_packs/builder.py
@@ -361,6 +361,7 @@ def _build_proof_pack(
     pack = DpmPreTradeProofPack(
         proof_pack_id=context.proof_pack_id,
         proof_pack_version=PROOF_PACK_VERSION,
+        tenant_id=tenant_id,
         portfolio_id=context.portfolio_id,
         mandate_id=mandate_id,
         source_type=source_type,

--- a/src/core/proof_packs/models.py
+++ b/src/core/proof_packs/models.py
@@ -179,6 +179,13 @@ class DpmProofPackStoredRef(BaseModel):
 class DpmPreTradeProofPack(BaseModel):
     proof_pack_id: str = Field(description="Stable pre-trade proof-pack identifier.")
     proof_pack_version: str = Field(description="Proof-pack contract version.")
+    tenant_id: str | None = Field(
+        default=None,
+        description=(
+            "Tenant that owns this proof pack. Legacy rows can carry no owner and are "
+            "therefore matched by no tenant-scoped repository read."
+        ),
+    )
     portfolio_id: str = Field(description="Portfolio identifier.")
     mandate_id: str | None = Field(default=None, description="Mandate identifier when available.")
     source_type: ProofPackSourceType = Field(description="Source used to generate the proof pack.")

--- a/src/core/proof_packs/repository.py
+++ b/src/core/proof_packs/repository.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from typing import Protocol
 
+from src.core.common.derived_identity import derived_identity
 from src.core.proof_packs.models import (
     DpmPreTradeProofPack,
     DpmProofPackRetentionMetadata,
@@ -18,6 +19,22 @@ class DpmProofPackConflictError(Exception):
     """Raised when immutable proof-pack identity or idempotency conflicts."""
 
 
+def proof_pack_idempotency_mapping_key(*, tenant_id: str, idempotency_key: str) -> str:
+    """Namespace a caller-chosen proof-pack replay key by admitted tenant."""
+
+    return derived_identity("pik", tenant_id, idempotency_key)
+
+
+def require_proof_pack_tenant(
+    *, proof_pack: DpmPreTradeProofPack, tenant_id: str
+) -> DpmPreTradeProofPack:
+    """Require the built aggregate to agree with admitted write authority."""
+
+    if proof_pack.tenant_id != tenant_id:
+        raise DpmProofPackConflictError("DPM_PROOF_PACK_TENANT_MISMATCH")
+    return proof_pack
+
+
 class DpmProofPackRepository(Protocol):
     def save_proof_pack(
         self,
@@ -25,22 +42,25 @@ class DpmProofPackRepository(Protocol):
         proof_pack: DpmPreTradeProofPack,
         idempotency_key: str | None,
         retention_expires_at: datetime | None,
+        tenant_id: str,
     ) -> None:
         """Persist an immutable proof pack."""
 
-    def get_proof_pack(self, *, proof_pack_id: str) -> DpmPreTradeProofPack | None:
+    def get_proof_pack(self, *, proof_pack_id: str, tenant_id: str) -> DpmPreTradeProofPack | None:
         """Return a proof pack by id, or None when absent."""
 
     def get_proof_pack_by_idempotency(
         self,
         *,
         idempotency_key: str,
+        tenant_id: str,
     ) -> DpmPreTradeProofPack | None:
         """Return the proof pack associated with an idempotency key."""
 
     def list_proof_packs(
         self,
         *,
+        tenant_id: str,
         portfolio_id: str | None = None,
         mandate_id: str | None = None,
         status: str | None = None,

--- a/src/infrastructure/postgres_migrations/dpm/0028_proof_pack_tenant_scope.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0028_proof_pack_tenant_scope.sql
@@ -1,0 +1,7 @@
+-- Proof packs created before tenant ownership was persisted remain deliberately
+-- unattributed. PostgreSQL equality excludes NULL, so no caller can claim them.
+ALTER TABLE dpm_pre_trade_proof_packs
+    ADD COLUMN IF NOT EXISTS tenant_id TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_dpm_pre_trade_proof_packs_tenant_created
+    ON dpm_pre_trade_proof_packs (tenant_id, created_at DESC, proof_pack_id DESC);

--- a/src/infrastructure/proof_packs/in_memory.py
+++ b/src/infrastructure/proof_packs/in_memory.py
@@ -13,6 +13,8 @@ from src.core.proof_packs.models import (
 from src.core.proof_packs.repository import (
     DpmProofPackConflictError,
     DpmProofPackRepository,
+    proof_pack_idempotency_mapping_key,
+    require_proof_pack_tenant,
 )
 
 RETENTION_POLICY_PRE_TRADE_PROOF_PACK = "DPM_PRE_TRADE_PROOF_PACK_7Y"
@@ -75,47 +77,60 @@ class InMemoryDpmProofPackRepository(DpmProofPackRepository):
         proof_pack: DpmPreTradeProofPack,
         idempotency_key: str | None,
         retention_expires_at: datetime | None,
+        tenant_id: str,
     ) -> None:
         with self._lock:
-            existing = self._proof_packs.get(proof_pack.proof_pack_id)
-            _ensure_proof_pack_content_is_immutable(existing=existing, proof_pack=proof_pack)
+            stamped = require_proof_pack_tenant(proof_pack=proof_pack, tenant_id=tenant_id)
+            existing = self._proof_packs.get(stamped.proof_pack_id)
+            _ensure_proof_pack_content_is_immutable(existing=existing, proof_pack=stamped)
+            mapping_key = (
+                None
+                if idempotency_key is None
+                else proof_pack_idempotency_mapping_key(
+                    tenant_id=tenant_id, idempotency_key=idempotency_key
+                )
+            )
             binding = _idempotency_binding(
-                idempotency_key=idempotency_key,
+                idempotency_key=mapping_key,
                 existing_proof_pack_id=(
-                    self._idempotency_index.get(idempotency_key)
-                    if idempotency_key is not None
-                    else None
+                    self._idempotency_index.get(mapping_key) if mapping_key is not None else None
                 ),
-                proof_pack_id=proof_pack.proof_pack_id,
+                proof_pack_id=stamped.proof_pack_id,
             )
             if binding is not None:
                 self._idempotency_index[binding[0]] = binding[1]
-            self._proof_packs[proof_pack.proof_pack_id] = deepcopy(proof_pack)
-            self._retention[proof_pack.proof_pack_id] = _retention_metadata(
-                proof_pack_id=proof_pack.proof_pack_id,
+            self._proof_packs[stamped.proof_pack_id] = deepcopy(stamped)
+            self._retention[stamped.proof_pack_id] = _retention_metadata(
+                proof_pack_id=stamped.proof_pack_id,
                 retention_expires_at=retention_expires_at,
             )
 
-    def get_proof_pack(self, *, proof_pack_id: str) -> DpmPreTradeProofPack | None:
+    def get_proof_pack(self, *, proof_pack_id: str, tenant_id: str) -> DpmPreTradeProofPack | None:
         with self._lock:
             row = self._proof_packs.get(proof_pack_id)
-            return deepcopy(row) if row is not None else None
+            return deepcopy(row) if row is not None and row.tenant_id == tenant_id else None
 
     def get_proof_pack_by_idempotency(
         self,
         *,
         idempotency_key: str,
+        tenant_id: str,
     ) -> DpmPreTradeProofPack | None:
         with self._lock:
-            proof_pack_id = self._idempotency_index.get(idempotency_key)
+            proof_pack_id = self._idempotency_index.get(
+                proof_pack_idempotency_mapping_key(
+                    tenant_id=tenant_id, idempotency_key=idempotency_key
+                )
+            )
             if proof_pack_id is None:
                 return None
             row = self._proof_packs.get(proof_pack_id)
-            return deepcopy(row) if row is not None else None
+            return deepcopy(row) if row is not None and row.tenant_id == tenant_id else None
 
     def list_proof_packs(
         self,
         *,
+        tenant_id: str,
         portfolio_id: str | None = None,
         mandate_id: str | None = None,
         status: str | None = None,
@@ -124,7 +139,11 @@ class InMemoryDpmProofPackRepository(DpmProofPackRepository):
     ) -> list[DpmPreTradeProofPack]:
         with self._lock:
             page = _list_proof_packs(
-                proof_packs=list(self._proof_packs.values()),
+                proof_packs=[
+                    proof_pack
+                    for proof_pack in self._proof_packs.values()
+                    if proof_pack.tenant_id == tenant_id
+                ],
                 filters=_ProofPackListFilters(
                     portfolio_id=portfolio_id,
                     mandate_id=mandate_id,

--- a/src/infrastructure/proof_packs/postgres.py
+++ b/src/infrastructure/proof_packs/postgres.py
@@ -12,7 +12,11 @@ from src.core.proof_packs.models import (
     DpmProofPackRetentionMetadata,
     DpmProofPackStoredRef,
 )
-from src.core.proof_packs.repository import DpmProofPackConflictError
+from src.core.proof_packs.repository import (
+    DpmProofPackConflictError,
+    proof_pack_idempotency_mapping_key,
+    require_proof_pack_tenant,
+)
 from src.infrastructure.mandates.serialization import dump_model_json, load_model_json
 from src.infrastructure.postgres_access import connect_postgres
 from src.infrastructure.postgres_migrations import apply_postgres_migrations
@@ -34,38 +38,51 @@ class PostgresDpmProofPackRepository:
         proof_pack: DpmPreTradeProofPack,
         idempotency_key: str | None,
         retention_expires_at: datetime | None,
+        tenant_id: str,
     ) -> None:
+        stamped = require_proof_pack_tenant(proof_pack=proof_pack, tenant_id=tenant_id)
+        mapping_key = (
+            None
+            if idempotency_key is None
+            else proof_pack_idempotency_mapping_key(
+                tenant_id=tenant_id, idempotency_key=idempotency_key
+            )
+        )
         with closing(self._connect()) as connection:
             existing = connection.execute(
                 """
-                SELECT content_hash
+                SELECT
+                    content_hash,
+                    tenant_id,
+                    payload_json ->> 'tenant_id' AS payload_tenant_id
                 FROM dpm_pre_trade_proof_packs
                 WHERE proof_pack_id = %s
                 """,
-                (proof_pack.proof_pack_id,),
+                (stamped.proof_pack_id,),
             ).fetchone()
             _raise_on_existing_proof_pack_conflict(
                 existing=existing,
-                proof_pack=proof_pack,
+                proof_pack=stamped,
             )
-            if idempotency_key is not None:
+            if mapping_key is not None:
                 existing_idempotency = connection.execute(
                     """
                     SELECT proof_pack_id
                     FROM dpm_pre_trade_proof_packs
                     WHERE idempotency_key = %s
                     """,
-                    (idempotency_key,),
+                    (mapping_key,),
                 ).fetchone()
                 _raise_on_idempotency_conflict(
                     existing_idempotency=existing_idempotency,
-                    proof_pack=proof_pack,
+                    proof_pack=stamped,
                 )
 
             connection.execute(
                 """
                 INSERT INTO dpm_pre_trade_proof_packs (
                     proof_pack_id,
+                    tenant_id,
                     portfolio_id,
                     mandate_id,
                     source_type,
@@ -76,16 +93,16 @@ class PostgresDpmProofPackRepository:
                     retention_expires_at,
                     payload_json,
                     created_at
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (proof_pack_id) DO NOTHING
                 """,
                 _proof_pack_insert_params(
-                    proof_pack=proof_pack,
-                    idempotency_key=idempotency_key,
+                    proof_pack=stamped,
+                    idempotency_key=mapping_key,
                     retention_expires_at=retention_expires_at,
                 ),
             )
-            for section in proof_pack.sections:
+            for section in stamped.sections:
                 connection.execute(
                     """
                     INSERT INTO dpm_pre_trade_proof_pack_sections (
@@ -100,21 +117,23 @@ class PostgresDpmProofPackRepository:
                     ON CONFLICT (proof_pack_id, section_id) DO NOTHING
                     """,
                     _proof_pack_section_insert_params(
-                        proof_pack=proof_pack,
+                        proof_pack=stamped,
                         section=section,
                     ),
                 )
             connection.commit()
 
-    def get_proof_pack(self, *, proof_pack_id: str) -> DpmPreTradeProofPack | None:
+    def get_proof_pack(self, *, proof_pack_id: str, tenant_id: str) -> DpmPreTradeProofPack | None:
         with closing(self._connect()) as connection:
             row = connection.execute(
                 """
                 SELECT payload_json
                 FROM dpm_pre_trade_proof_packs
                 WHERE proof_pack_id = %s
+                  AND tenant_id = %s
+                  AND payload_json ->> 'tenant_id' = %s
                 """,
-                (proof_pack_id,),
+                (proof_pack_id, tenant_id, tenant_id),
             ).fetchone()
         if row is None:
             return None
@@ -124,6 +143,7 @@ class PostgresDpmProofPackRepository:
         self,
         *,
         idempotency_key: str,
+        tenant_id: str,
     ) -> DpmPreTradeProofPack | None:
         with closing(self._connect()) as connection:
             row = connection.execute(
@@ -131,8 +151,16 @@ class PostgresDpmProofPackRepository:
                 SELECT payload_json
                 FROM dpm_pre_trade_proof_packs
                 WHERE idempotency_key = %s
+                  AND tenant_id = %s
+                  AND payload_json ->> 'tenant_id' = %s
                 """,
-                (idempotency_key,),
+                (
+                    proof_pack_idempotency_mapping_key(
+                        tenant_id=tenant_id, idempotency_key=idempotency_key
+                    ),
+                    tenant_id,
+                    tenant_id,
+                ),
             ).fetchone()
         if row is None:
             return None
@@ -141,14 +169,15 @@ class PostgresDpmProofPackRepository:
     def list_proof_packs(
         self,
         *,
+        tenant_id: str,
         portfolio_id: str | None = None,
         mandate_id: str | None = None,
         status: str | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> list[DpmPreTradeProofPack]:
-        clauses: list[str] = []
-        args: list[Any] = []
+        clauses: list[str] = ["tenant_id = %s", "payload_json ->> 'tenant_id' = %s"]
+        args: list[Any] = [tenant_id, tenant_id]
         for column, value in (
             ("portfolio_id", portfolio_id),
             ("mandate_id", mandate_id),
@@ -264,7 +293,11 @@ def _raise_on_existing_proof_pack_conflict(
     existing: Any,
     proof_pack: DpmPreTradeProofPack,
 ) -> None:
-    if existing is not None and existing["content_hash"] != proof_pack.content_hash:
+    if existing is not None and (
+        existing["content_hash"] != proof_pack.content_hash
+        or existing["tenant_id"] != proof_pack.tenant_id
+        or existing["payload_tenant_id"] != proof_pack.tenant_id
+    ):
         raise DpmProofPackConflictError("DPM_PROOF_PACK_IMMUTABLE_CONFLICT")
 
 
@@ -288,6 +321,7 @@ def _proof_pack_insert_params(
 ) -> tuple[Any, ...]:
     return (
         proof_pack.proof_pack_id,
+        proof_pack.tenant_id,
         proof_pack.portfolio_id,
         proof_pack.mandate_id,
         proof_pack.source_type,

--- a/tests/integration/dpm/proof_packs/test_proof_pack_tenant_fence_postgres.py
+++ b/tests/integration/dpm/proof_packs/test_proof_pack_tenant_fence_postgres.py
@@ -1,0 +1,257 @@
+"""Proof-pack tenant isolation, proven through the PostgreSQL adapter (#694)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.dependencies import (
+    get_mandate_repository,
+    get_outcome_review_repository,
+    get_proof_pack_repository,
+    get_wave_repository,
+)
+from src.api.main import app
+from src.core.models import EngineOptions
+from src.core.proof_packs import build_proof_pack_from_run
+from src.core.proof_packs.repository import DpmProofPackConflictError
+from src.core.rebalance.engine import run_simulation
+from src.core.rebalance_runs.models import DpmRunRecord
+from src.infrastructure.proof_packs.postgres import PostgresDpmProofPackRepository
+from src.infrastructure.mandates import InMemoryDpmMandateRepository
+from src.infrastructure.outcomes import InMemoryDpmOutcomeReviewRepository
+from src.infrastructure.waves import InMemoryDpmWaveRepository
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
+from tests.shared.factories import (
+    cash,
+    market_data_snapshot,
+    model_portfolio,
+    portfolio_snapshot,
+    position,
+    price,
+    shelf_entry,
+    target,
+)
+
+_PROOF = "proof-pack tenant fence proof"
+
+
+@pytest.fixture
+def repository() -> PostgresDpmProofPackRepository:
+    return PostgresDpmProofPackRepository(dsn=postgres_dsn_or_skip(_PROOF))
+
+
+@pytest.fixture
+def tenants() -> tuple[str, str]:
+    suffix = uuid.uuid4().hex[:10]
+    return f"tenant-alpha-{suffix}", f"tenant-beta-{suffix}"
+
+
+def _proof_pack(*, tenant_id: str, created_at: datetime, reason: str):
+    run_id = f"rr_{uuid.uuid4().hex[:12]}"
+    result = run_simulation(
+        portfolio=portfolio_snapshot(
+            portfolio_id="PB_TENANT_FENCE_001",
+            base_currency="USD",
+            positions=[position("EQ_A", "10")],
+            cash_balances=[cash("USD", "0")],
+        ),
+        market_data=market_data_snapshot(
+            prices=[price("EQ_A", "100", "USD"), price("EQ_B", "100", "USD")]
+        ),
+        model=model_portfolio(targets=[target("EQ_A", "0.50"), target("EQ_B", "0.50")]),
+        shelf=[
+            shelf_entry("EQ_A", status="APPROVED", asset_class="EQUITY"),
+            shelf_entry("EQ_B", status="APPROVED", asset_class="EQUITY"),
+        ],
+        options=EngineOptions(),
+        request_hash=f"sha256:{run_id}",
+        correlation_id=f"corr-{run_id}",
+    )
+    run = DpmRunRecord(
+        rebalance_run_id=run_id,
+        correlation_id=result.correlation_id,
+        request_hash=f"sha256:{run_id}",
+        idempotency_key=f"source-{run_id}",
+        portfolio_id="PB_TENANT_FENCE_001",
+        created_at=created_at,
+        result_json=result.model_dump(mode="json"),
+    )
+    return build_proof_pack_from_run(
+        tenant_id=tenant_id,
+        run=run,
+        created_by="pm-tenant-fence",
+        reason=reason,
+        created_at=created_at,
+        mandate_id="MANDATE_TENANT_FENCE_001",
+    )
+
+
+def _save(
+    repository: PostgresDpmProofPackRepository,
+    *,
+    tenant_id: str,
+    created_at: datetime,
+    reason: str,
+    idempotency_key: str | None = None,
+):
+    proof_pack = _proof_pack(tenant_id=tenant_id, created_at=created_at, reason=reason)
+    repository.save_proof_pack(
+        proof_pack=proof_pack,
+        idempotency_key=idempotency_key,
+        retention_expires_at=None,
+        tenant_id=tenant_id,
+    )
+    return proof_pack
+
+
+def test_all_four_http_reads_refuse_another_tenants_pack(
+    repository: PostgresDpmProofPackRepository, tenants: tuple[str, str]
+) -> None:
+    tenant_a, tenant_b = tenants
+    proof_pack = _save(
+        repository,
+        tenant_id=tenant_a,
+        created_at=datetime.now(timezone.utc),
+        reason="Prove the HTTP tenant fence.",
+    )
+    original_overrides = dict(app.dependency_overrides)
+    app.dependency_overrides[get_proof_pack_repository] = lambda: repository
+    app.dependency_overrides[get_wave_repository] = lambda: InMemoryDpmWaveRepository()
+    app.dependency_overrides[get_outcome_review_repository] = lambda: (
+        InMemoryDpmOutcomeReviewRepository()
+    )
+    app.dependency_overrides[get_mandate_repository] = lambda: InMemoryDpmMandateRepository()
+    try:
+        with TestClient(app) as client:
+            for suffix in ["", "/summary.md", "/report-input", "/ai-evidence-input"]:
+                response = client.get(
+                    f"/api/v1/rebalance/proof-packs/{proof_pack.proof_pack_id}{suffix}"
+                    f"?tenant_id={tenant_b}"
+                )
+                assert response.status_code == 404
+                assert response.json()["detail"] == "DPM_PROOF_PACK_NOT_FOUND"
+    finally:
+        app.dependency_overrides = original_overrides
+
+
+def test_null_tenant_pack_is_matched_by_no_caller(
+    repository: PostgresDpmProofPackRepository, tenants: tuple[str, str]
+) -> None:
+    tenant_a, tenant_b = tenants
+    proof_pack = _save(
+        repository,
+        tenant_id=tenant_a,
+        created_at=datetime.now(timezone.utc),
+        reason="Represent a pre-migration unattributed pack.",
+    )
+    with repository._connect() as connection:
+        connection.execute(
+            "UPDATE dpm_pre_trade_proof_packs "
+            "SET tenant_id = NULL, payload_json = payload_json - 'tenant_id' "
+            "WHERE proof_pack_id = %s",
+            (proof_pack.proof_pack_id,),
+        )
+        connection.commit()
+
+    assert (
+        repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id, tenant_id=tenant_a)
+        is None
+    )
+    assert (
+        repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id, tenant_id=tenant_b)
+        is None
+    )
+    assert all(
+        item.proof_pack_id != proof_pack.proof_pack_id
+        for item in repository.list_proof_packs(tenant_id=tenant_a)
+    )
+
+
+def test_replay_and_direct_read_both_refuse_disagreeing_aggregate_owner(
+    repository: PostgresDpmProofPackRepository, tenants: tuple[str, str]
+) -> None:
+    tenant_a, tenant_b = tenants
+    caller_key = f"idem-{uuid.uuid4().hex[:10]}"
+    proof_pack = _save(
+        repository,
+        tenant_id=tenant_a,
+        created_at=datetime.now(timezone.utc),
+        reason="Prove aggregate-owner agreement on replay.",
+        idempotency_key=caller_key,
+    )
+    with repository._connect() as connection:
+        connection.execute(
+            "UPDATE dpm_pre_trade_proof_packs SET tenant_id = %s WHERE proof_pack_id = %s",
+            (tenant_b, proof_pack.proof_pack_id),
+        )
+        connection.commit()
+
+    assert (
+        repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id, tenant_id=tenant_a)
+        is None
+    )
+    assert (
+        repository.get_proof_pack_by_idempotency(idempotency_key=caller_key, tenant_id=tenant_a)
+        is None
+    )
+    assert (
+        repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id, tenant_id=tenant_b)
+        is None
+    )
+
+
+def test_repeated_save_rejects_a_quarantined_existing_pack(
+    repository: PostgresDpmProofPackRepository, tenants: tuple[str, str]
+) -> None:
+    tenant_a, tenant_b = tenants
+    proof_pack = _save(
+        repository,
+        tenant_id=tenant_a,
+        created_at=datetime.now(timezone.utc),
+        reason="Prove save does not accept an unreadable replay.",
+    )
+    with repository._connect() as connection:
+        connection.execute(
+            "UPDATE dpm_pre_trade_proof_packs SET tenant_id = %s WHERE proof_pack_id = %s",
+            (tenant_b, proof_pack.proof_pack_id),
+        )
+        connection.commit()
+
+    with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IMMUTABLE_CONFLICT"):
+        repository.save_proof_pack(
+            proof_pack=proof_pack,
+            idempotency_key=None,
+            retention_expires_at=None,
+            tenant_id=tenant_a,
+        )
+
+
+def test_list_filters_tenant_and_owner_agreement_before_paging(
+    repository: PostgresDpmProofPackRepository, tenants: tuple[str, str]
+) -> None:
+    tenant_a, tenant_b = tenants
+    older = datetime(2026, 5, 3, 9, 0, tzinfo=timezone.utc)
+    owned = _save(
+        repository,
+        tenant_id=tenant_a,
+        created_at=older,
+        reason="Owned older pack.",
+    )
+    _save(
+        repository,
+        tenant_id=tenant_b,
+        created_at=datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc),
+        reason="Foreign newer pack.",
+    )
+
+    page = repository.list_proof_packs(
+        tenant_id=tenant_a,
+        portfolio_id="PB_TENANT_FENCE_001",
+        limit=1,
+    )
+
+    assert [item.proof_pack_id for item in page] == [owned.proof_pack_id]

--- a/tests/unit/dpm/api/test_portfolio_memory_api.py
+++ b/tests/unit/dpm/api/test_portfolio_memory_api.py
@@ -156,11 +156,12 @@ def _repositories() -> tuple[
     wave_repository = InMemoryDpmWaveRepository()
     outcome_repository = InMemoryDpmOutcomeReviewRepository()
     mandate_repository = InMemoryDpmMandateRepository()
-    proof_pack = _proof_pack().model_copy(update={"portfolio_id": PORTFOLIO_ID})
+    proof_pack = _proof_pack(tenant_id=TENANT_ID).model_copy(update={"portfolio_id": PORTFOLIO_ID})
     proof_pack_repository.save_proof_pack(
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id=TENANT_ID,
     )
     wave_repository.save_wave(
         wave=_wave(), idempotency_key=None, request_hash=None, tenant_id=TENANT_ID
@@ -1983,7 +1984,7 @@ def test_portfolio_memory_search_normalizes_text_filters_before_matching() -> No
 def test_portfolio_memory_search_counts_artifact_only_source_systems_and_types() -> None:
     proof_pack_repository = InMemoryDpmProofPackRepository()
     proof_pack_repository.save_proof_pack(
-        proof_pack=_proof_pack().model_copy(
+        proof_pack=_proof_pack(tenant_id=TENANT_ID).model_copy(
             update={
                 "portfolio_id": PORTFOLIO_ID,
                 "report_input_ref": DpmProofPackEvidenceRef(
@@ -1996,6 +1997,7 @@ def test_portfolio_memory_search_counts_artifact_only_source_systems_and_types()
         ),
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id=TENANT_ID,
     )
 
     page = search_portfolio_memory(

--- a/tests/unit/dpm/api/test_proof_pack_api.py
+++ b/tests/unit/dpm/api/test_proof_pack_api.py
@@ -158,7 +158,7 @@ def test_generate_get_and_render_direct_run_proof_pack(client: TestClient) -> No
     assert proof_pack["content_hash"].startswith("sha256:")
     assert proof_pack["source_hashes"]["mandate_twin"].startswith("sha256:")
     assert proof_pack["source_hashes"]["mandate_health"].startswith("sha256:")
-    assert body["markdown_url"].endswith("/summary.md")
+    assert body["markdown_url"].endswith("/summary.md?tenant_id=tenant-test")
     # The handoff link carries the tenant, because the endpoint it points at
     # requires one (issue #648) - a link without it is refused the moment a
     # consumer follows it, and a broken link is indistinguishable from a
@@ -180,14 +180,19 @@ def test_generate_get_and_render_direct_run_proof_pack(client: TestClient) -> No
     assert replay.status_code == 200
     assert replay.json()["proof_pack"]["content_hash"] == proof_pack["content_hash"]
 
-    fetched = client.get(f"/api/v1/rebalance/proof-packs/{proof_pack['proof_pack_id']}")
+    fetched = client.get(
+        f"/api/v1/rebalance/proof-packs/{proof_pack['proof_pack_id']}?tenant_id=tenant-test"
+    )
     assert fetched.status_code == 200
     fetched_proof_pack = fetched.json()["proof_pack"]
     assert fetched_proof_pack["proof_pack_id"] == proof_pack["proof_pack_id"]
     assert fetched_proof_pack["report_input_ref"]["ref_type"] == "DPM_PROOF_PACK_REPORT_INPUT"
     assert fetched_proof_pack["ai_evidence_ref"]["ref_type"] == "DPM_PROOF_PACK_AI_EVIDENCE_INPUT"
 
-    markdown = client.get(f"/api/v1/rebalance/proof-packs/{proof_pack['proof_pack_id']}/summary.md")
+    markdown = client.get(
+        f"/api/v1/rebalance/proof-packs/{proof_pack['proof_pack_id']}/summary.md"
+        "?tenant_id=tenant-test"
+    )
     assert markdown.status_code == 200
     assert "# Pre-Trade Proof Pack" in markdown.text
     assert "| `reporting_refs` | `READY` |" in markdown.text
@@ -588,12 +593,43 @@ def test_generate_proof_pack_does_not_hide_unexpected_service_exceptions(
 
 def test_proof_pack_read_routes_return_404_for_missing_pack(client: TestClient) -> None:
     for path in [
-        "/api/v1/rebalance/proof-packs/missing",
-        "/api/v1/rebalance/proof-packs/missing/summary.md",
+        "/api/v1/rebalance/proof-packs/missing?tenant_id=tenant-test",
+        "/api/v1/rebalance/proof-packs/missing/summary.md?tenant_id=tenant-test",
         "/api/v1/rebalance/proof-packs/missing/report-input?tenant_id=tenant-test",
         "/api/v1/rebalance/proof-packs/missing/ai-evidence-input?tenant_id=tenant-test",
     ]:
         response = client.get(path)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "DPM_PROOF_PACK_NOT_FOUND"
+
+
+def test_proof_pack_read_routes_require_tenant(client: TestClient) -> None:
+    for suffix in ["", "/summary.md", "/report-input", "/ai-evidence-input"]:
+        response = client.get(f"/api/v1/rebalance/proof-packs/missing{suffix}")
+
+        assert response.status_code == 422
+
+
+def test_proof_pack_read_routes_refuse_foreign_tenant(client: TestClient) -> None:
+    run_id = _simulate_run(client)
+    created = client.post(
+        "/api/v1/rebalance/proof-packs?tenant_id=tenant-test",
+        json={
+            "source_type": "REBALANCE_RUN",
+            "rebalance_run_id": run_id,
+            "actor_id": "pm_api",
+            "mandate_id": "mandate_api_001",
+        },
+        headers={"Idempotency-Key": "proof-pack-foreign-read"},
+    )
+    assert created.status_code == 200
+    proof_pack_id = created.json()["proof_pack"]["proof_pack_id"]
+
+    for suffix in ["", "/summary.md", "/report-input", "/ai-evidence-input"]:
+        response = client.get(
+            f"/api/v1/rebalance/proof-packs/{proof_pack_id}{suffix}?tenant_id=tenant-foreign"
+        )
 
         assert response.status_code == 404
         assert response.json()["detail"] == "DPM_PROOF_PACK_NOT_FOUND"
@@ -630,3 +666,13 @@ def test_proof_pack_openapi_documents_endpoints(client: TestClient) -> None:
         in ai_schema["properties"]["portfolio_memory_context"]["description"]
     )
     assert "DpmProofPackClientCommunicationBoundaryEvidence" in openapi["components"]["schemas"]
+    for path in [
+        "/api/v1/rebalance/proof-packs/{proof_pack_id}",
+        "/api/v1/rebalance/proof-packs/{proof_pack_id}/summary.md",
+        "/api/v1/rebalance/proof-packs/{proof_pack_id}/report-input",
+        "/api/v1/rebalance/proof-packs/{proof_pack_id}/ai-evidence-input",
+    ]:
+        parameters = openapi["paths"][path]["get"]["parameters"]
+        tenant = next(parameter for parameter in parameters if parameter["name"] == "tenant_id")
+        assert tenant["in"] == "query"
+        assert tenant["required"] is True

--- a/tests/unit/dpm/api/test_waves_api.py
+++ b/tests/unit/dpm/api/test_waves_api.py
@@ -5234,7 +5234,9 @@ def test_wave_simulate_selects_alternative_and_links_proof_pack_after_reload() -
     assert persisted.items[0].selected_alternative_id == "alt_min_turnover"
     assert persisted.items[0].proof_pack_id == selected_item["proof_pack_id"]
     assert (
-        proof_pack_repository.get_proof_pack(proof_pack_id=selected_item["proof_pack_id"])
+        proof_pack_repository.get_proof_pack(
+            proof_pack_id=selected_item["proof_pack_id"], tenant_id="tenant-sg"
+        )
         is not None
     )
 

--- a/tests/unit/dpm/portfolio_memory/test_proof_pack_collection.py
+++ b/tests/unit/dpm/portfolio_memory/test_proof_pack_collection.py
@@ -11,12 +11,14 @@ def test_proof_pack_memory_events_projects_proof_pack_and_timeline_events() -> N
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
 
     events = proof_pack_memory_events(
         portfolio_id=PORTFOLIO_ID,
         proof_pack_repository=repository,
         limit=100,
+        tenant_id="tenant-test",
     )
 
     assert [event.event_type for event in events] == [
@@ -36,12 +38,14 @@ def test_proof_pack_memory_events_uses_portfolio_filter() -> None:
         proof_pack=_proof_pack().model_copy(update={"portfolio_id": "PB_OTHER_001"}),
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
 
     events = proof_pack_memory_events(
         portfolio_id=PORTFOLIO_ID,
         proof_pack_repository=repository,
         limit=100,
+        tenant_id="tenant-test",
     )
 
     assert events == []

--- a/tests/unit/dpm/portfolio_memory/test_service.py
+++ b/tests/unit/dpm/portfolio_memory/test_service.py
@@ -43,6 +43,7 @@ class _CountingProofPackRepository(InMemoryDpmProofPackRepository):
     def list_proof_packs(
         self,
         *,
+        tenant_id: str,
         portfolio_id: str | None = None,
         mandate_id: str | None = None,
         status: str | None = None,
@@ -51,6 +52,7 @@ class _CountingProofPackRepository(InMemoryDpmProofPackRepository):
     ) -> list[DpmPreTradeProofPack]:
         self.list_calls += 1
         return super().list_proof_packs(
+            tenant_id=tenant_id,
             portfolio_id=portfolio_id,
             mandate_id=mandate_id,
             status=status,
@@ -203,9 +205,12 @@ def test_search_portfolio_memory_from_sources_uses_repository_bundle() -> None:
 def test_search_portfolio_memory_from_sources_batches_source_family_scans() -> None:
     proof_pack_repository = _CountingProofPackRepository()
     proof_pack_repository.save_proof_pack(
-        proof_pack=_proof_pack().model_copy(update={"portfolio_id": PORTFOLIO_ID}),
+        proof_pack=_proof_pack(tenant_id=TENANT_ID).model_copy(
+            update={"portfolio_id": PORTFOLIO_ID}
+        ),
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id=TENANT_ID,
     )
     wave_repository = _CountingWaveRepository()
     wave_repository.save_wave(
@@ -250,7 +255,7 @@ def test_search_portfolio_memory_from_sources_batches_source_family_scans() -> N
 def test_search_portfolio_memory_from_sources_supplements_explicit_portfolio_sources() -> None:
     proof_pack_repository = _CountingProofPackRepository()
     proof_pack_repository.save_proof_pack(
-        proof_pack=_proof_pack().model_copy(
+        proof_pack=_proof_pack(tenant_id=TENANT_ID).model_copy(
             update={
                 "proof_pack_id": "dpp_other_newer",
                 "portfolio_id": "PB_OTHER_NEWER",
@@ -259,9 +264,10 @@ def test_search_portfolio_memory_from_sources_supplements_explicit_portfolio_sou
         ),
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id=TENANT_ID,
     )
     proof_pack_repository.save_proof_pack(
-        proof_pack=_proof_pack().model_copy(
+        proof_pack=_proof_pack(tenant_id=TENANT_ID).model_copy(
             update={
                 "proof_pack_id": "dpp_other_second",
                 "portfolio_id": "PB_OTHER_SECOND",
@@ -270,9 +276,10 @@ def test_search_portfolio_memory_from_sources_supplements_explicit_portfolio_sou
         ),
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id=TENANT_ID,
     )
     proof_pack_repository.save_proof_pack(
-        proof_pack=_proof_pack().model_copy(
+        proof_pack=_proof_pack(tenant_id=TENANT_ID).model_copy(
             update={
                 "proof_pack_id": "dpp_explicit_older",
                 "portfolio_id": PORTFOLIO_ID,
@@ -281,6 +288,7 @@ def test_search_portfolio_memory_from_sources_supplements_explicit_portfolio_sou
         ),
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id=TENANT_ID,
     )
     outcome_repository = _CountingOutcomeReviewRepository()
     outcome_repository.save_outcome_review(
@@ -323,7 +331,7 @@ def test_search_portfolio_memory_from_sources_supplements_explicit_portfolio_sou
         portfolio_ids=[PORTFOLIO_ID],
         source_scan_limit=2,
         generated_at=datetime(2026, 5, 31, 11, 0, tzinfo=timezone.utc),
-        tenant_id="tenant-test",
+        tenant_id=TENANT_ID,
     )
 
     explicit_item = next(item for item in page.items if item.portfolio_id == PORTFOLIO_ID)

--- a/tests/unit/dpm/proof_packs/test_proof_pack_handoff_refs.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_handoff_refs.py
@@ -40,6 +40,7 @@ def test_find_stored_ref_returns_latest_matching_append_only_ref() -> None:
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
     repository.append_ref(
         ref=_stored_ref(
@@ -82,6 +83,7 @@ def test_hydrate_handoff_refs_overlays_stored_refs_without_mutating_pack() -> No
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
     repository.append_ref(
         ref=_stored_ref(
@@ -119,6 +121,7 @@ def test_ensure_handoff_refs_skips_existing_matching_content_refs() -> None:
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
 
     first = ensure_handoff_refs(
@@ -185,6 +188,7 @@ def test_require_handoff_ref_falls_back_to_latest_stored_ref() -> None:
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
     repository.append_ref(
         ref=_stored_ref(
@@ -213,6 +217,7 @@ def test_require_handoff_ref_returns_none_when_no_generated_ref_exists() -> None
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
 
     ref = require_handoff_ref(

--- a/tests/unit/dpm/proof_packs/test_proof_pack_persistence.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_persistence.py
@@ -17,11 +17,13 @@ class _CapturingProofPackRepository:
         proof_pack: object,
         idempotency_key: str | None,
         retention_expires_at: datetime | None,
+        tenant_id: str,
     ) -> None:
         self.saved = {
             "proof_pack": proof_pack,
             "idempotency_key": idempotency_key,
             "retention_expires_at": retention_expires_at,
+            "tenant_id": tenant_id,
         }
 
 
@@ -35,12 +37,14 @@ def test_persist_proof_pack_applies_seven_year_retention_from_persisted_at() -> 
         proof_pack=proof_pack,
         idempotency_key="idem-proof-pack-persistence",
         persisted_at=persisted_at,
+        tenant_id="tenant-test",
     )
 
     assert repository.saved == {
         "proof_pack": proof_pack,
         "idempotency_key": "idem-proof-pack-persistence",
         "retention_expires_at": persisted_at + timedelta(days=PROOF_PACK_RETENTION_DAYS),
+        "tenant_id": "tenant-test",
     }
 
 

--- a/tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_postgres_repository.py
@@ -38,9 +38,17 @@ class _FakeConnection:
 
     def execute(self, query: str, params: Sequence[Any] = ()) -> _FakeCursor:
         normalized = " ".join(query.split())
-        if normalized.startswith("SELECT content_hash FROM dpm_pre_trade_proof_packs"):
+        if normalized.startswith("SELECT content_hash, tenant_id"):
             row = self.proof_packs_by_id.get(str(params[0]))
-            return _FakeCursor({"content_hash": row["content_hash"]} if row else None)
+            return _FakeCursor(
+                {
+                    "content_hash": row["content_hash"],
+                    "tenant_id": row["tenant_id"],
+                    "payload_tenant_id": row["payload_json"].get("tenant_id"),
+                }
+                if row
+                else None
+            )
         if normalized.startswith("SELECT proof_pack_id FROM dpm_pre_trade_proof_packs"):
             row = self.proof_packs_by_idempotency.get(str(params[0]))
             return _FakeCursor({"proof_pack_id": row["proof_pack_id"]} if row else None)
@@ -49,13 +57,32 @@ class _FakeConnection:
         if normalized.startswith("INSERT INTO dpm_pre_trade_proof_pack_sections"):
             return _FakeCursor()
         if "SELECT payload_json FROM dpm_pre_trade_proof_packs WHERE proof_pack_id" in normalized:
-            return _FakeCursor(self.proof_packs_by_id.get(str(params[0])))
+            row = self.proof_packs_by_id.get(str(params[0]))
+            return _FakeCursor(
+                row
+                if row is not None
+                and row["tenant_id"] == params[1]
+                and row["payload_json"].get("tenant_id") == params[2]
+                else None
+            )
         if "SELECT payload_json FROM dpm_pre_trade_proof_packs WHERE idempotency_key" in normalized:
-            return _FakeCursor(self.proof_packs_by_idempotency.get(str(params[0])))
+            row = self.proof_packs_by_idempotency.get(str(params[0]))
+            return _FakeCursor(
+                row
+                if row is not None
+                and row["tenant_id"] == params[1]
+                and row["payload_json"].get("tenant_id") == params[2]
+                else None
+            )
         if normalized.startswith("SELECT payload_json FROM dpm_pre_trade_proof_packs WHERE"):
-            rows = list(self.proof_packs_by_id.values())
+            rows = [
+                row
+                for row in self.proof_packs_by_id.values()
+                if row["tenant_id"] == params[0]
+                and row["payload_json"].get("tenant_id") == params[1]
+            ]
             if "portfolio_id = %s" in normalized:
-                rows = [row for row in rows if row["portfolio_id"] == params[0]]
+                rows = [row for row in rows if row["portfolio_id"] == params[2]]
             return _FakeCursor(rows=rows)
         if normalized.startswith("SELECT proof_pack_id, retention_policy, retention_expires_at"):
             return _FakeCursor(self.proof_packs_by_id.get(str(params[0])))
@@ -71,18 +98,19 @@ class _FakeConnection:
             return _FakeCursor()
         row = {
             "proof_pack_id": proof_pack_id,
-            "portfolio_id": str(params[1]),
-            "mandate_id": params[2],
-            "status": str(params[4]),
-            "content_hash": str(params[5]),
-            "idempotency_key": params[6],
-            "retention_policy": params[7],
-            "retention_expires_at": params[8],
-            "payload_json": json.loads(str(params[9])),
+            "tenant_id": str(params[1]),
+            "portfolio_id": str(params[2]),
+            "mandate_id": params[3],
+            "status": str(params[5]),
+            "content_hash": str(params[6]),
+            "idempotency_key": params[7],
+            "retention_policy": params[8],
+            "retention_expires_at": params[9],
+            "payload_json": json.loads(str(params[10])),
         }
         self.proof_packs_by_id[proof_pack_id] = row
-        if params[6] is not None:
-            self.proof_packs_by_idempotency[str(params[6])] = row
+        if params[7] is not None:
+            self.proof_packs_by_idempotency[str(params[7])] = row
         return _FakeCursor()
 
     def _insert_ref(self, params: Sequence[Any]) -> _FakeCursor:
@@ -121,6 +149,7 @@ def test_postgres_proof_pack_repository_round_trips_pack_retention_and_refs(
         proof_pack=proof_pack,
         idempotency_key="idem-proof-pack-postgres",
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
     ref = DpmProofPackStoredRef(
         proof_pack_id=proof_pack.proof_pack_id,
@@ -132,12 +161,19 @@ def test_postgres_proof_pack_repository_round_trips_pack_retention_and_refs(
     )
     repository.append_ref(ref=ref)
 
-    assert repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id) == proof_pack
     assert (
-        repository.get_proof_pack_by_idempotency(idempotency_key="idem-proof-pack-postgres")
+        repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id, tenant_id="tenant-test")
         == proof_pack
     )
-    assert repository.list_proof_packs(portfolio_id=proof_pack.portfolio_id) == [proof_pack]
+    assert (
+        repository.get_proof_pack_by_idempotency(
+            idempotency_key="idem-proof-pack-postgres", tenant_id="tenant-test"
+        )
+        == proof_pack
+    )
+    assert repository.list_proof_packs(
+        tenant_id="tenant-test", portfolio_id=proof_pack.portfolio_id
+    ) == [proof_pack]
     assert (
         repository.get_retention_metadata(proof_pack_id=proof_pack.proof_pack_id).retention_policy
         == RETENTION_POLICY_PRE_TRADE_PROOF_PACK
@@ -172,8 +208,9 @@ def test_postgres_proof_pack_insert_params_preserve_storage_contract() -> None:
         retention_expires_at=RETENTION_EXPIRES_AT,
     )
 
-    assert params[:9] == (
+    assert params[:10] == (
         proof_pack.proof_pack_id,
+        proof_pack.tenant_id,
         proof_pack.portfolio_id,
         proof_pack.mandate_id,
         proof_pack.source_type,
@@ -183,8 +220,8 @@ def test_postgres_proof_pack_insert_params_preserve_storage_contract() -> None:
         RETENTION_POLICY_PRE_TRADE_PROOF_PACK,
         RETENTION_EXPIRES_AT.isoformat(),
     )
-    assert json.loads(str(params[9]))["proof_pack_id"] == proof_pack.proof_pack_id
-    assert params[10] == proof_pack.created_at.isoformat()
+    assert json.loads(str(params[10]))["proof_pack_id"] == proof_pack.proof_pack_id
+    assert params[11] == proof_pack.created_at.isoformat()
 
 
 def test_postgres_proof_pack_section_insert_params_preserve_section_contract() -> None:
@@ -212,7 +249,11 @@ def test_postgres_proof_pack_conflict_helpers_preserve_error_codes() -> None:
     mutated = _proof_pack(reason="Changed rationale.")
 
     postgres_module._raise_on_existing_proof_pack_conflict(
-        existing={"content_hash": proof_pack.content_hash},
+        existing={
+            "content_hash": proof_pack.content_hash,
+            "tenant_id": proof_pack.tenant_id,
+            "payload_tenant_id": proof_pack.tenant_id,
+        },
         proof_pack=proof_pack,
     )
     postgres_module._raise_on_idempotency_conflict(
@@ -221,9 +262,32 @@ def test_postgres_proof_pack_conflict_helpers_preserve_error_codes() -> None:
     )
     with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IMMUTABLE_CONFLICT"):
         postgres_module._raise_on_existing_proof_pack_conflict(
-            existing={"content_hash": proof_pack.content_hash},
+            existing={
+                "content_hash": proof_pack.content_hash,
+                "tenant_id": proof_pack.tenant_id,
+                "payload_tenant_id": proof_pack.tenant_id,
+            },
             proof_pack=mutated,
         )
+    for disagreeing_owner in [None, "tenant-other"]:
+        with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IMMUTABLE_CONFLICT"):
+            postgres_module._raise_on_existing_proof_pack_conflict(
+                existing={
+                    "content_hash": proof_pack.content_hash,
+                    "tenant_id": disagreeing_owner,
+                    "payload_tenant_id": proof_pack.tenant_id,
+                },
+                proof_pack=proof_pack,
+            )
+        with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IMMUTABLE_CONFLICT"):
+            postgres_module._raise_on_existing_proof_pack_conflict(
+                existing={
+                    "content_hash": proof_pack.content_hash,
+                    "tenant_id": proof_pack.tenant_id,
+                    "payload_tenant_id": disagreeing_owner,
+                },
+                proof_pack=proof_pack,
+            )
     with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IDEMPOTENCY_CONFLICT"):
         postgres_module._raise_on_idempotency_conflict(
             existing_idempotency={"proof_pack_id": proof_pack.proof_pack_id},
@@ -240,6 +304,7 @@ def test_postgres_proof_pack_repository_conflict_paths(
         proof_pack=proof_pack,
         idempotency_key="idem-proof-pack-postgres",
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
 
     mutated = _proof_pack(reason="Changed rationale.")
@@ -248,6 +313,7 @@ def test_postgres_proof_pack_repository_conflict_paths(
             proof_pack=mutated,
             idempotency_key="idem-proof-pack-postgres",
             retention_expires_at=None,
+            tenant_id="tenant-test",
         )
 
     other = proof_pack.model_copy(update={"proof_pack_id": "dpp_postgres_other"})
@@ -256,8 +322,12 @@ def test_postgres_proof_pack_repository_conflict_paths(
             proof_pack=other,
             idempotency_key="idem-proof-pack-postgres",
             retention_expires_at=None,
+            tenant_id="tenant-test",
         )
 
-    assert repository.get_proof_pack(proof_pack_id="missing") is None
-    assert repository.get_proof_pack_by_idempotency(idempotency_key="missing") is None
+    assert repository.get_proof_pack(proof_pack_id="missing", tenant_id="tenant-test") is None
+    assert (
+        repository.get_proof_pack_by_idempotency(idempotency_key="missing", tenant_id="tenant-test")
+        is None
+    )
     assert repository.get_retention_metadata(proof_pack_id="missing") is None

--- a/tests/unit/dpm/proof_packs/test_proof_pack_replay.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_replay.py
@@ -16,17 +16,20 @@ def test_find_replayable_proof_pack_prefers_idempotency_match() -> None:
         proof_pack=by_idempotency,
         idempotency_key="idem-proof-pack-replay",
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
     repository.save_proof_pack(
         proof_pack=by_source_identity,
         idempotency_key=None,
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
 
     replay = find_replayable_proof_pack(
         proof_pack_id=by_source_identity.proof_pack_id,
         idempotency_key="idem-proof-pack-replay",
         proof_pack_repository=repository,
+        tenant_id="tenant-test",
     )
 
     assert replay == by_idempotency
@@ -39,12 +42,14 @@ def test_find_replayable_proof_pack_falls_back_to_source_identity() -> None:
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
 
     replay = find_replayable_proof_pack(
         proof_pack_id=proof_pack.proof_pack_id,
         idempotency_key="different-idempotency-key",
         proof_pack_repository=repository,
+        tenant_id="tenant-test",
     )
 
     assert replay == proof_pack
@@ -57,6 +62,7 @@ def test_find_replayable_proof_pack_returns_none_when_no_replay_exists() -> None
         proof_pack_id="dpp_missing",
         idempotency_key=None,
         proof_pack_repository=repository,
+        tenant_id="tenant-test",
     )
 
     assert replay is None

--- a/tests/unit/dpm/proof_packs/test_proof_pack_repository.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_repository.py
@@ -67,7 +67,7 @@ def _ready_rebalance_result() -> RebalanceResult:
     )
 
 
-def _proof_pack(reason: str = "Rebalance back to target."):
+def _proof_pack(reason: str = "Rebalance back to target.", *, tenant_id: str = "tenant-test"):
     result = _ready_rebalance_result()
     run = DpmRunRecord(
         rebalance_run_id="rr_repo_001",
@@ -79,7 +79,7 @@ def _proof_pack(reason: str = "Rebalance back to target."):
         result_json=result.model_dump(mode="json"),
     )
     return build_proof_pack_from_run(
-        tenant_id="tenant-test",
+        tenant_id=tenant_id,
         run=run,
         created_by="pm_repo",
         reason=reason,
@@ -96,13 +96,16 @@ def test_in_memory_repository_round_trips_immutable_proof_pack_and_retention() -
         proof_pack=proof_pack,
         idempotency_key="idem-proof-pack-repository",
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
 
-    by_id = repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id)
-    by_idempotency = repository.get_proof_pack_by_idempotency(
-        idempotency_key="idem-proof-pack-repository"
+    by_id = repository.get_proof_pack(
+        proof_pack_id=proof_pack.proof_pack_id, tenant_id="tenant-test"
     )
-    listed = repository.list_proof_packs(portfolio_id="pf_repo_1")
+    by_idempotency = repository.get_proof_pack_by_idempotency(
+        idempotency_key="idem-proof-pack-repository", tenant_id="tenant-test"
+    )
+    listed = repository.list_proof_packs(tenant_id="tenant-test", portfolio_id="pf_repo_1")
     retention = repository.get_retention_metadata(proof_pack_id=proof_pack.proof_pack_id)
 
     assert by_id == proof_pack
@@ -123,11 +126,13 @@ def test_in_memory_repository_replays_same_identity_but_rejects_mutation() -> No
         proof_pack=proof_pack,
         idempotency_key="idem-proof-pack-repository",
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
     repository.save_proof_pack(
         proof_pack=proof_pack,
         idempotency_key="idem-proof-pack-repository",
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
 
     mutated = _proof_pack(reason="Changed rationale.")
@@ -136,6 +141,7 @@ def test_in_memory_repository_replays_same_identity_but_rejects_mutation() -> No
             proof_pack=mutated,
             idempotency_key="idem-proof-pack-repository",
             retention_expires_at=RETENTION_EXPIRES_AT,
+            tenant_id="tenant-test",
         )
 
 
@@ -148,6 +154,7 @@ def test_in_memory_repository_rejects_idempotency_conflict() -> None:
         proof_pack=first,
         idempotency_key="idem-proof-pack-repository",
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
 
     with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_IDEMPOTENCY_CONFLICT"):
@@ -155,7 +162,98 @@ def test_in_memory_repository_rejects_idempotency_conflict() -> None:
             proof_pack=second,
             idempotency_key="idem-proof-pack-repository",
             retention_expires_at=RETENTION_EXPIRES_AT,
+            tenant_id="tenant-test",
         )
+
+
+def test_in_memory_repository_rejects_aggregate_and_admitted_tenant_mismatch() -> None:
+    repository = InMemoryDpmProofPackRepository()
+
+    with pytest.raises(DpmProofPackConflictError, match="DPM_PROOF_PACK_TENANT_MISMATCH"):
+        repository.save_proof_pack(
+            proof_pack=_proof_pack(tenant_id="tenant-owned"),
+            idempotency_key=None,
+            retention_expires_at=None,
+            tenant_id="tenant-foreign",
+        )
+
+
+def test_in_memory_repository_fences_direct_list_and_replay_reads_by_tenant() -> None:
+    repository = InMemoryDpmProofPackRepository()
+    owned = _proof_pack(tenant_id="tenant-owned")
+    foreign = _proof_pack(reason="Foreign rationale.", tenant_id="tenant-foreign").model_copy(
+        update={"proof_pack_id": "dpp_foreign"}
+    )
+    repository.save_proof_pack(
+        proof_pack=owned,
+        idempotency_key="shared-caller-key",
+        retention_expires_at=None,
+        tenant_id="tenant-owned",
+    )
+    repository.save_proof_pack(
+        proof_pack=foreign,
+        idempotency_key="shared-caller-key",
+        retention_expires_at=None,
+        tenant_id="tenant-foreign",
+    )
+
+    assert (
+        repository.get_proof_pack(proof_pack_id=owned.proof_pack_id, tenant_id="tenant-foreign")
+        is None
+    )
+    assert (
+        repository.get_proof_pack_by_idempotency(
+            idempotency_key="shared-caller-key", tenant_id="tenant-owned"
+        )
+        == owned
+    )
+    assert (
+        repository.get_proof_pack_by_idempotency(
+            idempotency_key="shared-caller-key", tenant_id="tenant-foreign"
+        )
+        == foreign
+    )
+    assert repository.list_proof_packs(tenant_id="tenant-owned") == [owned]
+    assert repository.list_proof_packs(tenant_id="tenant-foreign") == [foreign]
+
+
+def test_in_memory_repository_quarantines_legacy_unattributed_pack() -> None:
+    repository = InMemoryDpmProofPackRepository()
+    legacy = _proof_pack().model_copy(update={"tenant_id": None})
+    repository._proof_packs[legacy.proof_pack_id] = legacy
+
+    assert (
+        repository.get_proof_pack(proof_pack_id=legacy.proof_pack_id, tenant_id="tenant-test")
+        is None
+    )
+    assert repository.list_proof_packs(tenant_id="tenant-test") == []
+
+
+def test_in_memory_repository_filters_tenant_before_pagination() -> None:
+    repository = InMemoryDpmProofPackRepository()
+    foreign = _proof_pack(reason="Foreign newest.", tenant_id="tenant-foreign").model_copy(
+        update={"proof_pack_id": "dpp_foreign_newest"}
+    )
+    owned = _proof_pack(reason="Owned older.", tenant_id="tenant-owned").model_copy(
+        update={
+            "proof_pack_id": "dpp_owned_older",
+            "created_at": CREATED_AT - timedelta(minutes=1),
+        }
+    )
+    repository.save_proof_pack(
+        proof_pack=foreign,
+        idempotency_key=None,
+        retention_expires_at=None,
+        tenant_id="tenant-foreign",
+    )
+    repository.save_proof_pack(
+        proof_pack=owned,
+        idempotency_key=None,
+        retention_expires_at=None,
+        tenant_id="tenant-owned",
+    )
+
+    assert repository.list_proof_packs(tenant_id="tenant-owned", limit=1) == [owned]
 
 
 def test_proof_pack_immutability_helper_allows_matching_content_hash() -> None:
@@ -270,6 +368,7 @@ def test_in_memory_repository_appends_refs_without_mutating_body() -> None:
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=RETENTION_EXPIRES_AT,
+        tenant_id="tenant-test",
     )
 
     ref = DpmProofPackStoredRef(
@@ -283,7 +382,10 @@ def test_in_memory_repository_appends_refs_without_mutating_body() -> None:
     repository.append_ref(ref=ref)
 
     assert repository.list_refs(proof_pack_id=proof_pack.proof_pack_id) == [ref]
-    assert repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id) == proof_pack
+    assert (
+        repository.get_proof_pack(proof_pack_id=proof_pack.proof_pack_id, tenant_id="tenant-test")
+        == proof_pack
+    )
 
 
 def test_postgres_migration_declares_proof_pack_persistence_tables() -> None:
@@ -307,3 +409,18 @@ def test_postgres_migration_declares_proof_pack_persistence_tables() -> None:
     missing = [token for token in required_tokens if token not in migration]
 
     assert missing == []
+
+
+def test_postgres_migration_quarantines_legacy_proof_packs_and_indexes_tenant_reads() -> None:
+    migration = (
+        ROOT
+        / "src"
+        / "infrastructure"
+        / "postgres_migrations"
+        / "dpm"
+        / "0028_proof_pack_tenant_scope.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "ADD COLUMN IF NOT EXISTS tenant_id TEXT NULL" in migration
+    assert "UPDATE dpm_pre_trade_proof_packs" not in migration
+    assert "(tenant_id, created_at DESC, proof_pack_id DESC)" in migration

--- a/tests/unit/dpm/proof_packs/test_proof_pack_service.py
+++ b/tests/unit/dpm/proof_packs/test_proof_pack_service.py
@@ -347,6 +347,7 @@ def test_handoff_ref_lookup_uses_append_only_refs_and_reports_missing_refs() -> 
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
 
     with pytest.raises(
@@ -356,6 +357,7 @@ def test_handoff_ref_lookup_uses_append_only_refs_and_reports_missing_refs() -> 
         proof_pack_service.get_report_input_ref(
             proof_pack_id=proof_pack.proof_pack_id,
             proof_pack_repository=repository,
+            tenant_id="tenant-test",
         )
     with pytest.raises(
         proof_pack_service.DpmProofPackAiEvidenceInputNotGeneratedError,
@@ -364,6 +366,7 @@ def test_handoff_ref_lookup_uses_append_only_refs_and_reports_missing_refs() -> 
         proof_pack_service.get_ai_evidence_ref(
             proof_pack_id=proof_pack.proof_pack_id,
             proof_pack_repository=repository,
+            tenant_id="tenant-test",
         )
 
     report_ref = DpmProofPackStoredRef(
@@ -389,6 +392,7 @@ def test_handoff_ref_lookup_uses_append_only_refs_and_reports_missing_refs() -> 
         proof_pack_service.get_report_input_ref(
             proof_pack_id=proof_pack.proof_pack_id,
             proof_pack_repository=repository,
+            tenant_id="tenant-test",
         ).content_hash
         == "sha256:report"
     )
@@ -396,6 +400,7 @@ def test_handoff_ref_lookup_uses_append_only_refs_and_reports_missing_refs() -> 
         proof_pack_service.get_ai_evidence_ref(
             proof_pack_id=proof_pack.proof_pack_id,
             proof_pack_repository=repository,
+            tenant_id="tenant-test",
         ).content_hash
         == "sha256:ai"
     )
@@ -424,7 +429,7 @@ def test_handoff_ref_lookup_reads_stored_refs_when_pack_is_not_hydrated() -> Non
         def __init__(self) -> None:
             self.calls = 0
 
-        def get_proof_pack(self, *, proof_pack_id: str):
+        def get_proof_pack(self, *, proof_pack_id: str, tenant_id: str):
             return proof_pack
 
         def list_refs(self, *, proof_pack_id: str):
@@ -439,6 +444,7 @@ def test_handoff_ref_lookup_reads_stored_refs_when_pack_is_not_hydrated() -> Non
         proof_pack_service.get_report_input_ref(
             proof_pack_id=proof_pack.proof_pack_id,
             proof_pack_repository=repository,
+            tenant_id="tenant-test",
         ).content_hash
         == "sha256:report"
     )
@@ -446,6 +452,7 @@ def test_handoff_ref_lookup_reads_stored_refs_when_pack_is_not_hydrated() -> Non
         proof_pack_service.get_ai_evidence_ref(
             proof_pack_id=proof_pack.proof_pack_id,
             proof_pack_repository=repository,
+            tenant_id="tenant-test",
         ).content_hash
         == "sha256:ai"
     )
@@ -458,6 +465,7 @@ def test_ensure_handoff_refs_is_idempotent_for_existing_matching_refs() -> None:
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
 
     first = proof_pack_service.ensure_handoff_refs(
@@ -485,6 +493,7 @@ def test_handoff_ref_lookup_prefers_latest_append_only_ref() -> None:
         proof_pack=proof_pack,
         idempotency_key=None,
         retention_expires_at=None,
+        tenant_id="tenant-test",
     )
     repository.append_ref(
         ref=DpmProofPackStoredRef(
@@ -510,6 +519,7 @@ def test_handoff_ref_lookup_prefers_latest_append_only_ref() -> None:
     report_ref = proof_pack_service.get_report_input_ref(
         proof_pack_id=proof_pack.proof_pack_id,
         proof_pack_repository=repository,
+        tenant_id="tenant-test",
     )
 
     assert report_ref.ref_id == "dpri_new"

--- a/tests/unit/test_documentation_current_state.py
+++ b/tests/unit/test_documentation_current_state.py
@@ -2930,15 +2930,13 @@ def test_the_wiki_tenant_scope_claims_are_derived_from_the_served_contract() -> 
     scoped = {
         "GET /api/v1/dpm/monitoring/runs",
         "GET /api/v1/dpm/monitoring/runs/{monitoring_run_id}",
-    }
-    # Named as unscoped on the page. `report-input` and `ai-evidence-input` are
-    # deliberately absent: they DO declare a required tenant_id and are still
-    # unfenced, which is why the page describes them separately and issue #694
-    # calls the parameter misleading rather than missing. A membership test
-    # here would report them as fenced.
-    unscoped = {
         "GET /api/v1/rebalance/proof-packs/{proof_pack_id}",
         "GET /api/v1/rebalance/proof-packs/{proof_pack_id}/summary.md",
+        "GET /api/v1/rebalance/proof-packs/{proof_pack_id}/report-input",
+        "GET /api/v1/rebalance/proof-packs/{proof_pack_id}/ai-evidence-input",
+    }
+    # Named as the remaining unscoped operation on the page.
+    unscoped = {
         "GET /api/v1/rebalance/waves/{wave_id}/outcome-reviews",
     }
 
@@ -2958,7 +2956,7 @@ def test_the_wiki_tenant_scope_claims_are_derived_from_the_served_contract() -> 
     )
     assert not fenced_but_claimed_unscoped, (
         "wiki/API-Surface.md still lists these as unscoped after they were fenced; "
-        f"update the page and issue #694: {fenced_but_claimed_unscoped}"
+        f"update the page: {fenced_but_claimed_unscoped}"
     )
 
     api_surface = (ROOT / "wiki" / "API-Surface.md").read_text(encoding="utf-8")
@@ -2967,4 +2965,5 @@ def test_the_wiki_tenant_scope_claims_are_derived_from_the_served_contract() -> 
         "the page must keep saying that a NULL-tenant run is quarantined rather "
         "than defaulted; that is the property the migration relies on"
     )
-    assert "issue #694" in api_surface
+    assert "Migration `0028`" in api_surface
+    assert "Legacy NULL-owner rows" in api_surface

--- a/wiki/API-Surface.md
+++ b/wiki/API-Surface.md
@@ -84,15 +84,17 @@ Workbench RFC-0098, and
   source-backed degraded or blocked section states instead of inventing missing evidence.
 - `GET /api/v1/rebalance/proof-packs/{proof_pack_id}`
   retrieves the persisted proof-pack JSON contract with section states, hashes, lineage, retention
-  posture, source references, and supportability summary.
+  posture, source references, and supportability summary. A required `tenant_id` query parameter
+  fences the aggregate before its body is returned.
 - `GET /api/v1/rebalance/proof-packs/{proof_pack_id}/summary.md`
-  renders deterministic human-readable Markdown from the persisted proof pack.
+  renders deterministic human-readable Markdown from the tenant-fenced persisted proof pack.
 - `GET /api/v1/rebalance/proof-packs/{proof_pack_id}/report-input`
   returns deterministic `DpmProofPackReportInput` for downstream report materialization without
-  requiring `lotus-report` to reconstruct proof-pack truth.
+  requiring `lotus-report` to reconstruct proof-pack truth. The required `tenant_id` fences both
+  the proof pack and its downstream enrichment.
 - `GET /api/v1/rebalance/proof-packs/{proof_pack_id}/ai-evidence-input`
   returns bounded `DpmProofPackAiEvidenceInput` with forbidden-action guardrails and forbidden-field
-  filtering for downstream AI workflows.
+  filtering for downstream AI workflows, under the same required tenant fence.
 
 These are manage-owned backend authority endpoints. Gateway and Workbench must consume these
 contracts later without reconstructing proof-pack evidence. Report materialization and AI memo
@@ -367,12 +369,11 @@ Two limits on that fence are worth stating plainly, because neither is visible f
   **see**; it does not yet stop a caller recording a run under a tenant it merely names. That gap
   is tracked on issue #693 and is not closed by this change.
 
-Three operations remain genuinely unscoped: `GET /rebalance/proof-packs/{proof_pack_id}` with its
-`summary.md` companion, and `GET /rebalance/waves/{wave_id}/outcome-reviews` — the last of which
-sits under the wave prefix while reading an aggregate that is not tenant-scoped. The proof-pack
-reads are worse than unscoped: `GET /rebalance/proof-packs/{proof_pack_id}/report-input` and
-`/ai-evidence-input` **require** a `tenant_id` and then use it only for downstream enrichment, so
-the parameter looks like a fence and is not one. Tracked on issue #694.
+One operation remains genuinely unscoped: `GET /rebalance/waves/{wave_id}/outcome-reviews`, which
+sits under the wave prefix while reading an aggregate that is not tenant-scoped. Proof-pack reads
+are no longer in this set. Migration `0028` records the admitted tenant on new proof packs; all four
+detail/handoff reads, replay, and portfolio-memory list reads require that owner to agree with the
+caller. Legacy NULL-owner rows and contradictory column/payload ownership are matched by no caller.
 
 The wave aggregate is **no longer** among them — migration `0027` scoped it, and this sentence
 previously described the state before that change.


### PR DESCRIPTION
## Summary
- persist the admitted tenant on proof-pack aggregates and tenant-scope idempotency mappings
- require tenant agreement on direct, replay, handoff, Markdown, portfolio-memory, and paged list reads
- quarantine legacy NULL-tenant and contradictory aggregate rows, with real PostgreSQL regression proof
- update OpenAPI vocabulary, README, repository context, quality evidence, and repo-authored wiki source

Closes #694

## Validation
- `make static-quality-gates` — passed
- `python -m mypy src` — 554 source files passed
- `python -m pytest tests/unit -q` — 3,479 passed, 13 skipped
- complete required PostgreSQL integration lane — 257 passed
- proof-pack PostgreSQL fence tests — 5 passed
- `make test-all-fast` — 3,726 passed, 50 skipped; the standalone local coverage check then reported 98.84% because this target skips required PostgreSQL tests. The PR coverage workflow aggregates the PostgreSQL coverage shard and is the authoritative gate.
- migration predicate mutation checks — direct HTTP, replay aggregate agreement, pre-pagination list fence, required OpenAPI tenant, and repeated-save owner agreement each failed when its guard was individually removed, then passed after restoration
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-manage -AllowUnpublishedSourceChanges` — passed with one intentional source change

## Integration dependency
Gateway compatibility PR sgajbi/lotus-gateway#784 was merged first at `08937a5455a3709495659c575180e9ec4c627fa3`; it forwards `X-Tenant-Id` on all six proof-pack operations.

## Wiki plan
Publish the updated repo-authored wiki after merge, then run strict parity verification.
