### PR TITLE
fix(mandates): fail closed on ambiguous legacy limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,15 @@ missing migration provenance, connection failure, or an unsafe bound exits nonze
 sanitized error. Idempotency keys are SHA-256 hashed and payloads, DSNs, and tenant guesses are
 never emitted. See [the operations runbook](docs/operations-runbook.md#null-tenant-quarantine-inventory).
 
+Migration `0030` closes the historical fabricated-limit ambiguity without guessing from the old
+`0.02`/`0.10`/`0.15` numeric shape. Existing snapshots did not record whether the Core compiler or
+`/health/recalculate` supplied their twin, and caller-supplied lineage could look identical. Rows
+with legacy limit values are preserved and marked `MANDATE_LIMIT_PROVENANCE_AMBIGUOUS`; effective
+reads and health scoring suppress those unverified limits. Their derived health evidence is
+retired, affected successful monitoring runs fail closed, and unrelated cash-flow, tax-lot,
+restriction, and workflow findings survive. Already-failed runs retain their evidence. Future
+writes persist `CORE_COMPILED` or `CALLER_SUPPLIED` producer provenance.
+
 Async scenario analysis defaults to inline execution in Docker. For accept-now/execute-later live
 proof, start the stack with `DPM_ASYNC_EXECUTION_MODE=ACCEPT_ONLY`; manual execution can be disabled
 with `DPM_ASYNC_MANUAL_EXECUTION_ENABLED=false` when the execute endpoint must be hidden.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -982,6 +982,15 @@ Current repository posture:
     holding the same mandate id, version and date hold separate rows rather than overwriting one
     another; same-date replays within a tenant remain idempotent. Rows persisted before the tenant
     fence carry a NULL tenant, match no scoped read, and are quarantined rather than defaulted.
+18. Snapshot producer provenance is repository-owned from migration `0030`: Core refresh writes
+    `CORE_COMPILED`, explicit `/health/recalculate` input writes `CALLER_SUPPLIED`, and pre-marker
+    rows remain `UNKNOWN_LEGACY`. Historical lineage is not a discriminator because the caller
+    could submit the same lineage. Legacy rows carrying any cash-band or turnover value retain the
+    raw payload and gain `MANDATE_LIMIT_PROVENANCE_AMBIGUOUS`; normal reads and health scoring
+    suppress those values. The migration invalidates affected health/successful-run aggregates
+    within the same tenant, preserves earlier run failures, and deletes only limit-dependent
+    exception reason codes. Never replace this with a numeric
+    fingerprint or promote a zero band minimum into a cash reserve.
 
 ## Architecture And Module Map
 

--- a/docs/operations-runbook.md
+++ b/docs/operations-runbook.md
@@ -70,6 +70,41 @@ and never emits payloads or the DSN.
 - Treat nonzero counts as an attribution backlog for an authorized data owner. This command is
   observation only and provides no remediation or tenant-assignment path.
 
+## Legacy mandate-limit provenance
+
+Migration `0030` handles snapshots written before the repository recorded whether Core compilation
+or explicit caller health input supplied the twin. Historical lineage cannot decide this because a
+caller could submit the same lineage.
+
+- Stored cash-band and turnover values remain intact for audit and recovery.
+- `MANDATE_LIMIT_PROVENANCE_AMBIGUOUS` makes them ineffective on reads and health calculations.
+- No legacy zero cash minimum is promoted into an explicit cash reserve.
+- All health snapshots and limit-dependent cash/turnover exceptions for the same tenant and mandate
+  are retired when any retained snapshot is ambiguous. Recalculation accepted a caller-selected
+  non-latest version, evidence did not record its snapshot identity, and snapshot upserts refreshed
+  `created_at`; neither a clean latest snapshot nor timestamp ordering can prove which version
+  produced it. Projected cash-flow, tax-lot, restriction, and workflow findings survive.
+- Successful monitoring runs that reference an affected mandate remain auditable but become
+  `FAILED` with empty aggregates. Their overall execution window cannot reconstruct per-mandate
+  reads once snapshot timestamps have been refreshed; runs that already failed retain their
+  original evidence.
+- NULL-tenant snapshots may receive the non-authoritative provenance marker, but their quarantined
+  runs, health, and exceptions are never changed or deleted before audited tenant attribution.
+- Future snapshots record `CORE_COMPILED` or `CALLER_SUPPLIED` producer provenance. After the
+  backfill the database drops the legacy default, so an old replica that omits provenance fails
+  instead of creating or overwriting an unmarked ambiguous row.
+- Recalculation resolves the exact tenant-scoped stored snapshot identity before trusting any
+  caller gap codes. A forged marker fails with `DPM_MANDATE_AMBIGUOUS_SNAPSHOT_NOT_FOUND`; omitting
+  a stored marker cannot bypass the fence. Manage calculates ambiguous history from the retained
+  effective snapshot, so caller changes to restrictions, policy, lineage, risk profile, or other
+  twin fields cannot alter evidence or overwrite the retained raw snapshot limits. A changed
+  portfolio is rejected because persistence identity is tenant/mandate/version/as-of, not portfolio.
+
+After rollout, verify `dpm:0030`, refresh the affected mandate from governed Core sources, then
+recalculate health and run monitoring again. Never clear the marker or reconstruct derived evidence
+by direct SQL. Rollback restores the pre-migration database backup as one unit; do not reverse only
+the payload marker while leaving dependent evidence migrated.
+
 ## Incident triage
 
 - If health fails, verify startup migration state and storage adapter configuration first.

--- a/docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md
+++ b/docs/rfcs/RFC-0038-mandate-digital-twin-health-and-command-center.md
@@ -529,6 +529,13 @@ Indexes:
 2. `(portfolio_id, as_of_date)`,
 3. `(mandate_id, created_at desc)`.
 
+Migration `0030` adds repository-owned `producer_kind`. Existing rows are `UNKNOWN_LEGACY`; a
+Core refresh writes `CORE_COMPILED`, while explicit caller health input writes `CALLER_SUPPLIED`.
+Because historical callers could reproduce Core-shaped lineage, legacy cash-band/turnover values
+are marked provenance-ambiguous and suppressed from effective reads/scoring without destroying the
+stored payload. Derived health and monitoring evidence fails closed rather than continuing to
+publish results based on an unverifiable contractual limit.
+
 `dpm_mandate_health_snapshots`
 
 1. `health_snapshot_id` primary key,

--- a/docs/rfcs/RFC-0038-source-data-field-map.md
+++ b/docs/rfcs/RFC-0038-source-data-field-map.md
@@ -37,6 +37,13 @@ classified as source-backed, derived, local policy, or a known gap.
 | next review due date | `DiscretionaryMandateBinding:v1.next_review_due_date` | Source-backed when returned by core and used by mandate health review-cadence scoring. | None for first-wave review-date evidence. |
 | source lineage | Core source product lineage fields | Preserved as `DpmSourceProductLineage`. | None for source-backed products. |
 
+Historical persistence note: before migration `0030`, both Core refresh and caller-supplied health
+recalculation wrote `created_by=lotus-manage`, and callers could submit Core-shaped lineage. That
+lineage cannot distinguish producer provenance. Any pre-marker snapshot carrying cash-band or
+turnover values is preserved but marked `MANDATE_LIMIT_PROVENANCE_AMBIGUOUS`; those values are
+suppressed from effective reads and scoring rather than rewritten from a numeric fingerprint.
+Future rows carry repository-owned `CORE_COMPILED` or `CALLER_SUPPLIED` provenance.
+
 ## Health Engine Source Map
 
 | Health dimension | Current inputs | Behavior in Slice 1 | Future enrichment |

--- a/quality/baseline_report.md
+++ b/quality/baseline_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Baseline Quality Report
 
-- Generated at: `2026-09-09T07:11:04+00:00`
+- Generated at: `2026-09-09T11:17:17+00:00`
 
-- Baseline source snapshot: `435e1c8b259c82c8aff0546d7083f336d5644e64`
+- Baseline source snapshot: `bae293d505b897af73799c3328efa90681dcf68a`
 
-- Report source snapshot: `c15e1b29+worktree`
+- Report source snapshot: `dd40b488+worktree`
 
 - Mode: report-only baseline. This records current posture; it does not enforce thresholds by itself.
 
@@ -12,9 +12,9 @@
 
 | Metric | Value |
 | --- | --- |
-| Python files | 945 |
-| Total Python LOC | 221340 |
-| Test functions | 3218 |
+| Python files | 946 |
+| Total Python LOC | 222370 |
+| Test functions | 3230 |
 | Service boundary findings | 0 |
 | Router infrastructure imports | 0 |
 

--- a/quality/complexity_report.md
+++ b/quality/complexity_report.md
@@ -1,10 +1,10 @@
 # lotus-manage Complexity Report
 
-- Generated at: `2026-09-09T07:11:04+00:00`
+- Generated at: `2026-09-09T11:17:17+00:00`
 
-- Baseline source snapshot: `435e1c8b259c82c8aff0546d7083f336d5644e64`
+- Baseline source snapshot: `bae293d505b897af73799c3328efa90681dcf68a`
 
-- Report source snapshot: `c15e1b29+worktree`
+- Report source snapshot: `dd40b488+worktree`
 
 - Mode: active source C-or-worse gate via `make complexity-gate`; broader dependency-free AST branch metrics remain report-only.
 
@@ -22,7 +22,7 @@
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 791 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 404 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 113 | 416 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |
@@ -52,7 +52,7 @@
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 791 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 404 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 113 | 416 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |

--- a/quality/quality_scorecard.md
+++ b/quality/quality_scorecard.md
@@ -1,10 +1,10 @@
 # lotus-manage Quality Scorecard
 
-- Generated at: `2026-09-09T07:11:04+00:00`
+- Generated at: `2026-09-09T11:17:17+00:00`
 
-- Baseline source snapshot: `435e1c8b259c82c8aff0546d7083f336d5644e64`
+- Baseline source snapshot: `bae293d505b897af73799c3328efa90681dcf68a`
 
-- Report source snapshot: `c15e1b29+worktree`
+- Report source snapshot: `dd40b488+worktree`
 
 - Purpose: make enterprise-readiness progress measurable without pretending report-only baselines are mature enforcement gates.
 

--- a/quality/refactor_health_report.md
+++ b/quality/refactor_health_report.md
@@ -1,12 +1,12 @@
 # lotus-manage Refactor Health Report
 
-- Generated at: `2026-09-09T07:11:04+00:00`
+- Generated at: `2026-09-09T11:17:17+00:00`
 
 - Baseline ref: `origin/main`
 
-- Baseline source snapshot: `435e1c8b259c82c8aff0546d7083f336d5644e64`
+- Baseline source snapshot: `bae293d505b897af73799c3328efa90681dcf68a`
 
-- Report source snapshot: `c15e1b29+worktree`
+- Report source snapshot: `dd40b488+worktree`
 
 - Scope: Python code under `src/`, `tests/`, and `scripts/`; current OpenAPI schema.
 
@@ -14,9 +14,9 @@
 
 | Metric | origin/main | current branch | Delta |
 | --- | --- | --- | --- |
-| Python files | 939 | 945 | +6 |
-| Total Python LOC | 220440 | 221340 | +900 |
-| Test functions | 3205 | 3218 | +13 |
+| Python files | 945 | 946 | +1 |
+| Total Python LOC | 221340 | 222370 | +1030 |
+| Test functions | 3218 | 3230 | +12 |
 | Service boundary findings | 0 | 0 | +0 |
 | Router infrastructure imports | 0 | 0 | +0 |
 
@@ -86,14 +86,14 @@
 | --- | --- | --- | --- |
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 791 |
-| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 404 |
+| 3 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 416 |
 | 4 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 380 |
 | 5 | _core_execution_context | tests/unit/dpm/api/test_construction_api.py | 354 |
 | 6 | _generate_wave_lifecycle | scripts/generate_rfc0041_wave_evidence.py | 350 |
-| 7 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 334 |
-| 8 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
-| 9 | test_wave_openapi_pins_campaign_workflow_assignment_and_automation_contracts | tests/unit/dpm/api/test_waves_api.py | 268 |
-| 10 | execute | tests/unit/dpm/supportability/test_dpm_mandate_repository.py | 246 |
+| 7 | test_unknown_legacy_limits_are_preserved_but_never_act_as_contractual_limits | tests/integration/dpm/mandates/test_legacy_mandate_limit_provenance_postgres.py | 334 |
+| 8 | test_portfolio_memory_api_returns_queryable_source_backed_memory | tests/unit/dpm/api/test_portfolio_memory_api.py | 334 |
+| 9 | run_demo_pack | scripts/run_demo_pack_live.py | 302 |
+| 10 | test_wave_openapi_pins_campaign_workflow_assignment_and_automation_contracts | tests/unit/dpm/api/test_waves_api.py | 268 |
 
 ## Most Complex Functions
 
@@ -119,7 +119,7 @@
 | 1 | test_rfc0042_gold_standard_tightening_preserves_source_boundaries | tests/unit/test_documentation_current_state.py | 1068 | 1558 |
 | 2 | test_rebalance_async_and_supportability_endpoints_use_expected_request_response_contracts | tests/unit/dpm/contracts/test_contract_openapi_supportability_docs.py | 275 | 791 |
 | 3 | test_portfolio_memory_composes_proof_pack_wave_handoff_and_outcome_events | tests/unit/dpm/api/test_portfolio_memory_api.py | 146 | 380 |
-| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 111 | 404 |
+| 4 | execute | tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py | 113 | 416 |
 | 5 | test_portfolio_memory_search_indexes_manage_local_evidence_without_global_discovery | tests/unit/dpm/api/test_portfolio_memory_api.py | 102 | 231 |
 | 6 | test_manage_consumer_declaration_tracks_current_core_inputs | tests/unit/test_domain_data_product_contracts.py | 89 | 153 |
 | 7 | test_rfc0041_slice0_source_map_guardrails_stay_truthful | tests/unit/test_documentation_current_state.py | 80 | 128 |

--- a/src/api/services/mandate_health_persistence.py
+++ b/src/api/services/mandate_health_persistence.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from src.core.mandate_repository import DpmMandateRepository
+from src.core.mandate_repository import DpmMandateRepository, MandateSnapshotProducer
 from src.core.mandates import (
+    MANDATE_LIMIT_PROVENANCE_AMBIGUOUS,
     DpmMandateDigitalTwin,
     DpmMandateHealthSnapshot,
     DpmMonitoringException,
@@ -15,9 +16,22 @@ def persist_mandate_health_evidence(
     monitoring_exceptions: list[DpmMonitoringException],
     tenant_id: str,
     twin: DpmMandateDigitalTwin | None = None,
+    mandate_producer_kind: MandateSnapshotProducer = "CALLER_SUPPLIED",
+    verified_retained_projection: bool = False,
 ) -> None:
-    if twin is not None:
-        repository.save_mandate_snapshot(twin, tenant_id=tenant_id)
+    caller_projection = (
+        twin is not None
+        and mandate_producer_kind == "CALLER_SUPPLIED"
+        and MANDATE_LIMIT_PROVENANCE_AMBIGUOUS in twin.field_gap_codes
+    )
+    if caller_projection and not verified_retained_projection:
+        raise ValueError("DPM_MANDATE_AMBIGUOUS_SNAPSHOT_NOT_VERIFIED")
+    if twin is not None and not caller_projection:
+        repository.save_mandate_snapshot(
+            twin,
+            tenant_id=tenant_id,
+            producer_kind=mandate_producer_kind,
+        )
     repository.save_health_snapshot(health_snapshot, tenant_id=tenant_id)
     for exception in monitoring_exceptions:
         repository.save_monitoring_exception(exception, tenant_id=tenant_id)

--- a/src/api/services/mandate_service.py
+++ b/src/api/services/mandate_service.py
@@ -42,6 +42,7 @@ from src.api.services.mandate_refresh import (
 )
 from src.core.mandate_repository import DpmMandateRepository
 from src.core.mandates import (
+    MANDATE_LIMIT_PROVENANCE_AMBIGUOUS,
     DpmCommandCenterSummary,
     DpmMandateDigitalTwin,
     DpmMandateHealthInput,
@@ -82,6 +83,7 @@ def refresh_mandate_from_core(
         repository=repository,
         tenant_id=tenant_id,
         twin=refresh_result.twin,
+        mandate_producer_kind="CORE_COMPILED",
         health_snapshot=refresh_result.health_snapshot,
         monitoring_exceptions=refresh_result.monitoring_exceptions,
     )
@@ -148,15 +150,59 @@ def recalculate_mandate_health(
 ) -> DpmMandateHealthSnapshot:
     if health_input.twin.mandate_id != mandate_id:
         raise DpmMandateSourceIncompleteError("DPM_MANDATE_HEALTH_INPUT_MISMATCH")
-    health_result = calculate_mandate_health_result(health_input, tenant_id=tenant_id)
+    retained_projection = _resolve_retained_ambiguous_projection(
+        repository=repository,
+        twin=health_input.twin,
+        tenant_id=tenant_id,
+    )
+    calculation_input = (
+        health_input.model_copy(update={"twin": retained_projection})
+        if retained_projection is not None
+        else health_input
+    )
+    health_result = calculate_mandate_health_result(calculation_input, tenant_id=tenant_id)
     persist_mandate_health_evidence(
         repository=repository,
         tenant_id=tenant_id,
-        twin=health_input.twin,
+        twin=calculation_input.twin,
         health_snapshot=health_result.snapshot,
         monitoring_exceptions=health_result.monitoring_exceptions,
+        verified_retained_projection=retained_projection is not None,
     )
     return health_result.snapshot
+
+
+def _resolve_retained_ambiguous_projection(
+    *,
+    repository: DpmMandateRepository,
+    twin: DpmMandateDigitalTwin,
+    tenant_id: str,
+) -> DpmMandateDigitalTwin | None:
+    matching_snapshot = next(
+        (
+            stored
+            for stored in repository.list_mandate_versions(
+                mandate_id=twin.mandate_id,
+                tenant_id=tenant_id,
+            )
+            if stored.mandate_version == twin.mandate_version
+            and stored.as_of_date == twin.as_of_date
+        ),
+        None,
+    )
+    submitted_as_ambiguous = MANDATE_LIMIT_PROVENANCE_AMBIGUOUS in twin.field_gap_codes
+    if matching_snapshot is None:
+        if not submitted_as_ambiguous:
+            return None
+        raise DpmMandateSourceIncompleteError("DPM_MANDATE_AMBIGUOUS_SNAPSHOT_NOT_FOUND")
+    stored_as_ambiguous = MANDATE_LIMIT_PROVENANCE_AMBIGUOUS in matching_snapshot.field_gap_codes
+    if stored_as_ambiguous:
+        if matching_snapshot.portfolio_id != twin.portfolio_id:
+            raise DpmMandateSourceIncompleteError("DPM_MANDATE_AMBIGUOUS_SNAPSHOT_NOT_FOUND")
+        return matching_snapshot
+    if submitted_as_ambiguous:
+        raise DpmMandateSourceIncompleteError("DPM_MANDATE_AMBIGUOUS_SNAPSHOT_NOT_FOUND")
+    return None
 
 
 def run_mandate_monitoring_once(
@@ -182,7 +228,6 @@ def run_mandate_monitoring_once(
         persist_result=lambda twin, snapshot, exceptions: persist_mandate_health_evidence(
             repository=repository,
             tenant_id=tenant_id,
-            twin=twin,
             health_snapshot=snapshot,
             monitoring_exceptions=exceptions,
         ),

--- a/src/core/mandate_health_scoring.py
+++ b/src/core/mandate_health_scoring.py
@@ -20,12 +20,16 @@ from src.core.mandate_models import (
     MandateRecommendedAction,
     MonitoringSeverity,
     default_source_analytics_posture as _default_source_analytics_posture,
+    effective_mandate_twin,
 )
 
 
 def calculate_mandate_health(
     input_: DpmMandateHealthInput, *, tenant_id: str
 ) -> DpmMandateHealthSnapshot:
+    effective_twin = effective_mandate_twin(input_.twin)
+    if effective_twin is not input_.twin:
+        input_ = input_.model_copy(update={"twin": effective_twin})
     dimension_scores = _mandate_health_dimension_scores(input_)
     health_state = _mandate_health_state(dimension_scores)
     top_reasons = _top_mandate_health_reasons(dimension_scores)

--- a/src/core/mandate_models.py
+++ b/src/core/mandate_models.py
@@ -201,6 +201,31 @@ class DpmMandateDigitalTwin(BaseModel):
     field_gap_codes: list[str] = Field(default_factory=list)
 
 
+MANDATE_LIMIT_PROVENANCE_AMBIGUOUS = "MANDATE_LIMIT_PROVENANCE_AMBIGUOUS"
+
+
+def effective_mandate_twin(twin: DpmMandateDigitalTwin) -> DpmMandateDigitalTwin:
+    """Return the fail-closed projection for legacy limits of unknown origin.
+
+    The stored values remain intact for audit and deliberate operator review.
+    They cannot act as contractual limits while the legacy writer is unknown.
+    """
+
+    if MANDATE_LIMIT_PROVENANCE_AMBIGUOUS not in twin.field_gap_codes:
+        return twin
+    return twin.model_copy(
+        update={
+            "constraints": twin.constraints.model_copy(
+                update={
+                    "cash_band_min_weight": None,
+                    "cash_band_max_weight": None,
+                    "turnover_budget": None,
+                }
+            )
+        }
+    )
+
+
 class DpmMandateHealthReason(BaseModel):
     dimension: MandateHealthDimension
     reason_code: str

--- a/src/core/mandate_repository.py
+++ b/src/core/mandate_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from typing import Optional, Protocol
+from typing import Literal, Optional, Protocol
 
 from src.core.mandates import (
     DpmMandateDigitalTwin,
@@ -11,8 +11,17 @@ from src.core.mandates import (
 )
 
 
+MandateSnapshotProducer = Literal["CORE_COMPILED", "CALLER_SUPPLIED"]
+
+
 class DpmMandateRepository(Protocol):
-    def save_mandate_snapshot(self, twin: DpmMandateDigitalTwin, *, tenant_id: str) -> None: ...
+    def save_mandate_snapshot(
+        self,
+        twin: DpmMandateDigitalTwin,
+        *,
+        tenant_id: str,
+        producer_kind: MandateSnapshotProducer = "CALLER_SUPPLIED",
+    ) -> None: ...
 
     def get_latest_mandate_by_portfolio(
         self,

--- a/src/core/mandates.py
+++ b/src/core/mandates.py
@@ -45,9 +45,11 @@ from src.core.mandate_models import (
     MandateRecommendedAction,
     MandateSourceReadinessProjection as _MandateSourceReadinessProjection,
     MonitoringSeverity,
+    MANDATE_LIMIT_PROVENANCE_AMBIGUOUS,
     SourceReadinessState as _SourceReadinessState,
     bounded_ratio as _bounded_ratio,
     default_source_analytics_posture as _default_source_analytics_posture,
+    effective_mandate_twin,
 )
 from src.core.mandate_health_scoring import calculate_mandate_health
 
@@ -76,6 +78,7 @@ __all__ = [
     "MandateHealthState",
     "MandateRecommendedAction",
     "MonitoringSeverity",
+    "MANDATE_LIMIT_PROVENANCE_AMBIGUOUS",
     "_DigitalTwinLineageSourceProduct",
     "_MandateSourceReadinessProjection",
     "_SourceReadinessState",
@@ -84,6 +87,7 @@ __all__ = [
     "build_health_input_from_core_sources",
     "calculate_mandate_health",
     "compile_mandate_digital_twin_from_core",
+    "effective_mandate_twin",
     "monitoring_exceptions_from_health",
 ]
 

--- a/src/infrastructure/mandates/in_memory.py
+++ b/src/infrastructure/mandates/in_memory.py
@@ -7,12 +7,13 @@ from datetime import date, datetime, timezone
 from threading import Lock
 from typing import Optional
 
-from src.core.mandate_repository import DpmMandateRepository
+from src.core.mandate_repository import DpmMandateRepository, MandateSnapshotProducer
 from src.core.mandates import (
     DpmMandateDigitalTwin,
     DpmMandateHealthSnapshot,
     DpmMonitoringException,
     DpmMonitoringRun,
+    effective_mandate_twin,
 )
 
 
@@ -64,7 +65,13 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
         self._monitoring_runs: dict[str, DpmMonitoringRun] = {}
         self._exceptions: dict[tuple[str, str], DpmMonitoringException] = {}
 
-    def save_mandate_snapshot(self, twin: DpmMandateDigitalTwin, *, tenant_id: str) -> None:
+    def save_mandate_snapshot(
+        self,
+        twin: DpmMandateDigitalTwin,
+        *,
+        tenant_id: str,
+        producer_kind: MandateSnapshotProducer = "CALLER_SUPPLIED",
+    ) -> None:
         with self._lock:
             key = (tenant_id, twin.mandate_id, twin.mandate_version, twin.as_of_date)
             self._mandates_by_key[key] = deepcopy(twin)
@@ -82,7 +89,7 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
                 if key[0] == tenant_id and twin.portfolio_id == portfolio_id
             ]
             latest = _latest_twin(rows)
-            return deepcopy(latest) if latest is not None else None
+            return effective_mandate_twin(deepcopy(latest)) if latest is not None else None
 
     def get_mandate_by_portfolio_as_of(
         self,
@@ -100,7 +107,7 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
                 and twin.as_of_date <= as_of_date
             ]
             latest = _latest_twin(rows)
-            return deepcopy(latest) if latest is not None else None
+            return effective_mandate_twin(deepcopy(latest)) if latest is not None else None
 
     def get_latest_mandate(
         self,
@@ -115,7 +122,7 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
                 if key[0] == tenant_id and twin.mandate_id == mandate_id
             ]
             latest = _latest_twin(rows)
-            return deepcopy(latest) if latest is not None else None
+            return effective_mandate_twin(deepcopy(latest)) if latest is not None else None
 
     def list_mandate_versions(
         self,
@@ -134,7 +141,7 @@ class InMemoryDpmMandateRepository(DpmMandateRepository):
                 key=lambda row: (row.as_of_date, _mandate_version_sort_key(row.mandate_version)),
                 reverse=True,
             )
-            return [deepcopy(row) for row in rows]
+            return [effective_mandate_twin(deepcopy(row)) for row in rows]
 
     def save_health_snapshot(self, snapshot: DpmMandateHealthSnapshot, *, tenant_id: str) -> None:
         with self._lock:

--- a/src/infrastructure/mandates/postgres.py
+++ b/src/infrastructure/mandates/postgres.py
@@ -12,8 +12,10 @@ from src.core.mandates import (
     DpmMandateHealthSnapshot,
     DpmMonitoringException,
     DpmMonitoringRun,
+    effective_mandate_twin,
 )
 from src.core.common.derived_identity import derived_identity
+from src.core.mandate_repository import MandateSnapshotProducer
 from src.infrastructure.mandates.serialization import dump_model_json, load_model_json
 from src.infrastructure.postgres_access import connect_postgres
 from src.infrastructure.postgres_migrations import apply_postgres_migrations
@@ -92,7 +94,13 @@ class PostgresDpmMandateRepository:
         self._dsn = dsn
         self._init_db()
 
-    def save_mandate_snapshot(self, twin: DpmMandateDigitalTwin, *, tenant_id: str) -> None:
+    def save_mandate_snapshot(
+        self,
+        twin: DpmMandateDigitalTwin,
+        *,
+        tenant_id: str,
+        producer_kind: MandateSnapshotProducer = "CALLER_SUPPLIED",
+    ) -> None:
         query = """
             INSERT INTO dpm_mandate_snapshots (
                 mandate_snapshot_id,
@@ -105,8 +113,9 @@ class PostgresDpmMandateRepository:
                 payload_json,
                 created_at,
                 created_by,
-                tenant_id
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                tenant_id,
+                producer_kind
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (tenant_id, mandate_id, mandate_version, as_of_date) DO UPDATE SET
                 portfolio_id=excluded.portfolio_id,
                 as_of_date=excluded.as_of_date,
@@ -114,7 +123,8 @@ class PostgresDpmMandateRepository:
                 source_lineage_json=excluded.source_lineage_json,
                 payload_json=excluded.payload_json,
                 created_at=excluded.created_at,
-                created_by=excluded.created_by
+                created_by=excluded.created_by,
+                producer_kind=excluded.producer_kind
         """
         payload_json = dump_model_json(twin)
         with closing(self._connect()) as connection:
@@ -136,6 +146,7 @@ class PostgresDpmMandateRepository:
                     datetime.now().astimezone().isoformat(),
                     "lotus-manage",
                     tenant_id,
+                    producer_kind,
                 ),
             )
             connection.commit()
@@ -202,7 +213,10 @@ class PostgresDpmMandateRepository:
         """
         with closing(self._connect()) as connection:
             rows = connection.execute(query, (tenant_id, mandate_id)).fetchall()
-        return [load_model_json(DpmMandateDigitalTwin, _payload(row)) for row in rows]
+        return [
+            effective_mandate_twin(load_model_json(DpmMandateDigitalTwin, _payload(row)))
+            for row in rows
+        ]
 
     def save_health_snapshot(self, snapshot: DpmMandateHealthSnapshot, *, tenant_id: str) -> None:
         query = """
@@ -579,7 +593,7 @@ class PostgresDpmMandateRepository:
 def _to_twin(row: Any) -> Optional[DpmMandateDigitalTwin]:
     if row is None:
         return None
-    return load_model_json(DpmMandateDigitalTwin, _payload(row))
+    return effective_mandate_twin(load_model_json(DpmMandateDigitalTwin, _payload(row)))
 
 
 def _monitoring_exception_list_query(

--- a/src/infrastructure/postgres_migrations/dpm/0030_mandate_snapshot_producer_provenance.sql
+++ b/src/infrastructure/postgres_migrations/dpm/0030_mandate_snapshot_producer_provenance.sql
@@ -1,0 +1,128 @@
+-- Issue #674. Before this migration the snapshot row recorded the service as
+-- created_by for both Core-compiled and caller-supplied twins. source_lineage
+-- is also caller-controlled on /health/recalculate, so it cannot prove which
+-- path produced a historical row. Existing rows therefore remain unknown;
+-- future writes carry a repository-owned producer classification.
+ALTER TABLE dpm_mandate_snapshots
+    ADD COLUMN IF NOT EXISTS producer_kind TEXT NOT NULL DEFAULT 'UNKNOWN_LEGACY';
+
+DO $producer_constraint$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'dpm_mandate_snapshots_producer_kind_check'
+          AND conrelid = 'dpm_mandate_snapshots'::regclass
+    ) THEN
+        ALTER TABLE dpm_mandate_snapshots
+            ADD CONSTRAINT dpm_mandate_snapshots_producer_kind_check
+            CHECK (producer_kind IN ('UNKNOWN_LEGACY', 'CORE_COMPILED', 'CALLER_SUPPLIED'));
+    END IF;
+END
+$producer_constraint$;
+
+CREATE INDEX IF NOT EXISTS idx_dpm_mandate_snapshots_unknown_producer
+    ON dpm_mandate_snapshots (mandate_snapshot_id)
+    WHERE producer_kind = 'UNKNOWN_LEGACY';
+
+-- A historical non-null contractual limit might be genuine caller input or
+-- an old compiler fabrication. Mark the whole unknown-producer cohort by
+-- field presence, not by the old compiler's numeric fingerprint. Values are
+-- retained for audit; application reads and scoring suppress them while this
+-- marker is present. No zero reserve is invented.
+UPDATE dpm_mandate_snapshots
+SET payload_json = marked.rewritten::text,
+    source_hash = 'sha256:' || encode(sha256(convert_to(marked.rewritten::text, 'UTF8')), 'hex')
+FROM (
+    SELECT
+        mandate_snapshot_id,
+        jsonb_set(
+            payload_json::jsonb,
+            '{field_gap_codes}',
+            COALESCE(payload_json::jsonb -> 'field_gap_codes', '[]'::jsonb)
+                || '["MANDATE_LIMIT_PROVENANCE_AMBIGUOUS"]'::jsonb,
+            true
+        ) AS rewritten
+    FROM dpm_mandate_snapshots
+    WHERE producer_kind = 'UNKNOWN_LEGACY'
+      AND (
+          payload_json::jsonb #>> '{constraints,cash_band_min_weight}' IS NOT NULL
+          OR payload_json::jsonb #>> '{constraints,cash_band_max_weight}' IS NOT NULL
+          OR payload_json::jsonb #>> '{constraints,turnover_budget}' IS NOT NULL
+      )
+      AND NOT (
+          COALESCE(payload_json::jsonb -> 'field_gap_codes', '[]'::jsonb)
+              ? 'MANDATE_LIMIT_PROVENANCE_AMBIGUOUS'
+      )
+) AS marked
+WHERE dpm_mandate_snapshots.mandate_snapshot_id = marked.mandate_snapshot_id;
+
+-- A successful run containing an affected mandate can no longer truthfully
+-- publish its old distribution. Preserve the attempted mandate ids for audit,
+-- but fail the run and clear result aggregates instead of manufacturing a
+-- replacement calculation inside SQL.
+UPDATE dpm_monitoring_runs AS run
+SET status = 'FAILED',
+    failure_reason = 'MANDATE_LIMIT_PROVENANCE_AMBIGUOUS',
+    source_readiness_summary_json = '{}',
+    payload_json = run.payload_json || jsonb_build_object(
+        'status', 'FAILED',
+        'failure_reason', 'MANDATE_LIMIT_PROVENANCE_AMBIGUOUS',
+        'total_mandates', 0,
+        'health_distribution', '{}'::jsonb,
+        'exception_count', 0,
+        'source_readiness_summary', '{}'::jsonb
+    )
+WHERE run.payload_json IS NOT NULL
+  AND run.status = 'SUCCEEDED'
+  AND EXISTS (
+      SELECT 1
+      FROM dpm_mandate_snapshots AS snapshot
+      WHERE snapshot.producer_kind = 'UNKNOWN_LEGACY'
+        AND COALESCE(snapshot.payload_json::jsonb -> 'field_gap_codes', '[]'::jsonb)
+            ? 'MANDATE_LIMIT_PROVENANCE_AMBIGUOUS'
+        AND snapshot.tenant_id IS NOT NULL
+        AND snapshot.tenant_id = run.tenant_id
+        AND run.payload_json -> 'mandate_ids' ? snapshot.mandate_id
+  );
+
+-- Retire only evidence whose meaning depended on the ambiguous cash band or
+-- turnover budget. Independent restriction/workflow findings survive.
+DELETE FROM dpm_monitoring_exceptions AS exception
+WHERE exception.reason_code IN (
+    'CASH_BELOW_BAND',
+    'CASH_ABOVE_BAND',
+    'TURNOVER_BUDGET_NEAR_LIMIT'
+)
+  AND EXISTS (
+      SELECT 1
+      FROM dpm_mandate_snapshots AS snapshot
+      WHERE snapshot.mandate_id = exception.mandate_id
+        AND snapshot.tenant_id IS NOT NULL
+        AND snapshot.tenant_id = exception.tenant_id
+        AND snapshot.producer_kind = 'UNKNOWN_LEGACY'
+        AND COALESCE(snapshot.payload_json::jsonb -> 'field_gap_codes', '[]'::jsonb)
+            ? 'MANDATE_LIMIT_PROVENANCE_AMBIGUOUS'
+  );
+
+-- A health snapshot is one indivisible assessment. It cannot be repaired in
+-- SQL without replaying the Python scoring inputs, so remove it rather than
+-- leave GET /health asserting a state derived from untrusted limits.
+DELETE FROM dpm_mandate_health_snapshots AS health
+WHERE EXISTS (
+    SELECT 1
+    FROM dpm_mandate_snapshots AS snapshot
+    WHERE snapshot.mandate_id = health.mandate_id
+      AND snapshot.tenant_id IS NOT NULL
+      AND snapshot.tenant_id = health.tenant_id
+      AND snapshot.producer_kind = 'UNKNOWN_LEGACY'
+      AND COALESCE(snapshot.payload_json::jsonb -> 'field_gap_codes', '[]'::jsonb)
+          ? 'MANDATE_LIMIT_PROVENANCE_AMBIGUOUS'
+);
+
+-- The backfill is complete inside this migration transaction. Do not leave a
+-- compatibility default behind: an older replica that omits producer_kind
+-- must fail its insert/upsert instead of creating an unmarked UNKNOWN_LEGACY
+-- row after the one-time marker pass.
+ALTER TABLE dpm_mandate_snapshots
+    ALTER COLUMN producer_kind DROP DEFAULT;

--- a/tests/integration/dpm/mandates/test_legacy_mandate_limit_provenance_postgres.py
+++ b/tests/integration/dpm/mandates/test_legacy_mandate_limit_provenance_postgres.py
@@ -1,0 +1,669 @@
+"""Legacy mandate-limit provenance is fail-closed in PostgreSQL (#674)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from contextlib import closing
+from datetime import date
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from src.core.mandates import (
+    MANDATE_LIMIT_PROVENANCE_AMBIGUOUS,
+    DpmMandateConstraintSet,
+    DpmMandateDigitalTwin,
+    DpmMandateReviewPolicy,
+)
+from src.infrastructure.mandates.postgres import PostgresDpmMandateRepository
+from src.infrastructure.postgres_migrations import _split_sql_statements
+from tests.integration.dpm.postgres_prerequisite import postgres_dsn_or_skip
+
+_PROOF = "legacy mandate limit provenance proof"
+_MIGRATION = Path(
+    "src/infrastructure/postgres_migrations/dpm/0030_mandate_snapshot_producer_provenance.sql"
+)
+
+
+@pytest.fixture
+def repository() -> PostgresDpmMandateRepository:
+    return PostgresDpmMandateRepository(dsn=postgres_dsn_or_skip(_PROOF))
+
+
+def _payload(*, mandate_id: str, portfolio_id: str, minimum: str = "0.02") -> str:
+    return json.dumps(
+        {
+            "mandate_id": mandate_id,
+            "portfolio_id": portfolio_id,
+            "mandate_version": "3",
+            "as_of_date": "2026-05-03",
+            "source_system": "lotus-core",
+            "base_currency": "SGD",
+            "reference_currency": "SGD",
+            "risk_profile": "BALANCED",
+            "investment_objective": "LONG_TERM_TOTAL_RETURN",
+            "time_horizon": "LONG_TERM",
+            "model_portfolio_id": "MODEL_LEGACY",
+            "constraints": {
+                "cash_band_min_weight": minimum,
+                "cash_band_max_weight": "0.10",
+                "turnover_budget": "0.15",
+            },
+            "review_policy": {"review_frequency": "QUARTERLY"},
+            # A caller could submit this same lineage, so it is deliberately
+            # not used as a producer discriminator.
+            "source_lineage": [
+                {
+                    "product_name": "DiscretionaryMandateBinding",
+                    "product_version": "v1",
+                    "source_system": "lotus-core",
+                }
+            ],
+            "field_gap_codes": ["UNRELATED_GAP"],
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _apply_migration(repository: PostgresDpmMandateRepository) -> None:
+    with closing(repository._connect()) as connection:
+        for statement in _split_sql_statements(_MIGRATION.read_text(encoding="utf-8")):
+            if statement.strip():
+                connection.execute(statement)
+        connection.commit()
+
+
+def _insert_snapshot(
+    repository: PostgresDpmMandateRepository,
+    *,
+    mandate_id: str,
+    portfolio_id: str,
+    tenant_id: str | None,
+    minimum: str = "0.02",
+) -> str:
+    payload = _payload(mandate_id=mandate_id, portfolio_id=portfolio_id, minimum=minimum)
+    with closing(repository._connect()) as connection:
+        connection.execute(
+            """
+            INSERT INTO dpm_mandate_snapshots (
+                mandate_snapshot_id, mandate_id, portfolio_id, mandate_version,
+                as_of_date, source_hash, source_lineage_json, payload_json,
+                created_at, created_by, tenant_id, producer_kind
+            ) VALUES (%s, %s, %s, '3', '2026-05-03', %s, '[]', %s,
+                      '2026-05-03T01:00:00+00:00', 'lotus-manage', %s, 'UNKNOWN_LEGACY')
+            """,
+            (
+                f"ms_{uuid.uuid4().hex}",
+                mandate_id,
+                portfolio_id,
+                "sha256:" + hashlib.sha256(payload.encode()).hexdigest(),
+                payload,
+                tenant_id,
+            ),
+        )
+        connection.commit()
+    return payload
+
+
+def _cleanup(repository: PostgresDpmMandateRepository, mandate_id: str, run_id: str) -> None:
+    with closing(repository._connect()) as connection:
+        connection.execute(
+            "DELETE FROM dpm_monitoring_exceptions WHERE mandate_id = %s", (mandate_id,)
+        )
+        connection.execute(
+            "DELETE FROM dpm_mandate_health_snapshots WHERE mandate_id = %s", (mandate_id,)
+        )
+        connection.execute("DELETE FROM dpm_mandate_snapshots WHERE mandate_id = %s", (mandate_id,))
+        connection.execute(
+            "DELETE FROM dpm_monitoring_runs WHERE monitoring_run_id = %s", (run_id,)
+        )
+        connection.commit()
+
+
+def test_unknown_legacy_limits_are_preserved_but_never_act_as_contractual_limits(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    mandate_id = f"MANDATE_PROV_{uuid.uuid4().hex[:10]}"
+    portfolio_id = f"PF_PROV_{uuid.uuid4().hex[:10]}"
+    tenant_id = "tenant-provenance"
+    other_tenant_id = "tenant-unrelated"
+    run_id = f"dmr_{uuid.uuid4().hex}"
+    earlier_run_id = f"dmr_{uuid.uuid4().hex}"
+    failed_run_id = f"dmr_{uuid.uuid4().hex}"
+    original_payload = _insert_snapshot(
+        repository,
+        mandate_id=mandate_id,
+        portfolio_id=portfolio_id,
+        tenant_id=tenant_id,
+    )
+    run_payload = {
+        "monitoring_run_id": run_id,
+        "as_of_date": "2026-05-03",
+        "requested_at": "2026-05-03T01:00:00Z",
+        "completed_at": "2026-05-03T01:00:01Z",
+        "status": "SUCCEEDED",
+        "mandate_ids": [mandate_id],
+        "filters": {"tenant_id": tenant_id},
+        "total_mandates": 1,
+        "health_distribution": {"READY": 1},
+        "exception_count": 2,
+        "source_readiness_summary": {"READY": 1},
+    }
+    try:
+        with closing(repository._connect()) as connection:
+            connection.execute(
+                """
+                INSERT INTO dpm_mandate_health_snapshots (
+                    health_snapshot_id, mandate_id, portfolio_id, as_of_date,
+                    health_score, health_state, source_readiness_state,
+                    dimension_scores_json, payload_json, created_at, tenant_id
+                ) VALUES (%s, %s, %s, '2026-05-03', 100, 'READY', 'READY',
+                          '[]', '{}', '2026-05-03T01:00:01Z', %s)
+                """,
+                (f"mh_{uuid.uuid4().hex}", mandate_id, portfolio_id, tenant_id),
+            )
+            connection.execute(
+                """
+                INSERT INTO dpm_mandate_health_snapshots (
+                    health_snapshot_id, mandate_id, portfolio_id, as_of_date,
+                    health_score, health_state, source_readiness_state,
+                    dimension_scores_json, payload_json, created_at, tenant_id
+                ) VALUES (%s, %s, %s, '2026-05-02', 100, 'READY', 'READY',
+                          '[]', '{}', '2026-05-03T02:00:01Z', %s)
+                """,
+                (f"mh_{uuid.uuid4().hex}", mandate_id, portfolio_id, tenant_id),
+            )
+            connection.execute(
+                """
+                INSERT INTO dpm_mandate_health_snapshots (
+                    health_snapshot_id, mandate_id, portfolio_id, as_of_date,
+                    health_score, health_state, source_readiness_state,
+                    dimension_scores_json, payload_json, created_at, tenant_id
+                ) VALUES (%s, %s, %s, '2026-05-03', 100, 'READY', 'READY',
+                          '[]', '{}', '2026-05-03T01:00:01Z', %s)
+                """,
+                (f"mh_{uuid.uuid4().hex}", mandate_id, portfolio_id, other_tenant_id),
+            )
+            for dimension, reason in (
+                ("CASH_LIQUIDITY", "CASH_ABOVE_BAND"),
+                ("CASH_LIQUIDITY", "PROJECTED_CASHFLOW_PRESSURE"),
+                ("TAX_TURNOVER", "TAX_LOTS_INCOMPLETE"),
+                ("ELIGIBILITY_RESTRICTIONS", "RESTRICTED_INSTRUMENT_HELD"),
+            ):
+                connection.execute(
+                    """
+                    INSERT INTO dpm_monitoring_exceptions (
+                        exception_id, monitoring_run_id, mandate_id, portfolio_id,
+                        as_of_date, dimension, severity, reason_code, state,
+                        recommended_action, source_lineage_json, payload_json,
+                        detected_at, tenant_id
+                    ) VALUES (%s, %s, %s, %s, '2026-05-03', %s, 'WARNING', %s,
+                              'ACTIVE', 'REVIEW_MANDATE', '[]', '{}',
+                              '2026-05-03T01:00:01Z', %s)
+                    """,
+                    (
+                        f"me_{uuid.uuid4().hex}",
+                        run_id,
+                        mandate_id,
+                        portfolio_id,
+                        dimension,
+                        reason,
+                        tenant_id,
+                    ),
+                )
+            connection.execute(
+                """
+                INSERT INTO dpm_monitoring_exceptions (
+                    exception_id, monitoring_run_id, mandate_id, portfolio_id,
+                    as_of_date, dimension, severity, reason_code, state,
+                    recommended_action, source_lineage_json, payload_json,
+                    detected_at, tenant_id
+                ) VALUES (%s, %s, %s, %s, '2026-05-03', 'CASH_LIQUIDITY',
+                          'WARNING', 'CASH_ABOVE_BAND', 'ACTIVE', 'REVIEW_MANDATE',
+                          '[]', '{}', '2026-05-03T01:00:01Z', %s)
+                """,
+                (
+                    f"me_{uuid.uuid4().hex}",
+                    f"other_{run_id}",
+                    mandate_id,
+                    portfolio_id,
+                    other_tenant_id,
+                ),
+            )
+            connection.execute(
+                """
+                INSERT INTO dpm_monitoring_exceptions (
+                    exception_id, monitoring_run_id, mandate_id, portfolio_id,
+                    as_of_date, dimension, severity, reason_code, state,
+                    recommended_action, source_lineage_json, payload_json,
+                    detected_at, tenant_id
+                ) VALUES (%s, %s, %s, %s, '2026-05-02', 'CASH_LIQUIDITY',
+                          'WARNING', 'CASH_ABOVE_BAND', 'ACTIVE', 'REVIEW_MANDATE',
+                          '[]', '{}', '2026-05-03T02:00:01Z', %s)
+                """,
+                (
+                    f"me_{uuid.uuid4().hex}",
+                    earlier_run_id,
+                    mandate_id,
+                    portfolio_id,
+                    tenant_id,
+                ),
+            )
+            connection.execute(
+                """
+                INSERT INTO dpm_monitoring_runs (
+                    monitoring_run_id, as_of_date, status, tenant_id, filters_json,
+                    source_readiness_summary_json, started_at, completed_at, payload_json
+                ) VALUES (%s, '2026-05-03', 'SUCCEEDED', %s, %s, %s,
+                          '2026-05-03T00:59:00Z', '2026-05-03T01:00:01Z', %s)
+                """,
+                (
+                    run_id,
+                    tenant_id,
+                    json.dumps(run_payload["filters"]),
+                    '{"READY":1}',
+                    json.dumps(run_payload),
+                ),
+            )
+            earlier_payload = {
+                **run_payload,
+                "monitoring_run_id": earlier_run_id,
+                "as_of_date": "2026-05-02",
+            }
+            connection.execute(
+                """
+                INSERT INTO dpm_monitoring_runs (
+                    monitoring_run_id, as_of_date, status, tenant_id, filters_json,
+                    source_readiness_summary_json, started_at, completed_at, payload_json
+                ) VALUES (%s, '2026-05-02', 'SUCCEEDED', %s, %s, %s,
+                          '2026-05-03T02:00:00Z', '2026-05-03T02:00:01Z', %s)
+                """,
+                (
+                    earlier_run_id,
+                    tenant_id,
+                    json.dumps(run_payload["filters"]),
+                    '{"READY":1}',
+                    json.dumps(earlier_payload),
+                ),
+            )
+            failed_payload = {
+                **run_payload,
+                "monitoring_run_id": failed_run_id,
+                "status": "FAILED",
+                "failure_reason": "UPSTREAM_TIMEOUT",
+            }
+            connection.execute(
+                """
+                INSERT INTO dpm_monitoring_runs (
+                    monitoring_run_id, as_of_date, status, failure_reason, tenant_id,
+                    filters_json, source_readiness_summary_json, started_at,
+                    completed_at, payload_json
+                ) VALUES (%s, '2026-05-03', 'FAILED', 'UPSTREAM_TIMEOUT', %s, %s, %s,
+                          '2026-05-03T01:00:00Z', '2026-05-03T01:00:01Z', %s)
+                """,
+                (
+                    failed_run_id,
+                    tenant_id,
+                    json.dumps(run_payload["filters"]),
+                    '{"READY":1}',
+                    json.dumps(failed_payload),
+                ),
+            )
+            clean_payload = json.loads(_payload(mandate_id=mandate_id, portfolio_id=portfolio_id))
+            clean_payload["mandate_version"] = "4"
+            clean_payload["as_of_date"] = "2026-05-04"
+            clean_payload["constraints"] = {
+                "cash_band_min_weight": None,
+                "cash_band_max_weight": None,
+                "turnover_budget": None,
+            }
+            clean_payload_json = json.dumps(clean_payload, separators=(",", ":"), sort_keys=True)
+            connection.execute(
+                """
+                INSERT INTO dpm_mandate_snapshots (
+                    mandate_snapshot_id, mandate_id, portfolio_id, mandate_version,
+                    as_of_date, source_hash, source_lineage_json, payload_json,
+                    created_at, created_by, tenant_id, producer_kind
+                ) VALUES (%s, %s, %s, '4', '2026-05-04', %s, '[]', %s,
+                          '2026-05-03T00:30:00Z', 'lotus-manage', %s, 'UNKNOWN_LEGACY')
+                """,
+                (
+                    f"ms_{uuid.uuid4().hex}",
+                    mandate_id,
+                    portfolio_id,
+                    "sha256:" + hashlib.sha256(clean_payload_json.encode()).hexdigest(),
+                    clean_payload_json,
+                    tenant_id,
+                ),
+            )
+            # Historical upserts refreshed this timestamp after the derived
+            # evidence had already been stamped, so time cannot recover the
+            # snapshot/evidence relationship.
+            connection.execute(
+                """UPDATE dpm_mandate_snapshots
+                   SET created_at = '2026-05-05T01:00:00Z'
+                   WHERE mandate_id = %s AND mandate_version = '3'""",
+                (mandate_id,),
+            )
+            connection.commit()
+
+        _apply_migration(repository)
+        _apply_migration(repository)  # replay is harmless and does not duplicate the marker
+
+        with closing(repository._connect()) as connection:
+            row = connection.execute(
+                """SELECT payload_json, source_hash, producer_kind
+                   FROM dpm_mandate_snapshots
+                   WHERE mandate_id = %s AND mandate_version = '3'""",
+                (mandate_id,),
+            ).fetchone()
+            clean_row = connection.execute(
+                """SELECT payload_json FROM dpm_mandate_snapshots
+                   WHERE mandate_id = %s AND mandate_version = '4'""",
+                (mandate_id,),
+            ).fetchone()
+            health_count = connection.execute(
+                """SELECT count(*) AS count FROM dpm_mandate_health_snapshots
+                   WHERE mandate_id = %s AND tenant_id = %s""",
+                (mandate_id, tenant_id),
+            ).fetchone()["count"]
+            exceptions = connection.execute(
+                """SELECT as_of_date, dimension, reason_code FROM dpm_monitoring_exceptions
+                   WHERE mandate_id = %s AND tenant_id = %s""",
+                (mandate_id, tenant_id),
+            ).fetchall()
+            other_health_count = connection.execute(
+                """SELECT count(*) AS count FROM dpm_mandate_health_snapshots
+                   WHERE mandate_id = %s AND tenant_id = %s""",
+                (mandate_id, other_tenant_id),
+            ).fetchone()["count"]
+            other_exception_count = connection.execute(
+                """SELECT count(*) AS count FROM dpm_monitoring_exceptions
+                   WHERE mandate_id = %s AND tenant_id = %s""",
+                (mandate_id, other_tenant_id),
+            ).fetchone()["count"]
+
+        stored = (
+            row["payload_json"]
+            if isinstance(row["payload_json"], str)
+            else json.dumps(row["payload_json"], separators=(",", ":"), sort_keys=True)
+        )
+        stored_payload = json.loads(stored)
+        original_constraints = json.loads(original_payload)["constraints"]
+        assert stored_payload["constraints"] == original_constraints
+        assert "cash_reserve_weight" not in stored_payload["constraints"]
+        assert stored_payload["field_gap_codes"].count(MANDATE_LIMIT_PROVENANCE_AMBIGUOUS) == 1
+        assert stored_payload["field_gap_codes"].count("UNRELATED_GAP") == 1
+        assert row["producer_kind"] == "UNKNOWN_LEGACY"
+        assert row["source_hash"] == "sha256:" + hashlib.sha256(stored.encode()).hexdigest()
+        assert clean_row is not None
+        assert (
+            MANDATE_LIMIT_PROVENANCE_AMBIGUOUS
+            not in json.loads(clean_row["payload_json"])["field_gap_codes"]
+        )
+
+        effective = repository.get_latest_mandate(mandate_id=mandate_id, tenant_id=tenant_id)
+        assert effective is not None
+        assert effective.constraints.cash_band_min_weight is None
+        assert effective.constraints.cash_band_max_weight is None
+        assert effective.constraints.turnover_budget is None
+        assert effective.constraints.cash_reserve_weight is None
+        assert health_count == 0
+        assert {
+            (item["as_of_date"], item["dimension"], item["reason_code"]) for item in exceptions
+        } == {
+            ("2026-05-03", "CASH_LIQUIDITY", "PROJECTED_CASHFLOW_PRESSURE"),
+            ("2026-05-03", "TAX_TURNOVER", "TAX_LOTS_INCOMPLETE"),
+            ("2026-05-03", "ELIGIBILITY_RESTRICTIONS", "RESTRICTED_INSTRUMENT_HELD"),
+        }
+        assert other_health_count == 1
+        assert other_exception_count == 1
+
+        run = repository.get_monitoring_run(monitoring_run_id=run_id, tenant_id=tenant_id)
+        assert run is not None
+        assert run.status == "FAILED"
+        assert run.failure_reason == MANDATE_LIMIT_PROVENANCE_AMBIGUOUS
+        assert run.total_mandates == 0
+        assert run.health_distribution == {}
+        assert run.exception_count == 0
+
+        earlier_run = repository.get_monitoring_run(
+            monitoring_run_id=earlier_run_id, tenant_id=tenant_id
+        )
+        assert earlier_run is not None
+        assert earlier_run.status == "FAILED"
+        assert earlier_run.failure_reason == MANDATE_LIMIT_PROVENANCE_AMBIGUOUS
+        assert earlier_run.total_mandates == 0
+        assert earlier_run.health_distribution == {}
+        assert earlier_run.exception_count == 0
+
+        failed_run = repository.get_monitoring_run(
+            monitoring_run_id=failed_run_id, tenant_id=tenant_id
+        )
+        assert failed_run is not None
+        assert failed_run.status == "FAILED"
+        assert failed_run.failure_reason == "UPSTREAM_TIMEOUT"
+        assert failed_run.total_mandates == 1
+        assert failed_run.health_distribution == {"READY": 1}
+        assert failed_run.exception_count == 2
+    finally:
+        _cleanup(repository, mandate_id, run_id)
+        with closing(repository._connect()) as connection:
+            connection.execute(
+                "DELETE FROM dpm_monitoring_runs WHERE monitoring_run_id = ANY(%s)",
+                ([failed_run_id, earlier_run_id],),
+            )
+            connection.commit()
+
+
+def test_future_repository_writes_record_their_actual_producer(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    tenant_id = "tenant-producer"
+    mandate_ids = [f"MANDATE_PRODUCER_{uuid.uuid4().hex[:10]}" for _ in range(2)]
+    run_id = f"unused_{uuid.uuid4().hex}"
+    try:
+        for mandate_id, producer in zip(
+            mandate_ids, ("CALLER_SUPPLIED", "CORE_COMPILED"), strict=True
+        ):
+            twin = DpmMandateDigitalTwin(
+                mandate_id=mandate_id,
+                portfolio_id=f"PF_{mandate_id}",
+                mandate_version="1",
+                as_of_date=date(2026, 9, 9),
+                base_currency="SGD",
+                reference_currency="SGD",
+                risk_profile="BALANCED",
+                investment_objective="LONG_TERM_TOTAL_RETURN",
+                time_horizon="LONG_TERM",
+                model_portfolio_id="MODEL_PRODUCER",
+                constraints=DpmMandateConstraintSet(),
+                review_policy=DpmMandateReviewPolicy(),
+            )
+            repository.save_mandate_snapshot(
+                twin,
+                tenant_id=tenant_id,
+                producer_kind=producer,  # type: ignore[arg-type]
+            )
+
+        with closing(repository._connect()) as connection:
+            rows = connection.execute(
+                """SELECT mandate_id, producer_kind FROM dpm_mandate_snapshots
+                   WHERE mandate_id = ANY(%s) ORDER BY producer_kind""",
+                (mandate_ids,),
+            ).fetchall()
+        assert {(row["mandate_id"], row["producer_kind"]) for row in rows} == {
+            (mandate_ids[0], "CALLER_SUPPLIED"),
+            (mandate_ids[1], "CORE_COMPILED"),
+        }
+    finally:
+        for mandate_id in mandate_ids:
+            _cleanup(repository, mandate_id, run_id)
+
+
+def test_post_migration_legacy_upsert_without_producer_is_rejected(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    mandate_id = f"MANDATE_OLD_REPLICA_{uuid.uuid4().hex[:10]}"
+    portfolio_id = f"PF_OLD_REPLICA_{uuid.uuid4().hex[:10]}"
+    tenant_id = "tenant-old-replica"
+    run_id = f"unused_{uuid.uuid4().hex}"
+    original_payload = _insert_snapshot(
+        repository,
+        mandate_id=mandate_id,
+        portfolio_id=portfolio_id,
+        tenant_id=tenant_id,
+    )
+    try:
+        _apply_migration(repository)
+        legacy_payload = _payload(mandate_id=mandate_id, portfolio_id=portfolio_id)
+        with closing(repository._connect()) as connection:
+            with pytest.raises(psycopg.errors.NotNullViolation):
+                connection.execute(
+                    """
+                    INSERT INTO dpm_mandate_snapshots (
+                        mandate_snapshot_id, mandate_id, portfolio_id, mandate_version,
+                        as_of_date, source_hash, source_lineage_json, payload_json,
+                        created_at, created_by, tenant_id
+                    ) VALUES (%s, %s, %s, '3', '2026-05-03', %s, '[]', %s,
+                              '2026-05-03T02:00:00+00:00', 'old-lotus-manage', %s)
+                    ON CONFLICT (tenant_id, mandate_id, mandate_version, as_of_date)
+                    DO UPDATE SET payload_json = excluded.payload_json,
+                                  source_hash = excluded.source_hash
+                    """,
+                    (
+                        f"ms_{uuid.uuid4().hex}",
+                        mandate_id,
+                        portfolio_id,
+                        "sha256:" + hashlib.sha256(legacy_payload.encode()).hexdigest(),
+                        legacy_payload,
+                        tenant_id,
+                    ),
+                )
+            connection.rollback()
+
+            row = connection.execute(
+                """SELECT payload_json, producer_kind
+                   FROM dpm_mandate_snapshots WHERE mandate_id = %s""",
+                (mandate_id,),
+            ).fetchone()
+            column_default = connection.execute(
+                """SELECT column_default FROM information_schema.columns
+                   WHERE table_schema = current_schema()
+                     AND table_name = 'dpm_mandate_snapshots'
+                     AND column_name = 'producer_kind'"""
+            ).fetchone()["column_default"]
+
+        assert row is not None
+        assert row["producer_kind"] == "UNKNOWN_LEGACY"
+        assert (
+            MANDATE_LIMIT_PROVENANCE_AMBIGUOUS in json.loads(row["payload_json"])["field_gap_codes"]
+        )
+        assert (
+            json.loads(row["payload_json"])["constraints"]
+            == json.loads(original_payload)["constraints"]
+        )
+        assert column_default is None
+    finally:
+        _cleanup(repository, mandate_id, run_id)
+
+
+def test_migration_preserves_quarantined_null_tenant_evidence(
+    repository: PostgresDpmMandateRepository,
+) -> None:
+    mandate_id = f"MANDATE_QUARANTINED_{uuid.uuid4().hex[:10]}"
+    portfolio_id = f"PF_QUARANTINED_{uuid.uuid4().hex[:10]}"
+    run_id = f"dmr_{uuid.uuid4().hex}"
+    _insert_snapshot(
+        repository,
+        mandate_id=mandate_id,
+        portfolio_id=portfolio_id,
+        tenant_id=None,
+    )
+    run_payload = {
+        "monitoring_run_id": run_id,
+        "as_of_date": "2026-05-03",
+        "requested_at": "2026-05-03T01:00:00Z",
+        "completed_at": "2026-05-03T01:00:01Z",
+        "status": "SUCCEEDED",
+        "mandate_ids": [mandate_id],
+        "filters": {},
+        "total_mandates": 1,
+        "health_distribution": {"READY": 1},
+        "exception_count": 1,
+        "source_readiness_summary": {"READY": 1},
+    }
+    try:
+        with closing(repository._connect()) as connection:
+            connection.execute(
+                """
+                INSERT INTO dpm_mandate_health_snapshots (
+                    health_snapshot_id, mandate_id, portfolio_id, as_of_date,
+                    health_score, health_state, source_readiness_state,
+                    dimension_scores_json, payload_json, created_at, tenant_id
+                ) VALUES (%s, %s, %s, '2026-05-03', 100, 'READY', 'READY',
+                          '[]', '{}', '2026-05-03T01:00:01Z', NULL)
+                """,
+                (f"mh_{uuid.uuid4().hex}", mandate_id, portfolio_id),
+            )
+            connection.execute(
+                """
+                INSERT INTO dpm_monitoring_exceptions (
+                    exception_id, monitoring_run_id, mandate_id, portfolio_id,
+                    as_of_date, dimension, severity, reason_code, state,
+                    recommended_action, source_lineage_json, payload_json,
+                    detected_at, tenant_id
+                ) VALUES (%s, %s, %s, %s, '2026-05-03', 'CASH_LIQUIDITY',
+                          'WARNING', 'CASH_ABOVE_BAND', 'ACTIVE', 'REVIEW_MANDATE',
+                          '[]', '{}', '2026-05-03T01:00:01Z', NULL)
+                """,
+                (f"me_{uuid.uuid4().hex}", run_id, mandate_id, portfolio_id),
+            )
+            connection.execute(
+                """
+                INSERT INTO dpm_monitoring_runs (
+                    monitoring_run_id, as_of_date, status, tenant_id, filters_json,
+                    source_readiness_summary_json, started_at, completed_at, payload_json
+                ) VALUES (%s, '2026-05-03', 'SUCCEEDED', NULL, '{}', '{"READY":1}',
+                          '2026-05-03T01:00:00Z', '2026-05-03T01:00:01Z', %s)
+                """,
+                (run_id, json.dumps(run_payload)),
+            )
+            connection.commit()
+
+        _apply_migration(repository)
+
+        with closing(repository._connect()) as connection:
+            snapshot = connection.execute(
+                """SELECT payload_json FROM dpm_mandate_snapshots
+                   WHERE mandate_id = %s AND tenant_id IS NULL""",
+                (mandate_id,),
+            ).fetchone()
+            run = connection.execute(
+                """SELECT status, failure_reason FROM dpm_monitoring_runs
+                   WHERE monitoring_run_id = %s AND tenant_id IS NULL""",
+                (run_id,),
+            ).fetchone()
+            health_count = connection.execute(
+                """SELECT count(*) AS count FROM dpm_mandate_health_snapshots
+                   WHERE mandate_id = %s AND tenant_id IS NULL""",
+                (mandate_id,),
+            ).fetchone()["count"]
+            exception_count = connection.execute(
+                """SELECT count(*) AS count FROM dpm_monitoring_exceptions
+                   WHERE mandate_id = %s AND tenant_id IS NULL""",
+                (mandate_id,),
+            ).fetchone()["count"]
+
+        assert snapshot is not None
+        snapshot_payload = json.loads(snapshot["payload_json"])
+        assert MANDATE_LIMIT_PROVENANCE_AMBIGUOUS in snapshot_payload["field_gap_codes"]
+        assert run == {"status": "SUCCEEDED", "failure_reason": None}
+        assert health_count == 1
+        assert exception_count == 1
+    finally:
+        _cleanup(repository, mandate_id, run_id)

--- a/tests/integration/dpm/mandates/test_mandate_tenant_isolation_postgres.py
+++ b/tests/integration/dpm/mandates/test_mandate_tenant_isolation_postgres.py
@@ -172,8 +172,8 @@ def test_rows_that_could_not_be_attributed_are_unreachable_from_every_tenant(
                 INSERT INTO dpm_mandate_snapshots (
                     mandate_snapshot_id, mandate_id, portfolio_id, mandate_version,
                     as_of_date, source_hash, source_lineage_json, payload_json,
-                    created_at, created_by
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    created_at, created_by, producer_kind
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'UNKNOWN_LEGACY')
                 """,
                 (
                     f"ms_{uuid.uuid4().hex[:12]}",

--- a/tests/integration/dpm/test_quarantined_tenant_inventory_postgres.py
+++ b/tests/integration/dpm/test_quarantined_tenant_inventory_postgres.py
@@ -131,9 +131,10 @@ def _insert_quarantined_rows(*, dsn: str, ids: dict[str, str]) -> None:
             """
             INSERT INTO dpm_mandate_snapshots (
                 mandate_snapshot_id, mandate_id, portfolio_id, mandate_version, as_of_date,
-                source_hash, source_lineage_json, payload_json, created_at, created_by
+                source_hash, source_lineage_json, payload_json, created_at, created_by,
+                producer_kind
             ) VALUES (%s, %s, %s, '1', '2026-09-09', 'sha256:inventory', '[]', '{}',
-                      '2026-09-09T00:00:00+00:00', 'inventory-proof')
+                      '2026-09-09T00:00:00+00:00', 'inventory-proof', 'UNKNOWN_LEGACY')
             """,
             (
                 ids["mandate_snapshot_id"],

--- a/tests/unit/dpm/api/test_mandates_api.py
+++ b/tests/unit/dpm/api/test_mandates_api.py
@@ -28,7 +28,11 @@ from src.core.dpm_source_context import (
     DpmCoreSustainabilityPreferenceProfileResponse,
 )
 from src.core.mandate_health_scoring import calculate_mandate_health
-from src.core.mandates import DpmMandateDigitalTwin, DpmMandateHealthInput
+from src.core.mandates import (
+    MANDATE_LIMIT_PROVENANCE_AMBIGUOUS,
+    DpmMandateDigitalTwin,
+    DpmMandateHealthInput,
+)
 from src.infrastructure.core_sourcing import DpmCoreResolverError, DpmCoreResolverUnavailableError
 from src.infrastructure.mandates import InMemoryDpmMandateRepository
 
@@ -1035,6 +1039,117 @@ def test_health_read_and_recalculate_error_mapping() -> None:
     assert missing.json()["detail"] == "DPM_MANDATE_HEALTH_NOT_FOUND"
     assert mismatch.status_code == 424
     assert mismatch.json()["detail"] == "DPM_MANDATE_HEALTH_INPUT_MISMATCH"
+
+
+def test_ambiguous_recalculation_requires_exact_tenant_scoped_snapshot() -> None:
+    repository = InMemoryDpmMandateRepository()
+    ambiguous_twin = _twin().model_copy(
+        update={"field_gap_codes": ["MANDATE_LIMIT_PROVENANCE_AMBIGUOUS"]}
+    )
+    health_input = DpmMandateHealthInput(twin=ambiguous_twin, cash_weight=Decimal("0.05"))
+
+    with _client(repository) as client:
+        missing = client.post(
+            f"/api/v1/mandates/{MANDATE_ID}/health/recalculate?tenant_id=tenant-test",
+            json=health_input.model_dump(mode="json"),
+        )
+        repository.save_mandate_snapshot(ambiguous_twin, tenant_id="tenant-test")
+        verified = client.post(
+            f"/api/v1/mandates/{MANDATE_ID}/health/recalculate?tenant_id=tenant-test",
+            json=health_input.model_dump(mode="json"),
+        )
+
+    assert missing.status_code == 424
+    assert missing.json()["detail"] == "DPM_MANDATE_AMBIGUOUS_SNAPSHOT_NOT_FOUND"
+    assert verified.status_code == 200
+
+
+def test_ambiguous_recalculation_uses_retained_snapshot_not_submitted_twin() -> None:
+    repository = InMemoryDpmMandateRepository()
+    retained_twin = _twin().model_copy(
+        update={"field_gap_codes": ["MANDATE_LIMIT_PROVENANCE_AMBIGUOUS"]}
+    )
+    repository.save_mandate_snapshot(retained_twin, tenant_id="tenant-test")
+    submitted_twin = retained_twin.model_copy(
+        update={
+            "constraints": retained_twin.constraints.model_copy(
+                update={"max_tracking_error": Decimal("0.01")}
+            )
+        }
+    )
+    health_input = DpmMandateHealthInput(
+        twin=submitted_twin,
+        tracking_error=Decimal("0.10"),
+    )
+
+    with _client(repository) as client:
+        response = client.post(
+            f"/api/v1/mandates/{MANDATE_ID}/health/recalculate?tenant_id=tenant-test",
+            json=health_input.model_dump(mode="json"),
+        )
+
+    assert response.status_code == 200
+    risk_drift = next(
+        score for score in response.json()["dimension_scores"] if score["dimension"] == "RISK_DRIFT"
+    )
+    assert risk_drift["reason_code"] == "RISK_DRIFT_READY"
+
+
+def test_ambiguous_recalculation_cannot_strip_stored_marker() -> None:
+    repository = InMemoryDpmMandateRepository()
+    retained_twin = _twin().model_copy(
+        update={"field_gap_codes": ["MANDATE_LIMIT_PROVENANCE_AMBIGUOUS"]}
+    )
+    repository.save_mandate_snapshot(retained_twin, tenant_id="tenant-test")
+    unmarked_twin = _twin().model_copy(
+        update={
+            "constraints": _twin().constraints.model_copy(
+                update={"max_tracking_error": Decimal("0.01")}
+            )
+        }
+    )
+    health_input = DpmMandateHealthInput(
+        twin=unmarked_twin,
+        tracking_error=Decimal("0.10"),
+    )
+
+    with _client(repository) as client:
+        response = client.post(
+            f"/api/v1/mandates/{MANDATE_ID}/health/recalculate?tenant_id=tenant-test",
+            json=health_input.model_dump(mode="json"),
+        )
+
+    assert response.status_code == 200
+    risk_drift = next(
+        score for score in response.json()["dimension_scores"] if score["dimension"] == "RISK_DRIFT"
+    )
+    assert risk_drift["reason_code"] == "RISK_DRIFT_READY"
+    stored = repository.get_latest_mandate(mandate_id=MANDATE_ID, tenant_id="tenant-test")
+    assert stored is not None
+    assert MANDATE_LIMIT_PROVENANCE_AMBIGUOUS in stored.field_gap_codes
+
+
+def test_ambiguous_recalculation_rejects_portfolio_change_on_persisted_key() -> None:
+    repository = InMemoryDpmMandateRepository()
+    retained_twin = _twin().model_copy(
+        update={"field_gap_codes": [MANDATE_LIMIT_PROVENANCE_AMBIGUOUS]}
+    )
+    repository.save_mandate_snapshot(retained_twin, tenant_id="tenant-test")
+    unmarked_other_portfolio = _twin().model_copy(update={"portfolio_id": "PF_FORGED"})
+    health_input = DpmMandateHealthInput(twin=unmarked_other_portfolio)
+
+    with _client(repository) as client:
+        response = client.post(
+            f"/api/v1/mandates/{MANDATE_ID}/health/recalculate?tenant_id=tenant-test",
+            json=health_input.model_dump(mode="json"),
+        )
+
+    assert response.status_code == 424
+    assert response.json()["detail"] == "DPM_MANDATE_AMBIGUOUS_SNAPSHOT_NOT_FOUND"
+    stored = repository.get_latest_mandate(mandate_id=MANDATE_ID, tenant_id="tenant-test")
+    assert stored is not None
+    assert stored.portfolio_id == PORTFOLIO_ID
+    assert MANDATE_LIMIT_PROVENANCE_AMBIGUOUS in stored.field_gap_codes
 
 
 def test_default_mandate_repository_dependency_is_available(

--- a/tests/unit/dpm/core/test_mandate_health.py
+++ b/tests/unit/dpm/core/test_mandate_health.py
@@ -18,6 +18,7 @@ from src.core.dpm_source_context import (
 )
 from src.core.mandates import (
     DIMENSION_WEIGHTS,
+    MANDATE_LIMIT_PROVENANCE_AMBIGUOUS,
     DpmMandateConstraintSet,
     DpmMandateDimensionScore,
     DpmMandateDigitalTwin,
@@ -45,6 +46,7 @@ from src.core.mandates import (
     calculate_mandate_health,
     build_health_input_from_core_sources,
     compile_mandate_digital_twin_from_core,
+    effective_mandate_twin,
     monitoring_exceptions_from_health,
 )
 
@@ -475,6 +477,31 @@ def _dimension(
 def test_dimension_weights_are_complete_and_balanced() -> None:
     assert sum(DIMENSION_WEIGHTS.values()) == 100
     assert set(DIMENSION_WEIGHTS) == set(MandateHealthDimension)
+
+
+def test_ambiguous_legacy_limits_are_preserved_but_suppressed_from_reads_and_scoring() -> None:
+    persisted = _twin(field_gap_codes=[MANDATE_LIMIT_PROVENANCE_AMBIGUOUS])
+
+    effective = effective_mandate_twin(persisted)
+    assert persisted.constraints.cash_band_min_weight == Decimal("0.02")
+    assert persisted.constraints.cash_band_max_weight == Decimal("0.10")
+    assert persisted.constraints.turnover_budget == Decimal("0.15")
+    assert effective.constraints.cash_band_min_weight is None
+    assert effective.constraints.cash_band_max_weight is None
+    assert effective.constraints.turnover_budget is None
+
+    snapshot = calculate_mandate_health(
+        _ready_input(twin=persisted),
+        tenant_id="tenant-test",
+    )
+    assert _dimension(snapshot, MandateHealthDimension.CASH_LIQUIDITY).reason_code == (
+        "CASH_BAND_NOT_SOURCED"
+    )
+    assert _dimension(snapshot, MandateHealthDimension.TAX_TURNOVER).reason_code == (
+        "TURNOVER_BUDGET_NOT_SOURCED"
+    )
+    assert snapshot.health_state == MandateHealthState.PENDING_REVIEW
+    assert snapshot.recommended_action == MandateRecommendedAction.FIX_SOURCE_DATA
 
 
 def test_compile_mandate_twin_uses_core_source_truth_and_explicit_gap_codes() -> None:

--- a/tests/unit/dpm/mandates/test_mandate_health_persistence.py
+++ b/tests/unit/dpm/mandates/test_mandate_health_persistence.py
@@ -1,6 +1,8 @@
+import pytest
+
 from src.api.services import mandate_health_persistence
 from src.api.services.mandate_health_persistence import persist_mandate_health_evidence
-from src.core.mandates import DpmMandateHealthInput
+from src.core.mandates import MANDATE_LIMIT_PROVENANCE_AMBIGUOUS, DpmMandateHealthInput
 from tests.unit.dpm.mandates.test_mandate_health_result import _twin
 from src.api.services.mandate_health_result import calculate_mandate_health_result
 
@@ -10,9 +12,17 @@ class _CapturingMandateRepository:
         self.saved_twins: list[object] = []
         self.saved_snapshots: list[object] = []
         self.saved_exceptions: list[object] = []
+        self.saved_producer_kinds: list[str] = []
 
-    def save_mandate_snapshot(self, twin: object, *, tenant_id: str) -> None:
+    def save_mandate_snapshot(
+        self,
+        twin: object,
+        *,
+        tenant_id: str,
+        producer_kind: str = "CALLER_SUPPLIED",
+    ) -> None:
         self.saved_twins.append(twin)
+        self.saved_producer_kinds.append(producer_kind)
 
     def save_health_snapshot(self, snapshot: object, *, tenant_id: str) -> None:
         self.saved_snapshots.append(snapshot)
@@ -37,6 +47,7 @@ def test_persist_mandate_health_evidence_saves_optional_twin_snapshot_and_except
     )
 
     assert repository.saved_twins == [twin]
+    assert repository.saved_producer_kinds == ["CALLER_SUPPLIED"]
     assert repository.saved_snapshots == [health_result.snapshot]
     assert repository.saved_exceptions == health_result.monitoring_exceptions
 
@@ -58,6 +69,66 @@ def test_persist_mandate_health_evidence_supports_health_only_monitoring_results
     assert repository.saved_twins == []
     assert repository.saved_snapshots == [health_result.snapshot]
     assert repository.saved_exceptions == health_result.monitoring_exceptions
+
+
+def test_persist_mandate_health_evidence_records_core_compiler_provenance() -> None:
+    repository = _CapturingMandateRepository()
+    twin = _twin()
+    health_result = calculate_mandate_health_result(
+        DpmMandateHealthInput(twin=twin), tenant_id="tenant-test"
+    )
+
+    persist_mandate_health_evidence(
+        repository=repository,  # type: ignore[arg-type]
+        twin=twin,
+        health_snapshot=health_result.snapshot,
+        monitoring_exceptions=[],
+        tenant_id="tenant-test",
+        mandate_producer_kind="CORE_COMPILED",
+    )
+
+    assert repository.saved_producer_kinds == ["CORE_COMPILED"]
+
+
+def test_unverified_caller_projection_cannot_persist_health_or_overwrite_limits() -> None:
+    repository = _CapturingMandateRepository()
+    twin = _twin().model_copy(update={"field_gap_codes": [MANDATE_LIMIT_PROVENANCE_AMBIGUOUS]})
+    health_result = calculate_mandate_health_result(
+        DpmMandateHealthInput(twin=twin), tenant_id="tenant-test"
+    )
+
+    with pytest.raises(ValueError, match="DPM_MANDATE_AMBIGUOUS_SNAPSHOT_NOT_VERIFIED"):
+        persist_mandate_health_evidence(
+            repository=repository,  # type: ignore[arg-type]
+            twin=twin,
+            health_snapshot=health_result.snapshot,
+            monitoring_exceptions=health_result.monitoring_exceptions,
+            tenant_id="tenant-test",
+        )
+
+    assert repository.saved_twins == []
+    assert repository.saved_snapshots == []
+    assert repository.saved_exceptions == []
+
+
+def test_verified_caller_projection_recalculates_without_overwriting_limits() -> None:
+    repository = _CapturingMandateRepository()
+    twin = _twin().model_copy(update={"field_gap_codes": [MANDATE_LIMIT_PROVENANCE_AMBIGUOUS]})
+    health_result = calculate_mandate_health_result(
+        DpmMandateHealthInput(twin=twin), tenant_id="tenant-test"
+    )
+
+    persist_mandate_health_evidence(
+        repository=repository,  # type: ignore[arg-type]
+        twin=twin,
+        health_snapshot=health_result.snapshot,
+        monitoring_exceptions=health_result.monitoring_exceptions,
+        tenant_id="tenant-test",
+        verified_retained_projection=True,
+    )
+
+    assert repository.saved_twins == []
+    assert repository.saved_snapshots == [health_result.snapshot]
 
 
 def test_mandate_health_persistence_exports_public_surface() -> None:

--- a/tests/unit/dpm/supportability/test_dpm_policy_pack_postgres_repository.py
+++ b/tests/unit/dpm/supportability/test_dpm_policy_pack_postgres_repository.py
@@ -84,6 +84,19 @@ class _FakeConnection:
             # Migration 0025 fences monitoring exceptions by tenant
             # (issue #648); this fake models a different table.
             return _FakeCursor()
+        if "MANDATE_LIMIT_PROVENANCE_AMBIGUOUS" in sql and any(
+            table in sql
+            for table in (
+                "dpm_mandate_snapshots",
+                "dpm_mandate_health_snapshots",
+                "dpm_monitoring_exceptions",
+                "dpm_monitoring_runs",
+            )
+        ):
+            # Migration 0030's cross-table rewrite is PostgreSQL-proven in
+            # test_legacy_mandate_limit_provenance_postgres.py. This fake owns
+            # only policy-pack behavior and must not emulate that migration.
+            return _FakeCursor()
         if is_migration_ddl(sql):
             return _FakeCursor()
         raise AssertionError(f"Unhandled SQL: {sql}")

--- a/tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py
+++ b/tests/unit/dpm/supportability/test_dpm_postgres_repository_scaffold.py
@@ -445,6 +445,18 @@ class _FakeConnection:
             # table, so the statement is acknowledged here and proven
             # for real in the mandate integration lane.
             return _FakeCursor()
+        if "MANDATE_LIMIT_PROVENANCE_AMBIGUOUS" in sql and any(
+            table in sql
+            for table in (
+                "dpm_mandate_snapshots",
+                "dpm_mandate_health_snapshots",
+                "dpm_monitoring_exceptions",
+                "dpm_monitoring_runs",
+            )
+        ):
+            # Migration 0030 is exercised by the real PostgreSQL mandate
+            # integration proof. This fake models rebalance-run storage only.
+            return _FakeCursor()
         if is_migration_ddl(sql):
             return _FakeCursor()
         raise AssertionError(f"Unexpected SQL: {sql}")

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -396,6 +396,34 @@ Idempotency keys are hashed; payloads and connection details are not emitted.
 - Detailed PowerShell and Bash invocation plus interpretation guidance lives in
   [docs/operations-runbook.md](https://github.com/sgajbi/lotus-manage/blob/main/docs/operations-runbook.md#null-tenant-quarantine-inventory).
 
+## Legacy mandate-limit provenance
+
+Migration `0030` preserves historical mandate cash-band and turnover values but marks them
+`MANDATE_LIMIT_PROVENANCE_AMBIGUOUS`, because the old compiler and caller-supplied recalculation
+could persist identical values and lineage. Numeric matching is never producer provenance.
+
+Effective mandate reads and health calculations suppress the ambiguous limits. Monitoring resolves
+the latest snapshot regardless of the requested run date, while recalculation accepted a selected
+non-latest version. Neither path recorded its chosen snapshot, and snapshot upserts refreshed
+`created_at`, so neither latest-state nor timestamp inference can recover that identity. All health
+snapshots and limit-dependent cash/turnover exceptions for an affected tenant/mandate are therefore
+retired, and every successful run referencing it becomes `FAILED` with empty aggregates. Projected
+cash-flow, tax-lot, restriction, workflow findings, and already-failed runs retain their original
+evidence. NULL-tenant snapshots may be marked, but their quarantined runs, health and exceptions
+remain untouched until audited attribution. Future writes record `CORE_COMPILED` or
+`CALLER_SUPPLIED` producer provenance; the migration drops its compatibility default after backfill
+so old replicas cannot create or overwrite unmarked ambiguous rows.
+
+Health recalculation resolves the exact tenant-scoped stored snapshot identity before trusting
+caller gap codes. Forged markers fail closed, and omitting a stored marker cannot bypass the fence.
+Manage calculates ambiguous history from the retained effective snapshot. Caller changes to
+restrictions, policy, lineage, risk profile, or other twin fields therefore cannot alter evidence
+or overwrite the retained raw snapshot limits. A portfolio change is rejected because the stored
+identity key is tenant/mandate/version/as-of rather than portfolio.
+
+Verify `dpm:0030`, refresh affected mandates from governed Core sources, then recalculate health and
+run monitoring again. Do not clear the marker or reconstruct deleted derived evidence by hand.
+
 ## Key references
 
 - [docs/documentation/project-overview.md](https://github.com/sgajbi/lotus-manage/blob/main/docs/documentation/project-overview.md)

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -328,6 +328,11 @@ Current functional behavior:
    dimensions, source-readiness posture, and monitoring action state through the Gateway/BFF only.
 5. Platform seed automation verifies ready, partial, and empty command-center postures before the
    screenshot pack is treated as demo-ready evidence.
+6. Historical cash-band and turnover values with no reliable producer marker remain stored for
+   audit but are explicitly provenance-ambiguous and ineffective. Migration `0030` retires only
+   dependent health/exception evidence, fails affected successful-run aggregates closed, preserves
+   earlier failures and unrelated findings, and records the producer of future Core and
+   caller-supplied snapshots.
 
 Non-functional controls:
 


### PR DESCRIPTION
## Summary

- preserve legacy cash-band and turnover values while marking unknown producer provenance explicitly
- suppress ambiguous limits from effective reads and mandate-health scoring without inventing a zero reserve
- invalidate only dependent tenant-scoped health evidence, fail affected monitoring aggregates closed, and preserve unrelated exceptions
- record `CORE_COMPILED` versus `CALLER_SUPPLIED` provenance for all future PostgreSQL snapshot writes
- document the migration, operator recovery flow, RFC truth, and wiki truth

## Acceptance evidence

- exact caller-colliding `0.02` / `0.10` / `0.15` values remain stored and hash-consistent
- legacy zero minimum never becomes an explicit reserve
- effective reads and scoring treat ambiguous limits as unsourced
- unrelated exception dimensions and other-tenant evidence survive
- affected monitoring runs remain auditable as `FAILED` with empty aggregates
- migration replay is idempotent and future producer markers are proven in PostgreSQL

## Local gates

- `make ci` with required PostgreSQL integration: passed (3,800 tests; dependency audit clean)
- complete unit suite: 3,511 passed
- complete PostgreSQL integration suite: 261 passed
- wiki source check with `-AllowUnpublishedSourceChanges`: passed; two intentional pages require publication after merge
- `git diff --check`: passed

Refs #674

