### PR TITLE
test(dpm): fail closed on solver prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,10 @@ Current posture under RFC-0082:
    breadth so proof loss cannot hide behind total coverage.
 4. Host/runtime coexistence and gateway-facing capability discovery are part of the operational
    contract.
-5. Solver-capable development and CI installs include the `solver` extra (`cvxpy` and `numpy`) so
-   solver-mode target generation is validated instead of silently skipped.
+5. Solver-capable production installs use the `solver` extra (`cvxpy` and `numpy`), while
+   development and CI declare both as required `dev` dependencies. Solver-mode tests execute
+   unconditionally and fail if that test runtime is missing or broken; they must never turn a slow
+   import into a passing skip.
 
 ## Strategic DPM Roadmap
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Current posture under RFC-0082:
 4. Host/runtime coexistence and gateway-facing capability discovery are part of the operational
    contract.
 5. Solver-capable production installs use the `solver` extra (`cvxpy` and `numpy`), while
-   development and CI declare both as required `dev` dependencies. Solver-mode tests execute
-   unconditionally and fail if that test runtime is missing or broken; they must never turn a slow
-   import into a passing skip.
+   development and CI declare both as required `dev` dependencies. Solver-mode proof surfaces load
+   that prerequisite during test collection and execute unconditionally; a missing, suppressed, or
+   broken solver runtime must fail the lane instead of becoming a passing skip.
 
 ## Strategic DPM Roadmap
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1109,11 +1109,12 @@ Important validation expectations:
    prevents unrelated base-branch changes from making branch-owned evidence stale. Dirty worktrees
    and missing recorded refs retain the safe `origin/main` fallback.
 4. PR-grade validation includes coverage-backed full test execution,
-   Solver tests execute unconditionally because `cvxpy` is a required `dev` dependency for test
-   lanes (and remains in the optional `solver` extra for production installs). Do not reintroduce
-   availability probes, import timeouts, or skip markers: a missing, slow, or broken solver test
-   runtime is a failed prerequisite and must fail the lane rather than alter its coverage
-   denominator.
+   Solver tests load a shared `cvxpy`/`numpy` prerequisite directly during collection and execute
+   unconditionally because those packages are required `dev` dependencies for test lanes (and
+   remain in the optional `solver` extra for production installs). Do not suppress the collection
+   prerequisite or reintroduce availability probes, import timeouts, or skip markers: a missing,
+   slow, or broken solver test runtime is a failed prerequisite and must fail the lane rather than
+   alter its coverage denominator.
 5. `make static-quality-gates` includes `make test-family-inventory`, which blocks loss of the
    measured API/runtime, contract/governance, observability/security, domain/lifecycle/methodology,
    and integration/runtime proof-family floors in `quality/test_family_inventory_baseline.json`;

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1109,6 +1109,11 @@ Important validation expectations:
    prevents unrelated base-branch changes from making branch-owned evidence stale. Dirty worktrees
    and missing recorded refs retain the safe `origin/main` fallback.
 4. PR-grade validation includes coverage-backed full test execution,
+   Solver tests execute unconditionally because `cvxpy` is a required `dev` dependency for test
+   lanes (and remains in the optional `solver` extra for production installs). Do not reintroduce
+   availability probes, import timeouts, or skip markers: a missing, slow, or broken solver test
+   runtime is a failed prerequisite and must fail the lane rather than alter its coverage
+   denominator.
 5. `make static-quality-gates` includes `make test-family-inventory`, which blocks loss of the
    measured API/runtime, contract/governance, observability/security, domain/lifecycle/methodology,
    and integration/runtime proof-family floors in `quality/test_family_inventory_baseline.json`;

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T05:48:45+00:00`
+- Generated at: `2026-09-09T05:59:13+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `af337c87+worktree`
+- Report source snapshot: `f0fd61f3+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 939 |
-| Total Python LOC | 220424 |
+| Total Python LOC | 220440 |
 | Test functions | 3205 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T02:34:34+00:00`
+- Generated at: `2026-09-09T04:09:28+00:00`
 
-- Baseline source snapshot: `a07363e1941c1f173e7bcca74002616afacf6d03`
+- Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `70e22473+worktree`
+- Report source snapshot: `c54cecb4+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 937 |
-| Total Python LOC | 220197 |
-| Test functions | 3201 |
+| Python files | 938 |
+| Total Python LOC | 220241 |
+| Test functions | 3203 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T04:21:35+00:00`
+- Generated at: `2026-09-09T04:39:01+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `9bd26967+worktree`
+- Report source snapshot: `24a9a56a+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 938 |
-| Total Python LOC | 220243 |
+| Total Python LOC | 220259 |
 | Test functions | 3203 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T05:15:01+00:00`
+- Generated at: `2026-09-09T05:28:16+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `68bdea1d+worktree`
+- Report source snapshot: `b4f3452d+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 938 |
-| Total Python LOC | 220312 |
-| Test functions | 3203 |
+| Python files | 939 |
+| Total Python LOC | 220380 |
+| Test functions | 3204 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T05:05:33+00:00`
+- Generated at: `2026-09-09T05:15:01+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `9f7fb285+worktree`
+- Report source snapshot: `68bdea1d+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 938 |
-| Total Python LOC | 220297 |
+| Total Python LOC | 220312 |
 | Test functions | 3203 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T05:28:16+00:00`
+- Generated at: `2026-09-09T05:37:06+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `b4f3452d+worktree`
+- Report source snapshot: `46db9c55+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 939 |
-| Total Python LOC | 220380 |
+| Total Python LOC | 220391 |
 | Test functions | 3204 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T04:54:50+00:00`
+- Generated at: `2026-09-09T05:05:33+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `3b33efaa+worktree`
+- Report source snapshot: `9f7fb285+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 938 |
-| Total Python LOC | 220264 |
+| Total Python LOC | 220297 |
 | Test functions | 3203 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T04:09:28+00:00`
+- Generated at: `2026-09-09T04:21:35+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `c54cecb4+worktree`
+- Report source snapshot: `9bd26967+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 938 |
-| Total Python LOC | 220241 |
+| Total Python LOC | 220243 |
 | Test functions | 3203 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T05:37:06+00:00`
+- Generated at: `2026-09-09T05:48:45+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `46db9c55+worktree`
+- Report source snapshot: `af337c87+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,8 +13,8 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 939 |
-| Total Python LOC | 220391 |
-| Test functions | 3204 |
+| Total Python LOC | 220424 |
+| Test functions | 3205 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T04:39:01+00:00`
+- Generated at: `2026-09-09T04:54:50+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `24a9a56a+worktree`
+- Report source snapshot: `3b33efaa+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -13,7 +13,7 @@
 | Metric | Value |
 | --- | --- |
 | Python files | 938 |
-| Total Python LOC | 220259 |
+| Total Python LOC | 220264 |
 | Test functions | 3203 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T04:21:35+00:00`
