### PR TITLE
feat(dpm): inventory quarantined tenant rows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: architecture-gate complexity-gate duplicate-implementation-gate dead-code-gate dependency-hygiene-gate workflow-policy-gate quality-report-gate test-family-inventory coverage-gate static-quality-gates install install-ci check check-all test test-unit test-integration test-idea-management-action-postgres test-e2e test-unit-coverage test-integration-coverage test-e2e-coverage test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate api-vocabulary-gate service-boundary-gate router-infrastructure-gate live-api-validate live-api-validate-core demo-certify format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-image-evidence docker-up docker-down
+.PHONY: architecture-gate complexity-gate duplicate-implementation-gate dead-code-gate dependency-hygiene-gate workflow-policy-gate quality-report-gate test-family-inventory coverage-gate static-quality-gates install install-ci check check-all test test-unit test-integration test-idea-management-action-postgres test-e2e test-unit-coverage test-integration-coverage test-e2e-coverage test-all test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate api-vocabulary-gate service-boundary-gate router-infrastructure-gate live-api-validate live-api-validate-core demo-certify format clean run check-deps security-audit migration-smoke migration-apply quarantine-inventory pre-commit docker-build docker-image-evidence docker-up docker-down
 
 COVERAGE_FAIL_UNDER ?= 99
 IMAGE_NAME ?= lotus-manage
@@ -159,6 +159,9 @@ migration-smoke:
 
 migration-apply:
 	python scripts/postgres_migrate.py --target dpm
+
+quarantine-inventory:
+	python scripts/quarantined_tenant_inventory.py --limit $${QUARANTINE_INVENTORY_LIMIT:-20}
 
 lint:
 	python -m ruff check .

--- a/README.md
+++ b/README.md
@@ -358,6 +358,23 @@ Invalid values fail production readiness with `POSTGRES_ACCESS_POLICY_INVALID:*`
 request hashes, or payload content. Runtime repositories do not retry writes blindly; operators
 should treat database failures as infrastructure faults and follow the Postgres rollout runbook.
 