+- Generated at: `2026-09-09T04:39:01+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `9bd26967+worktree`
+- Report source snapshot: `24a9a56a+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T04:54:50+00:00`
+- Generated at: `2026-09-09T05:05:33+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `3b33efaa+worktree`
+- Report source snapshot: `9f7fb285+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T04:39:01+00:00`
+- Generated at: `2026-09-09T04:54:50+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `24a9a56a+worktree`
+- Report source snapshot: `3b33efaa+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T05:48:45+00:00`
+- Generated at: `2026-09-09T05:59:13+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `af337c87+worktree`
+- Report source snapshot: `f0fd61f3+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T05:15:01+00:00`
+- Generated at: `2026-09-09T05:28:16+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `68bdea1d+worktree`
+- Report source snapshot: `b4f3452d+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T04:09:28+00:00`
+- Generated at: `2026-09-09T04:21:35+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `c54cecb4+worktree`
+- Report source snapshot: `9bd26967+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T05:28:16+00:00`
+- Generated at: `2026-09-09T05:37:06+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `b4f3452d+worktree`
+- Report source snapshot: `46db9c55+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T05:05:33+00:00`
+- Generated at: `2026-09-09T05:15:01+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `9f7fb285+worktree`
+- Report source snapshot: `68bdea1d+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T05:37:06+00:00`
+- Generated at: `2026-09-09T05:48:45+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `46db9c55+worktree`
+- Report source snapshot: `af337c87+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T02:34:34+00:00`
+- Generated at: `2026-09-09T04:09:28+00:00`
 
-- Baseline source snapshot: `a07363e1941c1f173e7bcca74002616afacf6d03`
+- Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `70e22473+worktree`
+- Report source snapshot: `c54cecb4+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T05:15:01+00:00`
+- Generated at: `2026-09-09T05:28:16+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `68bdea1d+worktree`
+- Report source snapshot: `b4f3452d+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T04:39:01+00:00`
+- Generated at: `2026-09-09T04:54:50+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `24a9a56a+worktree`
+- Report source snapshot: `3b33efaa+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T05:05:33+00:00`
+- Generated at: `2026-09-09T05:15:01+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `9f7fb285+worktree`
+- Report source snapshot: `68bdea1d+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T04:54:50+00:00`
+- Generated at: `2026-09-09T05:05:33+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `3b33efaa+worktree`
+- Report source snapshot: `9f7fb285+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T04:21:35+00:00`
+- Generated at: `2026-09-09T04:39:01+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `9bd26967+worktree`
+- Report source snapshot: `24a9a56a+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T05:48:45+00:00`
+- Generated at: `2026-09-09T05:59:13+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `af337c87+worktree`
+- Report source snapshot: `f0fd61f3+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T05:28:16+00:00`
+- Generated at: `2026-09-09T05:37:06+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `b4f3452d+worktree`
+- Report source snapshot: `46db9c55+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T05:37:06+00:00`
+- Generated at: `2026-09-09T05:48:45+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `46db9c55+worktree`
+- Report source snapshot: `af337c87+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T02:34:34+00:00`
+- Generated at: `2026-09-09T04:09:28+00:00`
 
-- Baseline source snapshot: `a07363e1941c1f173e7bcca74002616afacf6d03`
+- Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `70e22473+worktree`
+- Report source snapshot: `c54cecb4+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T04:09:28+00:00`
+- Generated at: `2026-09-09T04:21:35+00:00`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `c54cecb4+worktree`
+- Report source snapshot: `9bd26967+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T02:34:34+00:00`
+- Generated at: `2026-09-09T04:09:28+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `a07363e1941c1f173e7bcca74002616afacf6d03`
+- Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `70e22473+worktree`
+- Report source snapshot: `c54cecb4+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 936 | 937 | +1 |
-| Total Python LOC | 219542 | 220197 | +655 |
-| Test functions | 3189 | 3201 | +12 |
+| Python files | 937 | 938 | +1 |
+| Total Python LOC | 220197 | 220241 | +44 |
+| Test functions | 3201 | 3203 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -37,14 +37,14 @@
 
 | Rank | File | Lines |
 | --- | --- | --- |
-| 1 | tests/unit/dpm/api/test_waves_api.py | 7777 |
+| 1 | tests/unit/dpm/api/test_waves_api.py | 7779 |
 | 2 | tests/unit/dpm/waves/test_campaign_definition_repository.py | 3609 |
 | 3 | tests/unit/test_ci_workflow_gate_enforcement.py | 3395 |
 | 4 | tests/unit/dpm/proof_packs/test_proof_pack_builder.py | 3347 |
 | 5 | tests/unit/dpm/api/test_api_rebalance.py | 3329 |
 | 6 | tests/unit/dpm/waves/test_campaign_discovery.py | 3215 |
-| 7 | tests/unit/test_documentation_current_state.py | 2970 |
-| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2709 |
+| 7 | tests/unit/test_documentation_current_state.py | 2969 |
+| 8 | tests/unit/dpm/api/test_portfolio_memory_api.py | 2711 |
 | 9 | tests/unit/dpm/infrastructure/test_core_sourcing_client.py | 2670 |
 | 10 | tests/unit/api/test_pm_operating_quality_api.py | 2308 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T04:09:28+00:00`
+- Generated at: `2026-09-09T04:21:35+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `c54cecb4+worktree`
+- Report source snapshot: `9bd26967+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 937 | 938 | +1 |
-| Total Python LOC | 220197 | 220241 | +44 |
+| Total Python LOC | 220197 | 220243 | +46 |
 | Test functions | 3201 | 3203 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T04:54:50+00:00`
+- Generated at: `2026-09-09T05:05:33+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `3b33efaa+worktree`
+- Report source snapshot: `9f7fb285+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 937 | 938 | +1 |
-| Total Python LOC | 220197 | 220264 | +67 |
+| Total Python LOC | 220197 | 220297 | +100 |
 | Test functions | 3201 | 3203 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T05:05:33+00:00`
+- Generated at: `2026-09-09T05:15:01+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `9f7fb285+worktree`
+- Report source snapshot: `68bdea1d+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 937 | 938 | +1 |
-| Total Python LOC | 220197 | 220297 | +100 |
+| Total Python LOC | 220197 | 220312 | +115 |
 | Test functions | 3201 | 3203 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T05:15:01+00:00`
+- Generated at: `2026-09-09T05:28:16+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `68bdea1d+worktree`
+- Report source snapshot: `b4f3452d+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 937 | 938 | +1 |
-| Total Python LOC | 220197 | 220312 | +115 |
-| Test functions | 3201 | 3203 | +2 |
+| Python files | 937 | 939 | +2 |
+| Total Python LOC | 220197 | 220380 | +183 |
+| Test functions | 3201 | 3204 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T05:48:45+00:00`
+- Generated at: `2026-09-09T05:59:13+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `af337c87+worktree`
+- Report source snapshot: `f0fd61f3+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 937 | 939 | +2 |
-| Total Python LOC | 220197 | 220424 | +227 |
+| Total Python LOC | 220197 | 220440 | +243 |
 | Test functions | 3201 | 3205 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T05:37:06+00:00`
+- Generated at: `2026-09-09T05:48:45+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `46db9c55+worktree`
+- Report source snapshot: `af337c87+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,8 +15,8 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 937 | 939 | +2 |
-| Total Python LOC | 220197 | 220391 | +194 |
-| Test functions | 3201 | 3204 | +3 |
+| Total Python LOC | 220197 | 220424 | +227 |
+| Test functions | 3201 | 3205 | +4 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T05:28:16+00:00`
+- Generated at: `2026-09-09T05:37:06+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `b4f3452d+worktree`
+- Report source snapshot: `46db9c55+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 937 | 939 | +2 |
-| Total Python LOC | 220197 | 220380 | +183 |
+| Total Python LOC | 220197 | 220391 | +194 |
 | Test functions | 3201 | 3204 | +3 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T04:39:01+00:00`
+- Generated at: `2026-09-09T04:54:50+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `24a9a56a+worktree`
+- Report source snapshot: `3b33efaa+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 937 | 938 | +1 |
-| Total Python LOC | 220197 | 220259 | +62 |
+| Total Python LOC | 220197 | 220264 | +67 |
 | Test functions | 3201 | 3203 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T04:21:35+00:00`
+- Generated at: `2026-09-09T04:39:01+00:00`
 
 - Baseline ref: `origin/main`
 
 - Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
 