+Rows retained without verified tenant attribution remain deliberately quarantined: normal tenant
+reads match none of them. Operators can inventory every governed quarantine dataset without
+changing it by setting `DPM_SUPPORTABILITY_POSTGRES_DSN` and running:
+
+```bash
+make quarantine-inventory
+```
+
+The command reports counts, at most 20 identifying rows per dataset by default, truncation, and
+applied migration checksums. Migration `0029` supplies the partial NULL-tenant index that keeps the
+monitoring-run count and sample bounded as history grows. Set `QUARANTINE_INVENTORY_LIMIT` to
+`1..100` for a different bound.
+It runs in a repeatable-read, read-only transaction; an explicit successful zero is healthy, while
+missing migration provenance, connection failure, or an unsafe bound exits nonzero with a
+sanitized error. Idempotency keys are SHA-256 hashed and payloads, DSNs, and tenant guesses are
+never emitted. See [the operations runbook](docs/operations-runbook.md#null-tenant-quarantine-inventory).
+
 Async scenario analysis defaults to inline execution in Docker. For accept-now/execute-later live
 proof, start the stack with `DPM_ASYNC_EXECUTION_MODE=ACCEPT_ONLY`; manual execution can be disabled
 with `DPM_ASYNC_MANUAL_EXECUTION_ENABLED=false` when the execute endpoint must be hidden.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1072,6 +1072,14 @@ Use these commands as the primary local contract:
    `make domain-product-validate`
 9. test-family proof-breadth validation
    `make test-family-inventory`
+10. NULL-tenant quarantine inventory
+    `make quarantine-inventory`
+    This operator-only command is the canonical observation path for the seven datasets retained
+    without verified tenant attribution by migrations `0003` and `0024` through `0028`; migration
+    `0029` supplies the partial monitoring-run index required for bounded census cost. The command
+    must remain bounded, sanitized, migration-provenanced, and transactionally read-only. A
+    successful zero is distinct from failure; nonzero results do not authorize tenant inference or
+    mutation.
 
 ## Validation And CI Expectations
 

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -32,6 +32,44 @@ For full repo-native evidence in production-oriented work, run:
   parity; no service source tree outside `lotus-manage` is writable inside the CI container.
 - `make mesh-contract-validate`
 
+## NULL-tenant quarantine inventory
+
+Migrations `0003` and `0024` through `0028` deliberately retain rows that cannot be attributed to
+a verified tenant. Migration `0029` adds the partial index required to inventory the original
+`dpm_monitoring_runs` quarantine without scanning full monitoring history. Those rows match no
+ordinary tenant-scoped repository read and must not be assigned, updated, deleted, or exposed
+through an API merely to make a count disappear.
+
+From the `lotus-manage` repository root, set the same governed PostgreSQL DSN used by the service,
+then run either shell's equivalent:
+
+```powershell
+$env:DPM_SUPPORTABILITY_POSTGRES_DSN = '<bank-managed PostgreSQL DSN>'
+$env:QUARANTINE_INVENTORY_LIMIT = '20'
+make quarantine-inventory
+```
+
+```bash
+export DPM_SUPPORTABILITY_POSTGRES_DSN='<bank-managed PostgreSQL DSN>'
+export QUARANTINE_INVENTORY_LIMIT=20
+make quarantine-inventory
+```
+
+The JSON result covers all seven governed datasets, reports each total and a stable bounded sample,
+marks truncation explicitly, and includes the applied migration version and checksum. The command
+opens a repeatable-read, read-only transaction and always rolls it back. It hashes idempotency keys
+and never emits payloads or the DSN.
+
+- `status: success` with `totalQuarantinedRows: 0` is an explicit successful zero.
+- `truncated: true` means increase `QUARANTINE_INVENTORY_LIMIT` within `1..100` or query the
+  identified dataset through an approved database-support procedure; it is not authority to infer
+  ownership.
+- Exit code `1` with `QUARANTINE_INVENTORY_FAILED` means the inventory is not evidence. Verify
+  connectivity, the bound, and DPM migration application. The sanitized output intentionally omits
+  connection details.
+- Treat nonzero counts as an attribution backlog for an authorized data owner. This command is
+  observation only and provides no remediation or tenant-assignment path.
+
 ## Incident triage
 
 - If health fails, verify startup migration state and storage adapter configuration first.

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T05:59:13+00:00`
+- Generated at: `2026-09-09T07:11:04+00:00`
 
-- Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
+- Baseline source snapshot: `435e1c8b259c82c8aff0546d7083f336d5644e64`
 
-- Report source snapshot: `f0fd61f3+worktree`
+- Report source snapshot: `c15e1b29+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 939 |
-| Total Python LOC | 220440 |
-| Test functions | 3205 |
+| Python files | 945 |
+| Total Python LOC | 221340 |
+| Test functions | 3218 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T05:59:13+00:00`
+- Generated at: `2026-09-09T07:11:04+00:00`
 
-- Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
+- Baseline source snapshot: `435e1c8b259c82c8aff0546d7083f336d5644e64`
 
-- Report source snapshot: `f0fd61f3+worktree`
+- Report source snapshot: `c15e1b29+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T05:59:13+00:00`
+- Generated at: `2026-09-09T07:11:04+00:00`
 
-- Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
+- Baseline source snapshot: `435e1c8b259c82c8aff0546d7083f336d5644e64`
 
-- Report source snapshot: `f0fd61f3+worktree`
+- Report source snapshot: `c15e1b29+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T05:59:13+00:00`
+- Generated at: `2026-09-09T07:11:04+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `eb46ae6f8bea094335d25f2f4fe8049a45647a34`
+- Baseline source snapshot: `435e1c8b259c82c8aff0546d7083f336d5644e64`
 
-- Report source snapshot: `f0fd61f3+worktree`
+- Report source snapshot: `c15e1b29+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 937 | 939 | +2 |
-| Total Python LOC | 220197 | 220440 | +243 |
-| Test functions | 3201 | 3205 | +4 |
+| Python files | 939 | 945 | +6 |
+| Total Python LOC | 220440 | 221340 | +900 |
+| Test functions | 3205 | 3218 | +13 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ runtime validation, and release evidence.
 | `clean_generated_artifacts.py` | Removes ignored generated caches, coverage files, build output, logs, and `output/` evidence. | `make clean` |
 | `docker_image_evidence.py` | Writes Docker release manifest, image inspect, SBOM/scan/signature status, and provenance summary evidence. | `make docker-image-evidence` |
 | `postgres_migrate.py` | Migration smoke/apply helper. | `make migration-smoke` or `make migration-apply` |
+| `quarantined_tenant_inventory.py` | Read-only, bounded inventory of every governed NULL-tenant quarantine dataset. | `make quarantine-inventory` |
 | `Start-CanonicalManage.ps1` | Canonical local Manage service startup helper. | `make run-canonical` |
 
 Prefer the Make target that wraps a script because CI uses those targets as the stable contract.

--- a/scripts/quarantined_tenant_inventory.py
+++ b/scripts/quarantined_tenant_inventory.py
@@ -1,0 +1,81 @@
+"""Emit a bounded read-only inventory of NULL-tenant quarantine rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Sequence
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.infrastructure.quarantined_tenant_inventory import INVENTORY_SCHEMA_VERSION  # noqa: E402
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Report every retained NULL-tenant dataset without changing database rows."
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.getenv("DPM_SUPPORTABILITY_POSTGRES_DSN", "").strip(),
+        help="PostgreSQL DSN; defaults to DPM_SUPPORTABILITY_POSTGRES_DSN.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum identifying rows returned per dataset (1-100; default 20).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if not args.dsn:
+            raise RuntimeError("QUARANTINE_INVENTORY_DSN_REQUIRED")
+        if find_spec("psycopg") is None:
+            raise RuntimeError("QUARANTINE_INVENTORY_DRIVER_MISSING")
+        report = _run_inventory(dsn=args.dsn, limit=args.limit)
+    except Exception:
+        print(
+            json.dumps(
+                {
+                    "schemaVersion": INVENTORY_SCHEMA_VERSION,
+                    "status": "error",
+                    "errorCode": "QUARANTINE_INVENTORY_FAILED",
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+def _run_inventory(*, dsn: str, limit: int) -> dict[str, object]:
+    import psycopg
+    from psycopg.rows import dict_row
+
+    from src.infrastructure.postgres_access import connect_postgres
+    from src.infrastructure.quarantined_tenant_inventory import (
+        build_quarantined_tenant_inventory,
+    )
+
+    with connect_postgres(
+        dsn,
+        connect_fn=psycopg.connect,
+        row_factory=dict_row,
+        application_name="lotus-manage-quarantine-inventory",
+    ) as connection:
+        return build_quarantined_tenant_inventory(connection=connection, limit=limit)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/infrastructure/postgres_migrations/dpm/0029_monitoring_run_quarantine_inventory.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0029_monitoring_run_quarantine_inventory.sql
@@ -1,0 +1,6 @@
+-- Monitoring runs have carried a nullable tenant_id since 0003. The NULL rows
+-- remain deliberately quarantined, and the operator census must not turn the
+-- common zero-row case into a full history scan as this table grows.
+CREATE INDEX IF NOT EXISTS idx_dpm_monitoring_runs_null_tenant_inventory
+    ON dpm_monitoring_runs (monitoring_run_id)
+    WHERE tenant_id IS NULL;

--- a/src/infrastructure/quarantined_tenant_inventory.py
+++ b/src/infrastructure/quarantined_tenant_inventory.py
@@ -1,0 +1,234 @@
+"""Read-only inventory of rows retained without verified tenant attribution."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+
+_SAFE_IDENTIFIER = re.compile(r"^[a-z][a-z0-9_]*$")
+INVENTORY_SCHEMA_VERSION = "lotus-manage.quarantined-tenant-inventory.v1"
+
+
+@dataclass(frozen=True)
+class QuarantinedTenantDataset:
+    """One database dataset whose NULL tenant rows remain fail-closed."""
+
+    name: str
+    migration_version: str
+    migration_path: str
+    identifying_columns: tuple[str, ...]
+    hashed_columns: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        identifiers = (self.name, *self.identifying_columns)
+        if not self.identifying_columns or any(
+            _SAFE_IDENTIFIER.fullmatch(identifier) is None for identifier in identifiers
+        ):
+            raise ValueError("QUARANTINE_INVENTORY_UNSAFE_REGISTRY_IDENTIFIER")
+        if not self.hashed_columns <= set(self.identifying_columns):
+            raise ValueError("QUARANTINE_INVENTORY_INVALID_HASHED_COLUMN")
+
+
+QUARANTINED_TENANT_DATASETS = (
+    QuarantinedTenantDataset(
+        name="dpm_mandate_snapshots",
+        migration_version="0024",
+        migration_path="src/infrastructure/postgres_migrations/dpm/0024_mandate_tenant_scope.sql",
+        identifying_columns=(
+            "mandate_snapshot_id",
+            "mandate_id",
+            "portfolio_id",
+            "mandate_version",
+            "as_of_date",
+            "created_at",
+        ),
+    ),
+    QuarantinedTenantDataset(
+        name="dpm_mandate_health_snapshots",
+        migration_version="0024",
+        migration_path="src/infrastructure/postgres_migrations/dpm/0024_mandate_tenant_scope.sql",
+        identifying_columns=(
+            "health_snapshot_id",
+            "mandate_id",
+            "portfolio_id",
+            "as_of_date",
+            "created_at",
+        ),
+    ),
+    QuarantinedTenantDataset(
+        name="dpm_monitoring_exceptions",
+        migration_version="0025",
+        migration_path=(
+            "src/infrastructure/postgres_migrations/dpm/0025_monitoring_exception_tenant_scope.sql"
+        ),
+        identifying_columns=(
+            "exception_id",
+            "monitoring_run_id",
+            "mandate_id",
+            "portfolio_id",
+            "as_of_date",
+            "detected_at",
+        ),
+    ),
+    QuarantinedTenantDataset(
+        name="dpm_rebalance_wave_idempotency",
+        migration_version="0026",
+        migration_path=(
+            "src/infrastructure/postgres_migrations/dpm/0026_wave_idempotency_tenant_scope.sql"
+        ),
+        identifying_columns=("idempotency_key", "wave_id", "created_at"),
+        hashed_columns=frozenset({"idempotency_key"}),
+    ),
+    QuarantinedTenantDataset(
+        name="dpm_rebalance_waves",
+        migration_version="0027",
+        migration_path="src/infrastructure/postgres_migrations/dpm/0027_wave_tenant_scope.sql",
+        identifying_columns=("wave_id", "as_of_date", "created_at"),
+    ),
+    QuarantinedTenantDataset(
+        name="dpm_pre_trade_proof_packs",
+        migration_version="0028",
+        migration_path=(
+            "src/infrastructure/postgres_migrations/dpm/0028_proof_pack_tenant_scope.sql"
+        ),
+        identifying_columns=(
+            "proof_pack_id",
+            "portfolio_id",
+            "mandate_id",
+            "source_type",
+            "status",
+            "created_at",
+        ),
+    ),
+    QuarantinedTenantDataset(
+        name="dpm_monitoring_runs",
+        migration_version="0029",
+        migration_path=(
+            "src/infrastructure/postgres_migrations/dpm/"
+            "0029_monitoring_run_quarantine_inventory.sql"
+        ),
+        identifying_columns=("monitoring_run_id", "as_of_date", "status", "started_at"),
+    ),
+)
+
+
+def build_quarantined_tenant_inventory(*, connection: Any, limit: int) -> dict[str, Any]:
+    """Return a consistent bounded inventory and always roll back the read-only transaction."""
+
+    if limit < 1 or limit > 100:
+        raise ValueError("QUARANTINE_INVENTORY_LIMIT_OUT_OF_RANGE")
+
+    connection.execute("BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY")
+    try:
+        read_only_row = connection.execute("SHOW transaction_read_only").fetchone()
+        if str(_row_value(read_only_row, "transaction_read_only")).lower() != "on":
+            raise RuntimeError("QUARANTINE_INVENTORY_TRANSACTION_NOT_READ_ONLY")
+
+        migration_checksums = _load_migration_checksums(connection)
+        datasets = [
+            _inventory_dataset(
+                connection=connection,
+                dataset=dataset,
+                limit=limit,
+                migration_checksums=migration_checksums,
+            )
+            for dataset in QUARANTINED_TENANT_DATASETS
+        ]
+        return {
+            "schemaVersion": INVENTORY_SCHEMA_VERSION,
+            "status": "success",
+            "readOnly": True,
+            "limitPerDataset": limit,
+            "totalQuarantinedRows": sum(item["totalCount"] for item in datasets),
+            "datasets": datasets,
+        }
+    finally:
+        connection.rollback()
+
+
+def _load_migration_checksums(connection: Any) -> dict[str, str]:
+    rows = connection.execute(
+        """
+        SELECT version, checksum
+        FROM schema_migrations
+        WHERE namespace = %s
+        ORDER BY version ASC
+        """,
+        ("dpm",),
+    ).fetchall()
+    return {str(_row_value(row, "version")): str(_row_value(row, "checksum")) for row in rows}
+
+
+def _inventory_dataset(
+    *,
+    connection: Any,
+    dataset: QuarantinedTenantDataset,
+    limit: int,
+    migration_checksums: dict[str, str],
+) -> dict[str, Any]:
+    stored_version = f"dpm:{dataset.migration_version}"
+    checksum = migration_checksums.get(stored_version) or migration_checksums.get(
+        dataset.migration_version
+    )
+    if checksum is None:
+        raise RuntimeError(f"QUARANTINE_INVENTORY_MIGRATION_NOT_APPLIED:{stored_version}")
+
+    count_row = connection.execute(
+        f"SELECT COUNT(*) AS total_count FROM {dataset.name} WHERE tenant_id IS NULL"
+    ).fetchone()
+    total_count = int(_row_value(count_row, "total_count"))
+    columns = ", ".join(dataset.identifying_columns)
+    detail_rows = connection.execute(
+        f"SELECT {columns} FROM {dataset.name} "
+        f"WHERE tenant_id IS NULL ORDER BY {dataset.identifying_columns[0]} ASC LIMIT %s",
+        (limit,),
+    ).fetchall()
+    rows = [_safe_detail_row(row=row, dataset=dataset) for row in detail_rows]
+    return {
+        "dataset": dataset.name,
+        "migration": {
+            "namespace": "dpm",
+            "version": dataset.migration_version,
+            "storedVersion": stored_version,
+            "path": dataset.migration_path,
+            "checksum": checksum,
+        },
+        "totalCount": total_count,
+        "returnedCount": len(rows),
+        "truncated": total_count > len(rows),
+        "rows": rows,
+    }
+
+
+def _safe_detail_row(
+    *, row: Any, dataset: QuarantinedTenantDataset
+) -> dict[str, str | int | float | bool | None]:
+    detail: dict[str, str | int | float | bool | None] = {}
+    for column in dataset.identifying_columns:
+        value = _row_value(row, column)
+        if column in dataset.hashed_columns:
+            detail[f"{column}Sha256"] = hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+        else:
+            detail[column] = _json_scalar(value)
+    return detail
+
+
+def _row_value(row: Any, column: str) -> Any:
+    if isinstance(row, dict):
+        return row[column]
+    try:
+        return row[column]
+    except (KeyError, TypeError):
+        raise RuntimeError("QUARANTINE_INVENTORY_ROW_FACTORY_REQUIRED") from None
+
+
+def _json_scalar(value: Any) -> str | int | float | bool | None:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    return str(value)

--- a/tests/integration/dpm/test_quarantined_tenant_inventory_postgres.py
+++ b/tests/integration/dpm/test_quarantined_tenant_inventory_postgres.py
@@ -1,0 +1,256 @@
+"""Operator quarantine inventory proof against PostgreSQL (#699)."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from contextlib import closing
+
+import psycopg
+from psycopg.rows import dict_row
+
+from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository
+from src.infrastructure.proof_packs.postgres import PostgresDpmProofPackRepository
+from src.infrastructure.quarantined_tenant_inventory import (
+    QUARANTINED_TENANT_DATASETS,
+    build_quarantined_tenant_inventory,
+)
+from src.infrastructure.waves.postgres import PostgresDpmWaveRepository
+
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
+
+_PROOF = "quarantined tenant inventory proof"
+_TENANT = "tenant-inventory-proof"
+
+
+def test_inventory_reports_every_quarantine_without_making_it_tenant_readable() -> None:
+    dsn = postgres_dsn_or_skip(_PROOF)
+    suffix = uuid.uuid4().hex[:12]
+    ids = {
+        "mandate_snapshot_id": f"aaa_inventory_ms_{suffix}",
+        "health_snapshot_id": f"aaa_inventory_hs_{suffix}",
+        "exception_id": f"aaa_inventory_ex_{suffix}",
+        "idempotency_key": f"aaa-inventory-idem-{suffix}",
+        "wave_id": f"aaa_inventory_wave_{suffix}",
+        "proof_pack_id": f"aaa_inventory_pp_{suffix}",
+        "monitoring_run_id": f"aaa_inventory_run_{suffix}",
+        "mandate_id": f"MANDATE_INVENTORY_{suffix}",
+        "portfolio_id": f"PF_INVENTORY_{suffix}",
+    }
+
+    _insert_quarantined_rows(dsn=dsn, ids=ids)
+    try:
+        before = _row_counts(dsn=dsn, ids=ids)
+        with closing(psycopg.connect(dsn, row_factory=dict_row)) as connection:
+            inventory = build_quarantined_tenant_inventory(connection=connection, limit=100)
+        after = _row_counts(dsn=dsn, ids=ids)
+
+        assert inventory["status"] == "success"
+        assert inventory["readOnly"] is True
+        assert before == after == {dataset.name: 1 for dataset in QUARANTINED_TENANT_DATASETS}
+
+        with psycopg.connect(dsn, row_factory=dict_row) as connection:
+            index_row = connection.execute(
+                """
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE schemaname = current_schema()
+                  AND indexname = 'idx_dpm_monitoring_runs_null_tenant_inventory'
+                """
+            ).fetchone()
+        assert index_row is not None
+        assert "WHERE (tenant_id IS NULL)" in index_row["indexdef"]
+
+        by_name = {item["dataset"]: item for item in inventory["datasets"]}
+        assert set(by_name) == {dataset.name for dataset in QUARANTINED_TENANT_DATASETS}
+        assert all(item["totalCount"] >= 1 for item in by_name.values())
+        assert all(item["migration"]["checksum"] for item in by_name.values())
+
+        expected_identifiers = {
+            "dpm_mandate_snapshots": ("mandate_snapshot_id", ids["mandate_snapshot_id"]),
+            "dpm_mandate_health_snapshots": (
+                "health_snapshot_id",
+                ids["health_snapshot_id"],
+            ),
+            "dpm_monitoring_exceptions": ("exception_id", ids["exception_id"]),
+            "dpm_rebalance_waves": ("wave_id", ids["wave_id"]),
+            "dpm_pre_trade_proof_packs": ("proof_pack_id", ids["proof_pack_id"]),
+            "dpm_monitoring_runs": ("monitoring_run_id", ids["monitoring_run_id"]),
+        }
+        for dataset, (column, value) in expected_identifiers.items():
+            assert any(row[column] == value for row in by_name[dataset]["rows"])
+        expected_key_hash = hashlib.sha256(ids["idempotency_key"].encode()).hexdigest()
+        assert any(
+            row["idempotency_keySha256"] == expected_key_hash
+            for row in by_name["dpm_rebalance_wave_idempotency"]["rows"]
+        )
+
+        mandate_repository = PostgresDpmMandateRepository(dsn=dsn)
+        wave_repository = PostgresDpmWaveRepository(dsn=dsn)
+        proof_pack_repository = PostgresDpmProofPackRepository(dsn=dsn)
+        assert (
+            mandate_repository.get_latest_mandate(mandate_id=ids["mandate_id"], tenant_id=_TENANT)
+            is None
+        )
+        assert (
+            mandate_repository.get_monitoring_run(
+                monitoring_run_id=ids["monitoring_run_id"], tenant_id=_TENANT
+            )
+            is None
+        )
+        exceptions, _ = mandate_repository.list_monitoring_exceptions(
+            monitoring_run_id=ids["monitoring_run_id"],
+            mandate_id=None,
+            portfolio_id=None,
+            state=None,
+            limit=50,
+            cursor=None,
+            tenant_id=_TENANT,
+        )
+        assert exceptions == []
+        assert wave_repository.get_wave(wave_id=ids["wave_id"], tenant_id=_TENANT) is None
+        assert (
+            wave_repository.get_wave_by_idempotency(
+                idempotency_key=ids["idempotency_key"], tenant_id=_TENANT
+            )
+            is None
+        )
+        assert (
+            proof_pack_repository.get_proof_pack(
+                proof_pack_id=ids["proof_pack_id"], tenant_id=_TENANT
+            )
+            is None
+        )
+    finally:
+        _delete_quarantined_rows(dsn=dsn, ids=ids)
+
+
+def _insert_quarantined_rows(*, dsn: str, ids: dict[str, str]) -> None:
+    with psycopg.connect(dsn, row_factory=dict_row) as connection:
+        connection.execute(
+            """
+            INSERT INTO dpm_mandate_snapshots (
+                mandate_snapshot_id, mandate_id, portfolio_id, mandate_version, as_of_date,
+                source_hash, source_lineage_json, payload_json, created_at, created_by
+            ) VALUES (%s, %s, %s, '1', '2026-09-09', 'sha256:inventory', '[]', '{}',
+                      '2026-09-09T00:00:00+00:00', 'inventory-proof')
+            """,
+            (
+                ids["mandate_snapshot_id"],
+                ids["mandate_id"],
+                ids["portfolio_id"],
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO dpm_mandate_health_snapshots (
+                health_snapshot_id, mandate_id, portfolio_id, as_of_date, health_score,
+                health_state, source_readiness_state, dimension_scores_json, payload_json,
+                created_at
+            ) VALUES (%s, %s, %s, '2026-09-09', 50, 'REVIEW', 'COMPLETE', '[]', '{}',
+                      '2026-09-09T00:00:00+00:00')
+            """,
+            (ids["health_snapshot_id"], ids["mandate_id"], ids["portfolio_id"]),
+        )
+        connection.execute(
+            """
+            INSERT INTO dpm_monitoring_runs (
+                monitoring_run_id, as_of_date, status, filters_json,
+                source_readiness_summary_json, started_at
+            ) VALUES (%s, '2026-09-09', 'SUCCEEDED', '{}', '{}',
+                      '2026-09-09T00:00:00+00:00')
+            """,
+            (ids["monitoring_run_id"],),
+        )
+        connection.execute(
+            """
+            INSERT INTO dpm_monitoring_exceptions (
+                exception_id, monitoring_run_id, mandate_id, portfolio_id, as_of_date,
+                dimension, severity, reason_code, state, recommended_action,
+                source_lineage_json, payload_json, detected_at
+            ) VALUES (%s, %s, %s, %s, '2026-09-09', 'RISK', 'MEDIUM', 'INVENTORY',
+                      'OPEN', 'Review attribution', '[]', '{}',
+                      '2026-09-09T00:00:00+00:00')
+            """,
+            (
+                ids["exception_id"],
+                ids["monitoring_run_id"],
+                ids["mandate_id"],
+                ids["portfolio_id"],
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO dpm_rebalance_waves (
+                wave_id, state, trigger_type, as_of_date, created_at, created_by,
+                correlation_id, version, wave_json, retention_policy
+            ) VALUES (%s, 'CREATED', 'EXPLICIT_PORTFOLIO_LIST', '2026-09-09',
+                      '2026-09-09T00:00:00+00:00', 'inventory-proof', %s, 1, '{}', 'STANDARD')
+            """,
+            (ids["wave_id"], f"corr-{ids['wave_id']}"),
+        )
+        connection.execute(
+            """
+            INSERT INTO dpm_rebalance_wave_idempotency (
+                idempotency_key, wave_id, request_hash, created_at
+            ) VALUES (%s, %s, 'inventory-hash', '2026-09-09T00:00:00+00:00')
+            """,
+            (ids["idempotency_key"], ids["wave_id"]),
+        )
+        connection.execute(
+            """
+            INSERT INTO dpm_pre_trade_proof_packs (
+                proof_pack_id, portfolio_id, mandate_id, source_type, status, content_hash,
+                retention_policy, payload_json, created_at
+            ) VALUES (%s, %s, %s, 'OPERATOR', 'READY', 'inventory-hash', 'STANDARD', '{}',
+                      '2026-09-09T00:00:00+00:00')
+            """,
+            (ids["proof_pack_id"], ids["portfolio_id"], ids["mandate_id"]),
+        )
+        connection.commit()
+
+
+def _row_counts(*, dsn: str, ids: dict[str, str]) -> dict[str, int]:
+    predicates = {
+        "dpm_mandate_snapshots": ("mandate_snapshot_id", ids["mandate_snapshot_id"]),
+        "dpm_mandate_health_snapshots": ("health_snapshot_id", ids["health_snapshot_id"]),
+        "dpm_monitoring_exceptions": ("exception_id", ids["exception_id"]),
+        "dpm_rebalance_wave_idempotency": ("idempotency_key", ids["idempotency_key"]),
+        "dpm_rebalance_waves": ("wave_id", ids["wave_id"]),
+        "dpm_pre_trade_proof_packs": ("proof_pack_id", ids["proof_pack_id"]),
+        "dpm_monitoring_runs": ("monitoring_run_id", ids["monitoring_run_id"]),
+    }
+    with psycopg.connect(dsn, row_factory=dict_row) as connection:
+        return {
+            table: connection.execute(
+                f"SELECT COUNT(*) AS count FROM {table} WHERE {column} = %s AND tenant_id IS NULL",
+                (value,),
+            ).fetchone()["count"]
+            for table, (column, value) in predicates.items()
+        }
+
+
+def _delete_quarantined_rows(*, dsn: str, ids: dict[str, str]) -> None:
+    with psycopg.connect(dsn) as connection:
+        connection.execute(
+            "DELETE FROM dpm_monitoring_exceptions WHERE exception_id = %s",
+            (ids["exception_id"],),
+        )
+        connection.execute(
+            "DELETE FROM dpm_monitoring_runs WHERE monitoring_run_id = %s",
+            (ids["monitoring_run_id"],),
+        )
+        connection.execute(
+            "DELETE FROM dpm_mandate_health_snapshots WHERE health_snapshot_id = %s",
+            (ids["health_snapshot_id"],),
+        )
+        connection.execute(
+            "DELETE FROM dpm_mandate_snapshots WHERE mandate_snapshot_id = %s",
+            (ids["mandate_snapshot_id"],),
+        )
+        connection.execute(
+            "DELETE FROM dpm_pre_trade_proof_packs WHERE proof_pack_id = %s",
+            (ids["proof_pack_id"],),
+        )
+        connection.execute("DELETE FROM dpm_rebalance_waves WHERE wave_id = %s", (ids["wave_id"],))
+        connection.commit()

--- a/tests/unit/infrastructure/test_quarantined_tenant_inventory.py
+++ b/tests/unit/infrastructure/test_quarantined_tenant_inventory.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.infrastructure.quarantined_tenant_inventory import (
+    QUARANTINED_TENANT_DATASETS,
+    QuarantinedTenantDataset,
+    _json_scalar,
+    _row_value,
+    build_quarantined_tenant_inventory,
+)
+
+
+class _Result:
+    def __init__(
+        self, *, row: dict[str, Any] | None = None, rows: list[dict[str, Any]] | None = None
+    ):
+        self._row = row
+        self._rows = rows or []
+
+    def fetchone(self) -> dict[str, Any] | None:
+        return self._row
+
+    def fetchall(self) -> list[dict[str, Any]]:
+        return self._rows
+
+
+class _StringRow:
+    def __getitem__(self, column: str) -> str:
+        assert column == "value"
+        return "indexed"
+
+
+class _Connection:
+    def __init__(
+        self,
+        *,
+        rows: dict[str, list[dict[str, Any]]] | None = None,
+        applied_versions: set[str] | None = None,
+        read_only: str = "on",
+    ) -> None:
+        self.rows = rows or {}
+        self.applied_versions = applied_versions or {
+            "dpm:0003",
+            "dpm:0024",
+            "dpm:0025",
+            "dpm:0026",
+            "dpm:0027",
+            "dpm:0028",
+            "dpm:0029",
+        }
+        self.statements: list[str] = []
+        self.rollback_count = 0
+        self.read_only = read_only
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> _Result:
+        normalized = " ".join(sql.split())
+        self.statements.append(normalized)
+        if normalized == "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY":
+            return _Result()
+        if normalized == "SHOW transaction_read_only":
+            return _Result(row={"transaction_read_only": self.read_only})
+        if "FROM schema_migrations" in normalized:
+            return _Result(
+                rows=[
+                    {"version": version, "checksum": f"checksum:{version}"}
+                    for version in sorted(self.applied_versions)
+                ]
+            )
+        table = re.search(r" FROM (dpm_[a-z0-9_]+) ", f" {normalized} ")
+        assert table is not None, normalized
+        dataset_rows = self.rows.get(table.group(1), [])
+        if normalized.startswith("SELECT COUNT(*)"):
+            return _Result(row={"total_count": len(dataset_rows)})
+        assert params is not None
+        return _Result(rows=dataset_rows[: int(params[0])])
+
+    def rollback(self) -> None:
+        self.rollback_count += 1
+
+
+def test_registry_matches_every_final_nullable_tenant_dataset() -> None:
+    migrations = Path("src/infrastructure/postgres_migrations/dpm")
+    nullable_tables: set[str] = set()
+    not_null_tables: set[str] = set()
+    for path in sorted(migrations.glob("*.sql")):
+        sql = path.read_text(encoding="utf-8")
+        for table, definition in re.findall(
+            r"CREATE TABLE IF NOT EXISTS\s+(dpm_[a-z0-9_]+)\s*\((.*?)\);",
+            sql,
+            flags=re.DOTALL | re.IGNORECASE,
+        ):
+            tenant_column = re.search(r"tenant_id\s+TEXT([^,\n]*)", definition, re.IGNORECASE)
+            if tenant_column and "NOT NULL" not in tenant_column.group(1).upper():
+                nullable_tables.add(table)
+        nullable_tables.update(
+            re.findall(
+                r"ALTER TABLE\s+(dpm_[a-z0-9_]+).*?"
+                r"ADD COLUMN IF NOT EXISTS tenant_id\s+TEXT(?:\s+NULL)?\s*;",
+                sql,
+                flags=re.DOTALL | re.IGNORECASE,
+            )
+        )
+        not_null_tables.update(
+            re.findall(
+                r"ALTER TABLE\s+(dpm_[a-z0-9_]+)\s+ALTER COLUMN tenant_id SET NOT NULL",
+                sql,
+                flags=re.IGNORECASE,
+            )
+        )
+
+    final_nullable_tables = nullable_tables - not_null_tables
+    assert {dataset.name for dataset in QUARANTINED_TENANT_DATASETS} == final_nullable_tables
+    assert len(QUARANTINED_TENANT_DATASETS) == 7
+
+
+def test_monitoring_run_inventory_requires_its_bounded_scan_index() -> None:
+    migration = Path(
+        "src/infrastructure/postgres_migrations/dpm/0029_monitoring_run_quarantine_inventory.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "idx_dpm_monitoring_runs_null_tenant_inventory" in migration
+    assert "ON dpm_monitoring_runs (monitoring_run_id)" in migration
+    assert "WHERE tenant_id IS NULL" in migration
+    monitoring_runs = next(
+        dataset for dataset in QUARANTINED_TENANT_DATASETS if dataset.name == "dpm_monitoring_runs"
+    )
+    assert monitoring_runs.migration_version == "0029"
+
+
+def test_clean_estate_is_an_explicit_successful_zero_read_only_report() -> None:
+    connection = _Connection()
+
+    report = build_quarantined_tenant_inventory(connection=connection, limit=20)
+
+    assert report["status"] == "success"
+    assert report["readOnly"] is True
+    assert report["totalQuarantinedRows"] == 0
+    assert len(report["datasets"]) == 7
+    assert all(dataset["totalCount"] == 0 for dataset in report["datasets"])
+    assert all(dataset["rows"] == [] for dataset in report["datasets"])
+    assert all(dataset["truncated"] is False for dataset in report["datasets"])
+    assert connection.statements[0] == "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY"
+    assert connection.rollback_count == 1
+    assert not any(
+        re.match(r"^(INSERT|UPDATE|DELETE|MERGE|ALTER|CREATE|DROP|TRUNCATE)\b", statement)
+        for statement in connection.statements
+    )
+
+
+def test_inventory_is_bounded_stable_and_hashes_caller_idempotency_keys() -> None:
+    connection = _Connection(
+        rows={
+            "dpm_rebalance_wave_idempotency": [
+                {
+                    "idempotency_key": "caller-secret-key-1",
+                    "wave_id": "wave-1",
+                    "created_at": "2026-09-09T00:00:00+00:00",
+                },
+                {
+                    "idempotency_key": "caller-secret-key-2",
+                    "wave_id": "wave-2",
+                    "created_at": "2026-09-09T00:01:00+00:00",
+                },
+            ]
+        }
+    )
+
+    report = build_quarantined_tenant_inventory(connection=connection, limit=1)
+
+    dataset = next(
+        item for item in report["datasets"] if item["dataset"] == "dpm_rebalance_wave_idempotency"
+    )
+    assert dataset["totalCount"] == 2
+    assert dataset["returnedCount"] == 1
+    assert dataset["truncated"] is True
+    assert dataset["rows"] == [
+        {
+            "idempotency_keySha256": (
+                "0fd39fd4ea576370872afdec5b8cc0e87bba36f68097d8702ab17e19509a99d5"
+            ),
+            "wave_id": "wave-1",
+            "created_at": "2026-09-09T00:00:00+00:00",
+        }
+    ]
+    assert "caller-secret-key" not in str(report)
+
+
+def test_missing_schema_provenance_is_failure_and_still_rolls_back() -> None:
+    connection = _Connection(applied_versions={"dpm:0003"})
+
+    with pytest.raises(
+        RuntimeError,
+        match="QUARANTINE_INVENTORY_MIGRATION_NOT_APPLIED:dpm:0024",
+    ):
+        build_quarantined_tenant_inventory(connection=connection, limit=20)
+
+    assert connection.rollback_count == 1
+
+
+def test_registry_rejects_unsafe_or_inconsistent_definitions() -> None:
+    with pytest.raises(ValueError, match="QUARANTINE_INVENTORY_UNSAFE_REGISTRY_IDENTIFIER"):
+        QuarantinedTenantDataset(
+            name="unsafe; DROP TABLE evidence",
+            migration_version="9999",
+            migration_path="unsafe.sql",
+            identifying_columns=("id",),
+        )
+    with pytest.raises(ValueError, match="QUARANTINE_INVENTORY_INVALID_HASHED_COLUMN"):
+        QuarantinedTenantDataset(
+            name="safe_table",
+            migration_version="9999",
+            migration_path="safe.sql",
+            identifying_columns=("id",),
+            hashed_columns=frozenset({"not_selected"}),
+        )
+
+
+def test_database_must_confirm_the_transaction_is_read_only() -> None:
+    connection = _Connection(read_only="off")
+
+    with pytest.raises(RuntimeError, match="QUARANTINE_INVENTORY_TRANSACTION_NOT_READ_ONLY"):
+        build_quarantined_tenant_inventory(connection=connection, limit=20)
+
+    assert connection.rollback_count == 1
+
+
+def test_row_factory_and_scalar_serialization_fail_closed() -> None:
+    assert _row_value({"value": "found"}, "value") == "found"
+    assert _row_value(_StringRow(), "value") == "indexed"
+    with pytest.raises(RuntimeError, match="QUARANTINE_INVENTORY_ROW_FACTORY_REQUIRED"):
+        _row_value(("positional",), "value")
+    assert _json_scalar(date(2026, 9, 9)) == "2026-09-09"
+    assert _json_scalar(Path("safe-value")) == "safe-value"
+
+
+@pytest.mark.parametrize("limit", [0, 101])
+def test_limit_is_strictly_bounded(limit: int) -> None:
+    connection = _Connection()
+
+    with pytest.raises(ValueError, match="QUARANTINE_INVENTORY_LIMIT_OUT_OF_RANGE"):
+        build_quarantined_tenant_inventory(connection=connection, limit=limit)
+
+    assert connection.statements == []

--- a/tests/unit/infrastructure/test_quarantined_tenant_inventory_cli.py
+++ b/tests/unit/infrastructure/test_quarantined_tenant_inventory_cli.py
@@ -1,0 +1,48 @@
+"""CLI behavior for the NULL-tenant quarantine inventory."""
+
+from __future__ import annotations
+
+import json
+
+from scripts import quarantined_tenant_inventory
+
+
+def test_cli_emits_success_report_to_stdout(monkeypatch, capsys) -> None:
+    report = {
+        "schemaVersion": "lotus-manage.quarantined-tenant-inventory.v1",
+        "status": "success",
+        "readOnly": True,
+        "limitPerDataset": 5,
+        "totalQuarantinedRows": 0,
+        "datasets": [],
+    }
+    monkeypatch.setattr(quarantined_tenant_inventory, "_run_inventory", lambda **_kwargs: report)
+
+    exit_code = quarantined_tenant_inventory.main(["--dsn", "postgresql://test", "--limit", "5"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert json.loads(captured.out) == report
+    assert captured.err == ""
+
+
+def test_cli_failure_is_nonzero_and_does_not_leak_exception_or_dsn(monkeypatch, capsys) -> None:
+    def fail(**_kwargs):
+        raise RuntimeError("password=do-not-print host=private-db")
+
+    monkeypatch.setattr(quarantined_tenant_inventory, "_run_inventory", fail)
+
+    exit_code = quarantined_tenant_inventory.main(
+        ["--dsn", "postgresql://operator:secret@private-db/manage"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert json.loads(captured.err) == {
+        "schemaVersion": "lotus-manage.quarantined-tenant-inventory.v1",
+        "status": "error",
+        "errorCode": "QUARANTINE_INVENTORY_FAILED",
+    }
+    assert "secret" not in captured.err
+    assert "private-db" not in captured.err

--- a/tests/unit/test_quarantined_tenant_inventory_operations_runbook.py
+++ b/tests/unit/test_quarantined_tenant_inventory_operations_runbook.py
@@ -1,0 +1,32 @@
+"""Durable operator-documentation contract for the quarantine inventory (#699)."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_operator_surfaces_publish_one_safe_quarantine_inventory_command() -> None:
+    surfaces = {
+        path: (ROOT / path).read_text(encoding="utf-8")
+        for path in (
+            "README.md",
+            "docs/operations-runbook.md",
+            "scripts/README.md",
+            "REPOSITORY-ENGINEERING-CONTEXT.md",
+            "wiki/Operations-Runbook.md",
+        )
+    }
+
+    assert all("make quarantine-inventory" in content for content in surfaces.values())
+    assert "quarantine-inventory:" in (ROOT / "Makefile").read_text(encoding="utf-8")
+    runbook = surfaces["docs/operations-runbook.md"]
+    for required_truth in (
+        "all seven governed datasets",
+        "repeatable-read, read-only transaction",
+        "explicit successful zero",
+        "QUARANTINE_INVENTORY_FAILED",
+        "must not be assigned, updated, deleted, or exposed\nthrough an API",
+        "Migration `0029` adds the partial index",
+    ):
+        assert required_truth in runbook

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -375,6 +375,27 @@ python scripts/openapi_quality_gate.py
   `as_of_date` metadata when supplied; older, missing, or inconsistent source evidence remains
   non-certifying.
 
+## NULL-tenant quarantine inventory
+
+Rows that migrations `0003` and `0024` through `0028` could not truthfully attribute remain NULL
+and therefore match no tenant-scoped application read. Migration `0029` provides the partial index
+that keeps the original monitoring-run quarantine census bounded as history grows. From the
+`lotus-manage` repository root, set the bank-managed `DPM_SUPPORTABILITY_POSTGRES_DSN` and run
+`make quarantine-inventory`.
+
+The command inventories all seven governed datasets in a repeatable-read, read-only transaction.
+It returns total counts, a stable bounded sample, explicit truncation, and applied migration
+versions/checksums. `QUARANTINE_INVENTORY_LIMIT` defaults to `20` and accepts `1..100`.
+Idempotency keys are hashed; payloads and connection details are not emitted.
+
+- `status: success` and a zero total is a successful empty inventory.
+- A nonzero exit with `QUARANTINE_INVENTORY_FAILED` is not usable evidence; check connectivity,
+  the bound, and migration application.
+- Nonzero counts are an authorized data-owner attribution backlog, not permission to guess a tenant,
+  mutate rows, delete evidence, or bypass normal application isolation.
+- Detailed PowerShell and Bash invocation plus interpretation guidance lives in
+  [docs/operations-runbook.md](https://github.com/sgajbi/lotus-manage/blob/main/docs/operations-runbook.md#null-tenant-quarantine-inventory).
+
 ## Key references
 
 - [docs/documentation/project-overview.md](https://github.com/sgajbi/lotus-manage/blob/main/docs/documentation/project-overview.md)


### PR DESCRIPTION
Closes #699. Adds one authoritative seven-dataset registry and a bounded, sanitized, repeatable-read/read-only operator inventory with migration provenance, explicit zero/error semantics, real-PostgreSQL isolation proof, repo-native command, README/runbook/context updates, and authored wiki source. Local evidence: make ci passed with 3,795 tests, 99.01% combined coverage, static/governance gates, Bandit, and pip-audit; PostgreSQL integration suite passed 259 tests; wiki pre-merge parity check passed with the expected unpublished source delta. No wiki publication occurs until merge.