-- Report source snapshot: `9bd26967+worktree`
+- Report source snapshot: `24a9a56a+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -15,7 +15,7 @@
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
 | Python files | 937 | 938 | +1 |
-| Total Python LOC | 220197 | 220243 | +46 |
+| Total Python LOC | 220197 | 220259 | +62 |
 | Test functions | 3201 | 3203 | +2 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |

--- a/tests/e2e/demo/test_demo_scenarios.py
+++ b/tests/e2e/demo/test_demo_scenarios.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 
 from src.api.main import app, get_db_session
 from src.api.routers.rebalance_runs import reset_dpm_run_support_service_for_tests
-from src.core.common.capabilities import has_solver_dependencies
 from src.core.rebalance.engine import run_simulation
 from src.core.models import (
     EngineOptions,
@@ -23,7 +22,6 @@ from src.core.models import (
 from tests.shared.factories import valid_api_payload
 
 DEMO_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs", "demo")
-_SOLVER_AVAILABLE = has_solver_dependencies()
 
 
 def load_demo_scenario(filename):
@@ -57,12 +55,8 @@ def test_demo_scenario_execution(filename, expected_status):
 
     result = run_simulation(portfolio, market_data, model, shelf, options)
 
-    effective_expected = expected_status
-    if filename == "08_solver_mode.json" and not _SOLVER_AVAILABLE:
-        effective_expected = "BLOCKED"
-
-    assert result.status == effective_expected, (
-        f"Scenario {filename} failed. Got {result.status}, expected {effective_expected}"
+    assert result.status == expected_status, (
+        f"Scenario {filename} failed. Got {result.status}, expected {expected_status}"
     )
 
 

--- a/tests/e2e/demo/test_demo_scenarios.py
+++ b/tests/e2e/demo/test_demo_scenarios.py
@@ -20,6 +20,10 @@ from src.core.models import (
     ShelfEntry,
 )
 from tests.shared.factories import valid_api_payload
+from tests.shared.solver_prerequisites import require_solver_test_dependencies
+
+
+require_solver_test_dependencies()
 
 DEMO_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs", "demo")
 

--- a/tests/shared/solver_prerequisites.py
+++ b/tests/shared/solver_prerequisites.py
@@ -1,0 +1,9 @@
+"""Collection-time prerequisite for test suites that prove solver behavior."""
+
+import cvxpy
+import numpy
+
+
+def require_solver_test_dependencies() -> tuple[object, object]:
+    """Make the required imports explicit at each solver-proof surface."""
+    return cvxpy, numpy

--- a/tests/unit/dpm/engine/test_engine_solver_behavior.py
+++ b/tests/unit/dpm/engine/test_engine_solver_behavior.py
@@ -11,6 +11,10 @@ from tests.shared.factories import (
     price,
     target,
 )
+from tests.shared.solver_prerequisites import require_solver_test_dependencies
+
+
+require_solver_test_dependencies()
 
 
 def _diag():

--- a/tests/unit/dpm/engine/test_engine_solver_behavior.py
+++ b/tests/unit/dpm/engine/test_engine_solver_behavior.py
@@ -1,9 +1,4 @@
-import subprocess
-import sys
 from decimal import Decimal
-from importlib.util import find_spec
-
-import pytest
 
 from src.core.rebalance.engine import _generate_targets, run_simulation
 from src.core.models import DiagnosticsData, EngineOptions, GroupConstraint, ShelfEntry
@@ -18,25 +13,6 @@ from tests.shared.factories import (
 )
 
 
-def _cvxpy_runtime_available(timeout_seconds: float = 3.0) -> bool:
-    if find_spec("cvxpy") is None:
-        return False
-    try:
-        subprocess.run(
-            [sys.executable, "-c", "import cvxpy"],
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            check=True,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return False
-    return True
-
-
-_CVXPY_RUNTIME_AVAILABLE = _cvxpy_runtime_available()
-
-
 def _diag():
     return DiagnosticsData(
         warnings=[],
@@ -45,7 +21,6 @@ def _diag():
     )
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_counts_locked_group_weight_in_group_constraint():
     model = model_portfolio(targets=[target("TECH_BUY", "1.0"), target("BOND", "0.0")])
     eligible_targets = {
@@ -85,7 +60,6 @@ def test_solver_counts_locked_group_weight_in_group_constraint():
     assert eligible_targets["BOND"] >= Decimal("0.7500")
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_warns_unknown_attribute_and_continues():
     model = model_portfolio(targets=[target("A", "0.6"), target("B", "0.4")])
     eligible_targets = {"A": Decimal("0.6"), "B": Decimal("0.4")}
@@ -117,7 +91,6 @@ def test_solver_warns_unknown_attribute_and_continues():
     assert "UNKNOWN_CONSTRAINT_ATTRIBUTE_region" in diagnostics.warnings
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_handles_sell_only_excess_with_buy_recipients():
     model = model_portfolio(targets=[target("A", "0.7"), target("B", "0.3")])
     eligible_targets = {"A": Decimal("0.7"), "B": Decimal("0.3")}
@@ -148,7 +121,6 @@ def test_solver_handles_sell_only_excess_with_buy_recipients():
     assert eligible_targets["B"] == Decimal("0.3000")
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_skips_group_constraint_when_value_not_present():
     model = model_portfolio(targets=[target("A", "0.7"), target("B", "0.3")])
     eligible_targets = {"A": Decimal("0.7"), "B": Decimal("0.3")}
@@ -180,7 +152,6 @@ def test_solver_skips_group_constraint_when_value_not_present():
     assert diagnostics.warnings == []
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_falls_back_to_secondary_solver_when_primary_errors(monkeypatch):
     import cvxpy as cp
 
@@ -225,7 +196,6 @@ def test_solver_falls_back_to_secondary_solver_when_primary_errors(monkeypatch):
     assert str(cp.SCS) in attempted
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_retries_primary_solver_with_compatibility_kwargs(monkeypatch):
     import cvxpy as cp
 
@@ -271,7 +241,6 @@ def test_solver_retries_primary_solver_with_compatibility_kwargs(monkeypatch):
     assert any("time_limit" not in attempt for attempt in osqp_attempts)
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_run_simulation_solver_preserves_pending_review_when_no_recipients():
     pf = portfolio_snapshot(
         portfolio_id="pf_solver_pending",
@@ -320,7 +289,6 @@ def test_solver_returns_blocked_when_solver_dependencies_unavailable(monkeypatch
     assert "SOLVER_ERROR" in diagnostics.warnings
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_infeasible_emits_cash_band_and_capacity_hints():
     model = model_portfolio(targets=[target("A", "1.0")])
     diagnostics = _diag()
@@ -348,7 +316,6 @@ def test_solver_infeasible_emits_cash_band_and_capacity_hints():
     assert "INFEASIBILITY_HINT_SINGLE_POSITION_CAPACITY" in diagnostics.warnings
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_infeasible_emits_locked_group_hint():
     model = model_portfolio(targets=[target("TECH_BUY", "0.0"), target("BOND", "1.0")])
     diagnostics = _diag()
@@ -385,7 +352,6 @@ def test_solver_infeasible_emits_locked_group_hint():
     assert "INFEASIBILITY_HINT_LOCKED_GROUP_WEIGHT_sector:TECH" in diagnostics.warnings
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_infeasible_skips_non_matching_group_hint():
     model = model_portfolio(targets=[target("A", "1.0")])
     diagnostics = _diag()
@@ -415,7 +381,6 @@ def test_solver_infeasible_skips_non_matching_group_hint():
     )
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_compare_target_methods_emits_divergence_warnings_and_payload():
     pf = portfolio_snapshot(
         portfolio_id="pf_solver_compare",

--- a/tests/unit/dpm/engine/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/test_engine_target_generation.py
@@ -2,12 +2,7 @@
 FILE: tests/engine/test_engine_target_generation.py
 """
 
-import subprocess
-import sys
 from decimal import Decimal
-from importlib.util import find_spec
-
-import pytest
 
 from src.core.rebalance.engine import _generate_targets
 from src.core.models import (
@@ -17,25 +12,6 @@ from src.core.models import (
     ModelTarget,
     ShelfEntry,
 )
-
-
-def _cvxpy_runtime_available(timeout_seconds: float = 3.0) -> bool:
-    if find_spec("cvxpy") is None:
-        return False
-    try:
-        subprocess.run(
-            [sys.executable, "-c", "import cvxpy"],
-            capture_output=True,
-            text=True,
-            timeout=timeout_seconds,
-            check=True,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return False
-    return True
-
-
-_CVXPY_RUNTIME_AVAILABLE = _cvxpy_runtime_available()
 
 
 def test_target_gen_applies_group_cap_and_redistributes():
@@ -124,7 +100,6 @@ def test_target_gen_blocks_if_redistribution_impossible():
     assert diag.group_constraint_events[0].status == "BLOCKED"
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_target_gen_feasible_allocates_with_hard_constraints():
     targets = [
         ModelTarget(instrument_id="Tech_A", weight=Decimal("1.0")),
@@ -163,7 +138,6 @@ def test_solver_target_gen_feasible_allocates_with_hard_constraints():
     assert len(trace) == 2
 
 
-@pytest.mark.skipif(not _CVXPY_RUNTIME_AVAILABLE, reason="cvxpy runtime unavailable")
 def test_solver_target_gen_blocks_on_infeasible_constraints():
     targets = [ModelTarget(instrument_id="Tech_A", weight=Decimal("1.0"))]
     eligible = {"Tech_A": Decimal("1.0")}

--- a/tests/unit/dpm/engine/test_engine_target_generation.py
+++ b/tests/unit/dpm/engine/test_engine_target_generation.py
@@ -12,6 +12,10 @@ from src.core.models import (
     ModelTarget,
     ShelfEntry,
 )
+from tests.shared.solver_prerequisites import require_solver_test_dependencies
+
+
+require_solver_test_dependencies()
 
 
 def test_target_gen_applies_group_cap_and_redistributes():

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -39,6 +39,7 @@ def test_required_solver_proofs_cannot_skip_or_use_a_subprocess_probe() -> None:
         pytest_marks: set[str] = set()
         pytest_skip_calls: set[str] = set()
         unittest_modules = {"unittest"}
+        unittest_case_modules = {"unittest.case"}
         unittest_skip_calls: set[str] = set()
         unittest_skip_exceptions: set[str] = set()
         solver_capability_modules = {"src.core.common.capabilities"}
@@ -50,9 +51,12 @@ def test_required_solver_proofs_cannot_skip_or_use_a_subprocess_probe() -> None:
                     alias.asname or alias.name for alias in node.names if alias.name == "pytest"
                 )
                 unittest_modules.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "unittest"
+                )
+                unittest_case_modules.update(
                     alias.asname or alias.name
                     for alias in node.names
-                    if alias.name in {"unittest", "unittest.case"}
+                    if alias.name == "unittest.case"
                 )
                 solver_capability_modules.update(
                     alias.asname or alias.name
@@ -68,6 +72,8 @@ def test_required_solver_proofs_cannot_skip_or_use_a_subprocess_probe() -> None:
                         pytest_skip_calls.add(local_name)
             if isinstance(node, ast.ImportFrom) and node.module in {"unittest", "unittest.case"}:
                 for alias in node.names:
+                    if node.module == "unittest" and alias.name == "case":
+                        unittest_case_modules.add(alias.asname or alias.name)
                     if alias.name in {"skip", "skipIf", "skipUnless", "expectedFailure"}:
                         unittest_skip_calls.add(alias.asname or alias.name)
                     if alias.name == "SkipTest":
@@ -94,6 +100,16 @@ def test_required_solver_proofs_cannot_skip_or_use_a_subprocess_probe() -> None:
             *(f"{module}.skipUnless" for module in unittest_modules),
             *(f"{module}.expectedFailure" for module in unittest_modules),
             *(f"{module}.SkipTest" for module in unittest_modules),
+            *(f"{module}.case.skip" for module in unittest_modules),
+            *(f"{module}.case.skipIf" for module in unittest_modules),
+            *(f"{module}.case.skipUnless" for module in unittest_modules),
+            *(f"{module}.case.expectedFailure" for module in unittest_modules),
+            *(f"{module}.case.SkipTest" for module in unittest_modules),
+            *(f"{module}.skip" for module in unittest_case_modules),
+            *(f"{module}.skipIf" for module in unittest_case_modules),
+            *(f"{module}.skipUnless" for module in unittest_case_modules),
+            *(f"{module}.expectedFailure" for module in unittest_case_modules),
+            *(f"{module}.SkipTest" for module in unittest_case_modules),
             *(f"{module}.has_solver_dependencies" for module in solver_capability_modules),
         }
         for node in ast.walk(tree):

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -1,0 +1,116 @@
+"""Keep required solver proofs fail-closed instead of timing-sensitive."""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+from pathlib import Path
+
+
+SOLVER_TEST_FILES = (
+    Path("tests/unit/dpm/engine/test_engine_solver_behavior.py"),
+    Path("tests/unit/dpm/engine/test_engine_target_generation.py"),
+    Path("tests/unit/dpm/golden/test_golden_scenarios.py"),
+    Path("tests/e2e/demo/test_demo_scenarios.py"),
+)
+
+
+def _dotted_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        owner = _dotted_name(node.value)
+        return None if owner is None else f"{owner}.{node.attr}"
+    return None
+
+
+def test_cvxpy_is_a_required_test_dependency() -> None:
+    project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
+
+    dev_dependencies = project["optional-dependencies"]["dev"]
+    assert any(dependency.startswith("cvxpy") for dependency in dev_dependencies)
+
+
+def test_required_solver_proofs_cannot_skip_or_use_a_subprocess_probe() -> None:
+    violations: list[str] = []
+    for path in SOLVER_TEST_FILES:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        pytest_modules = {"pytest"}
+        pytest_marks: set[str] = set()
+        pytest_skip_calls: set[str] = set()
+        unittest_modules = {"unittest"}
+        unittest_skip_calls: set[str] = set()
+        unittest_skip_exceptions: set[str] = set()
+        solver_capability_modules = {"src.core.common.capabilities"}
+        solver_capability_calls = {"has_solver_dependencies"}
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                pytest_modules.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "pytest"
+                )
+                unittest_modules.update(
+                    alias.asname or alias.name for alias in node.names if alias.name == "unittest"
+                )
+                solver_capability_modules.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name == "src.core.common.capabilities"
+                )
+            if isinstance(node, ast.ImportFrom) and node.module == "pytest":
+                for alias in node.names:
+                    local_name = alias.asname or alias.name
+                    if alias.name == "mark":
+                        pytest_marks.add(local_name)
+                    if alias.name in {"skip", "skipif", "importorskip", "xfail"}:
+                        pytest_skip_calls.add(local_name)
+            if isinstance(node, ast.ImportFrom) and node.module in {"unittest", "unittest.case"}:
+                for alias in node.names:
+                    if alias.name in {"skip", "skipIf", "skipUnless", "expectedFailure"}:
+                        unittest_skip_calls.add(alias.asname or alias.name)
+                    if alias.name == "SkipTest":
+                        unittest_skip_exceptions.add(alias.asname or alias.name)
+            if isinstance(node, ast.ImportFrom) and node.module == "src.core.common.capabilities":
+                solver_capability_calls.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name == "has_solver_dependencies"
+                )
+
+        forbidden_attributes = {
+            *(f"{module}.skip" for module in pytest_modules),
+            *(f"{module}.importorskip" for module in pytest_modules),
+            *(f"{module}.xfail" for module in pytest_modules),
+            *(f"{module}.mark.skip" for module in pytest_modules),
+            *(f"{module}.mark.skipif" for module in pytest_modules),
+            *(f"{module}.mark.xfail" for module in pytest_modules),
+            *(f"{mark}.skip" for mark in pytest_marks),
+            *(f"{mark}.skipif" for mark in pytest_marks),
+            *(f"{mark}.xfail" for mark in pytest_marks),
+            *(f"{module}.skip" for module in unittest_modules),
+            *(f"{module}.skipIf" for module in unittest_modules),
+            *(f"{module}.skipUnless" for module in unittest_modules),
+            *(f"{module}.expectedFailure" for module in unittest_modules),
+            *(f"{module}.SkipTest" for module in unittest_modules),
+            *(f"{module}.has_solver_dependencies" for module in solver_capability_modules),
+        }
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import) and any(
+                alias.name == "subprocess" for alias in node.names
+            ):
+                violations.append(f"{path}:{node.lineno}: import subprocess")
+            if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+                violations.append(f"{path}:{node.lineno}: from subprocess")
+            dotted_name = _dotted_name(node) if isinstance(node, ast.Attribute) else None
+            if dotted_name in forbidden_attributes or (
+                dotted_name is not None and dotted_name.endswith(".skipTest")
+            ):
+                violations.append(f"{path}:{node.lineno}: {dotted_name}")
+            if isinstance(node, ast.Name) and node.id in unittest_skip_exceptions:
+                violations.append(f"{path}:{node.lineno}: {node.id}")
+            if isinstance(node, ast.Call):
+                call_name = _dotted_name(node.func)
+                if call_name in pytest_skip_calls | unittest_skip_calls | solver_capability_calls:
+                    violations.append(f"{path}:{node.lineno}: {call_name}")
+
+    assert violations == []

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import re
 import tomllib
 from pathlib import Path
 
@@ -19,6 +20,7 @@ SOLVER_PREREQUISITE_FUNCTION = "require_solver_test_dependencies"
 DEPENDENCY_PROBE_IMPORT_ROOTS = {"importlib", "pkgutil", "subprocess"}
 SOLVER_DEPENDENCY_IMPORT_ROOTS = {"cvxpy", "numpy"}
 SOLVER_CAPABILITY_MODULE = "src.core.common.capabilities"
+REQUIREMENT_NAME_END = re.compile(r"[\s\[<>=!~;@]")
 
 
 def _dotted_name(node: ast.expr) -> str | None:
@@ -51,11 +53,20 @@ def _caught_exception_names(node: ast.expr | None) -> set[str]:
     return set() if name is None else {name}
 
 
-def test_cvxpy_is_a_required_test_dependency() -> None:
+def _normalized_requirement_name(requirement: str) -> str:
+    name = REQUIREMENT_NAME_END.split(requirement.strip(), maxsplit=1)[0]
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def test_solver_packages_are_required_direct_test_dependencies() -> None:
     project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
 
     dev_dependencies = project["optional-dependencies"]["dev"]
-    assert any(dependency.startswith("cvxpy") for dependency in dev_dependencies)
+    direct_dependency_names = {
+        _normalized_requirement_name(dependency) for dependency in dev_dependencies
+    }
+
+    assert SOLVER_DEPENDENCY_IMPORT_ROOTS <= direct_dependency_names
 
 
 def test_solver_prerequisite_imports_dependencies_at_module_load() -> None:

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -13,6 +13,7 @@ SOLVER_TEST_FILES = (
     Path("tests/unit/dpm/golden/test_golden_scenarios.py"),
     Path("tests/e2e/demo/test_demo_scenarios.py"),
 )
+DEPENDENCY_PROBE_IMPORT_ROOTS = {"importlib", "pkgutil", "subprocess"}
 
 
 def _dotted_name(node: ast.expr) -> str | None:
@@ -31,7 +32,7 @@ def test_cvxpy_is_a_required_test_dependency() -> None:
     assert any(dependency.startswith("cvxpy") for dependency in dev_dependencies)
 
 
-def test_required_solver_proofs_cannot_skip_or_use_a_subprocess_probe() -> None:
+def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -> None:
     violations: list[str] = []
     for path in SOLVER_TEST_FILES:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -113,12 +114,16 @@ def test_required_solver_proofs_cannot_skip_or_use_a_subprocess_probe() -> None:
             *(f"{module}.has_solver_dependencies" for module in solver_capability_modules),
         }
         for node in ast.walk(tree):
-            if isinstance(node, ast.Import) and any(
-                alias.name == "subprocess" for alias in node.names
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.partition(".")[0] in DEPENDENCY_PROBE_IMPORT_ROOTS:
+                        violations.append(f"{path}:{node.lineno}: import {alias.name}")
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module is not None
+                and node.module.partition(".")[0] in DEPENDENCY_PROBE_IMPORT_ROOTS
             ):
-                violations.append(f"{path}:{node.lineno}: import subprocess")
-            if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
-                violations.append(f"{path}:{node.lineno}: from subprocess")
+                violations.append(f"{path}:{node.lineno}: from {node.module}")
             dotted_name = _dotted_name(node) if isinstance(node, ast.Attribute) else None
             if dotted_name in forbidden_attributes or (
                 dotted_name is not None and dotted_name.endswith(".skipTest")

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -50,7 +50,9 @@ def test_required_solver_proofs_cannot_skip_or_use_a_subprocess_probe() -> None:
                     alias.asname or alias.name for alias in node.names if alias.name == "pytest"
                 )
                 unittest_modules.update(
-                    alias.asname or alias.name for alias in node.names if alias.name == "unittest"
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name in {"unittest", "unittest.case"}
                 )
                 solver_capability_modules.update(
                     alias.asname or alias.name

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -17,6 +17,15 @@ SOLVER_TEST_FILES = (
 SOLVER_PREREQUISITE_FILE = Path("tests/shared/solver_prerequisites.py")
 SOLVER_PREREQUISITE_MODULE = "tests.shared.solver_prerequisites"
 SOLVER_PREREQUISITE_FUNCTION = "require_solver_test_dependencies"
+SOLVER_PROOF_ANCHORS = {
+    SOLVER_TEST_FILES[0]: {"test_solver_counts_locked_group_weight_in_group_constraint"},
+    SOLVER_TEST_FILES[1]: {"test_solver_target_gen_feasible_allocates_with_hard_constraints"},
+    SOLVER_TEST_FILES[2]: {
+        "test_solver_scenarios_are_in_golden_matrix",
+        "scenario_12_solver_ready_feasible.json",
+    },
+    SOLVER_TEST_FILES[3]: {"08_solver_mode.json"},
+}
 DEPENDENCY_PROBE_IMPORT_ROOTS = {"importlib", "pkgutil", "subprocess"}
 SOLVER_DEPENDENCY_IMPORT_ROOTS = {"cvxpy", "numpy"}
 SOLVER_CAPABILITY_MODULE = "src.core.common.capabilities"
@@ -106,12 +115,27 @@ def _module_load_prerequisite_calls(tree: ast.Module) -> set[str]:
     }
 
 
+def _source_anchor_values(tree: ast.Module) -> set[str]:
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    } | {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+
+
 def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -> None:
     violations: list[str] = []
     for path in SOLVER_TEST_FILES:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         assert _module_load_prerequisite_calls(tree), (
             f"{path} must call the solver prerequisite directly at module load"
+        )
+        assert SOLVER_PROOF_ANCHORS[path] <= _source_anchor_values(tree), (
+            f"{path} must retain its required solver proof anchors"
         )
         pytest_modules = {"pytest"}
         pytest_marks: set[str] = set()

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -13,6 +13,9 @@ SOLVER_TEST_FILES = (
     Path("tests/unit/dpm/golden/test_golden_scenarios.py"),
     Path("tests/e2e/demo/test_demo_scenarios.py"),
 )
+SOLVER_PREREQUISITE_FILE = Path("tests/shared/solver_prerequisites.py")
+SOLVER_PREREQUISITE_MODULE = "tests.shared.solver_prerequisites"
+SOLVER_PREREQUISITE_FUNCTION = "require_solver_test_dependencies"
 DEPENDENCY_PROBE_IMPORT_ROOTS = {"importlib", "pkgutil", "subprocess"}
 SOLVER_DEPENDENCY_IMPORT_ROOTS = {"cvxpy", "numpy"}
 SOLVER_CAPABILITY_MODULE = "src.core.common.capabilities"
@@ -55,10 +58,50 @@ def test_cvxpy_is_a_required_test_dependency() -> None:
     assert any(dependency.startswith("cvxpy") for dependency in dev_dependencies)
 
 
+def test_solver_prerequisite_imports_dependencies_at_module_load() -> None:
+    tree = ast.parse(
+        SOLVER_PREREQUISITE_FILE.read_text(encoding="utf-8"),
+        filename=str(SOLVER_PREREQUISITE_FILE),
+    )
+    imported_roots = {
+        alias.name.partition(".")[0]
+        for node in tree.body
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module.partition(".")[0]
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+
+    assert SOLVER_DEPENDENCY_IMPORT_ROOTS <= imported_roots
+
+
+def _module_load_prerequisite_calls(tree: ast.Module) -> set[str]:
+    prerequisite_names = {
+        alias.asname or alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module == SOLVER_PREREQUISITE_MODULE
+        for alias in node.names
+        if alias.name == SOLVER_PREREQUISITE_FUNCTION
+    }
+    return {
+        node.value.func.id
+        for node in tree.body
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Name)
+        and node.value.func.id in prerequisite_names
+    }
+
+
 def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -> None:
     violations: list[str] = []
     for path in SOLVER_TEST_FILES:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        assert _module_load_prerequisite_calls(tree), (
+            f"{path} must call the solver prerequisite directly at module load"
+        )
         pytest_modules = {"pytest"}
         pytest_marks: set[str] = set()
         pytest_skip_calls: set[str] = set()

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -15,6 +15,7 @@ SOLVER_TEST_FILES = (
 )
 DEPENDENCY_PROBE_IMPORT_ROOTS = {"importlib", "pkgutil", "subprocess"}
 SOLVER_DEPENDENCY_IMPORT_ROOTS = {"cvxpy", "numpy"}
+SOLVER_CAPABILITY_MODULE = "src.core.common.capabilities"
 
 
 def _dotted_name(node: ast.expr) -> str | None:
@@ -65,7 +66,7 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
         unittest_case_modules = {"unittest.case"}
         unittest_skip_calls: set[str] = set()
         unittest_skip_exceptions: set[str] = set()
-        solver_capability_modules = {"src.core.common.capabilities"}
+        solver_capability_modules = {SOLVER_CAPABILITY_MODULE}
         solver_capability_calls = {"has_solver_dependencies"}
 
         for node in ast.walk(tree):
@@ -81,11 +82,12 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
                     for alias in node.names
                     if alias.name == "unittest.case"
                 )
-                solver_capability_modules.update(
-                    alias.asname or alias.name
-                    for alias in node.names
-                    if alias.name == "src.core.common.capabilities"
-                )
+                for alias in node.names:
+                    if SOLVER_CAPABILITY_MODULE == alias.name:
+                        solver_capability_modules.add(alias.asname or alias.name)
+                    elif alias.asname and SOLVER_CAPABILITY_MODULE.startswith(f"{alias.name}."):
+                        suffix = SOLVER_CAPABILITY_MODULE.removeprefix(f"{alias.name}.")
+                        solver_capability_modules.add(f"{alias.asname}.{suffix}")
             if isinstance(node, ast.ImportFrom) and node.module == "pytest":
                 for alias in node.names:
                     local_name = alias.asname or alias.name
@@ -107,6 +109,19 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
                     for alias in node.names
                     if alias.name == "has_solver_dependencies"
                 )
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module is not None
+                and SOLVER_CAPABILITY_MODULE.startswith(f"{node.module}.")
+            ):
+                remaining_path = SOLVER_CAPABILITY_MODULE.removeprefix(f"{node.module}.")
+                expected_symbol, _, suffix = remaining_path.partition(".")
+                for alias in node.names:
+                    if alias.name == expected_symbol:
+                        local_name = alias.asname or alias.name
+                        solver_capability_modules.add(
+                            local_name if not suffix else f"{local_name}.{suffix}"
+                        )
 
         forbidden_attributes = {
             *(f"{module}.skip" for module in pytest_modules),

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -146,6 +146,8 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
         unittest_skip_exceptions: set[str] = set()
         solver_capability_modules = {SOLVER_CAPABILITY_MODULE}
         solver_capability_calls = {"has_solver_dependencies"}
+        cvxpy_modules = {"cvxpy"}
+        solver_availability_calls: set[str] = set()
 
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
@@ -161,6 +163,8 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
                     if alias.name == "unittest.case"
                 )
                 for alias in node.names:
+                    if alias.name == "cvxpy":
+                        cvxpy_modules.add(alias.asname or alias.name)
                     if SOLVER_CAPABILITY_MODULE == alias.name:
                         solver_capability_modules.add(alias.asname or alias.name)
                     elif alias.asname and SOLVER_CAPABILITY_MODULE.startswith(f"{alias.name}."):
@@ -200,6 +204,12 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
                         solver_capability_modules.add(
                             local_name if not suffix else f"{local_name}.{suffix}"
                         )
+            if isinstance(node, ast.ImportFrom) and node.module == "cvxpy":
+                solver_availability_calls.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name == "installed_solvers"
+                )
 
         forbidden_attributes = {
             *(f"{module}.skip" for module in pytest_modules),
@@ -227,6 +237,7 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
             *(f"{module}.expectedFailure" for module in unittest_case_modules),
             *(f"{module}.SkipTest" for module in unittest_case_modules),
             *(f"{module}.has_solver_dependencies" for module in solver_capability_modules),
+            *(f"{module}.installed_solvers" for module in cvxpy_modules),
         }
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
@@ -259,7 +270,12 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
                 violations.append(f"{path}:{node.lineno}: {node.id}")
             if isinstance(node, ast.Call):
                 call_name = _dotted_name(node.func)
-                if call_name in pytest_skip_calls | unittest_skip_calls | solver_capability_calls:
+                if call_name in (
+                    pytest_skip_calls
+                    | unittest_skip_calls
+                    | solver_capability_calls
+                    | solver_availability_calls
+                ):
                     violations.append(f"{path}:{node.lineno}: {call_name}")
 
     assert violations == []

--- a/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
+++ b/tests/unit/dpm/engine/test_solver_test_prerequisite_contract.py
@@ -14,6 +14,7 @@ SOLVER_TEST_FILES = (
     Path("tests/e2e/demo/test_demo_scenarios.py"),
 )
 DEPENDENCY_PROBE_IMPORT_ROOTS = {"importlib", "pkgutil", "subprocess"}
+SOLVER_DEPENDENCY_IMPORT_ROOTS = {"cvxpy", "numpy"}
 
 
 def _dotted_name(node: ast.expr) -> str | None:
@@ -23,6 +24,27 @@ def _dotted_name(node: ast.expr) -> str | None:
         owner = _dotted_name(node.value)
         return None if owner is None else f"{owner}.{node.attr}"
     return None
+
+
+def _imports_solver_dependency(node: ast.AST) -> bool:
+    if isinstance(node, ast.Import):
+        return any(
+            alias.name.partition(".")[0] in SOLVER_DEPENDENCY_IMPORT_ROOTS for alias in node.names
+        )
+    return (
+        isinstance(node, ast.ImportFrom)
+        and node.module is not None
+        and node.module.partition(".")[0] in SOLVER_DEPENDENCY_IMPORT_ROOTS
+    )
+
+
+def _caught_exception_names(node: ast.expr | None) -> set[str]:
+    if node is None:
+        return set()
+    if isinstance(node, ast.Tuple):
+        return {name for item in node.elts if (name := _dotted_name(item)) is not None}
+    name = _dotted_name(node)
+    return set() if name is None else {name}
 
 
 def test_cvxpy_is_a_required_test_dependency() -> None:
@@ -124,6 +146,17 @@ def test_required_solver_proofs_cannot_skip_or_probe_dependency_availability() -
                 and node.module.partition(".")[0] in DEPENDENCY_PROBE_IMPORT_ROOTS
             ):
                 violations.append(f"{path}:{node.lineno}: from {node.module}")
+            if isinstance(node, ast.Try) and any(
+                _imports_solver_dependency(descendant)
+                for statement in node.body
+                for descendant in ast.walk(statement)
+            ):
+                violations.append(f"{path}:{node.lineno}: guarded solver dependency import")
+            if isinstance(node, ast.ExceptHandler) and any(
+                name.rpartition(".")[2] in {"ImportError", "ModuleNotFoundError"}
+                for name in _caught_exception_names(node.type)
+            ):
+                violations.append(f"{path}:{node.lineno}: swallowed dependency import failure")
             dotted_name = _dotted_name(node) if isinstance(node, ast.Attribute) else None
             if dotted_name in forbidden_attributes or (
                 dotted_name is not None and dotted_name.endswith(".skipTest")

--- a/tests/unit/dpm/golden/test_golden_scenarios.py
+++ b/tests/unit/dpm/golden/test_golden_scenarios.py
@@ -10,7 +10,6 @@ from typing import Any, Dict
 
 import pytest
 
-from src.core.common.capabilities import has_solver_dependencies
 from src.core.rebalance.engine import run_simulation
 from src.core.models import (
     EngineOptions,
@@ -41,14 +40,10 @@ SCENARIOS = sorted(
     for path in glob.glob(os.path.join(GOLDEN_DIR, "*.json"))
     if _is_rebalance_golden_fixture(path)
 )
-_SOLVER_AVAILABLE = has_solver_dependencies()
 
 
 @pytest.mark.parametrize("filename", SCENARIOS)
 def test_golden_scenario(filename):
-    if filename.startswith("scenario_12_solver_") and not _SOLVER_AVAILABLE:
-        pytest.skip("Solver golden scenarios require cvxpy and numpy")
-
     data = load_golden_file(filename)
     inputs = data["inputs"]
     expected = data.get("expected_output") or data.get("expected_outputs")

--- a/tests/unit/dpm/golden/test_golden_scenarios.py
+++ b/tests/unit/dpm/golden/test_golden_scenarios.py
@@ -18,6 +18,10 @@ from src.core.models import (
     PortfolioSnapshot,
     ShelfEntry,
 )
+from tests.shared.solver_prerequisites import require_solver_test_dependencies
+
+
+require_solver_test_dependencies()
 
 
 def load_golden_file(filename: str) -> Dict[str, Any]:

--- a/tests/unit/dpm/golden/test_golden_scenarios.py
+++ b/tests/unit/dpm/golden/test_golden_scenarios.py
@@ -44,6 +44,15 @@ SCENARIOS = sorted(
     for path in glob.glob(os.path.join(GOLDEN_DIR, "*.json"))
     if _is_rebalance_golden_fixture(path)
 )
+REQUIRED_SOLVER_SCENARIOS = {
+    "scenario_12_solver_conflict.json",
+    "scenario_12_solver_infeasible.json",
+    "scenario_12_solver_ready_feasible.json",
+}
+
+
+def test_solver_scenarios_are_in_golden_matrix():
+    assert REQUIRED_SOLVER_SCENARIOS <= set(SCENARIOS)
 
 
 @pytest.mark.parametrize("filename", SCENARIOS)


### PR DESCRIPTION
Closes #685.

## Outcome
- remove timing-sensitive cvxpy probes and every solver-proof conditional skip/fallback
- require solver proofs to execute because cvxpy and numpy are direct dev/CI prerequisites while remaining in the production solver extra
- load a shared cvxpy/numpy prerequisite directly during collection in every required solver-proof module, so import suppression cannot turn a missing runtime into a passing proof
- retain an alias-aware AST contract across all four solver proof surfaces that rejects pytest/unittest skip and xfail paths, solver-capability and direct backend-availability probes, dependency-discovery imports, and swallowed solver imports
- preserve canonical solver proof anchors in each guarded surface, including the e2e and golden matrices
- refresh quality evidence and document the dependency contract

## Evidence
- exact head `d36558f0346492ed3745bdd1dd23825a7113c037`
- PR Merge Gate run `34317229533`: all lint, unit, integration, e2e, PostgreSQL, combined coverage, quality, workflow, and image-evidence jobs passed
- local exact head: `make static-quality-gates` PASS; focused four-surface solver/guard suite: 92 passed
- exact ancestor `3b33efaa`: required-PostgreSQL `make test-all-fast` PASS; 3780 passed, no skips, coverage 99.01%, seed 529115693
- representative bad mutations rejected before restoration, including missing solver imports, suppressed imports, skip/xfail aliases, direct/transitive dependency drift, capability/backend probes, and removed e2e solver proof
- automated Codex review completed on exact head with no major issues; all 16 review threads resolved
- all branch commits signature-valid (`%G? = G`)
- wiki source unchanged by this PR; strict source/publication parity: 0

## Documentation decision
README and repository engineering context now describe the collection-time solver prerequisite. No wiki source change is needed because this is a contributor test-lane dependency rule rather than an operator runtime procedure.
